### PR TITLE
Fix account discovery for Launchpad OAuth tokens

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -178,10 +178,13 @@ EOF
 }
 
 create_accounts() {
-  cat > "$TEST_HOME/.config/basecamp/accounts.json" << 'EOF'
-[
-  {"id": 99999, "name": "Test Account", "href": "https://3.basecampapi.com/99999"}
-]
+  local base_url="${BCQ_BASE_URL:-https://3.basecampapi.com}"
+  cat > "$TEST_HOME/.config/basecamp/accounts.json" << EOF
+{
+  "$base_url": [
+    {"id": 99999, "name": "Test Account", "href": "https://3.basecampapi.com/99999"}
+  ]
+}
 EOF
 }
 


### PR DESCRIPTION
## Summary

Fixes account discovery when authenticated via Launchpad OAuth (the fallback when BC3 OAuth 2.1 isn't available).

## Changes

1. **Introspect via correct endpoint**: Launchpad tokens must be introspected at `launchpad.37signals.com/authorization.json`, not the Basecamp API endpoint.

2. **Read oauth_type from stored credentials**: Previously used discovery (which reflects current server state), now reads from stored credentials to know how the token was obtained.

3. **Handle different response formats**: 
   - Launchpad returns `.id` directly
   - BC3 returns `.queenbee_id`
   - Filter to `bc3` product accounts only (excludes HEY, etc.)

4. **Scope accounts.json by endpoint**: Like credentials.json, accounts are now stored per-endpoint to support multiple Basecamp environments.

## Test plan

```bash
bats test/  # All 336 tests pass
bcq auth login  # Then check bcq auth status shows correct account
```