### PR TITLE
Integrate name resolution into commands

### DIFF
--- a/lib/commands/people.sh
+++ b/lib/commands/people.sh
@@ -224,19 +224,19 @@ _people_remove() {
 
 
 # Resolve assignee to person ID
-# Accepts: "me" or numeric ID
+# Accepts: "me", name, email, or numeric ID
 # Returns: numeric ID or empty string on error
+# Note: Uses names.sh resolve_person_id for name/email resolution
 resolve_assignee() {
   local assignee="$1"
 
-  if [[ "$assignee" == "me" ]]; then
-    local profile
-    profile=$(api_get "/my/profile.json")
-    echo "$profile" | jq -r '.id'
-  elif [[ "$assignee" =~ ^[0-9]+$ ]]; then
-    echo "$assignee"
+  # Use resolve_person_id which handles "me", names, emails, and numeric IDs
+  local resolved
+  resolved=$(resolve_person_id "$assignee" 2>/dev/null)
+  if [[ -n "$resolved" ]]; then
+    echo "$resolved"
   else
-    # Invalid format - return empty to signal error
+    # Return empty to signal error (caller handles error message)
     echo ""
   fi
 }

--- a/lib/commands/todolists.sh
+++ b/lib/commands/todolists.sh
@@ -49,13 +49,8 @@ _todolists_list() {
     esac
   done
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified. Use --in <project>" $EXIT_USAGE
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   # Get todoset from project dock
   local project_data todoset_id
@@ -135,13 +130,8 @@ _todolists_show() {
     die "Todolist ID required" $EXIT_USAGE "Usage: bcq todolists show <id>"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   local response
   response=$(api_get "/buckets/$project/todolists/$todolist_id.json")
@@ -220,13 +210,8 @@ _todolists_create() {
     die "Todolist name required" $EXIT_USAGE "Usage: bcq todolists create \"name\" --in <project>"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   # Get todoset from project dock
   local project_data todoset_id
@@ -298,13 +283,8 @@ _todolists_update() {
     die "Name or description required" $EXIT_USAGE "Use --name and/or --description"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   local payload="{}"
   [[ -n "$name" ]] && payload=$(echo "$payload" | jq --arg n "$name" '. + {name: $n}')
@@ -430,21 +410,11 @@ _todolistgroups_list() {
     esac
   done
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
-  if [[ -z "$project" ]]; then
-    die "No project specified. Use --in <project>" $EXIT_USAGE
-  fi
-
-  if [[ -z "$todolist_id" ]]; then
-    todolist_id=$(get_todolist_id)
-  fi
-
-  if [[ -z "$todolist_id" ]]; then
-    die "No todolist specified. Use --list <todolist_id>" $EXIT_USAGE
-  fi
+  # Resolve todolist (supports names, IDs, and config fallback)
+  todolist_id=$(require_todolist_id "${todolist_id:-}" "$project")
 
   # GET /buckets/:project/todolists/:todolist_id/groups.json
   local response
@@ -510,13 +480,8 @@ _todolistgroups_show() {
     die "Group ID required" $EXIT_USAGE "Usage: bcq todolistgroups show <id> --in <project>"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   # Groups are todolists: GET /buckets/:project/todolists/:group_id.json
   local response
@@ -567,21 +532,11 @@ _todolistgroups_create() {
     die "Group name required" $EXIT_USAGE "Usage: bcq todolistgroups create \"name\" --list <todolist_id> --in <project>"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
-
-  if [[ -z "$todolist_id" ]]; then
-    todolist_id=$(get_todolist_id)
-  fi
-
-  if [[ -z "$todolist_id" ]]; then
-    die "No todolist specified. Use --list <todolist_id>" $EXIT_USAGE
-  fi
+  # Resolve todolist (supports names, IDs, and config fallback)
+  todolist_id=$(require_todolist_id "${todolist_id:-}" "$project")
 
   local payload
   payload=$(jq -n --arg name "$name" '{name: $name}')
@@ -636,13 +591,8 @@ _todolistgroups_update() {
     die "Name required" $EXIT_USAGE "Use --name \"new name\""
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   local payload
   payload=$(jq -n --arg name "$name" '{name: $name}')
@@ -694,13 +644,8 @@ _todolistgroups_position() {
     die "Position required" $EXIT_USAGE "Use --to <position> (1 = top)"
   fi
 
-  if [[ -z "$project" ]]; then
-    project=$(get_project_id)
-  fi
-
-  if [[ -z "$project" ]]; then
-    die "No project specified" $EXIT_USAGE "Use --in <project>"
-  fi
+  # Resolve project (supports names, IDs, and config fallback)
+  project=$(require_project_id "${project:-}")
 
   local payload
   payload=$(jq -n --argjson pos "$position" '{position: $pos}')


### PR DESCRIPTION
## Summary

- Refactors todos.sh and todolists.sh commands to use the centralized name resolution from lib/names.sh (introduced in #12)
- Enables users to specify projects and todolists by name instead of numeric IDs
- Removes ~78 lines of duplicated resolution boilerplate

## Example Usage

```bash
# Use project name instead of ID
bcq todos --in "My Project"

# Use both project and todolist names
bcq todo "New task" --list "Sprint 42" --in "Acme Corp"

# Works for todolist groups too
bcq todolistgroups --list "Backlog" --in "Engineering"
```

## Files Changed

- `lib/commands/todos.sh` - All functions now use `require_project_id()`
- `lib/commands/todolists.sh` - Uses `require_project_id()` and `require_todolist_id()`
- `lib/commands/people.sh` - `resolve_assignee()` delegates to `resolve_person_id()`

## Test plan

- [x] All 374 existing tests pass
- [x] Manual testing with name-based project resolution
- [x] Manual testing with name-based todolist resolution