### PR TITLE
Improve basecamp skill with URL parsing and error handling

### DIFF
--- a/bin/bcq
+++ b/bin/bcq
@@ -183,6 +183,7 @@ main() {
     todolistgroups) cmd_todolistgroups "$@" ;;
     todos)      cmd_todos "$@" ;;
     uploads)    cmd_uploads "$@" ;;
+    url)        cmd_url "$@" ;;
     vaults)     cmd_vaults "$@" ;;
     webhooks)   cmd_webhooks "$@" ;;
 

--- a/lib/commands/url.sh
+++ b/lib/commands/url.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# url.sh - Basecamp URL parsing
+
+cmd_url() {
+  local action="${1:-}"
+
+  case "$action" in
+    parse) shift; _url_parse "$@" ;;
+    --help|-h) _help_url ;;
+    *)
+      if [[ -n "$action" ]] && [[ "$action" != -* ]]; then
+        # Assume it's a URL to parse
+        _url_parse "$action" "$@"
+      else
+        _help_url
+      fi
+      ;;
+  esac
+}
+
+_url_parse() {
+  local url=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --help|-h)
+        _help_url_parse
+        return
+        ;;
+      -*)
+        shift
+        ;;
+      *)
+        if [[ -z "$url" ]]; then
+          url="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$url" ]]; then
+    die "URL required" $EXIT_USAGE "Usage: bcq url parse <url>"
+  fi
+
+  # Validate it's a Basecamp URL
+  if [[ ! "$url" =~ basecamp\.com ]]; then
+    die "Not a Basecamp URL: $url" $EXIT_USAGE "Expected URL like: https://3.basecamp.com/..."
+  fi
+
+  # Parse the URL
+  # Pattern: https://3.basecamp.com/{account}/buckets/{bucket}/{type}/{id}[#{fragment}]
+  # Or: https://3.basecamp.com/{account}/projects/{project}[/{section}]
+
+  local account_id="" bucket_id="" recording_type="" recording_id="" comment_id=""
+  local url_path fragment=""
+
+  # Extract fragment if present
+  if [[ "$url" =~ \#(.+)$ ]]; then
+    fragment="${BASH_REMATCH[1]}"
+    url_path="${url%%#*}"
+  else
+    url_path="$url"
+  fi
+
+  # Remove protocol and domain
+  local path_only
+  path_only=$(echo "$url_path" | sed -E 's|^https?://[^/]+||')
+
+  # Parse path components
+  # Expected formats:
+  #   /{account}/buckets/{bucket}/{type}/{id}
+  #   /{account}/projects/{project}
+  #   /{account}/buckets/{bucket}/{type}  (list view)
+
+  if [[ "$path_only" =~ ^/([0-9]+)/buckets/([0-9]+)/([^/]+)/([0-9]+) ]]; then
+    # Full recording URL: /{account}/buckets/{bucket}/{type}/{id}
+    account_id="${BASH_REMATCH[1]}"
+    bucket_id="${BASH_REMATCH[2]}"
+    recording_type="${BASH_REMATCH[3]}"
+    recording_id="${BASH_REMATCH[4]}"
+  elif [[ "$path_only" =~ ^/([0-9]+)/buckets/([0-9]+)/([^/]+)/?$ ]]; then
+    # Type list URL: /{account}/buckets/{bucket}/{type}
+    account_id="${BASH_REMATCH[1]}"
+    bucket_id="${BASH_REMATCH[2]}"
+    recording_type="${BASH_REMATCH[3]}"
+  elif [[ "$path_only" =~ ^/([0-9]+)/projects/([0-9]+) ]]; then
+    # Project URL: /{account}/projects/{project}
+    account_id="${BASH_REMATCH[1]}"
+    bucket_id="${BASH_REMATCH[2]}"
+    recording_type="project"
+  elif [[ "$path_only" =~ ^/([0-9]+) ]]; then
+    # Account-only URL
+    account_id="${BASH_REMATCH[1]}"
+  else
+    die "Could not parse URL path: $path_only" $EXIT_USAGE
+  fi
+
+  # Parse fragment for comment ID
+  # Fragment format: __recording_{id} or just {id}
+  if [[ -n "$fragment" ]]; then
+    if [[ "$fragment" =~ __recording_([0-9]+) ]]; then
+      comment_id="${BASH_REMATCH[1]}"
+    elif [[ "$fragment" =~ ^[0-9]+$ ]]; then
+      comment_id="$fragment"
+    fi
+  fi
+
+  # Normalize recording type (remove trailing 's' for singular form)
+  local type_singular="$recording_type"
+  case "$recording_type" in
+    messages) type_singular="message" ;;
+    todos) type_singular="todo" ;;
+    todolists) type_singular="todolist" ;;
+    documents) type_singular="document" ;;
+    comments) type_singular="comment" ;;
+    uploads) type_singular="upload" ;;
+    cards) type_singular="card" ;;
+    chats|campfires) type_singular="campfire" ;;
+    schedules) type_singular="schedule" ;;
+    schedule_entries) type_singular="schedule_entry" ;;
+    vaults) type_singular="vault" ;;
+  esac
+
+  # Capitalize first letter (Bash 3.2 compatible)
+  local type_capitalized
+  type_capitalized="$(echo "${type_singular:0:1}" | tr '[:lower:]' '[:upper:]')${type_singular:1}"
+
+  # Build summary
+  local summary=""
+  if [[ -n "$recording_id" ]]; then
+    summary="$type_capitalized #$recording_id"
+    if [[ -n "$bucket_id" ]]; then
+      summary+=" in project #$bucket_id"
+    fi
+    if [[ -n "$comment_id" ]]; then
+      summary+=", comment #$comment_id"
+    fi
+  elif [[ -n "$bucket_id" ]]; then
+    if [[ "$recording_type" == "project" ]]; then
+      summary="Project #$bucket_id"
+    else
+      summary="$type_capitalized list in project #$bucket_id"
+    fi
+  elif [[ -n "$account_id" ]]; then
+    summary="Account #$account_id"
+  else
+    summary="Basecamp URL"
+  fi
+
+  # Build result JSON
+  local result
+  result=$(jq -n \
+    --arg url "$url" \
+    --arg account_id "$account_id" \
+    --arg bucket_id "$bucket_id" \
+    --arg type "$recording_type" \
+    --arg type_singular "$type_singular" \
+    --arg recording_id "$recording_id" \
+    --arg comment_id "$comment_id" \
+    '{
+      url: $url,
+      account_id: (if $account_id == "" then null else $account_id end),
+      bucket_id: (if $bucket_id == "" then null else $bucket_id end),
+      type: (if $type == "" then null else $type end),
+      type_singular: (if $type_singular == "" then null else $type_singular end),
+      recording_id: (if $recording_id == "" then null else $recording_id end),
+      comment_id: (if $comment_id == "" then null else $comment_id end)
+    }')
+
+  # Build breadcrumbs based on what we parsed
+  local bcs="[]"
+
+  if [[ -n "$recording_id" ]] && [[ -n "$bucket_id" ]]; then
+    bcs=$(breadcrumbs \
+      "$(breadcrumb "show" "bcq show $type_singular $recording_id --in $bucket_id" "View the $type_singular")" \
+      "$(breadcrumb "comment" "bcq comment \"text\" --on $recording_id --in $bucket_id" "Add a comment")" \
+      "$(breadcrumb "comments" "bcq comments --on $recording_id --in $bucket_id" "List comments")")
+
+    if [[ -n "$comment_id" ]]; then
+      # Append comment breadcrumb to existing
+      local comment_bc
+      comment_bc=$(breadcrumb "show-comment" "bcq comments show $comment_id --in $bucket_id" "View the comment")
+      bcs=$(echo "$bcs" | jq --argjson bc "$comment_bc" '. + [$bc]')
+    fi
+  fi
+
+  output "$result" "$summary" "$bcs" "_url_parse_md"
+}
+
+_url_parse_md() {
+  local data="$1"
+  local summary="$2"
+  local breadcrumbs="$3"
+
+  echo "## Parsed URL"
+  echo
+  echo "**$summary**"
+  echo
+
+  local account_id bucket_id type recording_id comment_id
+  account_id=$(echo "$data" | jq -r '.account_id // ""')
+  bucket_id=$(echo "$data" | jq -r '.bucket_id // ""')
+  type=$(echo "$data" | jq -r '.type // ""')
+  recording_id=$(echo "$data" | jq -r '.recording_id // ""')
+  comment_id=$(echo "$data" | jq -r '.comment_id // ""')
+
+  echo "| Component | Value |"
+  echo "|-----------|-------|"
+  [[ -n "$account_id" ]] && echo "| Account | $account_id |"
+  [[ -n "$bucket_id" ]] && echo "| Project | $bucket_id |"
+  [[ -n "$type" ]] && echo "| Type | $type |"
+  [[ -n "$recording_id" ]] && echo "| Recording ID | $recording_id |"
+  [[ -n "$comment_id" ]] && echo "| Comment ID | $comment_id |"
+  echo
+
+  md_breadcrumbs "$breadcrumbs"
+}
+
+_help_url() {
+  cat <<'EOF'
+## bcq url
+
+Parse and work with Basecamp URLs.
+
+### Usage
+
+    bcq url parse <url>     Parse a Basecamp URL
+    bcq url <url>           Shorthand for parse
+
+### Examples
+
+    # Parse a message URL
+    bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982"
+
+    # Parse URL with comment fragment
+    bcq url "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598"
+
+    # Get JSON output
+    bcq url parse "https://..." --json
+
+EOF
+}
+
+_help_url_parse() {
+  cat <<'EOF'
+## bcq url parse
+
+Parse a Basecamp URL into its components.
+
+### Usage
+
+    bcq url parse <url>
+
+### URL Formats
+
+Supported Basecamp URL patterns:
+
+    https://3.basecamp.com/{account}/buckets/{bucket}/{type}/{id}
+    https://3.basecamp.com/{account}/buckets/{bucket}/{type}/{id}#__recording_{comment}
+    https://3.basecamp.com/{account}/projects/{project}
+
+### Output
+
+Returns JSON with:
+- account_id: Basecamp account number
+- bucket_id: Project/bucket ID
+- type: Recording type (messages, todos, etc.)
+- recording_id: The recording's ID
+- comment_id: Comment ID from URL fragment (if present)
+
+### Examples
+
+    # Parse message URL
+    bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982"
+
+    # With comment fragment
+    bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598"
+
+### Common Workflows
+
+Reply to a comment (comments are flat, so you comment on the parent recording):
+
+    bcq url parse "https://..." --json | jq -r '.data | "bcq comment \"reply\" --on \(.recording_id) --in \(.bucket_id)"'
+
+EOF
+}

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -25,8 +25,15 @@ Interact with Basecamp: create todos, check project status, link code to tasks.
 
 ## URL Parsing
 
-When given a Basecamp URL, parse it to understand what's being referenced:
+Parse a Basecamp URL to extract its components:
 
+```bash
+bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598" --json
+```
+
+Returns: `account_id`, `bucket_id`, `type`, `recording_id`, `comment_id` (from fragment).
+
+**URL Structure:**
 ```
 https://3.basecamp.com/{account_id}/buckets/{project_id}/{type}/{id}#__recording_{comment_id}
 ```
@@ -36,18 +43,25 @@ https://3.basecamp.com/{account_id}/buckets/{project_id}/{type}/{id}#__recording
 - `/buckets/27/messages/123#__recording_456` → Comment 456 on message 123
 - `/buckets/27/card_tables/cards/789` → Card 789 in project 27
 - `/buckets/27/todos/101` → Todo 101 in project 27
-- `/buckets/27/todolists/202` → Todolist 202 in project 27
 
 **Fetch with bcq:**
 ```bash
-# Show any recording by ID (works for messages, todos, cards, comments, etc.)
+# Show any recording by ID
 bcq show <type> <id> --project <project_id> --json
 
-# Example: fetch a card
-bcq show card 9486682178 --project 27 --json
+# Example: fetch a message
+bcq show message 9478142982 --project 41746046 --json
+```
 
-# Example: fetch a comment (comments are also recordings)
-bcq show comment 9500689518 --project 27 --json
+**Replying to Comments:**
+
+Comments are flat on the parent recording (no nested replies). To reply:
+```bash
+# Parse the URL to get IDs
+bcq url parse "https://3.basecamp.com/.../messages/123#__recording_456" --json
+
+# Comment on the parent recording (message 123), not the comment
+bcq comment --content "Your reply" --on 123 --project <project_id>
 ```
 
 ## Context
@@ -89,7 +103,7 @@ bcq comment --content "Text" --on <recording_id> --project <id>  # Add comment
 ```bash
 bcq cards --in <project_id> --json                       # List cards
 bcq card --title "Title" --in <project_id>               # Create card
-bcq cards move <card_id> --to "Done" --in <project_id>   # Move card
+bcq cards move <card_id> --to "Done" --project <project_id>  # Move card
 bcq campfire post --content "Message" --in <project_id>  # Post to campfire
 ```
 
@@ -184,7 +198,6 @@ bcq auth login --scope full    # Re-auth with write access
 All shortcut commands require explicit flags:
 - `bcq todo --content "text"` (not `bcq todo "text"`)
 - `bcq card --title "title"` (not `bcq card "title"`)
-- `bcq project --name "name"` (not `bcq project "name"`)
 
 ## Learn More
 

--- a/test/url.bats
+++ b/test/url.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# url.bats - Tests for Basecamp URL parsing
+
+load test_helper
+
+
+# Help
+
+@test "bcq url --help shows help" {
+  run bcq url --help
+  assert_success
+  assert_output_contains "parse"
+}
+
+@test "bcq url parse --help shows help" {
+  run bcq url parse --help
+  assert_success
+  assert_output_contains "URL"
+}
+
+
+# Basic parsing
+
+@test "bcq url parse parses full message URL" {
+  run bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.account_id" "2914079"
+  assert_json_value ".data.bucket_id" "41746046"
+  assert_json_value ".data.type" "messages"
+  assert_json_value ".data.recording_id" "9478142982"
+}
+
+@test "bcq url parse parses URL with comment fragment" {
+  run bcq url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.account_id" "2914079"
+  assert_json_value ".data.bucket_id" "41746046"
+  assert_json_value ".data.type" "messages"
+  assert_json_value ".data.recording_id" "9478142982"
+  assert_json_value ".data.comment_id" "9488783598"
+}
+
+@test "bcq url shorthand works without parse subcommand" {
+  run bcq url "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.account_id" "2914079"
+}
+
+
+# Different recording types
+
+@test "bcq url parse parses todo URL" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/todos/789" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.type" "todos"
+  assert_json_value ".data.type_singular" "todo"
+  assert_json_value ".data.recording_id" "789"
+}
+
+@test "bcq url parse parses todolist URL" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/todolists/789" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.type" "todolists"
+  assert_json_value ".data.type_singular" "todolist"
+}
+
+@test "bcq url parse parses document URL" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/documents/789" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.type" "documents"
+  assert_json_value ".data.type_singular" "document"
+}
+
+@test "bcq url parse parses campfire URL" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/chats/789" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.type" "chats"
+  assert_json_value ".data.type_singular" "campfire"
+}
+
+
+# Project URLs
+
+@test "bcq url parse parses project URL" {
+  run bcq url parse "https://3.basecamp.com/2914079/projects/41746046" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.account_id" "2914079"
+  assert_json_value ".data.bucket_id" "41746046"
+  assert_json_value ".data.type" "project"
+}
+
+
+# Type list URLs
+
+@test "bcq url parse parses type list URL" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/todos" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.bucket_id" "456"
+  assert_json_value ".data.type" "todos"
+  assert_json_value ".data.recording_id" "null"
+}
+
+
+# Error cases
+
+@test "bcq url parse fails without URL" {
+  run bcq url parse
+  assert_failure
+  assert_output_contains "URL required"
+}
+
+@test "bcq url parse fails for non-Basecamp URL" {
+  run bcq url parse "https://github.com/test/repo"
+  assert_failure
+  assert_output_contains "Not a Basecamp URL"
+}
+
+
+# Summary output
+
+@test "bcq url parse has correct summary for message with comment" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/messages/789#__recording_111" --json
+  assert_success
+  assert_json_value ".summary" "Message #789 in project #456, comment #111"
+}
+
+@test "bcq url parse has correct summary for todo" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/todos/789" --json
+  assert_success
+  assert_json_value ".summary" "Todo #789 in project #456"
+}
+
+
+# Breadcrumbs
+
+@test "bcq url parse includes useful breadcrumbs" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/messages/789" --json
+  assert_success
+  is_valid_json
+
+  # Should have show, comment, comments breadcrumbs
+  local breadcrumb_count
+  breadcrumb_count=$(echo "$output" | jq '.breadcrumbs | length')
+  [[ "$breadcrumb_count" -ge 3 ]]
+}
+
+@test "bcq url parse includes comment breadcrumb when comment_id present" {
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/messages/789#__recording_111" --json
+  assert_success
+  is_valid_json
+
+  # Should have show-comment breadcrumb
+  local has_show_comment
+  has_show_comment=$(echo "$output" | jq '.breadcrumbs[] | select(.action == "show-comment") | .action')
+  [[ -n "$has_show_comment" ]]
+}
+
+
+# Markdown output
+
+@test "bcq url parse shows markdown by default in TTY" {
+  # Since bats runs non-TTY, force --md
+  run bcq url parse "https://3.basecamp.com/123/buckets/456/messages/789" --md
+  assert_success
+  assert_output_contains "Parsed URL"
+  assert_output_contains "Component"
+}


### PR DESCRIPTION
## Summary

Fixes skill ineffectiveness when working with Basecamp URLs and common CLI errors.

**Issues addressed:**
1. Pasting a Basecamp URL didn't activate the skill
2. Skill examples used old positional syntax that no longer works
3. No guidance on parsing URLs to understand what's being referenced
4. Limited error handling - didn't help with common issues like network errors

## Changes

**URL triggers added:**
- `3.basecamp.com`
- `basecampapi.com`  
- `https://3.basecamp.com/`

**URL parsing guidance:**
```
https://3.basecamp.com/{account_id}/buckets/{project_id}/{type}/{id}#__recording_{comment_id}
```

**Updated syntax to flag-based API:**
- `bcq todo --content "text"` (not positional)
- `bcq card --title "title"`
- `bcq comment --content "text" --on <id> --project <id>`

**Error handling for:**
- Connection refused (localhost config from local dev)
- Not found (wrong account_id)
- Invalid flag errors

## Test plan

- [x] Pasting `https://3.basecamp.com/2914079/buckets/27/card_tables/cards/123` activates skill
- [x] Skill examples use correct flag syntax
- [x] Error handling section helps diagnose common issues