### PR TITLE
Fix URL parsing for card_tables/cards nested path

### DIFF
--- a/lib/commands/url.sh
+++ b/lib/commands/url.sh
@@ -70,10 +70,17 @@ _url_parse() {
   # Parse path components
   # Expected formats:
   #   /{account}/buckets/{bucket}/{type}/{id}
+  #   /{account}/buckets/{bucket}/card_tables/cards/{id}  (nested card path)
   #   /{account}/projects/{project}
   #   /{account}/buckets/{bucket}/{type}  (list view)
 
-  if [[ "$path_only" =~ ^/([0-9]+)/buckets/([0-9]+)/([^/]+)/([0-9]+) ]]; then
+  if [[ "$path_only" =~ ^/([0-9]+)/buckets/([0-9]+)/card_tables/cards/([0-9]+) ]]; then
+    # Card URL: /{account}/buckets/{bucket}/card_tables/cards/{id}
+    account_id="${BASH_REMATCH[1]}"
+    bucket_id="${BASH_REMATCH[2]}"
+    recording_type="cards"
+    recording_id="${BASH_REMATCH[3]}"
+  elif [[ "$path_only" =~ ^/([0-9]+)/buckets/([0-9]+)/([^/]+)/([0-9]+) ]]; then
     # Full recording URL: /{account}/buckets/{bucket}/{type}/{id}
     account_id="${BASH_REMATCH[1]}"
     bucket_id="${BASH_REMATCH[2]}"

--- a/test/url.bats
+++ b/test/url.bats
@@ -85,6 +85,18 @@ load test_helper
   assert_json_value ".data.type_singular" "campfire"
 }
 
+@test "bcq url parse parses card URL with nested path" {
+  run bcq url parse "https://3.basecamp.com/2914079/buckets/27/card_tables/cards/9486682178#__recording_9500689518" --json
+  assert_success
+  is_valid_json
+  assert_json_value ".data.account_id" "2914079"
+  assert_json_value ".data.bucket_id" "27"
+  assert_json_value ".data.type" "cards"
+  assert_json_value ".data.type_singular" "card"
+  assert_json_value ".data.recording_id" "9486682178"
+  assert_json_value ".data.comment_id" "9500689518"
+}
+
 
 # Project URLs
 


### PR DESCRIPTION
## Summary
- Fix parsing of card URLs which have nested path `/buckets/{id}/card_tables/cards/{id}`
- Add test coverage for card URL parsing with comment fragments

## Problem
Card URLs like `https://3.basecamp.com/2914079/buckets/27/card_tables/cards/9486682178#__recording_9500689518` were not being parsed correctly. Only the account_id and comment_id were extracted; bucket_id, type, and recording_id were null.

## Solution
Add specific regex pattern for card URLs before the generic recording pattern, since cards have a nested path structure (`card_tables/cards`) rather than a single type segment.

## Test plan
- [x] `bats test/url.bats` - all 19 tests pass
- [x] Manual test: `bcq url "https://3.basecamp.com/2914079/buckets/27/card_tables/cards/9486682178#__recording_9500689518" --json`