### PR TITLE
Add step delete command for card management

### DIFF
--- a/test/cards_columns_steps.bats
+++ b/test/cards_columns_steps.bats
@@ -339,6 +339,18 @@ load test_helper
 }
 
 
+# Step delete errors
+
+@test "cards step delete without id shows error" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run bcq cards step delete
+  assert_failure
+  assert_output_contains "Step ID required"
+}
+
+
 # Step unknown action
 
 @test "cards step unknown action shows error" {


### PR DESCRIPTION
Implement `bcq cards step delete` to allow users to delete steps via CLI. The Basecamp API already supports `DELETE /buckets/:project/card_tables/steps/:id.json`, but bcq didn't expose this capability. This change provides a consistent interface matching other step operations (create, update, complete, uncomplete, move).

## Changes
- Add `delete` action to step dispatcher
- Implement `_cards_step_delete()` function following existing patterns
- Update help text and error hints
- Add validation test