### PR TITLE
ci: Add Dependabot auto-merge and supply chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       go-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 2
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
     commit-message:
       prefix: "deps"
 
@@ -22,5 +27,11 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "ci"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Group GitHub Actions updates together (fewer PRs, less conflict resolution)
- Add cooldown periods for supply chain attack protection per [StepSecurity research](https://www.stepsecurity.io/blog/introducing-the-npm-package-cooldown-check)
- Add auto-merge workflow that enables GitHub's auto-merge for Dependabot PRs

## Cooldown periods
| Update type | Delay | Rationale |
|-------------|-------|-----------|
| Patch | 2 days | StepSecurity baseline - most malicious packages caught within 24h |
| Minor | 3 days | Slightly more scrutiny for new features |
| Major | 7 days | Breaking changes need manual review anyway |

## Test plan
- [x] Merged all 5 backlogged Dependabot PRs
- [ ] Verify auto-merge workflow triggers on next Dependabot PR
- [ ] Confirm grouped Actions update creates single PR