### PR TITLE
ci: Speed up test workflow from 80s to ~25s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,13 +105,18 @@ jobs:
       - name: Build binary
         run: go build -o bin/bcq ./cmd/bcq
 
-      - name: Install BATS
-        run: |
-          git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
-          sudo /tmp/bats-core/install.sh /usr/local
+      - name: Cache BATS
+        id: cache-bats
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/libexec/bats-core
+          key: bats-1.11.0
 
-      - name: Install test dependencies
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install BATS
+        if: steps.cache-bats.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v1.11.0 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
 
       - name: Run BATS integration tests
         run: bats e2e/


### PR DESCRIPTION
## Summary

Optimizes the GitHub Actions test workflow to run ~3x faster by parallelizing jobs and moving expensive operations to non-blocking jobs on main.

**Key changes:**
- Split monolithic "Go Tests" job into parallel jobs: Tests, Lint, Security, Race Detection, Benchmarks
- Remove `-race` flag from main test job (moved to separate non-blocking job on main)
- Run govulncheck only on main pushes with binary caching
- Make race detection non-blocking (`continue-on-error: true`) - still runs but doesn't block workflow
- Make benchmarks main-only, non-blocking, with precise path filtering (only `internal/api/`, `internal/names/`, `internal/dateparse/`, or deps)

**Expected times:**

| Scenario | Before | After |
|----------|--------|-------|
| PR (warm cache) | ~80s | **~20-25s** |
| PR (cold cache) | ~80s | **~30-35s** |
| Main (blocking) | ~80s | **~20-25s** |
| Main (race check) | - | ~47s (non-blocking) |

**Jobs summary:**

| Job | PRs | Main | Blocking? |
|-----|-----|------|-----------|
| Tests (no race) | ✓ | ✓ | Yes |
| Lint | ✓ | ✓ | Yes |
| Security | - | ✓ | Yes |
| Race Detection | - | ✓ | No |
| Integration | ✓ | ✓ | Yes |
| Benchmarks | - | conditional | No |

## Test plan

- [x] Verify PR runs only: Tests, Lint, Integration jobs
- [x] Verify ~20-25s wall time on warm cache
- [x] Merge to main and verify all jobs run (including race-check, security, benchmarks)
- [x] Verify race-check and benchmarks show as non-blocking (yellow if failed, green overall)