### PR TITLE
Migrate todos command to SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/basecamp/bcq
 go 1.24.0
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260125211217-a1dedc2b1b54
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260125214045-6e4b87b848d1
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.6
 )
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260125211217-a1dedc2b1b54 h1:K1z6IIUJPsrkTLDOSAmk9bPHOfWtTcYJibA/UDTR7qY=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260125211217-a1dedc2b1b54/go.mod h1:1cMqk0Hyih/Oe/VJC1JXvPHI4FKBXI0RmgTxbG41ohQ=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260125214045-6e4b87b848d1 h1:jdRBjeaQsJu4dip1MGiw2fWZs102B2FClBjCiFWVV3c=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260125214045-6e4b87b848d1/go.mod h1:1cMqk0Hyih/Oe/VJC1JXvPHI4FKBXI0RmgTxbG41ohQ=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
## Summary

- Direct todo operations now use `app.SDK.Todos()`:
  - Get, List, Create
  - Complete, Uncomplete
  - Reposition

- Aggregation helpers (`listAllTodos`, `getTodosForSweep`, `getFirstTodolistID`) remain on `app.API` pending TodolistsService extraction

## Depends on

basecamp/basecamp-sdk@6e4b87b - TodosService with spec and fixtures

## Test plan

- [x] `go build ./...` passes
- [x] `make check` passes (255 tests)
- [x] CI passes
- [x] Manual test: `bcq todos --project <id>`
- [x] Manual test: `bcq todos complete <id>`