### PR TITLE
Migrate messages commands to use SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260125234224-c1f6fee2d9f2
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126013455-f23e975cbb68
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260125234224-c1f6fee2d9f2 h1:D8sdslHDnAaVAc8IiARVLRAZnq771jLncyzWShfxnP0=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260125234224-c1f6fee2d9f2/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126013455-f23e975cbb68 h1:sb23XZql/HXozHAJPteK6EYH1Tr1ZSBg0aCdQhJ9o5s=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126013455-f23e975cbb68/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
## Summary
- Migrate `messages.go` to use `app.SDK.Messages()` for List, Get, Create, Update, Pin, Unpin operations
- Migrate `messageboards.go` to use `app.SDK.MessageBoards().Get()`
- Migrate `messagetypes.go` to use `app.SDK.MessageTypes()` for List, Get, Create, Update, Delete operations
- Remove local `Message` struct in favor of SDK's `basecamp.Message` type
- Update SDK dependency to include MessagesService, MessageBoardsService, and MessageTypesService

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual testing of `bcq messages` commands
- [ ] Manual testing of `bcq messageboards` commands
- [ ] Manual testing of `bcq messagetypes` commands