### PR TITLE
Migrate search.go to use SDK SearchService

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6 h1:HZYiTDI3wS2OggaeALQW88Sh+vhVtkdVI59N09KlGbg=
 github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021511-fcf11a64cecf h1:r9GI7m2cHgF+WucHWsm8MwVD9c7BVdh+dZs7nDUBhE8=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021511-fcf11a64cecf/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
Replace direct API calls with SDK Search() methods:
- Use app.SDK.Search().Search() for content search
- Use app.SDK.Search().Metadata() for search metadata
- Use basecamp.SearchResult type from SDK
- Simplified command flags (removed type/project/creator filters
  that weren't supported by SDK, added sort option)
