### PR TITLE
Migrate campfire.go to use SDK CampfiresService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021658-5dc1b3b06953
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021718-e742779769cc
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -8,11 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021511-fcf11a64cecf h1:r9GI7m2cHgF+WucHWsm8MwVD9c7BVdh+dZs7nDUBhE8=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021511-fcf11a64cecf/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021658-5dc1b3b06953 h1:W79NIhoVySP//m67rOFXujeNIG5UpFwh4ceZ6/rKdtQ=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021658-5dc1b3b06953/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021718-e742779769cc h1:Vy3MuNDWhOwfn1fLmUXO8CVyONSrKQIhR3lpUVxr8J8=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021718-e742779769cc/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
Replace direct API calls with SDK methods:
- Use app.SDK.Campfires().List() for account-wide listing
- Use app.SDK.Campfires().Get() for single campfire details
- Use app.SDK.Campfires().ListLines() for messages
- Use app.SDK.Campfires().GetLine() for single message
- Use app.SDK.Campfires().CreateLine() for posting messages
- Use app.SDK.Campfires().DeleteLine() for deletion

Remove local CampfireLine struct in favor of basecamp.CampfireLine
from the SDK.
