### PR TITLE
Migrate tools.go to use SDK ToolsService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021400-bd490522c0c4
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021400-bd490522c0c4 h1:HIkFIVOVrH/zhwXdTuJmQH4ZdULTe2vtK/pbW58cMuw=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021400-bd490522c0c4/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6 h1:HZYiTDI3wS2OggaeALQW88Sh+vhVtkdVI59N09KlGbg=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021639-0ee5f04fa8b6/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
Replace direct API calls with SDK methods for all tools commands:
- show: uses SDK.Tools().Get()
- create: uses SDK.Tools().Create() + Update() for title
- update: uses SDK.Tools().Update()
- trash: uses SDK.Tools().Delete()
- enable: uses SDK.Tools().Enable()
- disable: uses SDK.Tools().Disable()
- reposition: uses SDK.Tools().Reposition()

Tool IDs are now parsed as int64 for SDK compatibility.
