### PR TITLE
Migrate recordings.go to use SDK RecordingsService

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021743-c24713ba916d
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021925-f4b3d7ca1658
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021743-c24713ba916d h1:OYvYxPgKCgTiEj5f7PR7qQHbellXhtsZQc8xgNYpuuM=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021743-c24713ba916d/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021925-f4b3d7ca1658 h1:sHLrf0NGmMKMXxcq8xhjdp3BRKRXV+XGgx7rEO28MEk=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260126021925-f4b3d7ca1658/go.mod h1:RnIREa1vKW6DqkxUjXwAdmlKY8NcOk/9iYeUZoXHHAs=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=


### PR DESCRIPTION
Replace direct API calls with SDK client methods:
- List uses app.SDK.Recordings().List()
- Trash/Archive/Restore use respective SDK methods
- Visibility uses app.SDK.Recordings().SetClientVisibility()

Remove local Recording type in favor of basecamp.Recording.
