### PR TITLE
Address PR review feedback from SDK migration

### DIFF
--- a/internal/commands/campfire.go
+++ b/internal/commands/campfire.go
@@ -465,9 +465,18 @@ func newCampfireLineDeleteCmd(project, campfireID *string) *cobra.Command {
 				}
 			}
 
-			bucketID, _ := strconv.ParseInt(resolvedProjectID, 10, 64)
-			campfireIDInt, _ := strconv.ParseInt(effectiveCampfireID, 10, 64)
-			lineIDInt, _ := strconv.ParseInt(lineID, 10, 64)
+			bucketID, err := strconv.ParseInt(resolvedProjectID, 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid project ID")
+			}
+			campfireIDInt, err := strconv.ParseInt(effectiveCampfireID, 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid campfire ID")
+			}
+			lineIDInt, err := strconv.ParseInt(lineID, 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid line ID")
+			}
 
 			// Delete line using SDK
 			err = app.SDK.Campfires().DeleteLine(cmd.Context(), bucketID, campfireIDInt, lineIDInt)

--- a/internal/commands/recordings.go
+++ b/internal/commands/recordings.go
@@ -259,6 +259,8 @@ func runRecordingsStatus(cmd *cobra.Command, app *appctx.App, recordingIDStr, pr
 	case "archived":
 		err = app.SDK.Recordings().Archive(cmd.Context(), bucketID, recordingID)
 	case "active":
+		// Unarchive() sets status to active via PUT /status/active.json
+		// This works for both archived AND trashed recordings
 		err = app.SDK.Recordings().Unarchive(cmd.Context(), bucketID, recordingID)
 	default:
 		return output.ErrUsage(fmt.Sprintf("Unknown status: %s", newStatus))

--- a/internal/commands/webhooks.go
+++ b/internal/commands/webhooks.go
@@ -216,7 +216,8 @@ Vault, Schedule::Entry, Kanban::Card, Question, Question::Answer`,
 				return output.ErrUsage("Invalid project ID")
 			}
 
-			// Build type array from comma-separated string
+			// Build type array from comma-separated string if specified
+			// If not specified, leave nil to let server use its defaults
 			var typeArray []string
 			if types != "" {
 				typeParts := strings.Split(types, ",")
@@ -227,14 +228,11 @@ Vault, Schedule::Entry, Kanban::Card, Question, Question::Answer`,
 						typeArray = append(typeArray, t)
 					}
 				}
-			} else {
-				// Default to all types if not specified
-				typeArray = []string{"Todo", "Todolist", "Message", "Comment", "Document", "Upload", "Vault", "Schedule::Entry", "Kanban::Card", "Question", "Question::Answer"}
 			}
 
 			req := &basecamp.CreateWebhookRequest{
 				PayloadURL: url,
-				Types:      typeArray,
+				Types:      typeArray, // nil = server defaults
 			}
 
 			webhook, err := app.SDK.Webhooks().Create(cmd.Context(), bucketID, req)


### PR DESCRIPTION
Fixes for Codex review comments:

1. webhooks.go: Let server use default webhook types instead of hard-coding
   (PR #58 feedback)

2. templates.go: Use raw API for archived/trashed status since SDK List()
   only returns active templates (PR #60 feedback)

3. campfire.go: Validate ParseInt errors before DeleteLine to avoid
   silent 0 IDs (PR #64 feedback)

4. recordings.go: Add comment clarifying that Unarchive() works for both
   archived AND trashed recordings via status/active endpoint (PR #68)

5. files.go: Preserve SDK errors in auto-detect mode instead of masking
   auth/permission errors as "not found" (PR #70 feedback)
