### PR TITLE
Run security and race-check jobs on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/bin
-          key: go-tools-${{ runner.os }}-govulncheck-v1.1.4
+          key: go-tools-${{ runner.os }}-go1.25-govulncheck-v1.1.4
 
       - name: Run govulncheck
         run: |


### PR DESCRIPTION
## Summary

- Remove `if` conditions that restricted `security` and `race-check` jobs to pushes to main
- These checks now run on pull requests, catching issues before merge

## Test plan

- [x] Verify Security and Race Detection jobs appear in this PR's workflow run
- [x] Both jobs should execute (not be skipped)