### PR TITLE
Add user theme support

### DIFF
--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -34,7 +34,8 @@ type Renderer struct {
 
 // NewRenderer creates a renderer with styles from the resolved theme.
 // Styling is enabled when writing to a TTY, or when forceStyled is true.
-// Theme resolution follows: NO_COLOR env → BCQ_THEME env → Omarchy → default.
+// Theme resolution follows: NO_COLOR env → BCQ_THEME env → user theme
+// (~/.config/bcq/theme/colors.toml, which may be symlinked to system themes) → default.
 func NewRenderer(w io.Writer, forceStyled bool) *Renderer {
 	return NewRendererWithTheme(w, forceStyled, tui.ResolveTheme())
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,9 +149,9 @@ setup_theme() {
 
   # Link to Omarchy theme if available
   if [[ -d "$omarchy_theme_dir" ]]; then
-    info "Linking bcq theme to Omarchy theme"
+    info "Linking bcq theme to system theme"
     mkdir -p "$HOME/.config/bcq"
-    ln -s "$omarchy_theme_dir" "$bcq_theme_dir"
+    ln -s "$omarchy_theme_dir" "$bcq_theme_dir" || info "Note: Could not link theme (continuing anyway)"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Add support for user-defined themes via `~/.config/bcq/theme/colors.toml`
- Auto-detect and link Omarchy theme during installation
- Support `NO_COLOR` env var (industry standard for disabling colors)
- Support `BCQ_THEME` env var for custom theme file path

## How it works

bcq looks for its own theme config at `~/.config/bcq/theme/colors.toml`. On systems like Omarchy, users symlink to their system theme:

```bash
ln -s ~/.config/omarchy/current/theme ~/.config/bcq/theme
```

The installer automatically creates this symlink if Omarchy is detected.

## Color mapping

| colors.toml | bcq semantic |
|-------------|--------------|
| `accent` / `color4` | Primary |
| `color1` | Error (red) |
| `color2` | Success (green) |
| `color3` | Warning (yellow) |
| `color7` | Secondary |
| `color8` | Muted, Border |
| `foreground` | Foreground |
| `background` | Background |

## Test plan

- [x] `make check` passes
- [ ] Test on Omarchy: verify theme colors match system theme
- [ ] Test `NO_COLOR=1 bcq projects` disables colors
- [ ] Test `BCQ_THEME=/path/to/colors.toml` uses custom theme
- [ ] Test fallback to default theme when no config exists