### PR TITLE
Improve styled format output for single objects

### DIFF
--- a/e2e/url.bats
+++ b/e2e/url.bats
@@ -184,7 +184,7 @@ load test_helper
   # Since bats runs non-TTY, force --md
   run bcq url parse "https://3.basecamp.com/123/buckets/456/messages/789" --md
   assert_success
-  # Check for styled terminal output (key-value pairs)
-  assert_output_contains "type"
+  # Check for styled terminal output (key-value pairs with humanized headers)
+  assert_output_contains "Type"
   assert_output_contains "message"
 }


### PR DESCRIPTION
## Summary

Enhance `renderObject()` to match the quality of table rendering:

- **Priority ordering**: fields display in semantic order (id/name first, timestamps last) using `columnPriority` instead of alphabetical
- **Humanized labels**: keys like `email_address` display as "Email Address"
- **Muted styling**: metadata fields (id, created_at, updated_at) render in muted color
- **Skip internal fields**: filter out `attachable_sgid`, `personable_type`, `recording_type`, and other internal Rails fields
- **Human-readable dates**: `formatDateValue()` shows relative times for recent dates ("5 minutes ago") and formatted dates for older ones

Same improvements applied to `MarkdownRenderer` for consistent output across formats.

### Before
```
admin              : yes
attachable_sgid    : BAh7BkkiC19yYWlscwY6BkVUewdJIglkYXRhB...
avatar_url         : https://bc3-production-assets-cdn.bas...
created_at         : 2015-05-20T15:56:38.218Z
email_address      : jeremy@37signals.com
name               : Jeremy Daer
personable_type    : User
...
```

### After
```
Name               : Jeremy Daer
Email Address      : jeremy@37signals.com
Title              : Programmer, SIP
Location           : San Diego, CA

Admin              : yes
Can Manage People  : yes
Employee           : yes

Id                 : 3
Created            : May 20, 2015
Updated            : Dec 27, 2025
```

## Test plan

- [x] `go test ./internal/output/...` passes
- [x] `bats e2e/*.bats` all 255 tests pass
- [x] Manual verification: `bcq me`, `bcq project show 1`