### PR TITLE
Add make tools target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@
 git clone https://github.com/basecamp/bcq
 cd bcq
 
+# Install dev tools (golangci-lint, govulncheck, etc.)
+make tools
+
 # Build
 make build
 

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ security: lint vuln secrets
 .PHONY: vuln
 vuln:
 	@echo "Running govulncheck..."
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	govulncheck ./...
 
 # Run secret scanner
 .PHONY: secrets
@@ -261,6 +261,15 @@ fuzz:
 fuzz-quick:
 	go test -fuzz=FuzzParseFrom -fuzztime=10s ./internal/dateparse/
 	go test -fuzz=FuzzURLPathParsing -fuzztime=10s ./internal/commands/
+
+# Install development tools
+.PHONY: tools
+tools:
+	$(GOCMD) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+	$(GOCMD) install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+	$(GOCMD) install golang.org/x/perf/cmd/benchstat@v0.0.0-20250106171221-62ad9bd2d39e
+	$(GOCMD) install github.com/zricethezav/gitleaks/v8@v8.21.2
+	$(GOCMD) install github.com/mikefarah/yq/v4@v4.50.1
 
 # Show help
 .PHONY: help
@@ -298,9 +307,10 @@ help:
 	@echo "  fmt            Format code"
 	@echo "  fmt-check      Check code formatting"
 	@echo "  lint           Run golangci-lint"
-	@echo "  check          Run all checks (fmt-check, vet, test)"
+	@echo "  check          Run all checks (fmt-check, vet, lint, test, test-e2e)"
 	@echo ""
 	@echo "Other:"
+	@echo "  tools          Install development tools (golangci-lint, govulncheck, etc.)"
 	@echo "  tidy           Tidy go.mod dependencies"
 	@echo "  verify         Verify dependencies"
 	@echo "  clean          Remove build artifacts"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -10,7 +10,7 @@ export BCQ_NO_KEYRING=1
 cd "$(dirname "$0")"
 
 if ! command -v bats &>/dev/null; then
-  echo "Error: bats not found. Install with: apt install bats (Linux) or brew install bats-core (macOS)" >&2
+  echo "Error: bats not found. Install with your package manager (e.g., pacman -S bats, brew install bats-core)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Adds `make tools` target to install development dependencies (golangci-lint, govulncheck, benchstat, gitleaks, yq)
- Documents the new target in CONTRIBUTING.md
- Updates bats error message to be distro-agnostic

## Test plan
- [ ] Run `make tools` and verify all tools install successfully
- [ ] Run `make help` and verify the new target is listed