### PR TITLE
Enable stats by default in dev builds

### DIFF
--- a/internal/appctx/context.go
+++ b/internal/appctx/context.go
@@ -62,6 +62,7 @@ type GlobalFlags struct {
 	// Behavior flags
 	Verbose  int // 0=off, 1=operations, 2=operations+requests (stacks with -v -v or -vv)
 	Stats    bool
+	NoStats  bool // Explicit disable (overrides --stats and dev default)
 	CacheDir string
 }
 
@@ -205,27 +206,68 @@ func (a *App) ApplyFlags() {
 
 // OK outputs a success response, automatically including stats if --stats flag is set.
 func (a *App) OK(data any, opts ...output.ResponseOption) error {
-	if a.Flags.Stats && a.Collector != nil {
+	if a.Flags.Stats && !a.Flags.NoStats && a.Collector != nil {
 		stats := a.Collector.Summary()
 		opts = append(opts, output.WithStats(&stats))
 	}
 	return a.Output.OK(data, opts...)
 }
 
-// Err outputs an error response, printing stats to stderr if --stats flag is set.
+// Err outputs an error response, including stats in the envelope for JSON/Markdown
+// or printing to stderr for styled output.
 func (a *App) Err(err error) error {
-	// Print the error response first
-	if outputErr := a.Output.Err(err); outputErr != nil {
+	// Determine if we should include stats
+	var opts []output.ErrorResponseOption
+	if a.shouldIncludeStatsInError() {
+		stats := a.Collector.Summary()
+		opts = append(opts, output.WithErrorStats(&stats))
+	}
+
+	// Print the error response
+	if outputErr := a.Output.Err(err, opts...); outputErr != nil {
 		return outputErr
 	}
 
-	// Print stats to stderr if enabled, but not in machine-consumable modes
-	// (agent, quiet, ids-only, count are meant for programmatic consumption)
-	if a.Flags.Stats && a.Collector != nil && !a.isMachineOutput() {
+	// Print stats to stderr for styled output only
+	if a.shouldPrintStatsToStderr() {
 		stats := a.Collector.Summary()
 		a.printStatsToStderr(&stats)
 	}
 	return nil
+}
+
+// shouldIncludeStatsInError returns true if stats should be included in the error envelope.
+func (a *App) shouldIncludeStatsInError() bool {
+	if !a.Flags.Stats || a.Flags.NoStats || a.Collector == nil {
+		return false
+	}
+	// Include stats in JSON/Markdown error envelopes (not for machine output modes)
+	if a.isMachineOutput() {
+		return false
+	}
+	if a.Output != nil {
+		switch a.Output.EffectiveFormat() {
+		case output.FormatJSON, output.FormatMarkdown:
+			return true
+		}
+	}
+	return false
+}
+
+func (a *App) shouldPrintStatsToStderr() bool {
+	if !a.Flags.Stats || a.Flags.NoStats || a.Collector == nil {
+		return false
+	}
+	if a.isMachineOutput() {
+		return false
+	}
+	if a.Output != nil {
+		switch a.Output.EffectiveFormat() {
+		case output.FormatJSON, output.FormatMarkdown, output.FormatQuiet, output.FormatIDs, output.FormatCount:
+			return false
+		}
+	}
+	return true
 }
 
 // isMachineOutput returns true if the output mode is intended for programmatic consumption.

--- a/internal/appctx/context_test.go
+++ b/internal/appctx/context_test.go
@@ -1,10 +1,13 @@
 package appctx
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/basecamp/bcq/internal/config"
+	"github.com/basecamp/bcq/internal/output"
 )
 
 func TestNewApp(t *testing.T) {
@@ -320,6 +323,213 @@ func TestAppOKWithStats(t *testing.T) {
 	err = app.OK(map[string]string{"test": "data"})
 	if err != nil {
 		t.Errorf("OK with stats failed: %v", err)
+	}
+}
+
+// Test NoStats flag overrides Stats flag
+func TestAppOKNoStatsOverridesStats(t *testing.T) {
+	tests := []struct {
+		name        string
+		stats       bool
+		noStats     bool
+		expectStats bool
+	}{
+		{"Stats=true, NoStats=true -> no stats", true, true, false},
+		{"Stats=true, NoStats=false -> stats included", true, false, true},
+		{"Stats=false, NoStats=false -> no stats", false, false, false},
+		{"Stats=false, NoStats=true -> no stats", false, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			app := NewApp(cfg)
+
+			// Use a buffer to capture output
+			var buf bytes.Buffer
+			app.Output = output.New(output.Options{
+				Format: output.FormatJSON,
+				Writer: &buf,
+			})
+
+			app.Flags.Stats = tt.stats
+			app.Flags.NoStats = tt.noStats
+
+			err := app.OK(map[string]string{"test": "data"})
+			if err != nil {
+				t.Fatalf("OK() failed: %v", err)
+			}
+
+			// Parse output and check for stats
+			var resp map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+				t.Fatalf("Failed to parse JSON output: %v", err)
+			}
+
+			meta, hasMeta := resp["meta"].(map[string]any)
+			hasStats := hasMeta && meta["stats"] != nil
+
+			if hasStats != tt.expectStats {
+				t.Errorf("stats presence = %v, want %v", hasStats, tt.expectStats)
+			}
+		})
+	}
+}
+
+// Test Err includes stats in JSON envelope when --stats is set
+func TestAppErrIncludesStatsInJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		format      output.Format
+		stats       bool
+		noStats     bool
+		expectStats bool
+	}{
+		{"JSON with stats", output.FormatJSON, true, false, true},
+		{"JSON without stats", output.FormatJSON, false, false, false},
+		{"JSON with NoStats override", output.FormatJSON, true, true, false},
+		{"Markdown with stats", output.FormatMarkdown, true, false, true},
+		{"Quiet suppresses stats", output.FormatQuiet, true, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			app := NewApp(cfg)
+
+			var buf bytes.Buffer
+			app.Output = output.New(output.Options{
+				Format: tt.format,
+				Writer: &buf,
+			})
+			app.Flags.Stats = tt.stats
+			app.Flags.NoStats = tt.noStats
+
+			testErr := output.ErrAPI(500, "test error")
+			err := app.Err(testErr)
+			if err != nil {
+				t.Fatalf("Err() failed: %v", err)
+			}
+
+			// Only check JSON-parseable formats
+			if tt.format == output.FormatJSON {
+				var resp map[string]any
+				if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+					t.Fatalf("Failed to parse JSON: %v", err)
+				}
+
+				meta, hasMeta := resp["meta"].(map[string]any)
+				hasStats := hasMeta && meta["stats"] != nil
+
+				if hasStats != tt.expectStats {
+					t.Errorf("stats presence = %v, want %v", hasStats, tt.expectStats)
+				}
+			}
+		})
+	}
+}
+
+// Test shouldPrintStatsToStderr respects NoStats flag
+func TestShouldPrintStatsToStderr(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    bool
+		noStats  bool
+		expected bool
+	}{
+		{"stats off, no-stats off", false, false, false},
+		{"stats on, no-stats off", true, false, true},
+		{"stats off, no-stats on", false, true, false},
+		{"stats on, no-stats on (override)", true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			app := NewApp(cfg)
+			// Use styled format to avoid machine output check
+			app.Flags.Styled = true
+			app.ApplyFlags()
+			app.Flags.Stats = tt.stats
+			app.Flags.NoStats = tt.noStats
+
+			got := app.shouldPrintStatsToStderr()
+			if got != tt.expected {
+				t.Errorf("shouldPrintStatsToStderr() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// Test shouldPrintStatsToStderr respects EffectiveFormat for non-TTY outputs
+func TestShouldPrintStatsToStderrEffectiveFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*App)
+		expected bool
+	}{
+		{
+			name: "FormatJSON suppresses stderr stats",
+			setup: func(a *App) {
+				a.Flags.JSON = true
+				a.ApplyFlags()
+			},
+			expected: false,
+		},
+		{
+			name: "FormatMarkdown suppresses stderr stats",
+			setup: func(a *App) {
+				a.Flags.MD = true
+				a.ApplyFlags()
+			},
+			expected: false,
+		},
+		{
+			name: "FormatQuiet suppresses stderr stats",
+			setup: func(a *App) {
+				a.Flags.Quiet = true
+				a.ApplyFlags()
+			},
+			expected: false,
+		},
+		{
+			name: "FormatIDs suppresses stderr stats",
+			setup: func(a *App) {
+				a.Flags.IDsOnly = true
+				a.ApplyFlags()
+			},
+			expected: false,
+		},
+		{
+			name: "FormatCount suppresses stderr stats",
+			setup: func(a *App) {
+				a.Flags.Count = true
+				a.ApplyFlags()
+			},
+			expected: false,
+		},
+		{
+			name: "FormatStyled allows stderr stats",
+			setup: func(a *App) {
+				a.Flags.Styled = true
+				a.ApplyFlags()
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			app := NewApp(cfg)
+			app.Flags.Stats = true // Enable stats
+			tt.setup(app)
+
+			got := app.shouldPrintStatsToStderr()
+			if got != tt.expected {
+				t.Errorf("shouldPrintStatsToStderr() = %v, want %v", got, tt.expected)
+			}
+		})
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -82,7 +82,9 @@ func NewRootCmd() *cobra.Command {
 
 	// Behavior flags
 	cmd.PersistentFlags().CountVarP(&flags.Verbose, "verbose", "v", "Verbose output (-v for ops, -vv for requests)")
-	cmd.PersistentFlags().BoolVar(&flags.Stats, "stats", false, "Show session statistics")
+	cmd.PersistentFlags().BoolVar(&flags.Stats, "stats", version.IsDev(), "Show session statistics (default: on in dev builds)")
+	cmd.PersistentFlags().BoolVar(&flags.NoStats, "no-stats", false, "Disable session statistics")
+	cmd.MarkFlagsMutuallyExclusive("stats", "no-stats")
 	cmd.PersistentFlags().StringVar(&flags.CacheDir, "cache-dir", "", "Cache directory")
 
 	// Register tab completion for flags.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1157,6 +1157,38 @@ func TestFormatConstants(t *testing.T) {
 	}
 }
 
+func TestEffectiveFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   Format
+		expected Format
+	}{
+		{"JSON stays JSON", FormatJSON, FormatJSON},
+		{"Markdown stays Markdown", FormatMarkdown, FormatMarkdown},
+		{"Styled stays Styled", FormatStyled, FormatStyled},
+		{"Quiet stays Quiet", FormatQuiet, FormatQuiet},
+		{"IDs stays IDs", FormatIDs, FormatIDs},
+		{"Count stays Count", FormatCount, FormatCount},
+		// FormatAuto resolves to FormatJSON when writer is not a TTY (bytes.Buffer)
+		{"Auto resolves to JSON for non-TTY", FormatAuto, FormatJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := New(Options{
+				Format: tt.format,
+				Writer: &buf,
+			})
+
+			got := w.EffectiveFormat()
+			if got != tt.expected {
+				t.Errorf("EffectiveFormat() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Edge Case Tests
 // =============================================================================

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -29,3 +29,8 @@ func UserAgent() string {
 	}
 	return "bcq/" + v + " (https://github.com/basecamp/bcq)"
 }
+
+// IsDev returns true if this is a development build.
+func IsDev() bool {
+	return Version == "dev"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,59 @@
+package version
+
+import "testing"
+
+func TestIsDev(t *testing.T) {
+	// Save original value
+	original := Version
+	defer func() { Version = original }()
+
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"dev", true},
+		{"1.0.0", false},
+		{"0.1.0", false},
+		{"v1.2.3", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			Version = tt.version
+			if got := IsDev(); got != tt.expected {
+				t.Errorf("IsDev() with Version=%q = %v, want %v", tt.version, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFull(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "dev"
+	if got := Full(); got != "bcq version dev (built from source)" {
+		t.Errorf("Full() with dev = %q, want %q", got, "bcq version dev (built from source)")
+	}
+
+	Version = "1.2.3"
+	if got := Full(); got != "bcq version 1.2.3" {
+		t.Errorf("Full() with 1.2.3 = %q, want %q", got, "bcq version 1.2.3")
+	}
+}
+
+func TestUserAgent(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "dev"
+	if got := UserAgent(); got != "bcq/dev (https://github.com/basecamp/bcq)" {
+		t.Errorf("UserAgent() with dev = %q", got)
+	}
+
+	Version = "1.0.0"
+	if got := UserAgent(); got != "bcq/1.0.0 (https://github.com/basecamp/bcq)" {
+		t.Errorf("UserAgent() with 1.0.0 = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- default `--stats` on for dev builds and add `--no-stats` opt-out
- avoid printing stats to stderr when output auto-resolves to JSON
- add output writer helper to resolve auto format

## Testing
- make
