### PR TITLE
Bump basecamp-sdk to main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260129223517-c11e5b17d989
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260130000510-964425c01429
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260129223517-c11e5b17d989 h1:VVj44JC6Lj3Q3Hz2JDrX3lSO1cCu36nqCmpmSSaHGlY=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260129223517-c11e5b17d989/go.mod h1:plVnCBgPC1cVCh6g8uumOKjZhrqO/ivXvWX6qINqw+w=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260130000510-964425c01429 h1:ZRZ6xOT4gJRprQVWuQijETODnl8R2Soo6Bc+7wD1oFI=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260130000510-964425c01429/go.mod h1:plVnCBgPC1cVCh6g8uumOKjZhrqO/ivXvWX6qINqw+w=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=


### PR DESCRIPTION
## Summary
- Bumps `basecamp-sdk/go` from the `wrapped` branch pseudo-version to the main branch after basecamp/basecamp-sdk#55 merged
- No code changes, just go.mod/go.sum pointer update

## Test plan
- `go build ./...` passes
- `make` passes (all 269 tests)