### PR TITLE
Fix benchstat install using @latest instead of invalid pseudo-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Install benchstat
         if: steps.filter.outputs.bench == 'true'
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20250106192532-ecc6f4f50f75
+        run: go install golang.org/x/perf/cmd/benchstat@latest
 
       - name: Compare benchmarks
         if: steps.filter.outputs.bench == 'true' && hashFiles('benchmarks-baseline.txt') != ''


### PR DESCRIPTION
## Summary
- Fix CI benchmark job failing due to invalid benchstat pseudo-version
- The pseudo-version `v0.0.0-20250106192532-ecc6f4f50f75` references a commit that no longer exists (likely rebased)
- Use `@latest` which is the standard approach for `golang.org/x` tools

## Test plan
- CI should pass on merge