### PR TITLE
Use SDK's X-Total-Count header for accurate truncation notices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.6
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260130081719-aaa4ee68c28f
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260130091738-d16a20757f0e
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260130003003-eaee310d53e5 h1:f1a/+2ClhuKq/ZQp/fEG1GHwqcF/5uClTMG9SwK/Jw4=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260130003003-eaee310d53e5/go.mod h1:plVnCBgPC1cVCh6g8uumOKjZhrqO/ivXvWX6qINqw+w=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260130081719-aaa4ee68c28f h1:hftkmJb9pkWJI4n2i3kWqROD9IHP7Fs4xOgNN4Gq22M=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260130081719-aaa4ee68c28f/go.mod h1:plVnCBgPC1cVCh6g8uumOKjZhrqO/ivXvWX6qINqw+w=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260130091738-d16a20757f0e h1:S9YETd9Dsi8l/tVZ/occ+TSzUs9mjcFJPIEaCpM8OA8=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260130091738-d16a20757f0e/go.mod h1:plVnCBgPC1cVCh6g8uumOKjZhrqO/ivXvWX6qINqw+w=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=

--- a/internal/commands/campfire.go
+++ b/internal/commands/campfire.go
@@ -95,10 +95,11 @@ func newCampfireListCmd(project *string) *cobra.Command {
 func runCampfireList(cmd *cobra.Command, app *appctx.App, project string, all bool) error {
 	// Account-wide campfire listing
 	if all {
-		campfires, err := app.Account().Campfires().List(cmd.Context())
+		result, err := app.Account().Campfires().List(cmd.Context())
 		if err != nil {
 			return err
 		}
+		campfires := result.Campfires
 
 		summary := fmt.Sprintf("%d campfires", len(campfires))
 
@@ -234,10 +235,11 @@ func runCampfireMessages(cmd *cobra.Command, app *appctx.App, campfireID, projec
 	campfireIDInt, _ := strconv.ParseInt(campfireID, 10, 64)
 
 	// Get recent messages (lines) using SDK
-	lines, err := app.Account().Campfires().ListLines(cmd.Context(), bucketID, campfireIDInt)
+	result, err := app.Account().Campfires().ListLines(cmd.Context(), bucketID, campfireIDInt)
 	if err != nil {
 		return err
 	}
+	lines := result.Lines
 
 	// Take last N messages
 	if limit > 0 && len(lines) > limit {

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -161,13 +161,13 @@ func runCardsList(cmd *cobra.Command, project, column, cardTable string, limit, 
 			return output.ErrUsage("Invalid column ID")
 		}
 
-		cards, err := app.Account().Cards().List(cmd.Context(), bucketID, columnID, opts)
+		cardsResult, err := app.Account().Cards().List(cmd.Context(), bucketID, columnID, opts)
 		if err != nil {
 			return convertSDKError(err)
 		}
 
-		return app.OK(cards,
-			output.WithSummary(fmt.Sprintf("%d cards", len(cards))),
+		return app.OK(cardsResult.Cards,
+			output.WithSummary(fmt.Sprintf("%d cards", len(cardsResult.Cards))),
 			output.WithBreadcrumbs(
 				output.Breadcrumb{
 					Action:      "create",
@@ -211,19 +211,19 @@ func runCardsList(cmd *cobra.Command, project, column, cardTable string, limit, 
 				"Use column ID or exact name",
 			)
 		}
-		cards, err := app.Account().Cards().List(cmd.Context(), bucketID, columnID, opts)
+		cardsResult, err := app.Account().Cards().List(cmd.Context(), bucketID, columnID, opts)
 		if err != nil {
 			return convertSDKError(err)
 		}
-		allCards = cards
+		allCards = cardsResult.Cards
 	} else {
 		// Get cards from all columns (no pagination - already validated above)
 		for _, col := range cardTableData.Lists {
-			cards, err := app.Account().Cards().List(cmd.Context(), bucketID, col.ID, nil)
+			cardsResult, err := app.Account().Cards().List(cmd.Context(), bucketID, col.ID, nil)
 			if err != nil {
 				continue // Skip columns with errors
 			}
-			allCards = append(allCards, cards...)
+			allCards = append(allCards, cardsResult.Cards...)
 		}
 	}
 

--- a/internal/commands/checkins.go
+++ b/internal/commands/checkins.go
@@ -190,10 +190,11 @@ func newCheckinsQuestionsCmd(project, questionnaireID *string) *cobra.Command {
 				opts.Page = page
 			}
 
-			questions, err := app.Account().Checkins().ListQuestions(cmd.Context(), bucketID, qID, opts)
+			questionsResult, err := app.Account().Checkins().ListQuestions(cmd.Context(), bucketID, qID, opts)
 			if err != nil {
 				return convertSDKError(err)
 			}
+			questions := questionsResult.Questions
 
 			return app.OK(questions,
 				output.WithSummary(fmt.Sprintf("%d check-in questions", len(questions))),
@@ -639,10 +640,11 @@ func newCheckinsAnswersCmd(project *string) *cobra.Command {
 				opts.Page = page
 			}
 
-			answers, err := app.Account().Checkins().ListAnswers(cmd.Context(), bucketID, questionID, opts)
+			answersResult, err := app.Account().Checkins().ListAnswers(cmd.Context(), bucketID, questionID, opts)
 			if err != nil {
 				return convertSDKError(err)
 			}
+			answers := answersResult.Answers
 
 			return app.OK(answers,
 				output.WithSummary(fmt.Sprintf("%d answers", len(answers))),

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -134,10 +134,11 @@ func runCommentsList(cmd *cobra.Command, project, recordingID string, limit, pag
 		opts.Page = page
 	}
 
-	comments, err := app.Account().Comments().List(cmd.Context(), bucketID, recID, opts)
+	commentsResult, err := app.Account().Comments().List(cmd.Context(), bucketID, recID, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	comments := commentsResult.Comments
 
 	// Build response options
 	respOpts := []output.ResponseOption{
@@ -157,7 +158,7 @@ func runCommentsList(cmd *cobra.Command, project, recordingID string, limit, pag
 	}
 
 	// Add truncation notice if results may be limited
-	if notice := output.TruncationNotice(len(comments), basecamp.DefaultCommentLimit, all, limit); notice != "" {
+	if notice := output.TruncationNoticeWithTotal(len(comments), commentsResult.Meta.TotalCount); notice != "" {
 		respOpts = append(respOpts, output.WithNotice(notice))
 	}
 

--- a/internal/commands/events.go
+++ b/internal/commands/events.go
@@ -92,10 +92,11 @@ Events track all changes to a recording. Common event actions:
 				opts.Page = page
 			}
 
-			events, err := app.Account().Events().List(cmd.Context(), bucketID, recordingID, opts)
+			eventsResult, err := app.Account().Events().List(cmd.Context(), bucketID, recordingID, opts)
 			if err != nil {
 				return convertSDKError(err)
 			}
+			events := eventsResult.Events
 
 			respOpts := []output.ResponseOption{
 				output.WithSummary(fmt.Sprintf("%d events for recording #%s", len(events), recordingIDStr)),
@@ -109,7 +110,7 @@ Events track all changes to a recording. Common event actions:
 			}
 
 			// Add truncation notice if results may be limited
-			if notice := output.TruncationNotice(len(events), basecamp.DefaultEventLimit, all, limit); notice != "" {
+			if notice := output.TruncationNoticeWithTotal(len(events), eventsResult.Meta.TotalCount); notice != "" {
 				respOpts = append(respOpts, output.WithNotice(notice))
 			}
 

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -155,21 +155,30 @@ func runFilesList(cmd *cobra.Command, project, vaultID string) error {
 	}
 
 	// Get folders (subvaults) using SDK
-	folders, err := app.Account().Vaults().List(cmd.Context(), bucketID, vaultIDNum, nil)
+	var folders []basecamp.Vault
+	foldersResult, err := app.Account().Vaults().List(cmd.Context(), bucketID, vaultIDNum, nil)
 	if err != nil {
 		folders = []basecamp.Vault{} // Best-effort
+	} else {
+		folders = foldersResult.Vaults
 	}
 
 	// Get uploads using SDK
-	uploads, err := app.Account().Uploads().List(cmd.Context(), bucketID, vaultIDNum, nil)
+	var uploads []basecamp.Upload
+	uploadsResult, err := app.Account().Uploads().List(cmd.Context(), bucketID, vaultIDNum, nil)
 	if err != nil {
 		uploads = []basecamp.Upload{} // Best-effort
+	} else {
+		uploads = uploadsResult.Uploads
 	}
 
 	// Get documents using SDK
-	documents, err := app.Account().Documents().List(cmd.Context(), bucketID, vaultIDNum, nil)
+	var documents []basecamp.Document
+	documentsResult, err := app.Account().Documents().List(cmd.Context(), bucketID, vaultIDNum, nil)
 	if err != nil {
 		documents = []basecamp.Document{} // Best-effort
+	} else {
+		documents = documentsResult.Documents
 	}
 
 	// Build result
@@ -330,10 +339,11 @@ func runFoldersList(cmd *cobra.Command, project, vaultID string, limit, page int
 	}
 
 	// Get folders using SDK
-	folders, err := app.Account().Vaults().List(cmd.Context(), bucketID, vaultIDNum, opts)
+	foldersResult, err := app.Account().Vaults().List(cmd.Context(), bucketID, vaultIDNum, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	folders := foldersResult.Vaults
 
 	return app.OK(folders,
 		output.WithSummary(fmt.Sprintf("%d folders", len(folders))),
@@ -551,10 +561,11 @@ func runUploadsList(cmd *cobra.Command, project, vaultID string, limit, page int
 	}
 
 	// Get uploads using SDK
-	uploads, err := app.Account().Uploads().List(cmd.Context(), bucketID, vaultIDNum, opts)
+	uploadsResult, err := app.Account().Uploads().List(cmd.Context(), bucketID, vaultIDNum, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	uploads := uploadsResult.Uploads
 
 	return app.OK(uploads,
 		output.WithSummary(fmt.Sprintf("%d files", len(uploads))),
@@ -683,10 +694,11 @@ func runDocsList(cmd *cobra.Command, project, vaultID string, limit, page int, a
 	}
 
 	// Get documents using SDK
-	documents, err := app.Account().Documents().List(cmd.Context(), bucketID, vaultIDNum, opts)
+	documentsResult, err := app.Account().Documents().List(cmd.Context(), bucketID, vaultIDNum, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	documents := documentsResult.Documents
 
 	return app.OK(documents,
 		output.WithSummary(fmt.Sprintf("%d documents", len(documents))),

--- a/internal/commands/forwards.go
+++ b/internal/commands/forwards.go
@@ -141,17 +141,18 @@ func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page in
 		opts.Page = page
 	}
 
-	forwards, err := app.Account().Forwards().List(cmd.Context(), bucketID, inboxIDInt, opts)
+	forwardsResult, err := app.Account().Forwards().List(cmd.Context(), bucketID, inboxIDInt, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	forwards := forwardsResult.Forwards
 
 	respOpts := []output.ResponseOption{
 		output.WithSummary(fmt.Sprintf("%d forwards", len(forwards))),
 	}
 
 	// Add truncation notice if results may be limited
-	if notice := output.TruncationNotice(len(forwards), 0, all, limit); notice != "" {
+	if notice := output.TruncationNoticeWithTotal(len(forwards), forwardsResult.Meta.TotalCount); notice != "" {
 		respOpts = append(respOpts, output.WithNotice(notice))
 	}
 
@@ -388,17 +389,18 @@ func newForwardsRepliesCmd(project *string) *cobra.Command {
 				opts.Page = page
 			}
 
-			replies, err := app.Account().Forwards().ListReplies(cmd.Context(), bucketID, forwardID, opts)
+			repliesResult, err := app.Account().Forwards().ListReplies(cmd.Context(), bucketID, forwardID, opts)
 			if err != nil {
 				return convertSDKError(err)
 			}
+			replies := repliesResult.Replies
 
 			respOpts := []output.ResponseOption{
 				output.WithSummary(fmt.Sprintf("%d replies to forward #%s", len(replies), forwardIDStr)),
 			}
 
 			// Add truncation notice if results may be limited
-			if notice := output.TruncationNotice(len(replies), 0, all, limit); notice != "" {
+			if notice := output.TruncationNoticeWithTotal(len(replies), repliesResult.Meta.TotalCount); notice != "" {
 				respOpts = append(respOpts, output.WithNotice(notice))
 			}
 

--- a/internal/commands/messages.go
+++ b/internal/commands/messages.go
@@ -138,10 +138,11 @@ func runMessagesList(cmd *cobra.Command, project string, messageBoard string, li
 	}
 
 	// Get messages using SDK
-	messages, err := app.Account().Messages().List(cmd.Context(), bucketID, boardID, opts)
+	messagesResult, err := app.Account().Messages().List(cmd.Context(), bucketID, boardID, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	messages := messagesResult.Messages
 
 	// Build response options
 	respOpts := []output.ResponseOption{
@@ -161,7 +162,7 @@ func runMessagesList(cmd *cobra.Command, project string, messageBoard string, li
 	}
 
 	// Add truncation notice if results may be limited
-	if notice := output.TruncationNotice(len(messages), basecamp.DefaultMessageLimit, all, limit); notice != "" {
+	if notice := output.TruncationNoticeWithTotal(len(messages), messagesResult.Meta.TotalCount); notice != "" {
 		respOpts = append(respOpts, output.WithNotice(notice))
 	}
 

--- a/internal/commands/messagetypes.go
+++ b/internal/commands/messagetypes.go
@@ -85,10 +85,11 @@ func runMessagetypesList(cmd *cobra.Command, project string) error {
 		return output.ErrUsage("Invalid project ID")
 	}
 
-	types, err := app.Account().MessageTypes().List(cmd.Context(), bucketID)
+	typesResult, err := app.Account().MessageTypes().List(cmd.Context(), bucketID)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	types := typesResult.MessageTypes
 
 	return app.OK(types,
 		output.WithSummary(fmt.Sprintf("%d message types", len(types))),

--- a/internal/commands/people.go
+++ b/internal/commands/people.go
@@ -227,9 +227,8 @@ func runPeopleList(cmd *cobra.Command, projectID string, limit, page int, all bo
 		opts.Page = page
 	}
 
-	var people []basecamp.Person
+	var peopleResult *basecamp.PeopleListResult
 	var err error
-
 	if projectID != "" {
 		// Resolve project name to ID if needed
 		resolvedID, _, resolveErr := app.Names.ResolveProject(cmd.Context(), projectID)
@@ -240,14 +239,15 @@ func runPeopleList(cmd *cobra.Command, projectID string, limit, page int, all bo
 		if parseErr != nil {
 			return output.ErrUsage("Invalid project ID")
 		}
-		people, err = app.Account().People().ListProjectPeople(cmd.Context(), bucketID, opts)
+		peopleResult, err = app.Account().People().ListProjectPeople(cmd.Context(), bucketID, opts)
 	} else {
-		people, err = app.Account().People().List(cmd.Context(), opts)
+		peopleResult, err = app.Account().People().List(cmd.Context(), opts)
 	}
 
 	if err != nil {
 		return convertSDKError(err)
 	}
+	people := peopleResult.People
 
 	// Opportunistic cache refresh: update completion cache as a side-effect.
 	// Only cache account-wide people list without pagination, not project-specific lists.

--- a/internal/commands/recordings.go
+++ b/internal/commands/recordings.go
@@ -194,10 +194,11 @@ func runRecordingsList(cmd *cobra.Command, app *appctx.App, recordingType, proje
 		opts.Bucket = []int64{projectID}
 	}
 
-	recordings, err := app.Account().Recordings().List(cmd.Context(), basecamp.RecordingType(recordingType), opts)
+	recordingsResult, err := app.Account().Recordings().List(cmd.Context(), basecamp.RecordingType(recordingType), opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	recordings := recordingsResult.Recordings
 
 	summary := fmt.Sprintf("%d %ss", len(recordings), recordingType)
 
@@ -213,7 +214,7 @@ func runRecordingsList(cmd *cobra.Command, app *appctx.App, recordingType, proje
 	}
 
 	// Add truncation notice if results may be limited
-	if notice := output.TruncationNotice(len(recordings), basecamp.DefaultRecordingLimit, all, limit); notice != "" {
+	if notice := output.TruncationNoticeWithTotal(len(recordings), recordingsResult.Meta.TotalCount); notice != "" {
 		respOpts = append(respOpts, output.WithNotice(notice))
 	}
 

--- a/internal/commands/schedule.go
+++ b/internal/commands/schedule.go
@@ -219,10 +219,11 @@ func runScheduleEntries(cmd *cobra.Command, app *appctx.App, project, scheduleID
 		opts.Status = status
 	}
 
-	entries, err := app.Account().Schedules().ListEntries(cmd.Context(), bucketID, scheduleIDInt, opts)
+	entriesResult, err := app.Account().Schedules().ListEntries(cmd.Context(), bucketID, scheduleIDInt, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	entries := entriesResult.Entries
 
 	summary := fmt.Sprintf("%d schedule entries", len(entries))
 

--- a/internal/commands/templates.go
+++ b/internal/commands/templates.go
@@ -62,15 +62,15 @@ func runTemplatesList(cmd *cobra.Command, status string) error {
 	}
 
 	var templates []basecamp.Template
-	var err error
 
 	// SDK List() defaults to active status (API default)
 	// For archived/trashed, use raw API with status parameter
 	if status == "active" || status == "" {
-		templates, err = app.Account().Templates().List(cmd.Context())
+		templatesResult, err := app.Account().Templates().List(cmd.Context())
 		if err != nil {
 			return convertSDKError(err)
 		}
+		templates = templatesResult.Templates
 	} else {
 		// Fall back to raw API for non-active statuses
 		path := fmt.Sprintf("/templates.json?status=%s", status)

--- a/internal/commands/todolistgroups.go
+++ b/internal/commands/todolistgroups.go
@@ -119,10 +119,11 @@ func runTodolistgroupsList(cmd *cobra.Command, project, todolist string) error {
 	}
 
 	// Get groups via SDK
-	groups, err := app.Account().TodolistGroups().List(cmd.Context(), bucketID, todolistID)
+	groupsResult, err := app.Account().TodolistGroups().List(cmd.Context(), bucketID, todolistID)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	groups := groupsResult.Groups
 
 	return app.OK(groups,
 		output.WithSummary(fmt.Sprintf("%d groups in todolist #%s", len(groups), todolist)),

--- a/internal/commands/todolists.go
+++ b/internal/commands/todolists.go
@@ -144,10 +144,11 @@ func runTodolistsList(cmd *cobra.Command, project string, limit, page int, all b
 	}
 
 	// Get todolists via SDK
-	todolists, err := app.Account().Todolists().List(cmd.Context(), bucketID, todosetID, opts)
+	todolistsResult, err := app.Account().Todolists().List(cmd.Context(), bucketID, todosetID, opts)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	todolists := todolistsResult.Todolists
 
 	respOpts := []output.ResponseOption{
 		output.WithSummary(fmt.Sprintf("%d todolists", len(todolists))),
@@ -166,7 +167,7 @@ func runTodolistsList(cmd *cobra.Command, project string, limit, page int, all b
 	}
 
 	// Add truncation notice if results may be limited
-	if notice := output.TruncationNotice(len(todolists), 0, all, limit); notice != "" {
+	if notice := output.TruncationNoticeWithTotal(len(todolists), todolistsResult.Meta.TotalCount); notice != "" {
 		respOpts = append(respOpts, output.WithNotice(notice))
 	}
 

--- a/internal/commands/webhooks.go
+++ b/internal/commands/webhooks.go
@@ -104,10 +104,11 @@ func runWebhooksList(cmd *cobra.Command, project string) error {
 		return output.ErrUsage("Invalid project ID")
 	}
 
-	webhooks, err := app.Account().Webhooks().List(cmd.Context(), bucketID)
+	webhooksResult, err := app.Account().Webhooks().List(cmd.Context(), bucketID)
 	if err != nil {
 		return convertSDKError(err)
 	}
+	webhooks := webhooksResult.Webhooks
 
 	return app.OK(webhooks,
 		output.WithSummary(fmt.Sprintf("%d webhooks", len(webhooks))),

--- a/internal/tui/resolve/comment.go
+++ b/internal/tui/resolve/comment.go
@@ -126,7 +126,7 @@ func (r *Resolver) fetchCommentableRecordings(ctx context.Context, bucketID int6
 	var errs []error
 
 	// Fetch todos
-	todos, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
+	todosResult, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
 		Bucket:    []int64{bucketID},
 		Status:    "active",
 		Sort:      "updated_at",
@@ -135,11 +135,11 @@ func (r *Resolver) fetchCommentableRecordings(ctx context.Context, bucketID int6
 	if err != nil {
 		errs = append(errs, fmt.Errorf("todos: %w", err))
 	} else {
-		allRecordings = append(allRecordings, todos...)
+		allRecordings = append(allRecordings, todosResult.Recordings...)
 	}
 
 	// Fetch messages
-	messages, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeMessage, &basecamp.RecordingsListOptions{
+	messagesResult, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeMessage, &basecamp.RecordingsListOptions{
 		Bucket:    []int64{bucketID},
 		Status:    "active",
 		Sort:      "updated_at",
@@ -148,11 +148,11 @@ func (r *Resolver) fetchCommentableRecordings(ctx context.Context, bucketID int6
 	if err != nil {
 		errs = append(errs, fmt.Errorf("messages: %w", err))
 	} else {
-		allRecordings = append(allRecordings, messages...)
+		allRecordings = append(allRecordings, messagesResult.Recordings...)
 	}
 
 	// Fetch documents
-	docs, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeDocument, &basecamp.RecordingsListOptions{
+	docsResult, err := r.sdk.ForAccount(r.config.AccountID).Recordings().List(ctx, basecamp.RecordingTypeDocument, &basecamp.RecordingsListOptions{
 		Bucket:    []int64{bucketID},
 		Status:    "active",
 		Sort:      "updated_at",
@@ -161,7 +161,7 @@ func (r *Resolver) fetchCommentableRecordings(ctx context.Context, bucketID int6
 	if err != nil {
 		errs = append(errs, fmt.Errorf("documents: %w", err))
 	} else {
-		allRecordings = append(allRecordings, docs...)
+		allRecordings = append(allRecordings, docsResult.Recordings...)
 	}
 
 	// If all fetches failed, return the combined error

--- a/internal/tui/resolve/comment_thread.go
+++ b/internal/tui/resolve/comment_thread.go
@@ -144,10 +144,10 @@ func FetchCommentThread(ctx context.Context, r *Resolver, projectID, recordingID
 	}
 
 	// Fetch comments
-	comments, err := accountClient.Comments().List(ctx, projectID, recordingID, nil)
+	commentsResult, err := accountClient.Comments().List(ctx, projectID, recordingID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch comments: %w", err)
 	}
 
-	return NewCommentThread(recording, comments), nil
+	return NewCommentThread(recording, commentsResult.Comments), nil
 }

--- a/internal/tui/resolve/person.go
+++ b/internal/tui/resolve/person.go
@@ -32,10 +32,11 @@ func (r *Resolver) Person(ctx context.Context) (*ResolvedValue, error) {
 	// Interactive mode - show picker with loading spinner
 	accountID := r.config.AccountID
 	loader := func() ([]tui.PickerItem, error) {
-		people, err := r.sdk.ForAccount(accountID).People().List(ctx, nil)
+		result, err := r.sdk.ForAccount(accountID).People().List(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch people: %w", err)
 		}
+		people := result.People
 
 		if len(people) == 0 {
 			return nil, output.ErrNotFoundHint("people", "", "No people found in this account")
@@ -100,10 +101,11 @@ func (r *Resolver) PersonInProject(ctx context.Context, projectID string) (*Reso
 	// Interactive mode - show picker with loading spinner
 	accountID := r.config.AccountID
 	loader := func() ([]tui.PickerItem, error) {
-		people, err := r.sdk.ForAccount(accountID).People().ListProjectPeople(ctx, bucketID, nil)
+		result, err := r.sdk.ForAccount(accountID).People().ListProjectPeople(ctx, bucketID, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch project people: %w", err)
 		}
+		people := result.People
 
 		if len(people) == 0 {
 			return nil, output.ErrNotFoundHint("people", projectID, "No members found in this project")

--- a/internal/tui/resolve/todolist.go
+++ b/internal/tui/resolve/todolist.go
@@ -111,12 +111,12 @@ func (r *Resolver) fetchTodolists(ctx context.Context, projectID string) ([]base
 	}
 
 	// Fetch todolists using SDK
-	todolists, err := r.sdk.ForAccount(r.config.AccountID).Todolists().List(ctx, bucketID, todosetID, nil)
+	result, err := r.sdk.ForAccount(r.config.AccountID).Todolists().List(ctx, bucketID, todosetID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch todolists: %w", err)
 	}
 
-	return todolists, nil
+	return result.Todolists, nil
 }
 
 // TodolistWithPersist resolves the todolist ID and optionally prompts to save it.


### PR DESCRIPTION
## Summary

Update all list commands to use the new SDK result types that expose `Meta.TotalCount` from the `X-Total-Count` header. Commands now show accurate truncation notices like "showing 25 of 150 items".

**Depends on:** basecamp/basecamp-sdk#61

## Changes

- Destructure SDK result types (e.g., `result.Todos`, `result.People`)
- Use `TruncationNoticeWithTotal()` instead of `TruncationNotice()`
- Update TUI resolve files for new result types
- Update completion cache refresh for new result types

## Files Changed

**Command files (17):**
- `campfire.go`, `cards.go`, `checkins.go`, `comment.go`, `events.go`
- `files.go`, `forwards.go`, `messages.go`, `messagetypes.go`, `people.go`
- `recordings.go`, `schedule.go`, `templates.go`, `todolistgroups.go`
- `todolists.go`, `todos.go`, `webhooks.go`

**TUI resolve files (4):**
- `comment.go`, `comment_thread.go`, `person.go`, `todolist.go`

**Completion (1):**
- `refresh.go`

## Test plan
- [x] `make` passes (vet, lint, tests)
- [x] Manual verification: `bcq todos list --limit 5` shows "X of Y" when truncated