### PR TITLE
Enable typo suggestions for unknown commands

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,13 +23,14 @@ func NewRootCmd() *cobra.Command {
 	var flags appctx.GlobalFlags
 
 	cmd := &cobra.Command{
-		Use:           "bcq",
-		Short:         "Command-line interface for Basecamp",
-		Long:          "bcq is a CLI tool for interacting with Basecamp projects, todos, messages, and more.",
-		Version:       version.Version,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		RunE:          commands.RunQuickStartDefault, // Run quick-start when no args
+		Use:                        "bcq",
+		Short:                      "Command-line interface for Basecamp",
+		Long:                       "bcq is a CLI tool for interacting with Basecamp projects, todos, messages, and more.",
+		Version:                    version.Version,
+		SilenceUsage:               true,
+		SilenceErrors:              true,
+		SuggestionsMinimumDistance: 2,                             // Enable typo suggestions
+		RunE:                       commands.RunQuickStartDefault, // Run quick-start when no args
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Skip setup for help and version commands
 			if cmd.Name() == "help" || cmd.Name() == "version" {


### PR DESCRIPTION
## Summary

Adds Cobra's built-in command suggestion feature when users mistype commands. This matches bc4's UX pattern for helpful error messages.

**Example:**
```
$ bcq todso
Error: unknown command "todso" for "bcq"

Did you mean this?
    todos
```

Inspired by [bc4](https://github.com/needmore/bc4)'s "did you mean?" suggestions for mistyped commands.

## Changes

- Set `SuggestionsMinimumDistance: 2` on root command to enable typo detection

## Test plan

- [x] `make` passes
- [x] Run `bcq todso` and verify suggestion appears
- [x] Run `bcq projcts` and verify "projects" is suggested

/cc @brigleb