### PR TITLE
Add styled error box for terminal output

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -824,8 +824,10 @@ func TestWriterStyledEmitsANSI(t *testing.T) {
 	output := buf.String()
 	// SHOULD contain ANSI escape codes when FormatStyled is used
 	assert.Contains(t, output, "\x1b[")
-	// Should still contain the error message
-	assert.Contains(t, output, "Error:")
+	// Should still contain the error message (in styled box format)
+	assert.Contains(t, output, "Error")
+	// Should contain the actual error message
+	assert.Contains(t, output, "project not found: 123")
 }
 
 func TestWriterMarkdownOutputsLiteralMarkdown(t *testing.T) {


### PR DESCRIPTION
## Summary

Renders errors in a bordered box with colored styling for better visual distinction in TTY output. Non-TTY output remains plain text for machine parsing.

**Example:**
```
┌─ Error ─────────────────────────────────────────┐
│ Project not found: "nonexistent"                │
│                                                 │
│ Hint: Use 'bcq projects' to list available      │
│ projects                                        │
└─────────────────────────────────────────────────┘
```

Inspired by [bc4](https://github.com/needmore/bc4)'s formatted terminal error output.

## Changes

- `internal/output/render.go`: Add `renderErrorBox()` for styled terminal errors
- Error hints and codes are displayed within the box

## Test plan

- [x] `make` passes
- [x] Trigger an error (e.g., invalid project) and verify styled box appears
- [x] Pipe output to file and verify plain text format

---
**Stack:** 2/7 — depends on #104

/cc @brigleb