### PR TITLE
Add URL argument support for commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/basecamp/bcq
 
 go 1.25.6
 
+replace github.com/basecamp/basecamp-sdk/go => /Users/jeremy/.superset/worktrees/basecamp-sdk/small-world/go
+
 require (
 	github.com/basecamp/basecamp-sdk/go v0.0.0-20260201055941-8e04971bb91d
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7

--- a/internal/commands/campfire.go
+++ b/internal/commands/campfire.go
@@ -358,21 +358,29 @@ func runCampfirePost(cmd *cobra.Command, app *appctx.App, campfireID, project, c
 
 func newCampfireLineShowCmd(project, campfireID *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "line <id>",
+		Use:     "line <id|url>",
 		Aliases: []string{"show"},
 		Short:   "Show a specific message",
-		Long:    "Show details of a specific message line.",
-		Args:    cobra.ExactArgs(1),
+		Long: `Show details of a specific message line.
+
+You can pass either a line ID or a Basecamp URL:
+  bcq campfire line 789 --in my-project
+  bcq campfire line https://3.basecamp.com/123/buckets/456/chats/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if err := ensureAccount(cmd, app); err != nil {
 				return err
 			}
 
-			lineID := args[0]
+			// Extract ID and project from URL if provided
+			lineID, urlProjectID := extractWithProject(args[0])
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -438,20 +446,28 @@ func newCampfireLineShowCmd(project, campfireID *string) *cobra.Command {
 
 func newCampfireLineDeleteCmd(project, campfireID *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <id>",
+		Use:   "delete <id|url>",
 		Short: "Delete a message",
-		Long:  "Delete a message line from a Campfire.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Delete a message line from a Campfire.
+
+You can pass either a line ID or a Basecamp URL:
+  bcq campfire delete 789 --in my-project
+  bcq campfire delete https://3.basecamp.com/123/buckets/456/chats/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if err := ensureAccount(cmd, app); err != nil {
 				return err
 			}
 
-			lineID := args[0]
+			// Extract ID and project from URL if provided
+			lineID, urlProjectID := extractWithProject(args[0])
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -251,10 +251,14 @@ func runCardsList(cmd *cobra.Command, project, column, cardTable string, limit, 
 
 func newCardsShowCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show card details",
-		Long:  "Display detailed information about a card.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display detailed information about a card.
+
+You can pass either a card ID or a Basecamp URL:
+  bcq cards show 789 --in my-project
+  bcq cards show https://3.basecamp.com/123/buckets/456/card_tables/cards/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -262,14 +266,19 @@ func newCardsShowCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			cardIDStr := args[0]
+			// Extract ID and project from URL if provided
+			cardIDStr, urlProjectID := extractWithProject(args[0])
+
 			cardID, err := strconv.ParseInt(cardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid card ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -476,10 +485,14 @@ func newCardsUpdateCmd(project *string) *cobra.Command {
 	var assignee string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update a card",
-		Long:  "Update an existing card.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing card.
+
+You can pass either a card ID or a Basecamp URL:
+  bcq cards update 789 --title "new title" --in my-project
+  bcq cards update https://3.basecamp.com/123/buckets/456/card_tables/cards/789 --title "new title"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -487,7 +500,9 @@ func newCardsUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			cardIDStr := args[0]
+			// Extract ID and project from URL if provided
+			cardIDStr, urlProjectID := extractWithProject(args[0])
+
 			cardID, err := strconv.ParseInt(cardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid card ID")
@@ -497,8 +512,11 @@ func newCardsUpdateCmd(project *string) *cobra.Command {
 				return output.ErrUsage("At least one field required")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -581,10 +599,14 @@ func newCardsMoveCmd(project, cardTable *string) *cobra.Command {
 	var targetColumn string
 
 	cmd := &cobra.Command{
-		Use:   "move <id>",
+		Use:   "move <id|url>",
 		Short: "Move a card to another column",
-		Long:  "Move a card to a different column in the card table.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Move a card to a different column in the card table.
+
+You can pass either a card ID or a Basecamp URL:
+  bcq cards move 789 --to "Done" --in my-project
+  bcq cards move https://3.basecamp.com/123/buckets/456/card_tables/cards/789 --to "Done"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -592,7 +614,9 @@ func newCardsMoveCmd(project, cardTable *string) *cobra.Command {
 				return err
 			}
 
-			cardIDStr := args[0]
+			// Extract ID and project from URL if provided
+			cardIDStr, urlProjectID := extractWithProject(args[0])
+
 			cardID, err := strconv.ParseInt(cardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid card ID")
@@ -609,8 +633,11 @@ func newCardsMoveCmd(project, cardTable *string) *cobra.Command {
 				return output.ErrUsage("--card-table is required when --to is a column name")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -972,10 +999,14 @@ func newCardsColumnCmd(project, cardTable *string) *cobra.Command {
 
 func newCardsColumnShowCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show column details",
-		Long:  "Display detailed information about a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display detailed information about a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column show 789 --in my-project
+  bcq cards column show https://3.basecamp.com/123/buckets/456/card_tables/columns/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -983,14 +1014,18 @@ func newCardsColumnShowCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1134,10 +1169,14 @@ func newCardsColumnUpdateCmd(project *string) *cobra.Command {
 	var description string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update a column",
-		Long:  "Update an existing card table column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing card table column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column update 789 --title "new name" --in my-project
+  bcq cards column update https://3.basecamp.com/123/buckets/456/card_tables/columns/789 --title "new name"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1145,7 +1184,8 @@ func newCardsColumnUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
@@ -1155,8 +1195,11 @@ func newCardsColumnUpdateCmd(project *string) *cobra.Command {
 				return output.ErrUsage("No update fields provided")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1206,10 +1249,14 @@ func newCardsColumnMoveCmd(project, cardTable *string) *cobra.Command {
 	var position int
 
 	cmd := &cobra.Command{
-		Use:   "move <id>",
+		Use:   "move <id|url>",
 		Short: "Move a column",
-		Long:  "Reposition a column within the card table.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Reposition a column within the card table.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column move 789 --position 2 --in my-project
+  bcq cards column move https://3.basecamp.com/123/buckets/456/card_tables/columns/789 --position 2`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1217,7 +1264,8 @@ func newCardsColumnMoveCmd(project, cardTable *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Column ID must be numeric")
@@ -1227,8 +1275,11 @@ func newCardsColumnMoveCmd(project, cardTable *string) *cobra.Command {
 				return output.ErrUsage("--position required (1-indexed)")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1290,10 +1341,14 @@ func newCardsColumnMoveCmd(project, cardTable *string) *cobra.Command {
 
 func newCardsColumnWatchCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "watch <id>",
+		Use:   "watch <id|url>",
 		Short: "Watch a column",
-		Long:  "Subscribe to updates for a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Subscribe to updates for a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column watch 789 --in my-project
+  bcq cards column watch https://3.basecamp.com/123/buckets/456/card_tables/columns/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1301,14 +1356,18 @@ func newCardsColumnWatchCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1348,10 +1407,14 @@ func newCardsColumnWatchCmd(project *string) *cobra.Command {
 
 func newCardsColumnUnwatchCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unwatch <id>",
+		Use:   "unwatch <id|url>",
 		Short: "Unwatch a column",
-		Long:  "Unsubscribe from updates for a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Unsubscribe from updates for a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column unwatch 789 --in my-project
+  bcq cards column unwatch https://3.basecamp.com/123/buckets/456/card_tables/columns/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1359,14 +1422,18 @@ func newCardsColumnUnwatchCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1406,10 +1473,14 @@ func newCardsColumnUnwatchCmd(project *string) *cobra.Command {
 
 func newCardsColumnOnHoldCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "on-hold <id>",
+		Use:   "on-hold <id|url>",
 		Short: "Enable on-hold section",
-		Long:  "Enable on-hold section for a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Enable on-hold section for a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column on-hold 789 --in my-project
+  bcq cards column on-hold https://3.basecamp.com/123/buckets/456/card_tables/columns/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1417,14 +1488,18 @@ func newCardsColumnOnHoldCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1463,10 +1538,14 @@ func newCardsColumnOnHoldCmd(project *string) *cobra.Command {
 
 func newCardsColumnNoOnHoldCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "no-on-hold <id>",
+		Use:   "no-on-hold <id|url>",
 		Short: "Disable on-hold section",
-		Long:  "Disable on-hold section for a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Disable on-hold section for a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column no-on-hold 789 --in my-project
+  bcq cards column no-on-hold https://3.basecamp.com/123/buckets/456/card_tables/columns/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1474,14 +1553,18 @@ func newCardsColumnNoOnHoldCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1522,10 +1605,14 @@ func newCardsColumnColorCmd(project *string) *cobra.Command {
 	var color string
 
 	cmd := &cobra.Command{
-		Use:   "color <id>",
+		Use:   "color <id|url>",
 		Short: "Set column color",
-		Long:  "Set the color for a column.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Set the color for a column.
+
+You can pass either a column ID or a Basecamp URL:
+  bcq cards column color 789 --color blue --in my-project
+  bcq cards column color https://3.basecamp.com/123/buckets/456/card_tables/columns/789 --color blue`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1533,7 +1620,8 @@ func newCardsColumnColorCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			columnIDStr := args[0]
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
@@ -1543,8 +1631,11 @@ func newCardsColumnColorCmd(project *string) *cobra.Command {
 				return output.ErrUsage("--color is required")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1793,10 +1884,14 @@ func newCardsStepUpdateCmd(project *string) *cobra.Command {
 	var assignees string
 
 	cmd := &cobra.Command{
-		Use:   "update <step_id>",
+		Use:   "update <step_id|url>",
 		Short: "Update a step",
-		Long:  "Update an existing step on a card.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing step on a card.
+
+You can pass either a step ID or a Basecamp URL:
+  bcq cards step update 789 --title "new title" --in my-project
+  bcq cards step update https://3.basecamp.com/123/buckets/456/card_tables/cards/steps/789 --title "new title"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1804,7 +1899,8 @@ func newCardsStepUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			stepIDStr := args[0]
+			// Extract ID and project from URL if provided
+			stepIDStr, urlProjectID := extractWithProject(args[0])
 			stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid step ID")
@@ -1814,8 +1910,11 @@ func newCardsStepUpdateCmd(project *string) *cobra.Command {
 				return output.ErrUsage("No update fields provided")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1874,10 +1973,14 @@ func newCardsStepUpdateCmd(project *string) *cobra.Command {
 
 func newCardsStepCompleteCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "complete <step_id>",
+		Use:   "complete <step_id|url>",
 		Short: "Complete a step",
-		Long:  "Mark a step as completed.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Mark a step as completed.
+
+You can pass either a step ID or a Basecamp URL:
+  bcq cards step complete 789 --in my-project
+  bcq cards step complete https://3.basecamp.com/123/buckets/456/card_tables/cards/steps/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1885,14 +1988,18 @@ func newCardsStepCompleteCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			stepIDStr := args[0]
+			// Extract ID and project from URL if provided
+			stepIDStr, urlProjectID := extractWithProject(args[0])
 			stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid step ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1931,10 +2038,14 @@ func newCardsStepCompleteCmd(project *string) *cobra.Command {
 
 func newCardsStepUncompleteCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "uncomplete <step_id>",
+		Use:   "uncomplete <step_id|url>",
 		Short: "Uncomplete a step",
-		Long:  "Mark a step as not completed.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Mark a step as not completed.
+
+You can pass either a step ID or a Basecamp URL:
+  bcq cards step uncomplete 789 --in my-project
+  bcq cards step uncomplete https://3.basecamp.com/123/buckets/456/card_tables/cards/steps/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -1942,14 +2053,18 @@ func newCardsStepUncompleteCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			stepIDStr := args[0]
+			// Extract ID and project from URL if provided
+			stepIDStr, urlProjectID := extractWithProject(args[0])
 			stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid step ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -1991,10 +2106,14 @@ func newCardsStepMoveCmd(project *string) *cobra.Command {
 	var position int
 
 	cmd := &cobra.Command{
-		Use:   "move <step_id>",
+		Use:   "move <step_id|url>",
 		Short: "Move a step",
-		Long:  "Reposition a step within a card (0-indexed).",
-		Args:  cobra.ExactArgs(1),
+		Long: `Reposition a step within a card (0-indexed).
+
+You can pass either a step ID or a Basecamp URL:
+  bcq cards step move 789 --card 456 --position 0 --in my-project
+  bcq cards step move https://3.basecamp.com/123/buckets/456/card_tables/cards/steps/789 --card 456 --position 0`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -2002,7 +2121,8 @@ func newCardsStepMoveCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			stepIDStr := args[0]
+			// Extract ID and project from URL if provided
+			stepIDStr, urlProjectID := extractWithProject(args[0])
 			stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Step ID must be numeric")
@@ -2020,8 +2140,11 @@ func newCardsStepMoveCmd(project *string) *cobra.Command {
 				return output.ErrUsage("Invalid card ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -2067,10 +2190,14 @@ func newCardsStepMoveCmd(project *string) *cobra.Command {
 
 func newCardsStepDeleteCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <step_id>",
+		Use:   "delete <step_id|url>",
 		Short: "Delete a step",
-		Long:  "Permanently delete a step from a card.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Permanently delete a step from a card.
+
+You can pass either a step ID or a Basecamp URL:
+  bcq cards step delete 789 --in my-project
+  bcq cards step delete https://3.basecamp.com/123/buckets/456/card_tables/cards/steps/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -2078,14 +2205,18 @@ func newCardsStepDeleteCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			stepIDStr := args[0]
+			// Extract ID and project from URL if provided
+			stepIDStr, urlProjectID := extractWithProject(args[0])
 			stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid step ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}

--- a/internal/commands/checkins.go
+++ b/internal/commands/checkins.go
@@ -223,7 +223,7 @@ func newCheckinsQuestionsCmd(project, questionnaireID *string) *cobra.Command {
 
 func newCheckinsQuestionCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "question [id]",
+		Use:   "question [id|url]",
 		Short: "Show or manage a question",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -245,9 +245,14 @@ func newCheckinsQuestionCmd(project *string) *cobra.Command {
 
 func newCheckinsQuestionShowCmd(project *string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show question details",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display details of a check-in question.
+
+You can pass either a question ID or a Basecamp URL:
+  bcq checkins question show 789 --in my-project
+  bcq checkins question show https://3.basecamp.com/123/buckets/456/questionnaires/questions/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCheckinsQuestionShow(cmd, *project, args[0])
 		},
@@ -261,8 +266,14 @@ func runCheckinsQuestionShow(cmd *cobra.Command, project, questionIDStr string) 
 		return err
 	}
 
-	// Resolve project, with interactive fallback
+	// Extract ID and project from URL if provided
+	questionIDStr, urlProjectID := extractWithProject(questionIDStr)
+
+	// Resolve project - use URL > flag > config, with interactive fallback
 	projectID := project
+	if projectID == "" && urlProjectID != "" {
+		projectID = urlProjectID
+	}
 	if projectID == "" {
 		projectID = app.Flags.Project
 	}
@@ -461,9 +472,14 @@ func newCheckinsQuestionUpdateCmd(project *string) *cobra.Command {
 	var days string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update a check-in question",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update a check-in question's title or schedule.
+
+You can pass either a question ID or a Basecamp URL:
+  bcq checkins question update 789 --title "new question" --in my-project
+  bcq checkins question update https://3.basecamp.com/123/buckets/456/questionnaires/questions/789 --title "new question"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -471,10 +487,14 @@ func newCheckinsQuestionUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			questionIDStr := args[0]
+			// Extract ID and project from URL if provided
+			questionIDStr, urlProjectID := extractWithProject(args[0])
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -576,9 +596,14 @@ func newCheckinsAnswersCmd(project *string) *cobra.Command {
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "answers <question_id>",
+		Use:   "answers <question_id|url>",
 		Short: "List answers for a question",
-		Args:  cobra.ExactArgs(1),
+		Long: `List answers for a check-in question.
+
+You can pass either a question ID or a Basecamp URL:
+  bcq checkins answers 789 --in my-project
+  bcq checkins answers https://3.basecamp.com/123/buckets/456/questions/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -597,10 +622,14 @@ func newCheckinsAnswersCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			questionIDStr := args[0]
+			// Extract ID and project from URL if provided
+			questionIDStr, urlProjectID := extractWithProject(args[0])
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -673,7 +702,7 @@ func newCheckinsAnswersCmd(project *string) *cobra.Command {
 
 func newCheckinsAnswerCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "answer [id]",
+		Use:   "answer [id|url]",
 		Short: "Show or manage an answer",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -695,9 +724,14 @@ func newCheckinsAnswerCmd(project *string) *cobra.Command {
 
 func newCheckinsAnswerShowCmd(project *string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show answer details",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display details of a check-in answer.
+
+You can pass either an answer ID or a Basecamp URL:
+  bcq checkins answer show 789 --in my-project
+  bcq checkins answer show https://3.basecamp.com/123/buckets/456/question_answers/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCheckinsAnswerShow(cmd, *project, args[0])
 		},
@@ -711,8 +745,14 @@ func runCheckinsAnswerShow(cmd *cobra.Command, project, answerIDStr string) erro
 		return err
 	}
 
-	// Resolve project, with interactive fallback
+	// Extract ID and project from URL if provided
+	answerIDStr, urlProjectID := extractWithProject(answerIDStr)
+
+	// Resolve project - use URL > flag > config, with interactive fallback
 	projectID := project
+	if projectID == "" && urlProjectID != "" {
+		projectID = urlProjectID
+	}
 	if projectID == "" {
 		projectID = app.Flags.Project
 	}
@@ -880,9 +920,14 @@ func newCheckinsAnswerUpdateCmd(project *string) *cobra.Command {
 	var content string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update an answer",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing check-in answer.
+
+You can pass either an answer ID or a Basecamp URL:
+  bcq checkins answer update 789 --content "updated answer" --in my-project
+  bcq checkins answer update https://3.basecamp.com/123/buckets/456/question_answers/789 --content "updated answer"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -890,14 +935,18 @@ func newCheckinsAnswerUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			answerIDStr := args[0]
+			// Extract ID and project from URL if provided
+			answerIDStr, urlProjectID := extractWithProject(args[0])
 
 			if content == "" {
 				return output.ErrUsage("--content is required")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}

--- a/internal/commands/forwards.go
+++ b/internal/commands/forwards.go
@@ -176,10 +176,14 @@ func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page in
 
 func newForwardsShowCmd(project *string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show a forward",
-		Long:  "Display detailed information about an email forward.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display detailed information about an email forward.
+
+You can pass either a forward ID or a Basecamp URL:
+  bcq forwards show 789 --in my-project
+  bcq forwards show https://3.basecamp.com/123/buckets/456/inbox_forwards/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -187,14 +191,19 @@ func newForwardsShowCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			forwardIDStr := args[0]
+			// Extract ID and project from URL if provided
+			forwardIDStr, urlProjectID := extractWithProject(args[0])
+
 			forwardID, err := strconv.ParseInt(forwardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid forward ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -325,10 +334,14 @@ func newForwardsRepliesCmd(project *string) *cobra.Command {
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "replies <forward_id>",
+		Use:   "replies <forward_id|url>",
 		Short: "List replies to a forward",
-		Long:  "List all replies to an email forward.",
-		Args:  cobra.ExactArgs(1),
+		Long: `List all replies to an email forward.
+
+You can pass either a forward ID or a Basecamp URL:
+  bcq forwards replies 789 --in my-project
+  bcq forwards replies https://3.basecamp.com/123/buckets/456/inbox_forwards/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -347,14 +360,19 @@ func newForwardsRepliesCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			forwardIDStr := args[0]
+			// Extract ID and project from URL if provided
+			forwardIDStr, urlProjectID := extractWithProject(args[0])
+
 			forwardID, err := strconv.ParseInt(forwardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid forward ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -432,10 +450,14 @@ func newForwardsRepliesCmd(project *string) *cobra.Command {
 
 func newForwardsReplyCmd(project *string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "reply <forward_id> <reply_id>",
+		Use:   "reply <forward_id|url> <reply_id|url>",
 		Short: "Show a specific reply",
-		Long:  "Display detailed information about a reply to an email forward.",
-		Args:  cobra.ExactArgs(2),
+		Long: `Display detailed information about a reply to an email forward.
+
+You can pass either IDs or Basecamp URLs:
+  bcq forwards reply 789 456 --in my-project
+  bcq forwards reply https://3.basecamp.com/123/buckets/456/inbox_forwards/789 456`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -443,20 +465,25 @@ func newForwardsReplyCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			forwardIDStr := args[0]
+			// Extract IDs and project from URLs if provided
+			forwardIDStr, urlProjectID := extractWithProject(args[0])
+			replyIDStr := extractID(args[1])
+
 			forwardID, err := strconv.ParseInt(forwardIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid forward ID")
 			}
 
-			replyIDStr := args[1]
 			replyID, err := strconv.ParseInt(replyIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid reply ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/basecamp/bcq/internal/appctx"
 	"github.com/basecamp/bcq/internal/output"
+	"github.com/basecamp/bcq/internal/urlarg"
 )
 
 // DockTool represents a tool in a project's dock.
@@ -186,4 +187,50 @@ func ensurePersonInProject(cmd *cobra.Command, app *appctx.App, projectID string
 		return "", err
 	}
 	return resolved.Value, nil
+}
+
+// extractID extracts the primary ID from an argument.
+// If the argument is a Basecamp URL (copy/pasted from browser), extracts the recording ID.
+// Otherwise, returns the argument as-is (assumed to be an ID).
+//
+// This allows users to paste URLs directly:
+//
+//	bcq todos show https://3.basecamp.com/123/buckets/456/todos/789
+//
+// Instead of having to manually extract the ID:
+//
+//	bcq todos show 789 --in 456
+func extractID(arg string) string {
+	return urlarg.ExtractID(arg)
+}
+
+// extractProjectID extracts the project (bucket) ID from an argument.
+// If the argument is a Basecamp URL, extracts the bucket ID.
+// Otherwise, returns the argument as-is.
+func extractProjectID(arg string) string {
+	return urlarg.ExtractProjectID(arg)
+}
+
+// extractWithProject extracts both recording ID and project ID from an argument.
+// If the argument is a Basecamp URL, extracts both; if the URL contains a project,
+// it can be used to auto-populate the --in flag.
+// Returns (recordingID, projectID). If projectID is empty, it wasn't in the URL.
+func extractWithProject(arg string) (recordingID, projectID string) {
+	return urlarg.ExtractWithProject(arg)
+}
+
+// extractCommentWithProject extracts a comment ID and project ID from an argument.
+// For URLs with a fragment (#__recording_N), returns the comment ID instead of the recording ID.
+func extractCommentWithProject(arg string) (id, projectID string) {
+	return urlarg.ExtractCommentWithProject(arg)
+}
+
+// extractIDs extracts IDs from multiple arguments, handling URLs.
+func extractIDs(args []string) []string {
+	return urlarg.ExtractIDs(args)
+}
+
+// isURL checks if the input looks like a Basecamp URL.
+func isURL(input string) bool {
+	return urlarg.IsURL(input)
 }

--- a/internal/commands/lineup.go
+++ b/internal/commands/lineup.go
@@ -109,10 +109,14 @@ func newLineupUpdateCmd() *cobra.Command {
 	var date string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update a lineup marker",
-		Long:  "Update an existing lineup marker's name or date.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing lineup marker's name or date.
+
+You can pass either a marker ID or a Basecamp URL:
+  bcq lineup update 789 --name "new name"
+  bcq lineup update https://3.basecamp.com/123/my/lineup/markers/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -120,7 +124,7 @@ func newLineupUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			markerIDStr := args[0]
+			markerIDStr := extractID(args[0])
 			markerID, err := strconv.ParseInt(markerIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid marker ID")
@@ -183,10 +187,14 @@ func newLineupUpdateCmd() *cobra.Command {
 
 func newLineupDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <id>",
+		Use:   "delete <id|url>",
 		Short: "Delete a lineup marker",
-		Long:  "Delete an existing lineup marker.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Delete an existing lineup marker.
+
+You can pass either a marker ID or a Basecamp URL:
+  bcq lineup delete 789
+  bcq lineup delete https://3.basecamp.com/123/my/lineup/markers/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -194,7 +202,7 @@ func newLineupDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			markerIDStr := args[0]
+			markerIDStr := extractID(args[0])
 			markerID, err := strconv.ParseInt(markerIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid marker ID")

--- a/internal/commands/messages.go
+++ b/internal/commands/messages.go
@@ -171,10 +171,14 @@ func runMessagesList(cmd *cobra.Command, project string, messageBoard string, li
 
 func newMessagesShowCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show <id>",
+		Use:   "show <id|url>",
 		Short: "Show message details",
-		Long:  "Display detailed information about a message.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Display detailed information about a message.
+
+You can pass either a message ID or a Basecamp URL:
+  bcq messages show 789 --in my-project
+  bcq messages show https://3.basecamp.com/123/buckets/456/messages/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -182,14 +186,19 @@ func newMessagesShowCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			messageIDStr := args[0]
+			// Extract ID and project from URL if provided
+			messageIDStr, urlProjectID := extractWithProject(args[0])
+
 			messageID, err := strconv.ParseInt(messageIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid message ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -344,10 +353,14 @@ func newMessagesUpdateCmd(project *string) *cobra.Command {
 	var content string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update <id|url>",
 		Short: "Update a message",
-		Long:  "Update an existing message's subject or content.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Update an existing message's subject or content.
+
+You can pass either a message ID or a Basecamp URL:
+  bcq messages update 789 --subject "new title" --in my-project
+  bcq messages update https://3.basecamp.com/123/buckets/456/messages/789 --subject "new title"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -355,7 +368,9 @@ func newMessagesUpdateCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			messageIDStr := args[0]
+			// Extract ID and project from URL if provided
+			messageIDStr, urlProjectID := extractWithProject(args[0])
+
 			messageID, err := strconv.ParseInt(messageIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid message ID")
@@ -365,8 +380,11 @@ func newMessagesUpdateCmd(project *string) *cobra.Command {
 				return output.ErrUsage("at least one of --subject or --content is required")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -423,10 +441,14 @@ func newMessagesUpdateCmd(project *string) *cobra.Command {
 
 func newMessagesPinCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pin <id>",
+		Use:   "pin <id|url>",
 		Short: "Pin a message",
-		Long:  "Pin a message to the top of the message board.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Pin a message to the top of the message board.
+
+You can pass either a message ID or a Basecamp URL:
+  bcq messages pin 789 --in my-project
+  bcq messages pin https://3.basecamp.com/123/buckets/456/messages/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -434,14 +456,19 @@ func newMessagesPinCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			messageIDStr := args[0]
+			// Extract ID and project from URL if provided
+			messageIDStr, urlProjectID := extractWithProject(args[0])
+
 			messageID, err := strconv.ParseInt(messageIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid message ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}
@@ -495,10 +522,14 @@ func newMessagesPinCmd(project *string) *cobra.Command {
 
 func newMessagesUnpinCmd(project *string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unpin <id>",
+		Use:   "unpin <id|url>",
 		Short: "Unpin a message",
-		Long:  "Remove a message from the pinned position.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Remove a message from the pinned position.
+
+You can pass either a message ID or a Basecamp URL:
+  bcq messages unpin 789 --in my-project
+  bcq messages unpin https://3.basecamp.com/123/buckets/456/messages/789`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 
@@ -506,14 +537,19 @@ func newMessagesUnpinCmd(project *string) *cobra.Command {
 				return err
 			}
 
-			messageIDStr := args[0]
+			// Extract ID and project from URL if provided
+			messageIDStr, urlProjectID := extractWithProject(args[0])
+
 			messageID, err := strconv.ParseInt(messageIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid message ID")
 			}
 
-			// Resolve project, with interactive fallback
+			// Resolve project - use URL > flag > config, with interactive fallback
 			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
 			if projectID == "" {
 				projectID = app.Flags.Project
 			}

--- a/internal/urlarg/urlarg.go
+++ b/internal/urlarg/urlarg.go
@@ -1,0 +1,108 @@
+// Package urlarg provides utilities for parsing Basecamp URLs into IDs.
+// This allows users to paste URLs from the browser as command arguments.
+package urlarg
+
+import (
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// Parsed represents components extracted from a Basecamp URL.
+type Parsed struct {
+	AccountID   string
+	ProjectID   string // BucketID in Basecamp terminology
+	Type        string // e.g., "todos", "messages", "cards"
+	RecordingID string
+	CommentID   string
+}
+
+// router is the shared SDK router instance.
+var router = basecamp.DefaultRouter()
+
+// IsURL checks if the input looks like a Basecamp URL.
+// Returns true if the URL can be matched (either as an API route or structurally).
+func IsURL(input string) bool {
+	return router.Match(input) != nil
+}
+
+// Parse extracts IDs from a Basecamp URL.
+// Returns nil if the input is not a valid Basecamp URL.
+//
+// Supported URL patterns:
+//   - https://3.basecamp.com/{account}/buckets/{bucket}/{type}/{id}
+//   - https://3.basecamp.com/{account}/buckets/{bucket}/{type}/{id}#__recording_{comment}
+//   - https://3.basecamp.com/{account}/buckets/{bucket}/card_tables/cards/{id}
+//   - https://3.basecamp.com/{account}/projects/{project}
+func Parse(input string) *Parsed {
+	m := router.Match(input)
+	if m == nil {
+		return nil
+	}
+	return &Parsed{
+		AccountID:   m.AccountID,
+		ProjectID:   m.ProjectID,
+		Type:        m.PathType,
+		RecordingID: m.ResourceID(),
+		CommentID:   m.CommentID,
+	}
+}
+
+// ExtractID extracts the primary ID from an argument.
+// If the argument is a Basecamp URL, extracts the recording ID.
+// Otherwise, returns the argument as-is (assumed to be an ID).
+func ExtractID(arg string) string {
+	if parsed := Parse(arg); parsed != nil {
+		if parsed.RecordingID != "" {
+			return parsed.RecordingID
+		}
+		if parsed.ProjectID != "" {
+			return parsed.ProjectID
+		}
+		if parsed.AccountID != "" {
+			return parsed.AccountID
+		}
+	}
+	return arg
+}
+
+// ExtractProjectID extracts the project (bucket) ID from an argument.
+// If the argument is a Basecamp URL, extracts the bucket ID.
+// Otherwise, returns the argument as-is.
+func ExtractProjectID(arg string) string {
+	if parsed := Parse(arg); parsed != nil && parsed.ProjectID != "" {
+		return parsed.ProjectID
+	}
+	return arg
+}
+
+// ExtractWithProject extracts both the recording ID and project ID from an argument.
+// Returns (recordingID, projectID). If projectID is empty, it wasn't in the URL.
+func ExtractWithProject(arg string) (recordingID, projectID string) {
+	if parsed := Parse(arg); parsed != nil {
+		return parsed.RecordingID, parsed.ProjectID
+	}
+	return arg, ""
+}
+
+// ExtractCommentWithProject extracts a comment ID and project ID from an argument.
+// For URLs with a fragment (e.g., #__recording_789), returns the comment ID.
+// For URLs without a fragment, returns the recording ID (same as ExtractWithProject).
+// Returns (commentOrRecordingID, projectID).
+func ExtractCommentWithProject(arg string) (id, projectID string) {
+	if parsed := Parse(arg); parsed != nil {
+		// Prefer comment ID from fragment when present
+		if parsed.CommentID != "" {
+			return parsed.CommentID, parsed.ProjectID
+		}
+		return parsed.RecordingID, parsed.ProjectID
+	}
+	return arg, ""
+}
+
+// ExtractIDs extracts IDs from multiple arguments, handling URLs.
+func ExtractIDs(args []string) []string {
+	result := make([]string, len(args))
+	for i, arg := range args {
+		result[i] = ExtractID(arg)
+	}
+	return result
+}

--- a/internal/urlarg/urlarg_test.go
+++ b/internal/urlarg/urlarg_test.go
@@ -1,0 +1,265 @@
+package urlarg
+
+import (
+	"testing"
+)
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://3.basecamp.com/123/buckets/456/todos/789", true},
+		{"https://3.basecamp.com/123/projects/456", true},
+		{"http://localhost:3000/123/buckets/456/todos/789", true},
+		{"123", false},
+		{"my-project", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsURL(tt.input); got != tt.want {
+				t.Errorf("IsURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Parsed
+		wantNil bool
+	}{
+		{
+			name:  "full todo URL",
+			input: "https://3.basecamp.com/123/buckets/456/todos/789",
+			want: &Parsed{
+				AccountID:   "123",
+				ProjectID:   "456",
+				Type:        "todos",
+				RecordingID: "789",
+			},
+		},
+		{
+			name:  "message URL",
+			input: "https://3.basecamp.com/123/buckets/456/messages/789",
+			want: &Parsed{
+				AccountID:   "123",
+				ProjectID:   "456",
+				Type:        "messages",
+				RecordingID: "789",
+			},
+		},
+		{
+			name:  "URL with comment fragment",
+			input: "https://3.basecamp.com/123/buckets/456/todos/789#__recording_999",
+			want: &Parsed{
+				AccountID:   "123",
+				ProjectID:   "456",
+				Type:        "todos",
+				RecordingID: "789",
+				CommentID:   "999",
+			},
+		},
+		{
+			name:  "card URL",
+			input: "https://3.basecamp.com/123/buckets/456/card_tables/cards/789",
+			want: &Parsed{
+				AccountID:   "123",
+				ProjectID:   "456",
+				Type:        "cards",
+				RecordingID: "789",
+			},
+		},
+		{
+			name:  "column URL",
+			input: "https://3.basecamp.com/123/buckets/456/card_tables/columns/789",
+			want: &Parsed{
+				AccountID:   "123",
+				ProjectID:   "456",
+				Type:        "columns",
+				RecordingID: "789",
+			},
+		},
+		{
+			name:  "project URL",
+			input: "https://3.basecamp.com/123/projects/456",
+			want: &Parsed{
+				AccountID: "123",
+				ProjectID: "456",
+				Type:      "project",
+			},
+		},
+		{
+			name:  "type list URL (todolists)",
+			input: "https://3.basecamp.com/123/buckets/456/todolists",
+			want: &Parsed{
+				AccountID: "123",
+				ProjectID: "456",
+				Type:      "todolists",
+			},
+		},
+		{
+			name:    "plain ID",
+			input:   "789",
+			wantNil: true,
+		},
+		{
+			name:    "project name",
+			input:   "my-project",
+			wantNil: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Parse(%q) = %+v, want nil", tt.input, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("Parse(%q) = nil, want %+v", tt.input, tt.want)
+				return
+			}
+			if got.AccountID != tt.want.AccountID {
+				t.Errorf("AccountID = %q, want %q", got.AccountID, tt.want.AccountID)
+			}
+			if got.ProjectID != tt.want.ProjectID {
+				t.Errorf("ProjectID = %q, want %q", got.ProjectID, tt.want.ProjectID)
+			}
+			if got.Type != tt.want.Type {
+				t.Errorf("Type = %q, want %q", got.Type, tt.want.Type)
+			}
+			if got.RecordingID != tt.want.RecordingID {
+				t.Errorf("RecordingID = %q, want %q", got.RecordingID, tt.want.RecordingID)
+			}
+			if got.CommentID != tt.want.CommentID {
+				t.Errorf("CommentID = %q, want %q", got.CommentID, tt.want.CommentID)
+			}
+		})
+	}
+}
+
+func TestExtractID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://3.basecamp.com/123/buckets/456/todos/789", "789"},
+		{"https://3.basecamp.com/123/projects/456", "456"},
+		{"https://3.basecamp.com/123/buckets/456/card_tables/cards/789", "789"},
+		{"789", "789"},
+		{"my-project", "my-project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ExtractID(tt.input); got != tt.want {
+				t.Errorf("ExtractID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProjectID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://3.basecamp.com/123/buckets/456/todos/789", "456"},
+		{"https://3.basecamp.com/123/projects/456", "456"},
+		{"456", "456"},
+		{"my-project", "my-project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ExtractProjectID(tt.input); got != tt.want {
+				t.Errorf("ExtractProjectID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractWithProject(t *testing.T) {
+	tests := []struct {
+		input           string
+		wantRecordingID string
+		wantProjectID   string
+	}{
+		{"https://3.basecamp.com/123/buckets/456/todos/789", "789", "456"},
+		{"789", "789", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotRecordingID, gotProjectID := ExtractWithProject(tt.input)
+			if gotRecordingID != tt.wantRecordingID {
+				t.Errorf("recordingID = %q, want %q", gotRecordingID, tt.wantRecordingID)
+			}
+			if gotProjectID != tt.wantProjectID {
+				t.Errorf("projectID = %q, want %q", gotProjectID, tt.wantProjectID)
+			}
+		})
+	}
+}
+
+func TestExtractCommentWithProject(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantID   string
+		wantProj string
+	}{
+		// Comment URL with fragment — should extract comment ID, not recording ID
+		{"https://3.basecamp.com/123/buckets/456/todos/111#__recording_789", "789", "456"},
+		// Regular URL without fragment — should extract recording ID
+		{"https://3.basecamp.com/123/buckets/456/todos/789", "789", "456"},
+		// Plain ID
+		{"789", "789", ""},
+		// Numeric fragment
+		{"https://3.basecamp.com/123/buckets/456/messages/111#999", "999", "456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotID, gotProj := ExtractCommentWithProject(tt.input)
+			if gotID != tt.wantID {
+				t.Errorf("id = %q, want %q", gotID, tt.wantID)
+			}
+			if gotProj != tt.wantProj {
+				t.Errorf("projectID = %q, want %q", gotProj, tt.wantProj)
+			}
+		})
+	}
+}
+
+func TestExtractIDs(t *testing.T) {
+	args := []string{
+		"https://3.basecamp.com/123/buckets/456/todos/789",
+		"111",
+		"https://3.basecamp.com/123/buckets/456/messages/222",
+	}
+	want := []string{"789", "111", "222"}
+	got := ExtractIDs(args)
+
+	if len(got) != len(want) {
+		t.Errorf("ExtractIDs() = %v, want %v", got, want)
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("ExtractIDs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Users can now paste Basecamp URLs directly as arguments instead of manually extracting IDs. The URL parsing is delegated to the SDK's router, which understands all Basecamp URL patterns.

**Examples:**
```bash
# Before: manually extract IDs
bcq todos show 789 --in 456

# After: paste URL directly
bcq todos show https://3.basecamp.com/123/buckets/456/todos/789

# Works with comments too
bcq comments list --on https://3.basecamp.com/.../todos/789
```

The project ID is automatically extracted from the URL when present, eliminating the need for `--in` flags with URL arguments.

Inspired by [bc4](https://github.com/needmore/bc4)'s support for Basecamp URLs as command arguments.

## Changes

- `internal/urlarg/`: New package delegating to SDK router for URL parsing
- All resource commands updated to accept URLs via `extractID()` and `extractWithProject()`
- `go.mod`: Updated SDK dependency with router support

## Test plan

- [x] `make` passes
- [x] Test URL extraction: `bcq todos show <pasted-url>`
- [x] Verify project auto-detection from URL
- [x] Verify plain IDs still work

---
**Stack:** 3/7 — depends on #105

/cc @brigleb