### PR TITLE
Add interactive first-run setup wizard

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -168,6 +168,7 @@ func Execute() {
 	cmd.AddCommand(commands.NewTimelineCmd())
 	cmd.AddCommand(commands.NewReportsCmd())
 	cmd.AddCommand(commands.NewCompletionCmd())
+	cmd.AddCommand(commands.NewSetupCmd())
 
 	// Use ExecuteC to get the executed command (for correct context access)
 	executedCmd, err := cmd.ExecuteC()

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -104,6 +104,7 @@ func commandCategories() []CommandCategory {
 				{Name: "auth", Category: "auth", Description: "Authenticate with Basecamp", Actions: []string{"login", "logout", "status", "refresh"}},
 				{Name: "config", Category: "auth", Description: "Manage configuration", Actions: []string{"show", "init", "set", "unset", "project"}},
 				{Name: "me", Category: "auth", Description: "Show current user profile"},
+				{Name: "setup", Category: "auth", Description: "Interactive first-time setup"},
 				{Name: "quick-start", Category: "auth", Description: "Show getting started guide"},
 			},
 		},

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -61,6 +61,7 @@ func TestCatalogMatchesRegisteredCommands(t *testing.T) {
 	root.AddCommand(commands.NewTimelineCmd())
 	root.AddCommand(commands.NewReportsCmd())
 	root.AddCommand(commands.NewCompletionCmd())
+	root.AddCommand(commands.NewSetupCmd())
 
 	// Trigger Cobra's auto-addition of help subcommand
 	root.InitDefaultHelpCmd()

--- a/internal/commands/quickstart.go
+++ b/internal/commands/quickstart.go
@@ -51,7 +51,13 @@ func NewQuickStartCmd() *cobra.Command {
 }
 
 // RunQuickStartDefault is called when bcq is run with no args.
+// If this is a first run (unauthenticated, interactive TTY, no BASECAMP_TOKEN),
+// it runs the setup wizard. Otherwise, it falls through to the quick-start output.
 func RunQuickStartDefault(cmd *cobra.Command, args []string) error {
+	app := appctx.FromContext(cmd.Context())
+	if app != nil && isFirstRun(app) {
+		return runWizard(cmd, app)
+	}
 	return runQuickStart(cmd, args)
 }
 

--- a/internal/commands/wizard_test.go
+++ b/internal/commands/wizard_test.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/bcq/internal/output"
+)
+
+// TestIsFirstRunUnauthenticated verifies isFirstRun returns true for unauthenticated,
+// non-TTY apps (isFirstRun also checks IsInteractive, which requires a real TTY).
+// Since tests don't run in a TTY, isFirstRun returns false even when unauthenticated.
+func TestIsFirstRunUnauthenticated(t *testing.T) {
+	app, _ := setupQuickstartTestApp(t, "", "")
+
+	// Not a TTY in test environment, so isFirstRun returns false
+	assert.False(t, isFirstRun(app), "isFirstRun should be false in non-TTY test")
+}
+
+// TestIsFirstRunWithBasecampToken verifies isFirstRun returns false when BASECAMP_TOKEN is set.
+func TestIsFirstRunWithBasecampToken(t *testing.T) {
+	app, _ := setupQuickstartTestApp(t, "", "")
+	t.Setenv("BASECAMP_TOKEN", "test-token-123")
+
+	assert.False(t, isFirstRun(app), "isFirstRun should be false when BASECAMP_TOKEN is set")
+}
+
+// TestIsFirstRunAuthenticated verifies isFirstRun returns false when already authenticated.
+func TestIsFirstRunAuthenticated(t *testing.T) {
+	// BASECAMP_TOKEN makes IsAuthenticated() return true
+	t.Setenv("BASECAMP_TOKEN", "test-token-123")
+	app, _ := setupQuickstartTestApp(t, "12345", "")
+
+	assert.False(t, isFirstRun(app), "isFirstRun should be false when authenticated")
+}
+
+// TestWizardResultJSON verifies the WizardResult struct serializes correctly.
+func TestWizardResultJSON(t *testing.T) {
+	app, buf := setupQuickstartTestApp(t, "", "")
+
+	result := WizardResult{
+		Version:     "1.0.0",
+		Status:      "complete",
+		AccountID:   "12345",
+		AccountName: "Test Company",
+		ProjectID:   "67890",
+		ProjectName: "My Project",
+		ConfigScope: "global",
+	}
+
+	err := app.OK(result, output.WithSummary("Setup complete"))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"account_id": "12345"`)
+	assert.Contains(t, out, `"project_id": "67890"`)
+	assert.Contains(t, out, `"config_scope": "global"`)
+}
+
+// TestWizardSummaryLine verifies summary generation.
+func TestWizardSummaryLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   WizardResult
+		expected string
+	}{
+		{
+			name:     "with account name",
+			result:   WizardResult{AccountName: "Test Co"},
+			expected: "Setup complete - Test Co",
+		},
+		{
+			name:     "without account name",
+			result:   WizardResult{AccountID: "123"},
+			expected: "Setup complete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, wizardSummaryLine(tt.result))
+		})
+	}
+}
+
+// TestWizardBreadcrumbs verifies breadcrumb generation based on wizard outcome.
+func TestWizardBreadcrumbs(t *testing.T) {
+	t.Run("with project", func(t *testing.T) {
+		result := WizardResult{ProjectID: "123"}
+		crumbs := wizardBreadcrumbs(result)
+
+		assert.True(t, len(crumbs) >= 2)
+		assert.Equal(t, "list_projects", crumbs[0].Action)
+
+		// Should have todos breadcrumb when project is set
+		var hasTodos bool
+		for _, c := range crumbs {
+			if c.Action == "list_todos" {
+				hasTodos = true
+			}
+		}
+		assert.True(t, hasTodos, "expected list_todos breadcrumb when project is set")
+	})
+
+	t.Run("without project", func(t *testing.T) {
+		result := WizardResult{}
+		crumbs := wizardBreadcrumbs(result)
+
+		// Should suggest setting a project
+		var hasSetProject bool
+		for _, c := range crumbs {
+			if c.Action == "set_project" {
+				hasSetProject = true
+			}
+		}
+		assert.True(t, hasSetProject, "expected set_project breadcrumb when no project")
+	})
+}
+
+// TestNewSetupCmd verifies the setup command is created correctly.
+func TestNewSetupCmd(t *testing.T) {
+	cmd := NewSetupCmd()
+	assert.Equal(t, "setup", cmd.Use)
+	assert.Contains(t, cmd.Short, "setup")
+}


### PR DESCRIPTION
## Summary

Provides guided onboarding for new users with authentication, account selection, and project configuration. The wizard runs automatically when bcq is invoked with no arguments and no prior authentication.

**Features:**
- Authentication with scope selection (read-only or full access)
- Interactive account picker
- Optional default project selection
- Configuration persistence (global or local)
- Summary with example commands

**Trigger conditions:**
- No stored credentials
- No `BASECAMP_TOKEN` environment variable
- Interactive TTY session
- No arguments provided

Can also be triggered manually via `bcq setup`.

Inspired by [bc4](https://github.com/needmore/bc4)'s interactive first-run configuration flow.

## Changes

- `internal/commands/wizard.go`: New wizard implementation
- `internal/commands/quickstart.go`: `RunQuickStartDefault` for auto-trigger
- `internal/cli/root.go`: Register `setup` command
- `internal/commands/commands.go`: Add to command catalog

## Test plan

- [x] `make` passes
- [x] Clear credentials and run `bcq` — verify wizard starts
- [x] Run `bcq setup` explicitly
- [x] Verify config is saved to chosen location

---
**Stack:** 5/7 — depends on #107

/cc @brigleb