### PR TITLE
Fix shell completion installation instructions

### DIFF
--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -38,13 +38,18 @@ Zsh:
   # you will need to enable it. You can execute the following once:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
-  # To load completions for every new session, add to ~/.zshrc:
+  # To load completions in your current session:
+  $ source <(bcq completion zsh)
+
+  # To load completions for every new session, add AFTER compinit in ~/.zshrc:
   eval "$(bcq completion zsh)"
 
-  # Or install to a directory in your fpath:
+  # Or install to a directory in your fpath (add BEFORE compinit in ~/.zshrc):
   $ mkdir -p ~/.zsh/completions
   $ bcq completion zsh > ~/.zsh/completions/_bcq
-  # Then add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
+  # Then add to ~/.zshrc:
+  #   fpath=(~/.zsh/completions $fpath)
+  #   autoload -U compinit; compinit
 
 Fish:
   $ bcq completion fish | source
@@ -138,13 +143,15 @@ to enable it. You can execute the following once:
 To load completions in your current shell session:
   $ source <(bcq completion zsh)
 
-To load completions for every new session, add to ~/.zshrc:
+To load completions for every new session, add AFTER compinit in ~/.zshrc:
   eval "$(bcq completion zsh)"
 
-Or install to a directory in your fpath:
+Or install to a directory in your fpath (add BEFORE compinit in ~/.zshrc):
   $ mkdir -p ~/.zsh/completions
   $ bcq completion zsh > ~/.zsh/completions/_bcq
-  # Then add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
+  # Then add to ~/.zshrc:
+  #   fpath=(~/.zsh/completions $fpath)
+  #   autoload -U compinit; compinit
 `,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Fix Linux bash completion install command to use `sudo tee` (direct `>` redirect fails without root)
- Add simpler `eval "$(bcq completion <shell>)"` option for ~/.bashrc and ~/.zshrc
- Replace `${fpath[1]}/_bcq` with user-writable `~/.zsh/completions` directory for zsh

## Why
The original instructions didn't work on Linux without sudo, and the zsh fpath approach assumed the first fpath directory was user-writable (often not the case).

Fixes #124