### PR TITLE
Improve skill documentation based on stress test findings

### DIFF
--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -664,6 +665,8 @@ func formatCell(val any) string {
 			return "yes"
 		}
 		return "no"
+	case json.Number:
+		return v.String()
 	case float64:
 		if v == float64(int(v)) {
 			return fmt.Sprintf("%d", int(v))
@@ -681,6 +684,8 @@ func formatCell(val any) string {
 			switch elem := item.(type) {
 			case string:
 				items = append(items, elem)
+			case json.Number:
+				items = append(items, elem.String())
 			case float64:
 				if elem == float64(int(elem)) {
 					items = append(items, fmt.Sprintf("%d", int(elem)))

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -75,7 +75,7 @@ Full bcq CLI coverage: 130 endpoints across todos, cards, messages, files, sched
 3. **Comments are flat** - reply to parent recording, not to comments
 4. **Check context** via `.basecamp/config.json` before assuming project
 5. **Rich text fields accept Markdown** - bcq converts to HTML automatically
-6. **Project scope is mandatory** - `--in <project>` is required for resource queries (todos, cards, messages, etc.). There is no cross-project query mode. For cross-project data, use `bcq recordings <type>` or loop through projects individually.
+6. **Project scope is mandatory** — via `--in <project>` or `.basecamp/config.json`. There is no cross-project query mode. For cross-project data, use `bcq recordings <type>` or loop through projects individually.
 
 ### Output Modes
 
@@ -106,7 +106,7 @@ bcq <cmd> --page 1     # First page only, no auto-pagination
 
 ## Quick Reference
 
-> **Note:** Most queries require `--in <project>`. For cross-project data, use `bcq recordings <type>` or loop through projects individually.
+> **Note:** Most queries require project scope (via `--in <project>` or `.basecamp/config.json`). For cross-project data, use `bcq recordings <type>` or loop through projects individually.
 
 | Task | Command |
 |------|---------|


### PR DESCRIPTION
Updates the Basecamp skill documentation to address gaps discovered during agent stress testing. These changes help agents avoid common command errors and understand API limitations.

I understand some of these may be overkill or overly subjective - and may improve anyway with API and SDK updates.

- Clarify that `--in <project>` is mandatory for resource queries
- Document that `--assignee` only works on todos, not cards
- Add `--card-table` requirement for multi-board projects
- Document `--status` filtering defaults to active recordings
- Add card completion detection via `parent.type: "Kanban::DoneColumn"`
- Note that card move timestamps are not tracked by Basecamp

Closes #118
Closes #119
Closes #120