### PR TITLE
Account for SDK normalizing HTTP 204 to JSON null

### DIFF
--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -173,15 +173,9 @@ func newAPIDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			// Handle empty response (204 No Content)
-			data := resp.Data
-			if len(data) == 0 {
-				data = []byte("{}")
-			}
-
 			summary := fmt.Sprintf("DELETE %s", path)
 
-			return app.OK(data,
+			return app.OK(resp.Data,
 				output.WithSummary(summary),
 			)
 		},

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
@@ -122,7 +123,7 @@ You can also pass a Basecamp URL directly:
 			}
 
 			// Check for empty response (204 No Content)
-			if len(resp.Data) == 0 {
+			if resp.StatusCode == http.StatusNoContent {
 				if recordType == "" || recordType == "recording" || recordType == "recordings" {
 					return output.ErrUsageHint(
 						fmt.Sprintf("Recording %s not found or type required", id),


### PR DESCRIPTION
## Summary

Companion to [basecamp/basecamp-sdk#77](https://github.com/basecamp/basecamp-sdk/pull/77) — the SDK now normalizes 204 No Content responses to `json.RawMessage("null")` instead of empty bytes.

- **show.go**: Check `resp.StatusCode == 204` instead of `len(resp.Data) == 0` to detect empty responses
- **api.go**: Remove the DELETE empty-body substitution hack (`data = []byte("{}")`). The SDK's null now flows through `NormalizeData` cleanly — `nil` is omitted via `omitempty`, producing `{"ok":true, "summary":"DELETE /path"}` instead of the old synthetic `"data":{}`.

Stacked on #130.

## Test plan

- [x] `make` passes (vet, lint, tests, CLI integration tests)