### PR TITLE
Bump SDK for webhook receiver infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basecamp/bcq
 go 1.25.7
 
 require (
-	github.com/basecamp/basecamp-sdk/go v0.0.0-20260208080023-41dc6e1bc88c
+	github.com/basecamp/basecamp-sdk/go v0.0.0-20260208085410-18d534da6770
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260208080023-41dc6e1bc88c h1:CFtr+Z6nPzk7qvW/H2oJl9e+lsqo83UkIbC0tMhQeB0=
-github.com/basecamp/basecamp-sdk/go v0.0.0-20260208080023-41dc6e1bc88c/go.mod h1:7F8Tk/eRY66zi1vDE8L+0vj9NPkoTfBECksHAqwEvVc=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260208085410-18d534da6770 h1:cEBBRw+mA7XnFFk04k3gVBzdtdI3BnsXmhrWxoA7+A4=
+github.com/basecamp/basecamp-sdk/go v0.0.0-20260208085410-18d534da6770/go.mod h1:7F8Tk/eRY66zi1vDE8L+0vj9NPkoTfBECksHAqwEvVc=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.0.0-20260208080023-41dc6e1bc88c",
-    "revision": "41dc6e1bc88c",
-    "updated_at": "2026-02-08T08:00:23Z"
+    "version": "v0.0.0-20260208085410-18d534da6770",
+    "revision": "18d534da6770",
+    "updated_at": "2026-02-08T08:54:10Z"
   },
   "api": {
     "repo": "basecamp/bc3",


### PR DESCRIPTION
## Summary
- Bumps SDK to `v0.0.0-20260208085410-18d534da6770` (SDK PR #85 merge)
- Adds webhook receiver types: `WebhookEvent`, `WebhookDelivery`, `WebhookCopy`
- Extends `Webhook` with `RecentDeliveries` (now visible in `webhooks show` JSON output)
- Extends `Person` with `CanPing`, `CanAccessTimesheet`, `CanAccessHillCharts`
- Extends `Recording` with `Content`, `CommentsCount`, `CommentsURL`, `SubscriptionURL`
- No breaking changes — all additions are new fields/types

## Test plan
- [x] `make` passes (vet, lint, unit tests, e2e tests)
- [x] `make provenance-check` passes
- [x] `go build ./...` compiles clean