### PR TITLE
Campfire: group consecutive messages and add date separators

### DIFF
--- a/internal/tui/workspace/data/hub.go
+++ b/internal/tui/workspace/data/hub.go
@@ -672,10 +672,11 @@ func (h *Hub) CampfireLines(projectID, campfireID int64) *Pool[CampfireLinesResu
 			for _, line := range result.Lines {
 				creator := personName(line.Creator)
 				infos = append(infos, CampfireLineInfo{
-					ID:        line.ID,
-					Body:      line.Content,
-					Creator:   creator,
-					CreatedAt: line.CreatedAt.Format("3:04pm"),
+					ID:          line.ID,
+					Body:        line.Content,
+					Creator:     creator,
+					CreatedAt:   line.CreatedAt.Format("3:04pm"),
+					CreatedAtTS: line.CreatedAt,
 					BoostEmbed: BoostEmbed{
 						BoostsSummary: BoostSummary{Count: line.BoostsCount},
 					},

--- a/internal/tui/workspace/data/types.go
+++ b/internal/tui/workspace/data/types.go
@@ -69,10 +69,11 @@ type ForwardInfo struct {
 
 // CampfireLineInfo is a lightweight representation of a campfire line.
 type CampfireLineInfo struct {
-	ID        int64
-	Body      string // HTML content
-	Creator   string
-	CreatedAt string // formatted time
+	ID          int64
+	Body        string // HTML content
+	Creator     string
+	CreatedAt   string    // formatted time
+	CreatedAtTS time.Time // raw timestamp for grouping
 	BoostEmbed
 }
 


### PR DESCRIPTION
## Summary
- Consecutive messages from the same sender within 5 minutes are grouped under a single name+timestamp header
- Date separators ("Today", "Yesterday", "Mon, Jan 2") inserted when the date changes between messages
- Boost indicators preserved on grouped (non-header) lines — shown inline after the message body
- `CampfireLineInfo` gains `CreatedAtTS time.Time` for grouping comparisons

## Test plan
- [ ] `TestCampfire_MessageGrouping` — three consecutive messages from "Alice" within 1 minute show header once
- [ ] `TestCampfire_DifferentSender_BreaksGroup` — Alice then Bob each get headers
- [ ] `TestCampfire_DateSeparator` — messages spanning two days show date separator
- [ ] `TestSameTimeGroup` — edge cases for the 5-minute grouping window