### PR TITLE
Visual polish: title-case headers, friendly dates, toast styling, field alignment

### DIFF
--- a/internal/tui/workspace/chrome/toast.go
+++ b/internal/tui/workspace/chrome/toast.go
@@ -82,6 +82,8 @@ func (t Toast) View() string {
 
 	style := lipgloss.NewStyle().
 		Foreground(fg).
+		Background(theme.Background).
+		Padding(0, 1).
 		Align(lipgloss.Center).
 		Width(t.width)
 

--- a/internal/tui/workspace/views/detail.go
+++ b/internal/tui/workspace/views/detail.go
@@ -1062,7 +1062,7 @@ func (v *Detail) syncPreview() {
 		fields = append(fields, widget.PreviewField{Key: "Created", Value: v.data.createdAt.Format("Jan 2, 2006")})
 	}
 	if v.data.dueOn != "" {
-		fields = append(fields, widget.PreviewField{Key: "Due", Value: v.data.dueOn})
+		fields = append(fields, widget.PreviewField{Key: "Due", Value: formatDueDate(v.data.dueOn)})
 	}
 	if v.data.category != "" {
 		fields = append(fields, widget.PreviewField{Key: "Category", Value: v.data.category})
@@ -1276,6 +1276,28 @@ func fetchSubscriptionState(sub *basecamp.Subscription, err error) bool {
 		return false
 	}
 	return sub.Subscribed
+}
+
+// formatDueDate converts an ISO date string to a human-friendly label.
+func formatDueDate(iso string) string {
+	t, err := time.ParseInLocation("2006-01-02", iso, time.Local)
+	if err != nil {
+		return iso
+	}
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	switch {
+	case t.Equal(today):
+		return "Today"
+	case t.Equal(today.AddDate(0, 0, 1)):
+		return "Tomorrow"
+	case t.Equal(today.AddDate(0, 0, -1)):
+		return "Yesterday"
+	case t.Year() == now.Year():
+		return t.Format("Mon, Jan 2")
+	default:
+		return t.Format("Mon, Jan 2, 2006")
+	}
 }
 
 // titleCase uppercases the first letter of s. Recording types are always ASCII

--- a/internal/tui/workspace/views/hey.go
+++ b/internal/tui/workspace/views/hey.go
@@ -295,11 +295,11 @@ func (v *Hey) syncEntries(entries []workspace.ActivityEntryInfo) {
 		}
 	}
 
-	addGroup("JUST NOW", justNow)
-	addGroup("1 HOUR AGO", hourAgo)
-	addGroup("TODAY", today)
-	addGroup("YESTERDAY", yesterday)
-	addGroup("OLDER", older)
+	addGroup("Just Now", justNow)
+	addGroup("1 Hour Ago", hourAgo)
+	addGroup("Today", today)
+	addGroup("Yesterday", yesterday)
+	addGroup("Older", older)
 
 	v.list.SetItems(items)
 }

--- a/internal/tui/workspace/views/home.go
+++ b/internal/tui/workspace/views/home.go
@@ -515,19 +515,19 @@ func (v *Home) rebuildList() {
 	var items []widget.ListItem
 
 	if len(v.recentItems) > 0 {
-		items = append(items, widget.ListItem{Title: "RECENTS", Header: true})
+		items = append(items, widget.ListItem{Title: "Recents", Header: true})
 		items = append(items, v.recentItems...)
 	}
 	if len(v.heyItems) > 0 {
-		items = append(items, widget.ListItem{Title: "HEY!", Header: true})
+		items = append(items, widget.ListItem{Title: "Hey!", Header: true})
 		items = append(items, v.heyItems...)
 	}
 	if len(v.assignItems) > 0 {
-		items = append(items, widget.ListItem{Title: "ASSIGNMENTS", Header: true})
+		items = append(items, widget.ListItem{Title: "Assignments", Header: true})
 		items = append(items, v.assignItems...)
 	}
 	if len(v.bookmarkItems) > 0 {
-		items = append(items, widget.ListItem{Title: "BOOKMARKS", Header: true})
+		items = append(items, widget.ListItem{Title: "Bookmarks", Header: true})
 		items = append(items, v.bookmarkItems...)
 	}
 
@@ -544,13 +544,13 @@ func (v *Home) openSelected() tea.Cmd {
 	// Section headers navigate to their corresponding full view
 	if item.Header {
 		switch item.Title {
-		case "RECENTS":
+		case "Recents":
 			return workspace.Navigate(workspace.ViewMyStuff, v.session.Scope())
-		case "HEY!":
+		case "Hey!":
 			return workspace.Navigate(workspace.ViewHey, v.session.Scope())
-		case "ASSIGNMENTS":
+		case "Assignments":
 			return workspace.Navigate(workspace.ViewAssignments, v.session.Scope())
-		case "BOOKMARKS":
+		case "Bookmarks":
 			return workspace.Navigate(workspace.ViewProjects, v.session.Scope())
 		}
 		return nil

--- a/internal/tui/workspace/views/timeline_shared.go
+++ b/internal/tui/workspace/views/timeline_shared.go
@@ -82,11 +82,11 @@ func syncTimelineEntries(
 		}
 	}
 
-	addGroup("JUST NOW", justNow)
-	addGroup("1 HOUR AGO", hourAgo)
-	addGroup("TODAY", today)
-	addGroup("YESTERDAY", yesterday)
-	addGroup("OLDER", older)
+	addGroup("Just Now", justNow)
+	addGroup("1 Hour Ago", hourAgo)
+	addGroup("Today", today)
+	addGroup("Yesterday", yesterday)
+	addGroup("Older", older)
 
 	list.SetItems(items)
 	return entryMeta

--- a/internal/tui/workspace/widget/preview.go
+++ b/internal/tui/workspace/widget/preview.go
@@ -98,13 +98,19 @@ func (p *Preview) View() string {
 			Render(p.title))
 	}
 
-	// Fields
+	// Fields — align keys by padding to the widest key
 	if len(p.fields) > 0 {
+		maxKeyWidth := 0
+		for _, f := range p.fields {
+			if w := lipgloss.Width(f.Key); w > maxKeyWidth {
+				maxKeyWidth = w
+			}
+		}
 		var fieldLines []string
-		keyStyle := lipgloss.NewStyle().Foreground(theme.Muted)
+		keyStyle := lipgloss.NewStyle().Foreground(theme.Muted).Width(maxKeyWidth + 1).Align(lipgloss.Right)
 		valStyle := lipgloss.NewStyle().Foreground(theme.Foreground)
 		for _, f := range p.fields {
-			line := keyStyle.Render(f.Key+": ") + valStyle.Render(f.Value)
+			line := keyStyle.Render(f.Key+":") + " " + valStyle.Render(f.Value)
 			fieldLines = append(fieldLines, lipgloss.NewStyle().MaxWidth(p.width).Render(line))
 		}
 		sections = append(sections, strings.Join(fieldLines, "\n"))


### PR DESCRIPTION
## Summary
- Section headers use title case ("Recents", "Hey!") instead of ALL-CAPS across home, hey, and timeline views
- Due dates render as "Today", "Tomorrow", "Yesterday", "Mon, Jan 2" instead of ISO format
- Toast gets background color and padding for visual contrast
- Preview fields right-align keys to the widest label for clean columnar layout

## Test plan
- [ ] `TestFormatDueDate` — today/tomorrow/yesterday/same-year/other-year/invalid all format correctly
- [ ] `TestDetail_SyncPreview_DueDateFormatted` — due date field in preview uses formatted value
- [ ] Visual: home screen headers show "Recents" not "RECENTS"
- [ ] Visual: toast has subtle background