### PR TITLE
Search excerpts and partial-failure surfacing

### DIFF
--- a/internal/tui/format/recording.go
+++ b/internal/tui/format/recording.go
@@ -21,7 +21,7 @@ type Recording struct {
 func (r Recording) ToPickerTitle() string {
 	title := r.Title
 	if title == "" {
-		title = truncate(stripHTML(r.Content), 50)
+		title = truncate(StripHTML(r.Content), 50)
 	}
 	if title == "" {
 		title = fmt.Sprintf("%s #%d", r.Type, r.ID)
@@ -114,8 +114,8 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
-// stripHTML removes HTML tags from a string (basic implementation).
-func stripHTML(s string) string {
+// StripHTML removes HTML tags from a string and normalizes whitespace.
+func StripHTML(s string) string {
 	var result strings.Builder
 	inTag := false
 	for _, c := range s {

--- a/internal/tui/workspace/msg.go
+++ b/internal/tui/workspace/msg.go
@@ -175,9 +175,10 @@ type MessageDetailLoadedMsg struct {
 
 // SearchResultsMsg is sent when search results arrive.
 type SearchResultsMsg struct {
-	Results []SearchResultInfo
-	Query   string
-	Err     error
+	Results    []SearchResultInfo
+	Query      string
+	Err        error
+	PartialErr error // non-nil when some accounts failed but results exist
 }
 
 // SearchResultInfo is a type alias for data.SearchResultInfo.

--- a/internal/tui/workspace/views/account_extra.go
+++ b/internal/tui/workspace/views/account_extra.go
@@ -23,7 +23,7 @@ func sessionAccounts(session *workspace.Session) []data.AccountInfo {
 // accountExtra prefixes extra with a 1-based account index when multi-account.
 // Returns extra unchanged when len(accounts) <= 1, accountID is not found,
 // or extra is empty. Never creates Extra where none existed — the list widget
-// suppresses Description whenever Extra is non-empty.
+// truncates Description to fit when Extra is also present.
 func accountExtra(accounts []data.AccountInfo, accountID, extra string) string {
 	if extra == "" || len(accounts) <= 1 {
 		return extra

--- a/internal/tui/workspace/widget/list.go
+++ b/internal/tui/workspace/widget/list.go
@@ -530,11 +530,21 @@ func (l *List) renderItem(item ListItem, selected bool, theme tui.Theme) string 
 		extraWidth := lipgloss.Width(extra)
 		gap := l.width - titleWidth - extraWidth
 		if gap > 1 {
-			line += strings.Repeat(" ", gap) + extra
+			// Fit description between title and extra when both are present.
+			// Reserve at least 2 chars of gap so extra always renders.
+			if item.Description != "" && gap > 4 {
+				maxDesc := gap - 3 // 1 leading space + 2 minimum gap
+				desc := " " + Truncate(item.Description, maxDesc)
+				line += descStyle.Render(desc)
+			}
+			gap = l.width - lipgloss.Width(line) - extraWidth
+			if gap > 0 {
+				line += strings.Repeat(" ", gap) + extra
+			}
 		}
 	}
 
-	// Add description inline (after title) to maintain 1-row-per-item invariant
+	// Add description inline (after title) when no extra badge
 	if item.Description != "" && item.Extra == "" {
 		desc := descStyle.Render(" " + item.Description)
 		if lipgloss.Width(line)+lipgloss.Width(desc) <= l.width {

--- a/internal/tui/workspace/widget/list_test.go
+++ b/internal/tui/workspace/widget/list_test.go
@@ -284,6 +284,33 @@ func TestList_ScrollIndicator_NoOverflow(t *testing.T) {
 	assert.LessOrEqual(t, len(lines), 10, "list view should not exceed widget height")
 }
 
+func TestList_DescriptionWithExtra_BothVisible(t *testing.T) {
+	l := NewList(tui.NewStyles())
+	l.SetSize(80, 10)
+	l.SetFocused(true)
+	l.SetItems([]ListItem{
+		{ID: "1", Title: "Fix login bug", Description: "The login form crashes", Extra: "Todo"},
+	})
+
+	view := l.View()
+	assert.Contains(t, view, "Fix login bug")
+	assert.Contains(t, view, "Todo", "Extra badge should be visible")
+	assert.Contains(t, view, "login form", "Description should be visible alongside Extra")
+}
+
+func TestList_DescriptionWithExtra_NarrowWidth(t *testing.T) {
+	l := NewList(tui.NewStyles())
+	l.SetSize(30, 10)
+	l.SetFocused(true)
+	l.SetItems([]ListItem{
+		{ID: "1", Title: "Short", Description: "Long description text here", Extra: "Badge"},
+	})
+
+	view := l.View()
+	assert.Contains(t, view, "Short")
+	assert.Contains(t, view, "Badge", "Extra should render even at narrow width")
+}
+
 func TestList_LongFilter_NoOverflow(t *testing.T) {
 	l := NewList(tui.NewStyles())
 	l.SetSize(40, 20)


### PR DESCRIPTION
## Summary
- Search results show content excerpts (from SDK `Content`/`Description` fields) as the list item description, with HTML stripped for clean display
- List widget now fits Description between title and Extra badge when both are present (previously Description was suppressed when Extra was set)
- Multi-account search collects per-account failures: partial failures show a toast with failed account names; total failures report a full error
- Excerpt truncation at 120 chars with "..." suffix

## Test plan
- [ ] `TestSearch_PartialFailure_ShowsToast` — partial failure produces StatusMsg with account name
- [ ] `TestSearch_PartialFailure_NoResults_ReportsFullError` — all-fail produces ErrorMsg
- [ ] `TestSearch_HandleResults_ExcerptAsDescription` — excerpt shown as description, fallback to project when no excerpt
- [ ] `TestTruncateExcerpt` — truncation and HTML stripping
- [ ] `TestStripBasicHTML` — tag removal