### PR TITLE
Detail view: inline loading, card editing, comment composer, message body editing

### DIFF
--- a/internal/tui/workspace/data/hub.go
+++ b/internal/tui/workspace/data/hub.go
@@ -952,6 +952,30 @@ func (h *Hub) ClearTodoAssignees(ctx context.Context, accountID string, projectI
 	return err
 }
 
+// ClearCardDueOn clears the due date on a card. Uses a raw Put to bypass
+// the SDK's omitempty on DueOn which prevents sending empty strings.
+func (h *Hub) ClearCardDueOn(ctx context.Context, accountID string, projectID, cardID int64) error {
+	client := h.multi.ClientFor(accountID)
+	if client == nil {
+		return fmt.Errorf("no client for account %s", accountID)
+	}
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d.json", projectID, cardID)
+	_, err := client.Put(ctx, path, map[string]any{"due_on": nil})
+	return err
+}
+
+// ClearCardAssignees clears all assignees on a card. Uses a raw Put to bypass
+// the SDK's omitempty on AssigneeIDs which prevents sending empty slices.
+func (h *Hub) ClearCardAssignees(ctx context.Context, accountID string, projectID, cardID int64) error {
+	client := h.multi.ClientFor(accountID)
+	if client == nil {
+		return fmt.Errorf("no client for account %s", accountID)
+	}
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d.json", projectID, cardID)
+	_, err := client.Put(ctx, path, map[string]any{"assignee_ids": []int64{}})
+	return err
+}
+
 // UpdateCard updates a card's fields.
 func (h *Hub) UpdateCard(ctx context.Context, accountID string, projectID, cardID int64, req *basecamp.UpdateCardRequest) error {
 	client := h.multi.ClientFor(accountID)
@@ -959,6 +983,16 @@ func (h *Hub) UpdateCard(ctx context.Context, accountID string, projectID, cardI
 		return fmt.Errorf("no client for account %s", accountID)
 	}
 	_, err := client.Cards().Update(ctx, projectID, cardID, req)
+	return err
+}
+
+// UpdateMessage updates a message's fields.
+func (h *Hub) UpdateMessage(ctx context.Context, accountID string, projectID, messageID int64, req *basecamp.UpdateMessageRequest) error {
+	client := h.multi.ClientFor(accountID)
+	if client == nil {
+		return fmt.Errorf("no client for account %s", accountID)
+	}
+	_, err := client.Messages().Update(ctx, projectID, messageID, req)
 	return err
 }
 


### PR DESCRIPTION
## Summary
- **Inline loading**: Full-screen spinner only on first load; reloads and comment posts show inline muted spinner at bottom of existing content. FocusMsg triggers re-fetch.
- **Card due dates + assign**: `D`, `a`, `A` keys now work for cards (not just todos). New Hub methods: `ClearCardDueOn`, `ClearCardAssignees`.
- **Comment editing with Composer**: Replace single-line textinput with full Composer in rich mode. `ctrl+enter` to save, `esc` to cancel.
- **Message body editing**: `e` on messages opens Composer pre-populated with body content. New Hub method: `UpdateMessage`.

## Test plan
- [ ] Open a todo detail, post a comment → content stays visible during post
- [ ] In card detail, press `D` → due date input appears
- [ ] Focus a comment, press `E` → full Composer opens (not single-line)
- [ ] In message detail, press `e` → Composer opens with message body
- [ ] `go test ./internal/tui/workspace/views/ -run Detail`