### PR TITLE
Open-in-browser from list views with full cross-account scope

### DIFF
--- a/internal/tui/workspace/view.go
+++ b/internal/tui/workspace/view.go
@@ -45,6 +45,22 @@ type Filterable interface {
 	StartFilter()
 }
 
+// FocusedItemScope holds the account/project/recording context of the
+// currently focused list item.  Zero-valued fields mean "unknown/same as
+// the session scope".
+type FocusedItemScope struct {
+	AccountID   string
+	ProjectID   int64
+	RecordingID int64
+}
+
+// FocusedRecording is an optional interface for views that can identify the
+// scope of the currently focused item. Used by open-in-browser to route
+// through the correct account/project.
+type FocusedRecording interface {
+	FocusedItem() FocusedItemScope
+}
+
 // SplitPaneFocuser is an optional interface for views that use a split-pane
 // layout with internal tab-cycling. When the sidebar is open, the workspace
 // routes tab to the view instead of consuming it for sidebar focus switching.

--- a/internal/tui/workspace/views/activity.go
+++ b/internal/tui/workspace/views/activity.go
@@ -61,6 +61,23 @@ func NewActivity(session *workspace.Session) *Activity {
 
 func (v *Activity) Title() string { return "Activity" }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Activity) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.RecordingID,
+	}
+}
+
 func (v *Activity) ShortHelp() []key.Binding {
 	if v.list.Filtering() {
 		return filterHints()

--- a/internal/tui/workspace/views/assignments.go
+++ b/internal/tui/workspace/views/assignments.go
@@ -76,6 +76,23 @@ func NewAssignments(session *workspace.Session) *Assignments {
 
 func (v *Assignments) Title() string { return "Assignments" }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Assignments) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.assignmentMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.ID,
+	}
+}
+
 func (v *Assignments) ShortHelp() []key.Binding {
 	if v.list.Filtering() {
 		return filterHints()

--- a/internal/tui/workspace/views/campfire.go
+++ b/internal/tui/workspace/views/campfire.go
@@ -827,6 +827,11 @@ func (v *Campfire) View() string {
 	)
 }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Campfire) FocusedItem() workspace.FocusedItemScope {
+	return workspace.FocusedItemScope{} // no single-item URL for chat stream
+}
+
 func (v *Campfire) updateLastID() {
 	for _, line := range v.lines {
 		if line.ID > v.lastID {

--- a/internal/tui/workspace/views/hey.go
+++ b/internal/tui/workspace/views/hey.go
@@ -80,6 +80,23 @@ func NewHey(session *workspace.Session) *Hey {
 
 func (v *Hey) Title() string { return "Hey!" }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Hey) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.ID,
+	}
+}
+
 func (v *Hey) ShortHelp() []key.Binding {
 	if v.list.Filtering() {
 		return filterHints()

--- a/internal/tui/workspace/views/messages.go
+++ b/internal/tui/workspace/views/messages.go
@@ -96,6 +96,16 @@ func (v *Messages) Title() string {
 	return "Message Board"
 }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Messages) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	id, _ := strconv.ParseInt(item.ID, 10, 64)
+	return workspace.FocusedItemScope{RecordingID: id}
+}
+
 // ShortHelp implements View.
 func (v *Messages) ShortHelp() []key.Binding {
 	if v.list.Filtering() {

--- a/internal/tui/workspace/views/pulse.go
+++ b/internal/tui/workspace/views/pulse.go
@@ -58,6 +58,23 @@ func NewPulse(session *workspace.Session) *Pulse {
 
 func (v *Pulse) Title() string { return "Pulse" }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Pulse) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.ID,
+	}
+}
+
 func (v *Pulse) ShortHelp() []key.Binding {
 	if v.list.Filtering() {
 		return filterHints()

--- a/internal/tui/workspace/views/search.go
+++ b/internal/tui/workspace/views/search.go
@@ -131,6 +131,23 @@ func (v *Search) InputActive() bool {
 // StartFilter implements workspace.Filterable.
 func (v *Search) StartFilter() { v.list.StartFilter() }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Search) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.resultMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.ID,
+	}
+}
+
 // ShortHelp implements View.
 func (v *Search) ShortHelp() []key.Binding {
 	if v.list.Filtering() {

--- a/internal/tui/workspace/views/timeline.go
+++ b/internal/tui/workspace/views/timeline.go
@@ -63,6 +63,23 @@ func NewTimeline(session *workspace.Session, projectID int64) *Timeline {
 
 func (v *Timeline) Title() string { return "Project Activity" }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Timeline) FocusedItem() workspace.FocusedItemScope {
+	item := v.list.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return workspace.FocusedItemScope{}
+	}
+	return workspace.FocusedItemScope{
+		AccountID:   meta.AccountID,
+		ProjectID:   meta.ProjectID,
+		RecordingID: meta.RecordingID,
+	}
+}
+
 func (v *Timeline) ShortHelp() []key.Binding {
 	if v.list.Filtering() {
 		return filterHints()

--- a/internal/tui/workspace/views/todos.go
+++ b/internal/tui/workspace/views/todos.go
@@ -283,6 +283,20 @@ func (v *Todos) IsModal() bool {
 	return v.editingDesc || v.settingDue || v.assigning || v.creatingList || v.renamingList
 }
 
+// FocusedItem implements workspace.FocusedRecording.
+func (v *Todos) FocusedItem() workspace.FocusedItemScope {
+	if v.focus != todosPaneRight {
+		return workspace.FocusedItemScope{}
+	}
+	item := v.listTodos.Selected()
+	if item == nil {
+		return workspace.FocusedItemScope{}
+	}
+	var id int64
+	fmt.Sscanf(item.ID, "%d", &id)
+	return workspace.FocusedItemScope{RecordingID: id}
+}
+
 // ShortHelp implements View.
 func (v *Todos) ShortHelp() []key.Binding {
 	if v.listLists.Filtering() || v.listTodos.Filtering() {

--- a/internal/tui/workspace/workspace.go
+++ b/internal/tui/workspace/workspace.go
@@ -69,6 +69,7 @@ type Workspace struct {
 
 	// ViewFactory builds views from targets — set by the command that creates the workspace.
 	viewFactory ViewFactory
+	openFunc    func(Scope) tea.Cmd
 
 	width, height int
 }
@@ -107,6 +108,7 @@ func New(session *Session, factory ViewFactory) *Workspace {
 		quickJump:       chrome.NewQuickJump(styles),
 		boostPicker:     NewBoostPicker(styles),
 		viewFactory:     factory,
+		openFunc:        openInBrowser,
 		sidebarTargets:  []ViewTarget{ViewActivity, ViewHome},
 		sidebarIndex:    -1,
 		sidebarRatio:    0.30,
@@ -559,7 +561,20 @@ func (w *Workspace) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return w.navigate(ViewActivity, w.session.Scope())
 
 	case key.Matches(msg, w.keys.Open):
-		return openInBrowser(w.session.Scope())
+		scope := w.session.Scope()
+		if fr, ok := w.router.Current().(FocusedRecording); ok {
+			fi := fr.FocusedItem()
+			if fi.RecordingID != 0 {
+				scope.RecordingID = fi.RecordingID
+			}
+			if fi.ProjectID != 0 {
+				scope.ProjectID = fi.ProjectID
+			}
+			if fi.AccountID != "" {
+				scope.AccountID = fi.AccountID
+			}
+		}
+		return w.openFunc(scope)
 
 	case key.Matches(msg, w.keys.Sidebar):
 		return w.toggleSidebar()

--- a/internal/tui/workspace/workspace_test.go
+++ b/internal/tui/workspace/workspace_test.go
@@ -1461,3 +1461,103 @@ func TestHumanizeError_Truncation(t *testing.T) {
 	assert.Len(t, got, 80, "long errors should be truncated to 80 chars")
 	assert.True(t, strings.HasSuffix(got, "..."))
 }
+
+// testFocusedView satisfies View and FocusedRecording for open-in-browser tests.
+type testFocusedView struct {
+	testView
+	focused FocusedItemScope
+}
+
+func (v *testFocusedView) FocusedItem() FocusedItemScope { return v.focused }
+
+func TestWorkspace_OpenInBrowser_UsesFocusedItemScope(t *testing.T) {
+	session := testSessionWithContext("default-acct", "Default")
+	session.SetScope(Scope{AccountID: "default-acct", ProjectID: 1})
+	w := testWorkspaceWithSession(session)
+
+	// Capture the scope that openFunc receives.
+	var captured Scope
+	w.openFunc = func(scope Scope) tea.Cmd {
+		captured = scope
+		return func() tea.Msg { return StatusMsg{Text: "spy"} }
+	}
+
+	// Push a view that implements FocusedRecording with cross-account context.
+	fv := &testFocusedView{
+		testView: testView{title: "Search"},
+		focused: FocusedItemScope{
+			AccountID:   "x-acct",
+			ProjectID:   42,
+			RecordingID: 100,
+		},
+	}
+	w.router.Push(fv, Scope{}, 0)
+	w.syncChrome()
+
+	// Press 'o' to trigger open-in-browser.
+	w.handleKey(keyMsg("o"))
+
+	// The scope passed to openFunc should merge focused item values
+	// over the session scope.
+	assert.Equal(t, "x-acct", captured.AccountID,
+		"AccountID should come from FocusedItem, not session")
+	assert.Equal(t, int64(42), captured.ProjectID,
+		"ProjectID should come from FocusedItem, not session")
+	assert.Equal(t, int64(100), captured.RecordingID,
+		"RecordingID should come from FocusedItem")
+}
+
+func TestWorkspace_OpenInBrowser_FallsBackToSessionScope(t *testing.T) {
+	session := testSessionWithContext("sess-acct", "Session")
+	session.SetScope(Scope{AccountID: "sess-acct", ProjectID: 7})
+	w := testWorkspaceWithSession(session)
+
+	var captured Scope
+	w.openFunc = func(scope Scope) tea.Cmd {
+		captured = scope
+		return func() tea.Msg { return StatusMsg{Text: "spy"} }
+	}
+
+	// Push a plain testView (does NOT implement FocusedRecording).
+	pushTestView(w, "Campfire")
+
+	w.handleKey(keyMsg("o"))
+
+	// Without FocusedRecording, the session scope should pass through unchanged.
+	assert.Equal(t, "sess-acct", captured.AccountID,
+		"AccountID should fall back to session scope")
+	assert.Equal(t, int64(7), captured.ProjectID,
+		"ProjectID should fall back to session scope")
+	assert.Equal(t, int64(0), captured.RecordingID,
+		"RecordingID should be zero when no focused item")
+}
+
+func TestWorkspace_OpenInBrowser_PartialFocusedOverride(t *testing.T) {
+	session := testSessionWithContext("sess-acct", "Session")
+	session.SetScope(Scope{AccountID: "sess-acct", ProjectID: 7})
+	w := testWorkspaceWithSession(session)
+
+	var captured Scope
+	w.openFunc = func(scope Scope) tea.Cmd {
+		captured = scope
+		return func() tea.Msg { return StatusMsg{Text: "spy"} }
+	}
+
+	// Focused item only has RecordingID — AccountID and ProjectID stay zero,
+	// so the session values should be preserved.
+	fv := &testFocusedView{
+		testView: testView{title: "Todos"},
+		focused:  FocusedItemScope{RecordingID: 55},
+	}
+	w.router.Push(fv, Scope{}, 0)
+	w.syncChrome()
+
+	w.handleKey(keyMsg("o"))
+
+	assert.Equal(t, "sess-acct", captured.AccountID,
+		"AccountID should stay from session when focused has empty string")
+	assert.Equal(t, int64(7), captured.ProjectID,
+		"ProjectID should stay from session when focused has zero")
+	assert.Equal(t, int64(55), captured.RecordingID,
+		"RecordingID should come from focused item")
+}


### PR DESCRIPTION
## Summary
- New \`FocusedItemScope\` struct carries AccountID, ProjectID, RecordingID from the focused list item
- \`FocusedRecording\` interface: \`FocusedItem() FocusedItemScope\` (replaces recording-ID-only approach)
- Workspace \`o\` handler merges all non-zero fields into scope before building URL
- Implemented on 9 views: assignments, hey, pulse, activity, timeline, search, messages, todos, campfire

Previously, pressing \`o\` from global views (Hey!, Assignments, etc.) opened the account/project root instead of the focused item because only the recording ID was passed without account/project context.

## Test plan
- [ ] In Assignments list, press \`o\` → opens the specific todo in browser
- [ ] In Hey! list, press \`o\` → opens the correct recording URL
- [ ] In project-scoped Todos, press \`o\` → opens the focused todo