### PR TITLE
Boost from Hey!, Assignments, and Pulse with cross-account routing

### DIFF
--- a/internal/tui/workspace/data/hub.go
+++ b/internal/tui/workspace/data/hub.go
@@ -829,9 +829,18 @@ func (h *Hub) Boosts(projectID, recordingID int64) *Pool[BoostSummary] {
 }
 
 // CreateBoost creates a new boost on a recording.
+// accountID selects which account's client to use; empty means the Hub's current account.
 // Returns the created BoostInfo or an error.
-func (h *Hub) CreateBoost(ctx context.Context, projectID, recordingID int64, content string) (BoostInfo, error) {
-	client := h.accountClient()
+func (h *Hub) CreateBoost(ctx context.Context, accountID string, projectID, recordingID int64, content string) (BoostInfo, error) {
+	var client *basecamp.AccountClient
+	if accountID != "" {
+		client = h.multi.ClientFor(accountID)
+		if client == nil {
+			return BoostInfo{}, fmt.Errorf("no client for account %s", accountID)
+		}
+	} else {
+		client = h.accountClient()
+	}
 	boost, err := client.Boosts().CreateRecording(ctx, projectID, recordingID, content)
 	if err != nil {
 		return BoostInfo{}, err

--- a/internal/tui/workspace/msg.go
+++ b/internal/tui/workspace/msg.go
@@ -312,6 +312,7 @@ func SetStatus(text string, isError bool) tea.Cmd {
 type BoostTarget struct {
 	ProjectID   int64
 	RecordingID int64
+	AccountID   string
 	Title       string // brief context for the picker UI
 }
 

--- a/internal/tui/workspace/views/assignments.go
+++ b/internal/tui/workspace/views/assignments.go
@@ -101,6 +101,7 @@ func (v *Assignments) ShortHelp() []key.Binding {
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
 		key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "complete")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 		key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "trash")),
 	}
 }
@@ -213,6 +214,8 @@ func (v *Assignments) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "x":
 				return v, v.completeSelected()
+			case "b", "B":
+				return v, v.boostSelected()
 			case "t":
 				return v, v.trashSelected()
 			}
@@ -301,10 +304,10 @@ func (v *Assignments) syncAssignments(assignments []workspace.AssignmentInfo) {
 		}
 	}
 
-	addGroup("OVERDUE", overdue)
-	addGroup("THIS WEEK", thisWeek)
-	addGroup("LATER", later)
-	addGroup("NO DUE DATE", noDue)
+	addGroup("Overdue", overdue)
+	addGroup("This Week", thisWeek)
+	addGroup("Later", later)
+	addGroup("No Due Date", noDue)
 
 	v.list.SetItems(items)
 }
@@ -385,4 +388,25 @@ func (v *Assignments) trashSelected() tea.Cmd {
 		workspace.SetStatus("Press t again to trash", false),
 		tea.Tick(3*time.Second, func(time.Time) tea.Msg { return assignmentTrashTimeoutMsg{} }),
 	)
+}
+
+func (v *Assignments) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.assignmentMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Content,
+			},
+		}
+	}
 }

--- a/internal/tui/workspace/views/hey.go
+++ b/internal/tui/workspace/views/hey.go
@@ -105,6 +105,7 @@ func (v *Hey) ShortHelp() []key.Binding {
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
 		key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "complete")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 		key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "trash")),
 	}
 }
@@ -236,6 +237,8 @@ func (v *Hey) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "x":
 				return v, v.completeSelected()
+			case "b", "B":
+				return v, v.boostSelected()
 			case "t":
 				return v, v.trashSelected()
 			}
@@ -402,6 +405,27 @@ func (v *Hey) trashSelected() tea.Cmd {
 		workspace.SetStatus("Press t again to trash", false),
 		tea.Tick(3*time.Second, func(time.Time) tea.Msg { return heyTrashTimeoutMsg{} }),
 	)
+}
+
+func (v *Hey) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Title,
+			},
+		}
+	}
 }
 
 func (v *Hey) schedulePoll() tea.Cmd {

--- a/internal/tui/workspace/views/pulse.go
+++ b/internal/tui/workspace/views/pulse.go
@@ -82,6 +82,7 @@ func (v *Pulse) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 	}
 }
 
@@ -155,6 +156,12 @@ func (v *Pulse) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if v.loading {
 			return v, nil
+		}
+		if !v.list.Filtering() {
+			switch msg.String() {
+			case "b", "B":
+				return v, v.boostSelected()
+			}
 		}
 		keys := workspace.DefaultListKeyMap()
 		switch {
@@ -252,4 +259,25 @@ func (v *Pulse) openSelected() tea.Cmd {
 	scope.OriginView = "Pulse"
 	scope.OriginHint = meta.Creator + " · " + meta.Type
 	return workspace.Navigate(workspace.ViewDetail, scope)
+}
+
+func (v *Pulse) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Title,
+			},
+		}
+	}
 }

--- a/internal/tui/workspace/workspace.go
+++ b/internal/tui/workspace/workspace.go
@@ -71,6 +71,10 @@ type Workspace struct {
 	viewFactory ViewFactory
 	openFunc    func(Scope) tea.Cmd
 
+	// createBoostFunc is the function called to create a boost. Defaults to
+	// createBoost; tests can replace it with a spy.
+	createBoostFunc func(BoostTarget, string) tea.Cmd
+
 	width, height int
 }
 
@@ -113,6 +117,7 @@ func New(session *Session, factory ViewFactory) *Workspace {
 		sidebarIndex:    -1,
 		sidebarRatio:    0.30,
 	}
+	w.createBoostFunc = w.createBoost
 
 	// Metrics panel reads live stats from the Hub's metrics collector.
 	if hub := session.Hub(); hub != nil {
@@ -258,7 +263,7 @@ func (w *Workspace) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case BoostSelectedMsg:
 		w.pickingBoost = false
 		w.boostPicker.Blur()
-		return w, w.createBoost(w.boostTarget, msg.Emoji)
+		return w, w.createBoostFunc(w.boostTarget, msg.Emoji)
 
 	case OpenBoostPickerMsg:
 		w.pickingBoost = true
@@ -1289,7 +1294,7 @@ func isAuthError(err error) bool {
 func (w *Workspace) createBoost(target BoostTarget, emoji string) tea.Cmd {
 	return func() tea.Msg {
 		ctx := w.session.Hub().ProjectContext()
-		_, err := w.session.Hub().CreateBoost(ctx, target.ProjectID, target.RecordingID, emoji)
+		_, err := w.session.Hub().CreateBoost(ctx, target.AccountID, target.ProjectID, target.RecordingID, emoji)
 		if err != nil {
 			return ErrorMsg{Err: err, Context: "creating boost"}
 		}

--- a/internal/tui/workspace/workspace_test.go
+++ b/internal/tui/workspace/workspace_test.go
@@ -73,6 +73,7 @@ func testWorkspace() (w *Workspace, viewLog *[]*testView) {
 		help:            chrome.NewHelp(styles),
 		palette:         chrome.NewPalette(styles),
 		accountSwitcher: chrome.NewAccountSwitcher(styles),
+		boostPicker:     NewBoostPicker(styles),
 		viewFactory:     factory,
 		sidebarTargets:  []ViewTarget{ViewActivity, ViewHome},
 		sidebarIndex:    -1,
@@ -483,6 +484,7 @@ func testWorkspaceWithSession(session *Session) *Workspace {
 		help:            chrome.NewHelp(styles),
 		palette:         chrome.NewPalette(styles),
 		accountSwitcher: chrome.NewAccountSwitcher(styles),
+		boostPicker:     NewBoostPicker(styles),
 		viewFactory: func(target ViewTarget, _ *Session, scope Scope) View {
 			return &testView{title: targetName(target)}
 		},
@@ -1072,6 +1074,7 @@ func TestWorkspace_Navigate_ViewScopeRetainsOrigin(t *testing.T) {
 		help:            chrome.NewHelp(styles),
 		palette:         chrome.NewPalette(styles),
 		accountSwitcher: chrome.NewAccountSwitcher(styles),
+		boostPicker:     NewBoostPicker(styles),
 		viewFactory:     factory,
 		sidebarTargets:  []ViewTarget{ViewActivity, ViewHome},
 		sidebarIndex:    -1,
@@ -1115,6 +1118,7 @@ func TestWorkspace_OriginDoesNotLeakAcrossNavigations(t *testing.T) {
 		help:            chrome.NewHelp(styles),
 		palette:         chrome.NewPalette(styles),
 		accountSwitcher: chrome.NewAccountSwitcher(styles),
+		boostPicker:     NewBoostPicker(styles),
 		viewFactory:     factory,
 		sidebarTargets:  []ViewTarget{ViewActivity, ViewHome},
 		sidebarIndex:    -1,
@@ -1460,6 +1464,82 @@ func TestHumanizeError_Truncation(t *testing.T) {
 	got := humanizeError(fmt.Errorf("%s", long))
 	assert.Len(t, got, 80, "long errors should be truncated to 80 chars")
 	assert.True(t, strings.HasSuffix(got, "..."))
+}
+
+func TestWorkspace_BoostTarget_PreservesAccountID(t *testing.T) {
+	session := testSessionWithContext("default-acct", "Default")
+	w := testWorkspaceWithSession(session)
+	pushTestView(w, "Hey!")
+
+	target := BoostTarget{
+		AccountID:   "cross-acct",
+		ProjectID:   42,
+		RecordingID: 100,
+		Title:       "Some todo",
+	}
+
+	// OpenBoostPickerMsg stores the target and arms the picker.
+	w.Update(OpenBoostPickerMsg{Target: target})
+
+	assert.True(t, w.pickingBoost, "picker should be armed")
+	assert.Equal(t, "cross-acct", w.boostTarget.AccountID,
+		"boostTarget must preserve the cross-account AccountID")
+	assert.Equal(t, int64(42), w.boostTarget.ProjectID,
+		"boostTarget must preserve ProjectID")
+	assert.Equal(t, int64(100), w.boostTarget.RecordingID,
+		"boostTarget must preserve RecordingID")
+}
+
+func TestWorkspace_BoostEmoji_PassesCrossAccountTarget(t *testing.T) {
+	session := testSessionWithContext("default-acct", "Default")
+	w := testWorkspaceWithSession(session)
+	pushTestView(w, "Pulse")
+
+	// Spy on createBoostFunc to capture the target and emoji.
+	var capturedTarget BoostTarget
+	var capturedEmoji string
+	w.createBoostFunc = func(target BoostTarget, emoji string) tea.Cmd {
+		capturedTarget = target
+		capturedEmoji = emoji
+		return nil
+	}
+
+	// Arm the picker with a cross-account target.
+	w.Update(OpenBoostPickerMsg{Target: BoostTarget{
+		AccountID:   "other-acct",
+		ProjectID:   99,
+		RecordingID: 200,
+		Title:       "Design doc",
+	}})
+	require.True(t, w.pickingBoost)
+
+	// Simulate emoji selection — this calls createBoostFunc(w.boostTarget, emoji).
+	w.Update(BoostSelectedMsg{Emoji: "🎉"})
+
+	assert.False(t, w.pickingBoost, "picker should be disarmed after selection")
+	assert.Equal(t, "🎉", capturedEmoji)
+	assert.Equal(t, "other-acct", capturedTarget.AccountID,
+		"createBoost must receive the cross-account AccountID")
+	assert.Equal(t, int64(99), capturedTarget.ProjectID)
+	assert.Equal(t, int64(200), capturedTarget.RecordingID)
+}
+
+func TestWorkspace_BoostPickerDismiss_ClearsState(t *testing.T) {
+	w, _ := testWorkspace()
+	pushTestView(w, "Todos")
+
+	target := BoostTarget{
+		AccountID:   "acct-1",
+		ProjectID:   10,
+		RecordingID: 50,
+	}
+	w.Update(OpenBoostPickerMsg{Target: target})
+	require.True(t, w.pickingBoost)
+
+	// Pressing Esc while the picker is open should dismiss it.
+	w.handleKey(keyMsg("esc"))
+
+	assert.False(t, w.pickingBoost, "Esc should dismiss the boost picker")
 }
 
 // testFocusedView satisfies View and FocusedRecording for open-in-browser tests.


### PR DESCRIPTION
## Summary
- Add \`b\`/\`B\` key to Hey!, Assignments, and Pulse views with full scope in \`OpenBoostPickerMsg\`
- \`BoostTarget\` gains \`AccountID\` field
- \`Hub.CreateBoost\` now accepts \`accountID\` and routes through \`multi.ClientFor()\` when non-empty, falling back to the current account client otherwise

This fixes cross-account boosting where items from a different account would silently hit the wrong API endpoint.

> Stacked on #151 (uses \`FocusedItemScope\` in the same views)

## Test plan
- [ ] In Hey! view, press \`b\` on a todo → boost picker opens with correct recording ID
- [ ] Boost an item from a different account → no API error
- [ ] ShortHelp in Hey!/Assignments/Pulse shows \`b boost\`