### PR TITLE
Data freshness: poll intervals and mutation rollback notification

### DIFF
--- a/internal/tui/workspace/data/hub_global.go
+++ b/internal/tui/workspace/data/hub_global.go
@@ -42,7 +42,7 @@ func (h *Hub) HeyActivity() *Pool[[]ActivityEntryInfo] {
 		return NewPool("hey:activity", PoolConfig{
 			FreshTTL: 30 * time.Second,
 			StaleTTL: 5 * time.Minute,
-			PollBase: 30 * time.Second,
+			PollBase: 45 * time.Second,
 			PollBg:   2 * time.Minute,
 			PollMax:  5 * time.Minute,
 		}, func(ctx context.Context) ([]ActivityEntryInfo, error) {
@@ -96,6 +96,7 @@ func (h *Hub) Pulse() *Pool[[]ActivityEntryInfo] {
 		return NewPool("pulse", PoolConfig{
 			FreshTTL: 30 * time.Second,
 			StaleTTL: 5 * time.Minute,
+			PollBase: 60 * time.Second,
 		}, func(ctx context.Context) ([]ActivityEntryInfo, error) {
 			types := []basecamp.RecordingType{
 				basecamp.RecordingTypeMessage,
@@ -138,6 +139,7 @@ func (h *Hub) Assignments() *Pool[[]AssignmentInfo] {
 		return NewPool("assignments", PoolConfig{
 			FreshTTL: 30 * time.Second,
 			StaleTTL: 5 * time.Minute,
+			PollBase: 60 * time.Second,
 		}, func(ctx context.Context) ([]AssignmentInfo, error) {
 			identity := h.multi.Identity()
 			if identity == nil {
@@ -191,6 +193,7 @@ func (h *Hub) PingRooms() *Pool[[]PingRoomInfo] {
 		return NewPool("ping-rooms", PoolConfig{
 			FreshTTL: 1 * time.Minute,
 			StaleTTL: 5 * time.Minute,
+			PollBase: 60 * time.Second,
 		}, func(ctx context.Context) ([]PingRoomInfo, error) {
 			accounts := h.multi.Accounts()
 			if len(accounts) == 0 {
@@ -265,7 +268,7 @@ func (h *Hub) Timeline() *Pool[[]TimelineEventInfo] {
 		return NewPool("timeline", PoolConfig{
 			FreshTTL: 30 * time.Second,
 			StaleTTL: 5 * time.Minute,
-			PollBase: 30 * time.Second,
+			PollBase: 45 * time.Second,
 			PollBg:   2 * time.Minute,
 			PollMax:  5 * time.Minute,
 		}, func(ctx context.Context) ([]TimelineEventInfo, error) {
@@ -430,6 +433,7 @@ func (h *Hub) Projects() *Pool[[]ProjectInfo] {
 		return NewPool("projects", PoolConfig{
 			FreshTTL: 30 * time.Second,
 			StaleTTL: 5 * time.Minute,
+			PollBase: 120 * time.Second,
 		}, func(ctx context.Context) ([]ProjectInfo, error) {
 			accounts := h.multi.Accounts()
 			if len(accounts) == 0 {

--- a/internal/tui/workspace/data/mutation.go
+++ b/internal/tui/workspace/data/mutation.go
@@ -86,7 +86,10 @@ func (mp *MutatingPool[T]) Apply(ctx context.Context, mutation Mutation[T]) tea.
 	return func() tea.Msg {
 		if err := mutation.ApplyRemotely(ctx); err != nil {
 			mp.rollback(gen, mid)
-			return MutationErrorMsg{Key: key, Err: err}
+			return tea.BatchMsg{
+				func() tea.Msg { return MutationErrorMsg{Key: key, Err: err} },
+				func() tea.Msg { return PoolUpdatedMsg{Key: key} },
+			}
 		}
 
 		remoteData, err := fetchFn(ctx)


### PR DESCRIPTION
## Summary
- **Poll intervals**: Add PollBase to Assignments (60s), Projects (120s), PingRooms (60s), Pulse (60s) — these pools previously never auto-refreshed. Fix Hey/Timeline where PollBase == FreshTTL (both 30s) by bumping PollBase to 45s.
- **Mutation rollback**: Emit \`PoolUpdatedMsg\` alongside \`MutationErrorMsg\` on rollback so views re-read the corrected (rolled-back) state instead of showing ghost items.

## Test plan
- [ ] Assignments auto-refresh after 60s
- [ ] Create a todo, simulate failure → ghost item disappears
- [ ] \`go test ./internal/tui/workspace/data/ -run Mutation\`