### PR TITLE
Boost from Hey!, Assignments, and Pulse with cross-account routing

### DIFF
--- a/internal/tui/workspace/data/hub.go
+++ b/internal/tui/workspace/data/hub.go
@@ -829,9 +829,18 @@ func (h *Hub) Boosts(projectID, recordingID int64) *Pool[BoostSummary] {
 }
 
 // CreateBoost creates a new boost on a recording.
+// accountID selects which account's client to use; empty means the Hub's current account.
 // Returns the created BoostInfo or an error.
-func (h *Hub) CreateBoost(ctx context.Context, projectID, recordingID int64, content string) (BoostInfo, error) {
-	client := h.accountClient()
+func (h *Hub) CreateBoost(ctx context.Context, accountID string, projectID, recordingID int64, content string) (BoostInfo, error) {
+	var client *basecamp.AccountClient
+	if accountID != "" {
+		client = h.multi.ClientFor(accountID)
+		if client == nil {
+			return BoostInfo{}, fmt.Errorf("no client for account %s", accountID)
+		}
+	} else {
+		client = h.accountClient()
+	}
 	boost, err := client.Boosts().CreateRecording(ctx, projectID, recordingID, content)
 	if err != nil {
 		return BoostInfo{}, err

--- a/internal/tui/workspace/msg.go
+++ b/internal/tui/workspace/msg.go
@@ -312,6 +312,7 @@ func SetStatus(text string, isError bool) tea.Cmd {
 type BoostTarget struct {
 	ProjectID   int64
 	RecordingID int64
+	AccountID   string
 	Title       string // brief context for the picker UI
 }
 

--- a/internal/tui/workspace/views/assignments.go
+++ b/internal/tui/workspace/views/assignments.go
@@ -101,6 +101,7 @@ func (v *Assignments) ShortHelp() []key.Binding {
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
 		key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "complete")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 		key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "trash")),
 	}
 }
@@ -213,6 +214,8 @@ func (v *Assignments) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "x":
 				return v, v.completeSelected()
+			case "b", "B":
+				return v, v.boostSelected()
 			case "t":
 				return v, v.trashSelected()
 			}
@@ -385,4 +388,25 @@ func (v *Assignments) trashSelected() tea.Cmd {
 		workspace.SetStatus("Press t again to trash", false),
 		tea.Tick(3*time.Second, func(time.Time) tea.Msg { return assignmentTrashTimeoutMsg{} }),
 	)
+}
+
+func (v *Assignments) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.assignmentMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Content,
+			},
+		}
+	}
 }

--- a/internal/tui/workspace/views/hey.go
+++ b/internal/tui/workspace/views/hey.go
@@ -105,6 +105,7 @@ func (v *Hey) ShortHelp() []key.Binding {
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
 		key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "complete")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 		key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "trash")),
 	}
 }
@@ -236,6 +237,8 @@ func (v *Hey) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "x":
 				return v, v.completeSelected()
+			case "b", "B":
+				return v, v.boostSelected()
 			case "t":
 				return v, v.trashSelected()
 			}
@@ -402,6 +405,27 @@ func (v *Hey) trashSelected() tea.Cmd {
 		workspace.SetStatus("Press t again to trash", false),
 		tea.Tick(3*time.Second, func(time.Time) tea.Msg { return heyTrashTimeoutMsg{} }),
 	)
+}
+
+func (v *Hey) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Title,
+			},
+		}
+	}
 }
 
 func (v *Hey) schedulePoll() tea.Cmd {

--- a/internal/tui/workspace/views/pulse.go
+++ b/internal/tui/workspace/views/pulse.go
@@ -82,6 +82,7 @@ func (v *Pulse) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("j/k"), key.WithHelp("j/k", "navigate")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "boost")),
 	}
 }
 
@@ -155,6 +156,12 @@ func (v *Pulse) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if v.loading {
 			return v, nil
+		}
+		if !v.list.Filtering() {
+			switch msg.String() {
+			case "b", "B":
+				return v, v.boostSelected()
+			}
 		}
 		keys := workspace.DefaultListKeyMap()
 		switch {
@@ -252,4 +259,25 @@ func (v *Pulse) openSelected() tea.Cmd {
 	scope.OriginView = "Pulse"
 	scope.OriginHint = meta.Creator + " · " + meta.Type
 	return workspace.Navigate(workspace.ViewDetail, scope)
+}
+
+func (v *Pulse) boostSelected() tea.Cmd {
+	item := v.list.Selected()
+	if item == nil {
+		return nil
+	}
+	meta, ok := v.entryMeta[item.ID]
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		return workspace.OpenBoostPickerMsg{
+			Target: workspace.BoostTarget{
+				ProjectID:   meta.ProjectID,
+				RecordingID: meta.ID,
+				AccountID:   meta.AccountID,
+				Title:       meta.Title,
+			},
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add `b`/`B` boost key to Hey!, Assignments, and Pulse views (matching existing Todos/Messages/Cards pattern)
- Add `AccountID` to `BoostTarget` for cross-account boost routing
- `Hub.CreateBoost` uses `ClientFor(accountID)` when target is from a different account
- Error on nil client when account lookup fails

## Test plan
- `TestWorkspace_BoostTarget_PreservesAccountID` — OpenBoostPickerMsg stores cross-account target
- `TestWorkspace_BoostEmoji_PassesCrossAccountTarget` — createBoostFunc spy verifies account-aware routing
- `TestWorkspace_BoostPickerDismiss_ClearsState` — Esc dismisses picker