### PR TITLE
Switch to GitHub-native release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,25 +68,8 @@ signs:
     output: true
 
 changelog:
-  sort: asc
-  use: github
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      - '^ci:'
-      - '^chore:'
-      - Merge pull request
-      - Merge branch
-  groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
-      order: 0
-    - title: Bug Fixes
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
-      order: 1
-    - title: Other
-      order: 999
+  # Use GitHub's auto-generated release notes (categories configured in .github/release.yml)
+  use: github-native
 
 release:
   github:


### PR DESCRIPTION
## Summary

- Add `.github/release.yml` to categorize PRs by label (Features, Bug Fixes, Documentation) and exclude dependabot
- Switch goreleaser to `github-native` changelog for PR links, @mentions, and contributor sections

v0.1.1 used goreleaser's commit-based changelog which dumped everything into "Other". This switches to GitHub's auto-generated release notes so future releases look like [gh CLI's](https://github.com/cli/cli/releases/tag/v2.87.0).

## Test plan

- [x] Next release tag produces GitHub-native changelog with PR categories