### PR TITLE
Prep for v0.2.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
     name: Release
     needs: [test, security]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GOPRIVATE: github.com/basecamp/basecamp-sdk
     steps:


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 30` to the release job — Docker buildx with QEMU can hang; the default GitHub Actions timeout is 6 hours
- Label unreleased PRs for proper changelog categorization: #132, #160, #161 → `enhancement`; #162 → `bug`

## Test plan

- [x] CI passes
- [x] Labels visible on PRs #132, #160, #161, #162