### PR TITLE
Remove Docker release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  packages: write  # Required for Docker push to ghcr.io
   id-token: write  # Required for keyless cosign signing via OIDC
   security-events: write  # Required for SARIF upload in security scan
   pull-requests: read
@@ -100,7 +99,7 @@ jobs:
     name: Release
     needs: [test, security]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       GOPRIVATE: github.com/basecamp/basecamp-sdk
     steps:
@@ -162,19 +161,6 @@ jobs:
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@17ae1740179002c89186b61233e0f892c3118b11 # v0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build changelog context
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -129,27 +129,3 @@ release:
 #     description: "Command-line interface for Basecamp"
 #     license: MIT
 #     skip_upload: auto
-
-# Docker multi-arch images
-# Uses Dockerfile.goreleaser which copies the pre-built binary (avoids private SDK auth issues)
-dockers_v2:
-  - id: basecamp
-    ids: [basecamp]
-    dockerfile: Dockerfile.goreleaser
-    images:
-      - "ghcr.io/basecamp/cli"
-    tags:
-      - "{{ .Version }}"
-      - "{{ if not .Prerelease }}latest{{ end }}"
-    platforms:
-      - linux/amd64
-      - linux/arm64
-    labels:
-      "org.opencontainers.image.title": "basecamp"
-      "org.opencontainers.image.description": "Command-line interface for Basecamp"
-      "org.opencontainers.image.url": "https://github.com/basecamp/basecamp-cli"
-      "org.opencontainers.image.source": "https://github.com/basecamp/basecamp-cli"
-      "org.opencontainers.image.version": "{{ .Version }}"
-      "org.opencontainers.image.revision": "{{ .Commit }}"
-      "org.opencontainers.image.created": "{{ .Date }}"
-      "org.opencontainers.image.licenses": "MIT"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,0 @@
-# Minimal Dockerfile for GoReleaser (dockers_v2)
-# GoReleaser builds the binary with proper auth, then copies it here
-FROM gcr.io/distroless/static-debian12:nonroot
-ARG TARGETPLATFORM
-COPY ${TARGETPLATFORM}/basecamp /basecamp
-USER nonroot:nonroot
-ENTRYPOINT ["/basecamp"]


### PR DESCRIPTION
## What

Remove Docker multi-arch image builds from the release pipeline.

## Why

The CLI is a statically-linked Go binary (`CGO_ENABLED=0`) with zero runtime dependencies, cross-compiled for 10 OS/arch targets. Docker adds no value for an interactive CLI that requires browser OAuth, system keyring access, and shell integration — none of which work in a container.

QEMU multi-arch builds were the slowest part of the release pipeline (the `timeout-minutes: 30` existed because of QEMU hangs). Release job timeout reduced to 15 minutes.

**Removed:**
- `Dockerfile.goreleaser`
- `dockers_v2` section from `.goreleaser.yaml`
- QEMU, Docker Buildx, and GHCR login steps from `release.yml`
- `packages: write` permission (was only needed for GHCR push)

## Testing

- [x] `goreleaser check` passes
- [x] No stale Docker/GHCR references in release config