### PR TITLE
Fix AI labeler no-op relabeling noise

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -85,10 +85,16 @@ jobs:
             bug|enhancement|documentation) ;;
             *) echo "Unexpected: $LABEL — skipping"; exit 0 ;;
           esac
+          PR=${{ github.event.pull_request.number }}
+          CURRENT=$(gh pr view "$PR" --json labels --jq '.labels[].name')
           for L in bug enhancement documentation; do
-            gh pr edit ${{ github.event.pull_request.number }} --remove-label "$L" 2>/dev/null || true
+            if [ "$L" != "$LABEL" ] && echo "$CURRENT" | grep -qx "$L"; then
+              gh pr edit "$PR" --remove-label "$L"
+            fi
           done
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "$LABEL"
+          if ! echo "$CURRENT" | grep -qx "$LABEL"; then
+            gh pr edit "$PR" --add-label "$LABEL"
+          fi
 
   breaking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- AI labeler was unconditionally removing and re-adding classification labels on every `synchronize` event, even when the label hadn't changed — producing timeline noise like "added bug and removed bug"
- Now checks current labels first: only removes labels that differ from the chosen one and are actually present, only adds if not already there

## Test plan

- [ ] Push to a PR already labeled `bug` where the model still picks `bug` — verify no label events in timeline
- [ ] Push to a PR labeled `bug` where the model now picks `enhancement` — verify `bug` removed and `enhancement` added
- [ ] Open a new PR with no classification label — verify label is added normally