### PR TITLE
Restore error guards on AI labeler edit calls

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -89,11 +89,11 @@ jobs:
           CURRENT=$(gh pr view "$PR" --json labels --jq '.labels[].name')
           for L in bug enhancement documentation; do
             if [ "$L" != "$LABEL" ] && echo "$CURRENT" | grep -qx "$L"; then
-              gh pr edit "$PR" --remove-label "$L"
+              gh pr edit "$PR" --remove-label "$L" 2>/dev/null || true
             fi
           done
           if ! echo "$CURRENT" | grep -qx "$LABEL"; then
-            gh pr edit "$PR" --add-label "$LABEL"
+            gh pr edit "$PR" --add-label "$LABEL" 2>/dev/null || true
           fi
 
   breaking:


### PR DESCRIPTION
## Summary

- #179 removed the `2>/dev/null || true` guards when it made labeling conditional
- The label snapshot from `gh pr view` can go stale if another workflow or human changes labels between the read and the edit — without guards, that race fails the job
- Restores `2>/dev/null || true` on both remove and add calls

## Test plan

- [ ] Concurrent label change between snapshot and edit doesn't fail the workflow