### PR TITLE
Support custom OAuth redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To use your own OAuth app (e.g., a custom Launchpad integration):
 | `BASECAMP_OAUTH_CLIENT_SECRET` | OAuth client secret |
 | `BASECAMP_OAUTH_REDIRECT_URI` | Redirect URI (must be `http://` loopback with explicit port) |
 
-Both `CLIENT_ID` and `CLIENT_SECRET` must be set together.
+Both `BASECAMP_OAUTH_CLIENT_ID` and `BASECAMP_OAUTH_CLIENT_SECRET` must be set together.
 
 ## AI Agent Integration
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -387,10 +387,8 @@ func (m *Manager) launchpadURL() (string, error) {
 
 func (m *Manager) loadClientCredentials(ctx context.Context, oauthCfg *oauth.Config, oauthType string, opts *LoginOptions) (*ClientCredentials, error) {
 	if oauthType == "bc3" {
-		customRedirect := opts.RedirectURI != defaultRedirectURI
-
 		// BC3 with default redirect: try stored client first
-		if !customRedirect {
+		if opts.RedirectURI == defaultRedirectURI {
 			creds, err := m.loadBC3Client()
 			if err == nil {
 				return creds, nil
@@ -401,7 +399,7 @@ func (m *Manager) loadClientCredentials(ctx context.Context, oauthCfg *oauth.Con
 		if oauthCfg.RegistrationEndpoint == "" {
 			return nil, output.ErrAuth("OAuth server does not support Dynamic Client Registration")
 		}
-		return m.registerBC3Client(ctx, oauthCfg.RegistrationEndpoint, customRedirect, opts)
+		return m.registerBC3Client(ctx, oauthCfg.RegistrationEndpoint, opts)
 	}
 
 	// Launchpad: resolve client credentials from env vars
@@ -460,7 +458,8 @@ func (m *Manager) loadBC3Client() (*ClientCredentials, error) {
 	return &creds, nil
 }
 
-func (m *Manager) registerBC3Client(ctx context.Context, registrationEndpoint string, customRedirect bool, opts *LoginOptions) (*ClientCredentials, error) {
+func (m *Manager) registerBC3Client(ctx context.Context, registrationEndpoint string, opts *LoginOptions) (*ClientCredentials, error) {
+	customRedirect := opts.RedirectURI != defaultRedirectURI
 	regReq := map[string]any{
 		"client_name":                "basecamp-cli",
 		"client_uri":                 "https://github.com/basecamp/basecamp-cli",

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -644,6 +644,8 @@ func TestRegisterBC3Client_UsesResolvedRedirectURI(t *testing.T) {
 	defer srv.Close()
 
 	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
 	m := &Manager{
 		cfg:        config.Default(),
 		httpClient: srv.Client(),
@@ -651,7 +653,7 @@ func TestRegisterBC3Client_UsesResolvedRedirectURI(t *testing.T) {
 	}
 	opts := &LoginOptions{RedirectURI: "http://localhost:7777/cb"}
 
-	creds, err := m.registerBC3Client(context.Background(), srv.URL+"/register", false, opts)
+	creds, err := m.registerBC3Client(context.Background(), srv.URL+"/register", opts)
 	require.NoError(t, err)
 	assert.Equal(t, "dcr-id", creds.ClientID)
 
@@ -680,7 +682,7 @@ func TestRegisterBC3Client_CustomRedirectNotPersisted(t *testing.T) {
 	opts := &LoginOptions{RedirectURI: "http://localhost:7777/cb"}
 
 	// Custom redirect: should NOT persist
-	_, err := m.registerBC3Client(context.Background(), srv.URL+"/register", true, opts)
+	_, err := m.registerBC3Client(context.Background(), srv.URL+"/register", opts)
 	require.NoError(t, err)
 
 	clientFile := filepath.Join(tmpDir, "basecamp", "client.json")
@@ -707,7 +709,7 @@ func TestRegisterBC3Client_DefaultRedirectPersisted(t *testing.T) {
 	opts := &LoginOptions{RedirectURI: defaultRedirectURI}
 
 	// Default redirect: should persist
-	_, err := m.registerBC3Client(context.Background(), srv.URL+"/register", false, opts)
+	_, err := m.registerBC3Client(context.Background(), srv.URL+"/register", opts)
 	require.NoError(t, err)
 
 	clientFile := filepath.Join(tmpDir, "basecamp", "client.json")


### PR DESCRIPTION
## Summary

- Add `BASECAMP_OAUTH_REDIRECT_URI` env var and `LoginOptions.RedirectURI` field so users with custom OAuth client credentials can specify a matching redirect URI
- Add `resolveOAuthCallback()` with full RFC 8252 loopback validation (http scheme, loopback host, explicit port, no userinfo/query/fragment)
- Rename credential env vars to `BASECAMP_OAUTH_CLIENT_ID`/`BASECAMP_OAUTH_CLIENT_SECRET` with strict pairing
- BC3 DCR clients registered with a custom redirect URI are session-only (not persisted to `client.json`)
- Improve auth timeout error to include listener address

Closes #183

## Test plan

- [x] `make check` passes (fmt, vet, lint, unit tests, e2e tests)
- [x] `TestResolveOAuthCallback` — 11 subtests covering default, env override, programmatic override, CallbackAddr compat, and all validation rejections
- [x] `TestResolveClientCredentials` — 4 subtests covering both-set, ID-only error, secret-only error, neither-set
- [x] `TestBuildAuthURL_UsesResolvedRedirectURI` — resolved URI propagates to authorization URL
- [x] `TestExchangeCode_UsesResolvedRedirectURI` — resolved URI propagates to token exchange
- [x] `TestRegisterBC3Client_UsesResolvedRedirectURI` — resolved URI sent in DCR request body
- [x] `TestRegisterBC3Client_CustomRedirectNotPersisted` — custom redirect skips client.json write
- [x] `TestRegisterBC3Client_DefaultRedirectPersisted` — default redirect persists as before
- [x] `TestLoadClientCredentials_BC3_CustomRedirect_SkipsStoredClient` — custom redirect bypasses stored client, forces fresh DCR