### PR TITLE
Fix notarize enabled template to return boolean

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,7 +72,7 @@ signs:
 # Sign and notarize macOS binaries (cross-platform via embedded quill)
 notarize:
   macos:
-    - enabled: '{{ and .Env.MACOS_SIGN_P12 .Env.MACOS_SIGN_PASSWORD .Env.MACOS_NOTARY_KEY .Env.MACOS_NOTARY_KEY_ID .Env.MACOS_NOTARY_ISSUER_ID }}'
+    - enabled: '{{ and (ne .Env.MACOS_SIGN_P12 "") (ne .Env.MACOS_SIGN_PASSWORD "") (ne .Env.MACOS_NOTARY_KEY "") (ne .Env.MACOS_NOTARY_KEY_ID "") (ne .Env.MACOS_NOTARY_ISSUER_ID "") }}'
       ids:
         - basecamp
       sign:


### PR DESCRIPTION
## Summary

The `enabled` field in `.goreleaser.yaml` used `{{ and .Env.X .Env.Y }}` which returns the last truthy value (the raw base64 string), not `"true"`. GoReleaser checks for the string `"true"` specifically, so notarization was silently skipped in v0.2.2 despite all secrets being present.

Switch to `{{ and (ne .Env.X "") (ne .Env.Y "") }}` which returns the boolean `true`/`false`, rendering as the string GoReleaser expects.

Verified locally:
- Non-empty env vars → notarize block activates (attempts signing)
- Empty env vars → notarize block skipped (`reason=disabled`)

Follow-up to #185.