### PR TITLE
Document v0.2.2 features in SKILL.md

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -85,7 +85,7 @@ basecamp <cmd> --agent     # Machine-readable, no interactive prompts
 basecamp <cmd> --ids-only  # Just IDs, one per line
 basecamp <cmd> --count     # Just the count
 basecamp <cmd> --stats     # Include session stats in output
-basecamp <cmd> --md / -m   # Markdown output (portable, pipeable to glow/bat)
+basecamp <cmd> --md / --markdown / -m  # Markdown output (portable, pipeable to glow/bat)
 basecamp <cmd> --styled    # Force ANSI-styled output even when piped
 basecamp <cmd> -v          # Verbose: show operations
 basecamp <cmd> -vv         # Very verbose: show operations + HTTP requests


### PR DESCRIPTION
## Summary

- Document `--no-subscribe`/`--subscribe` flags across messages, files, and schedule sections (from #187)
- Add `--md`/`--markdown`/`-m`, `--styled`, `-v`/`-vv` output mode flags (from #187)
- Add "Post silently" quick reference row for agent automation
- Document `config trust`/`untrust` commands with authority key explanation (from #181)
- Note mutual exclusivity of `--subscribe`/`--no-subscribe`

Closes #189

## Test plan

- [x] `make check` passes (skill file is data-only, no compilation impact)
- [x] Markdown renders correctly (tables, code blocks, inline code)