### PR TITLE
Add direct-push alerting and sensitive-change gate

### DIFF
--- a/.github/workflows/direct-push-alert.yml
+++ b/.github/workflows/direct-push-alert.yml
@@ -1,0 +1,16 @@
+name: Direct Push Alert
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  alert:
+    uses: basecamp/.github/.github/workflows/direct-push-alert.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -1,0 +1,21 @@
+name: Sensitive Change Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    uses: basecamp/.github/.github/workflows/sensitive-change-gate.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    with:
+      extra-patterns: |
+        scripts/publish-aur.sh
+        scripts/sync-skills.sh
+        scripts/manage-release-env.sh
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary
- **direct-push-alert**: Detects commits pushed directly to the default branch (bypassing PR flow) and creates/appends to a tracking issue.
- **sensitive-change-gate**: Detects PR changes to control-plane paths (workflows, CODEOWNERS, .goreleaser.yaml, release scripts). Runs in shadow mode — posts an informational comment but does not block.

Both are thin callers to reusable workflows in `basecamp/.github`, pinned to SHA `a667bfaa`.

## Test plan
- [ ] Open a PR touching `.github/workflows/` — verify shadow comment appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two GitHub Actions: one alerts on direct pushes to `main`, and another flags sensitive control‑plane changes in PRs (shadow mode). Improves visibility and nudges contributors to the PR flow without blocking merges.

- **New Features**
  - direct-push-alert: On push to `main`, posts to/updates a tracking issue using a reusable workflow in `basecamp/.github` (pinned to a commit).
  - sensitive-change-gate: On PRs, comments when changes touch workflows, CODEOWNERS, `.goreleaser.yaml`, or release scripts; runs in shadow mode. Extra paths monitored: `scripts/publish-aur.sh`, `scripts/sync-skills.sh`, `scripts/manage-release-env.sh`.

<sup>Written for commit bbb5c7c986708a026bc131adf32236e1fa3493e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

