### PR TITLE
Fix install script version detection on Windows

### DIFF
--- a/scripts/ensure-basecamp.sh
+++ b/scripts/ensure-basecamp.sh
@@ -72,7 +72,7 @@ install_basecamp() {
   url=$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/basecamp/basecamp-cli/releases/latest" 2>/dev/null) || true
   version="${url##*/}"
   version="${version#v}"
-  if [[ -z "$version" || "$version" == "latest" ]]; then
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+ ]]; then
     echo "Could not determine latest version" >&2
     return 1
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,7 +71,7 @@ get_latest_version() {
   url=$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" 2>/dev/null) || true
   version="${url##*/}"
   version="${version#v}"
-  if [[ -z "$version" || "$version" == "latest" ]]; then
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+ ]]; then
     error "Could not determine latest version. Check your network connection."
   fi
   echo "$version"


### PR DESCRIPTION
## Summary

- Replace GitHub API + `grep`/`sed` JSON parsing in `get_latest_version()` with GitHub's `releases/latest` redirect approach
- Extract version from the final URL using pure bash string manipulation (`${url##*/}`, `${version#v}`)
- Apply the same fix to both `scripts/install.sh` and `scripts/ensure-basecamp.sh`

Fixes "Could not determine latest version" when running the installer from Windows PowerShell (Git Bash). The old approach silently failed due to API rate limiting, PATH issues with grep/sed, or TLS differences between Windows curl and MSYS curl.

The new approach has no external tool dependencies beyond curl, no API rate limiting, and works identically across macOS, Linux, and Windows (Git Bash/MSYS2/Cygwin).

## Test plan

- [x] `curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/basecamp/basecamp-cli/releases/latest` resolves correctly — returned `https://github.com/basecamp/basecamp-cli/releases/tag/v0.2.3`
- [x] `bash scripts/install.sh` completes on macOS — resolved v0.2.3, downloaded, checksum + cosign verified, installed
- [x] `bash scripts/ensure-basecamp.sh --check` still works — `basecamp 0.2.3 OK (>= 0.1.0)`
- [ ] Test from Windows PowerShell: `curl -fsSL https://basecamp.com/install-cli | bash` — needs Windows machine