### PR TITLE
Tighten install script version guard to full semver

### DIFF
--- a/scripts/ensure-basecamp.sh
+++ b/scripts/ensure-basecamp.sh
@@ -73,7 +73,7 @@ install_basecamp() {
   version="${url##*/}"
   version="${version#v}"
   if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Could not determine latest version" >&2
+    echo "Could not determine latest version (resolved '${version:-<empty>}' from '${url:-<no URL>}')" >&2
     return 1
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,7 +72,7 @@ get_latest_version() {
   version="${url##*/}"
   version="${version#v}"
   if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    error "Could not determine latest version. Check your network connection."
+    error "Could not determine latest version (resolved '${version:-<empty>}' from '${url:-<no URL>}'). Check your network connection or repository tags."
   fi
   echo "$version"
 }
@@ -307,8 +307,8 @@ main() {
 
   if [[ -n "$VERSION" ]]; then
     version="$VERSION"
-    if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      error "Invalid version '${version}'. Expected semver format (e.g. 1.2.3)."
+    if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+      error "Invalid version '${version}'. Expected semver format (e.g. 1.2.3 or 1.2.3-rc.1)."
     fi
   else
     version=$(get_latest_version)


### PR DESCRIPTION
## Summary

- Tighten the version regex in both `scripts/install.sh` and `scripts/ensure-basecamp.sh` from `^[0-9]+\.[0-9]+` to `^[0-9]+\.[0-9]+\.[0-9]+`
- A partial version like `0.2` would have passed the old guard and produced a guaranteed-to-fail download URL

Follow-up to #223 — addresses post-merge review feedback.

## Test plan

- [x] `make check` passes
- [x] `curl -fsSL -o /dev/null -w '%{url_effective}' https://github.com/basecamp/basecamp-cli/releases/latest` still resolves `v0.2.3` correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened version checks in the install scripts to require full semver (X.Y.Z) with anchored regex and clearer diagnostics. `get_latest_version` remains strict (stable tags only), while env-supplied versions can include prereleases like 1.2.3-rc.1.

- **Bug Fixes**
  - Anchored latest-tag regex to `^[0-9]+\.[0-9]+\.[0-9]+$` in `scripts/install.sh` and `scripts/ensure-basecamp.sh`; error messages now include the resolved tag/URL.
  - Validated `VERSION`/`BASECAMP_VERSION` with `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` to reject partials/trailing junk and allow prereleases.
  - Verified latest release resolution still returns `v0.2.3`.

<sup>Written for commit d283885c45b208efdef45fa58a2f0e50a2c52d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

