### PR TITLE
Fix search returning irrelevant results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.0
-	github.com/basecamp/basecamp-sdk/go v0.2.2
+	github.com/basecamp/basecamp-sdk/go v0.3.0
 	github.com/basecamp/cli v0.1.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aymanbagabas/go-udiff v0.4.0 h1:TKnLPh7IbnizJIBKFWa9mKayRUBQ9Kh1BPCk6
 github.com/aymanbagabas/go-udiff v0.4.0/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.2.2 h1:wfMrjTytLCLsBG2SrQh5UDvGgj3QHVwg6KRvkL+ayeg=
-github.com/basecamp/basecamp-sdk/go v0.2.2/go.mod h1:WmckHy36EAqP+BW//1J9QdMi16l3PNx2XP0vt/kSlXE=
+github.com/basecamp/basecamp-sdk/go v0.3.0 h1:34KPSAJ3SvjQntPA4f2kd05J/bvkxl2gJcf/YDUHQJU=
+github.com/basecamp/basecamp-sdk/go v0.3.0/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
 github.com/basecamp/cli v0.1.1 h1:FAF3M09xo1m7gJJXf38glCkT50ZUuvz+31f+c3R3zcc=
 github.com/basecamp/cli v0.1.1/go.mod h1:NTHe+keCTGI2qM5sMXdkUN0QgU3zGbwnBxcmg8vD5QU=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,13 +1,13 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.2.2",
-    "revision": "fc708516fa1e",
+    "version": "v0.3.0",
+    "revision": "4b2db790a366",
     "updated_at": "2026-03-04T03:36:34Z"
   },
   "api": {
     "repo": "basecamp/bc3",
-    "revision": "37be1c9481c88845c02ac8e4b95319b8d29ad460",
+    "revision": "477bf59f25189351f93572c58985f33e36fdbc1b",
     "synced_at": ""
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `basecamp-sdk/go` v0.2.2 → v0.3.0
- Search no longer sends spurious `sort=` and `page=0`, restoring BC3's relevance ranking
- Search query param corrected from `query=` to `q=` to match BC3's actual API

Before: `search.json?query=omacon&sort=&page=0` → recency-sorted, irrelevant results
After: `search.json?q=omacon` → relevance-ranked results

## Test plan

- [x] `make check` passes (unit, 263 e2e, lint, vet, fmt, provenance)
- [x] `basecamp search "omacon" -vv` → URL is `search.json?q=omacon`, no spurious params
- [x] `basecamp search "omacon" --sort created_at -vv` → `sort=created_at` appears when explicit
- [x] `basecamp recordings --type Todo --sort created_at -vv` → other endpoints unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search results are now relevance-ranked by default. We upgraded `github.com/basecamp/basecamp-sdk/go` to v0.3.0 to use `q` and stop sending stray `sort` and `page=0`.

- **Bug Fixes**
  - Use `q=` for search requests to match BC3.
  - Omit zero-value optional params for unqualified searches, so no `sort=` or `page=0`.

<sup>Written for commit 5bd70658d66d88ee9e93129cbee3db1eff38b546. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

