### PR TITLE
Restore --stats to output modes documentation

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -88,7 +88,7 @@ Full CLI coverage: 130 endpoints across todos, cards, messages, files, schedule,
 
 Always pass `--json` or `--md` explicitly — auto-detection depends on config and may not produce the format you expect. Use `--md` when composing reports, summarizing data, or displaying results inline. `--agent` is for headless integration scripts.
 
-**Other modes:** `--quiet` (success: raw JSON, no envelope; errors: `{ok:false,...}`), `--ids-only`, `--count`, `--styled` (force ANSI), `-v` / `-vv` (verbose/trace).
+**Other modes:** `--quiet` (success: raw JSON, no envelope; errors: `{ok:false,...}`), `--ids-only`, `--count`, `--stats` (session statistics), `--styled` (force ANSI), `-v` / `-vv` (verbose/trace).
 
 ### CLI Introspection
 


### PR DESCRIPTION
## Summary

- Add `--stats` (session statistics) back to the SKILL.md "Other modes" summary line — it was dropped during the output modes rewrite in #221

Follow-up from post-merge review feedback on #221.

## Test plan

- [x] `diff skills/basecamp/SKILL.md .claude-plugin/skills/basecamp/SKILL.md` is empty (hardlinked)
- [x] Documentation-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `--stats` (session statistics) to the “Other modes” line in the Basecamp skill docs to match current CLI behavior. Documentation-only change to improve discoverability of the flag.

<sup>Written for commit c6cc8d989634aefb3648104114880357e686a201. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

