### PR TITLE
Fix review followups from #235

### DIFF
--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -171,7 +171,8 @@ load test_helper
 
   run basecamp recordings
   assert_failure
-  assert_output_contains "type required"
+  assert_json_value '.error' '<type> required'
+  assert_json_value '.code' 'usage'
 }
 
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -474,14 +474,13 @@ func isBareRequiredFlagError(err error, cmd *cobra.Command) bool {
 }
 
 // isMachineConsumer returns true when the root command's flags indicate a
-// non-interactive consumer: --agent, --json, or stdout piped to a non-TTY.
+// non-interactive consumer: --agent, --json, --quiet, etc., or stdout piped to a non-TTY.
 func isMachineConsumer(root *cobra.Command) bool {
 	pf := root.PersistentFlags()
-	if agent, _ := pf.GetBool("agent"); agent {
-		return true
-	}
-	if jsonFlag, _ := pf.GetBool("json"); jsonFlag {
-		return true
+	for _, flag := range []string{"agent", "json", "quiet", "ids-only", "count"} {
+		if v, _ := pf.GetBool(flag); v {
+			return true
+		}
 	}
 	fi, err := os.Stdout.Stat()
 	if err == nil && (fi.Mode()&os.ModeCharDevice) == 0 {

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -1413,7 +1413,7 @@ func newCardsStepsCmd(project *string) *cobra.Command {
 				cardID = args[0]
 			}
 			if cardID == "" {
-				return missingArg(cmd, "card-id|url")
+				return missingArg(cmd, "<card-id|url>")
 			}
 
 			cardIDInt, err := strconv.ParseInt(cardID, 10, 64)

--- a/internal/commands/recordings.go
+++ b/internal/commands/recordings.go
@@ -62,7 +62,7 @@ Type is required: todos, messages, documents, comments, cards, uploads.`,
 			}
 
 			if effectiveType == "" {
-				return missingArg(cmd, "type")
+				return missingArg(cmd, "<type>")
 			}
 
 			return runRecordingsList(cmd, app, effectiveType, project, status, sortBy, direction, limit, page, all)


### PR DESCRIPTION
## Summary
- Expand `isMachineConsumer` in root.go to check `--quiet`/`--ids-only`/`--count` flags, matching `isMachineOutput` and `App.IsMachineOutput()` behavior
- Add missing angle brackets to `missingArg` calls in `cards steps` and `recordings` for consistent `<arg> required` error format
- Remove unused `vaultTitle` variable in files list (pre-existing lint issue on main)

## Test plan
- [x] `make check` passes (all Go tests, lint, vet, e2e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands machine-output detection to include `--quiet`, `--ids-only`, and `--count`, and standardizes missing-argument errors across commands. Updates e2e to expect JSON error shape; removes an unused var flagged by lint.

- **Bug Fixes**
  - `isMachineConsumer` now treats `--quiet`, `--ids-only`, and `--count` as machine consumers (parity with `isMachineOutput` and `App.IsMachineOutput()`).
  - Standardized missing-arg errors: `<card-id|url>` in `cards steps` and `<type>` in `recordings`; e2e asserts JSON error and `usage` code.
  - Removed unused `vaultTitle` in files list.

<sup>Written for commit 707f71b2a521d4c05609f048db53be2504bd8018. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

