### PR TITLE
Add examples to api command and subcommands

### DIFF
--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -18,6 +18,8 @@ func NewAPICmd() *cobra.Command {
 		Use:   "api <verb> <path>",
 		Short: "Raw API access",
 		Long:  "Make raw API requests to any Basecamp endpoint. Useful for operations not covered by dedicated commands.",
+		Example: `  basecamp api get /projects.json
+  basecamp api post /buckets/123/todolists/456/todos.json -d '{"content":"Buy milk"}'`,
 	}
 
 	cmd.AddCommand(
@@ -35,7 +37,10 @@ func newAPIGetCmd() *cobra.Command {
 		Use:   "get <path>",
 		Short: "GET request to API",
 		Long:  "Make a raw GET request to any Basecamp API endpoint.",
-		Args:  cobra.ExactArgs(1),
+		Example: `  basecamp api get /projects.json
+  basecamp api get /buckets/123/todos/456.json
+  basecamp api get https://3.basecampapi.com/999/projects.json`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if err := ensureAccount(cmd, app); err != nil {
@@ -66,7 +71,9 @@ func newAPIPostCmd() *cobra.Command {
 		Use:   "post <path>",
 		Short: "POST request to API",
 		Long:  "Make a raw POST request to any Basecamp API endpoint.",
-		Args:  cobra.ExactArgs(1),
+		Example: `  basecamp api post /buckets/123/todolists/456/todos.json -d '{"content":"Buy milk"}'
+  basecamp api post /buckets/123/message_boards/789/messages.json -d '{"subject":"Hello","content":"<p>World</p>"}'`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Show help when invoked with no data
 			if data == "" {
@@ -111,10 +118,11 @@ func newAPIPutCmd() *cobra.Command {
 	var data string
 
 	cmd := &cobra.Command{
-		Use:   "put <path>",
-		Short: "PUT request to API",
-		Long:  "Make a raw PUT request to any Basecamp API endpoint.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "put <path>",
+		Short:   "PUT request to API",
+		Long:    "Make a raw PUT request to any Basecamp API endpoint.",
+		Example: `  basecamp api put /buckets/123/todos/456.json -d '{"content":"Updated todo"}'`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Show help when invoked with no data
 			if data == "" {
@@ -157,10 +165,11 @@ func newAPIPutCmd() *cobra.Command {
 
 func newAPIDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <path>",
-		Short: "DELETE request to API",
-		Long:  "Make a raw DELETE request to any Basecamp API endpoint.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "delete <path>",
+		Short:   "DELETE request to API",
+		Long:    "Make a raw DELETE request to any Basecamp API endpoint.",
+		Example: `  basecamp api delete /buckets/123/todos/456.json`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if err := ensureAccount(cmd, app); err != nil {


### PR DESCRIPTION
## Summary
- Adds `Example` field to the `api` parent command and all four subcommands (get, post, put, delete)
- Examples surface in `--help` output and in `missingArg`/`noChanges` machine-mode error hints

## Context
DHH feedback card 9660578055 — the `api` command was unclear without concrete examples showing what paths and payloads look like.

## Test plan
- [x] `bin/ci` passes
- [x] `basecamp api -h` / `basecamp api get -h` show examples

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add concrete examples to the `api` command and its `get`, `post`, `put`, and `delete` subcommands. Examples now show common paths, absolute URLs, and `-d` payloads in `--help` and error hints to make raw API usage clearer.

- **New Features**
  - Added `Example` strings to the parent `api` command and all subcommands.
  - Examples appear in `--help` and in `missingArg`/`noChanges` machine-mode hints.

<sup>Written for commit 174383434c555b4b175e9c2760826b22a90ba7f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

