### PR TITLE
Add pingable fallback to ResolvePerson

### DIFF
--- a/internal/names/resolver.go
+++ b/internal/names/resolver.go
@@ -35,6 +35,7 @@ type Resolver struct {
 	mu        sync.RWMutex
 	projects  []Project
 	people    []Person
+	pingable  []Person              // cached /people/pingable.json
 	todolists map[string][]Todolist // keyed by project ID
 	me        *Person               // cached /my/profile.json result
 }
@@ -80,6 +81,7 @@ func (r *Resolver) SetAccountID(accountID string) {
 		// Clear cache since data is account-specific
 		r.projects = nil
 		r.people = nil
+		r.pingable = nil
 		r.me = nil
 		r.todolists = make(map[string][]Todolist)
 	}
@@ -206,8 +208,50 @@ func (r *Resolver) ResolvePerson(ctx context.Context, input string) (string, str
 		return "", "", output.ErrAmbiguous("person", names)
 	}
 
-	// Not found - provide suggestions
-	suggestions := suggest(input, people, func(p Person) string { return p.Name })
+	// Fallback: try pingable people (/people/pingable.json) which includes
+	// people not in /people.json (e.g., clients, external collaborators).
+	pingable, pingErr := r.getPingable(ctx)
+	if pingErr != nil {
+		return "", "", pingErr
+	}
+
+	if len(pingable) > 0 {
+		// Try email exact match
+		for _, p := range pingable {
+			if strings.EqualFold(p.Email, input) {
+				return strconv.FormatInt(p.ID, 10), p.Name, nil
+			}
+		}
+
+		// Try name resolution
+		pingMatch, pingMatches := resolve(input, pingable, func(p Person) (int64, string) {
+			return p.ID, p.Name
+		})
+		if pingMatch != nil {
+			return strconv.FormatInt(pingMatch.ID, 10), pingMatch.Name, nil
+		}
+		if len(pingMatches) > 1 {
+			pingNames := make([]string, len(pingMatches))
+			for i, m := range pingMatches {
+				pingNames[i] = m.Name
+			}
+			return "", "", output.ErrAmbiguous("person", pingNames)
+		}
+	}
+
+	// Not found - provide suggestions from both lists (deduplicated by ID)
+	seen := make(map[int64]struct{}, len(people))
+	allPeople := make([]Person, 0, len(people)+len(pingable))
+	for _, p := range people {
+		seen[p.ID] = struct{}{}
+		allPeople = append(allPeople, p)
+	}
+	for _, p := range pingable {
+		if _, ok := seen[p.ID]; !ok {
+			allPeople = append(allPeople, p)
+		}
+	}
+	suggestions := suggest(input, allPeople, func(p Person) string { return p.Name })
 	if len(suggestions) > 0 {
 		return "", "", output.ErrNotFoundHint("Person", input, "Did you mean: "+strings.Join(suggestions, ", "))
 	}
@@ -268,6 +312,7 @@ func (r *Resolver) ClearCache() {
 	defer r.mu.Unlock()
 	r.projects = nil
 	r.people = nil
+	r.pingable = nil
 	r.me = nil
 	r.todolists = make(map[string][]Todolist)
 }
@@ -370,6 +415,40 @@ func (r *Resolver) getPeople(ctx context.Context) ([]Person, error) {
 
 	r.people = people
 	return people, nil
+}
+
+func (r *Resolver) getPingable(ctx context.Context) ([]Person, error) {
+	r.mu.RLock()
+	if r.pingable != nil {
+		defer r.mu.RUnlock()
+		return r.pingable, nil
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if r.pingable != nil {
+		return r.pingable, nil
+	}
+
+	sdkPeople, err := r.forAccount().People().Pingable(ctx)
+	if err != nil {
+		return nil, convertSDKError(err)
+	}
+
+	pingable := make([]Person, 0, len(sdkPeople))
+	for _, p := range sdkPeople {
+		pingable = append(pingable, Person{
+			ID:    p.ID,
+			Name:  p.Name,
+			Email: p.EmailAddress,
+		})
+	}
+
+	r.pingable = pingable
+	return pingable, nil
 }
 
 func (r *Resolver) getTodolists(ctx context.Context, projectID string) ([]Todolist, error) {

--- a/internal/names/resolver_test.go
+++ b/internal/names/resolver_test.go
@@ -358,6 +358,7 @@ func TestResolverClearCache(t *testing.T) {
 	r := &Resolver{
 		projects:  []Project{{ID: 1, Name: "Test"}},
 		people:    []Person{{ID: 2, Name: "Alice"}},
+		pingable:  []Person{{ID: 4, Name: "Client"}},
 		todolists: map[string][]Todolist{"123": {{ID: 3, Name: "Tasks"}}},
 	}
 
@@ -365,6 +366,7 @@ func TestResolverClearCache(t *testing.T) {
 
 	assert.Nil(t, r.projects, "projects should be nil after ClearCache")
 	assert.Nil(t, r.people, "people should be nil after ClearCache")
+	assert.Nil(t, r.pingable, "pingable should be nil after ClearCache")
 	assert.Empty(t, r.todolists, "todolists should be empty after ClearCache")
 }
 
@@ -392,6 +394,12 @@ func (m *mockResolver) setPeople(people []Person) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.people = people
+}
+
+func (m *mockResolver) setPingable(pingable []Person) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pingable = pingable
 }
 
 func (m *mockResolver) setTodolists(projectID string, todolists []Todolist) {
@@ -686,6 +694,7 @@ func TestResolverSetAccountID(t *testing.T) {
 	r := newMockResolver()
 	r.setProjects([]Project{{ID: 1, Name: "Test"}})
 	r.setPeople([]Person{{ID: 2, Name: "Alice"}})
+	r.setPingable([]Person{{ID: 4, Name: "Client"}})
 	r.setTodolists("123", []Todolist{{ID: 3, Name: "Tasks"}})
 
 	// Set same account ID - should not clear cache
@@ -702,6 +711,7 @@ func TestResolverSetAccountID(t *testing.T) {
 	r.mu.RLock()
 	assert.Nil(t, r.projects, "projects should be nil after changing account ID")
 	assert.Nil(t, r.people, "people should be nil after changing account ID")
+	assert.Nil(t, r.pingable, "pingable should be nil after changing account ID")
 	assert.Empty(t, r.todolists, "todolists should be empty after changing account ID")
 	assert.Equal(t, "67890", r.accountID)
 	r.mu.RUnlock()
@@ -775,4 +785,74 @@ func TestResolveSpecialCharacters(t *testing.T) {
 			assert.Equal(t, tt.wantID, match.ID)
 		})
 	}
+}
+
+// =============================================================================
+// Pingable Fallback Tests
+// =============================================================================
+
+func TestResolverResolvePerson_PingableFallback_ByName(t *testing.T) {
+	r := newMockResolver()
+	r.setPeople([]Person{
+		{ID: 111, Name: "Alice Smith", Email: "alice@example.com"},
+	})
+	r.setPingable([]Person{
+		{ID: 999, Name: "External Client", Email: "client@external.com"},
+	})
+
+	ctx := context.Background()
+	id, name, err := r.ResolvePerson(ctx, "External Client")
+	require.NoError(t, err)
+	assert.Equal(t, "999", id)
+	assert.Equal(t, "External Client", name)
+}
+
+func TestResolverResolvePerson_PingableFallback_ByEmail(t *testing.T) {
+	r := newMockResolver()
+	r.setPeople([]Person{
+		{ID: 111, Name: "Alice Smith", Email: "alice@example.com"},
+	})
+	r.setPingable([]Person{
+		{ID: 999, Name: "External Client", Email: "client@external.com"},
+	})
+
+	ctx := context.Background()
+	id, name, err := r.ResolvePerson(ctx, "client@external.com")
+	require.NoError(t, err)
+	assert.Equal(t, "999", id)
+	assert.Equal(t, "External Client", name)
+}
+
+func TestResolverResolvePerson_PeoplePreferredOverPingable(t *testing.T) {
+	r := newMockResolver()
+	r.setPeople([]Person{
+		{ID: 111, Name: "Alice Smith", Email: "alice@example.com"},
+	})
+	r.setPingable([]Person{
+		{ID: 222, Name: "Alice Smith", Email: "alice2@example.com"},
+	})
+
+	ctx := context.Background()
+	id, _, err := r.ResolvePerson(ctx, "Alice Smith")
+	require.NoError(t, err)
+	// People list is checked first, so ID 111 wins
+	assert.Equal(t, "111", id)
+}
+
+func TestResolverResolvePerson_PingableFallback_NotFound(t *testing.T) {
+	r := newMockResolver()
+	r.setPeople([]Person{
+		{ID: 111, Name: "Alice Smith", Email: "alice@example.com"},
+	})
+	r.setPingable([]Person{
+		{ID: 222, Name: "Bob Jones", Email: "bob@example.com"},
+	})
+
+	ctx := context.Background()
+	_, _, err := r.ResolvePerson(ctx, "Charlie Nobody")
+	require.Error(t, err)
+
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeNotFound, outErr.Code)
 }


### PR DESCRIPTION
## Summary
- `ResolvePerson` only searched `/people.json`, missing people findable via `/people/pingable.json` (clients, external collaborators)
- After the primary people list fails to match, fall back to the pingable endpoint for both email and name resolution
- Cache the pingable list per session, clear on account switch
- Suggestions on not-found draw from both lists

**Stacked on #249**

## Test plan
- [x] `TestResolverResolvePerson_PingableFallback_ByName` — name match via pingable
- [x] `TestResolverResolvePerson_PingableFallback_ByEmail` — email match via pingable
- [x] `TestResolverResolvePerson_PeoplePreferredOverPingable` — people list takes priority
- [x] `TestResolverResolvePerson_PingableFallback_NotFound` — not-found in both lists
- [x] `make check` green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes person resolution by falling back to `/people/pingable.json` when `/people.json` has no match, so clients and external collaborators resolve correctly. Adds per-session caching, deduped suggestions, and proper error propagation.

- **Bug Fixes**
  - Fall back to `/people/pingable.json` for email and name when `/people.json` has no match; prefer the main people list if both match.
  - Cache the pingable list per session; clear on account switch and `ClearCache()`.
  - Build suggestions from both lists and dedupe by ID.
  - Propagate pingable fetch errors instead of masking as not-found.

<sup>Written for commit f181cfc022c430b4f81ff52530d41c68f66ac360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

