### PR TITLE
Fix auth token refresh by passing client credentials

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -201,12 +201,15 @@ func (m *Manager) refreshLocked(ctx context.Context, origin string, creds *Crede
 	case "bc3":
 		cc, err := m.loadBC3Client()
 		if err != nil {
-			// DCR credentials from custom-redirect logins are intentionally
-			// not persisted (see registerBC3Client). After a process restart
-			// the client.json won't exist and refresh is impossible.
-			return output.ErrAuth("Cannot load BC3 client credentials for token refresh. " +
-				"This can happen after a custom-redirect login (credentials are session-only). " +
-				"Please re-authenticate: basecamp auth login")
+			if os.IsNotExist(err) {
+				// DCR credentials from custom-redirect logins are intentionally
+				// not persisted (see registerBC3Client). After a process restart
+				// the client.json won't exist and refresh is impossible.
+				return output.ErrAuth("Cannot load BC3 client credentials for token refresh. " +
+					"This can happen after a custom-redirect login (credentials are session-only). " +
+					"Please re-authenticate: basecamp auth login")
+			}
+			return output.ErrAuth(fmt.Sprintf("Cannot load BC3 client credentials for token refresh: %v", err))
 		}
 		clientID = cc.ClientID
 		clientSecret = cc.ClientSecret

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1343,10 +1343,16 @@ func TestLoginBC3DefaultsToRead(t *testing.T) {
 }
 
 func TestRefreshLocked_LaunchpadSendsClientID(t *testing.T) {
+	t.Setenv("BASECAMP_OAUTH_CLIENT_ID", "")
+	t.Setenv("BASECAMP_OAUTH_CLIENT_SECRET", "")
+
+	var mu sync.Mutex
 	var capturedBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
 		capturedBody = string(body)
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"access_token":"new-token","refresh_token":"new-refresh"}`)
 	}))
@@ -1374,15 +1380,21 @@ func TestRefreshLocked_LaunchpadSendsClientID(t *testing.T) {
 	err := m.refreshLocked(context.Background(), srv.URL, creds)
 	require.NoError(t, err)
 
-	assert.Contains(t, capturedBody, "client_id="+launchpadClientID)
-	assert.Contains(t, capturedBody, "client_secret="+launchpadClientSecret)
+	mu.Lock()
+	body := capturedBody
+	mu.Unlock()
+	assert.Contains(t, body, "client_id="+launchpadClientID)
+	assert.Contains(t, body, "client_secret="+launchpadClientSecret)
 }
 
 func TestRefreshLocked_BC3SendsClientID(t *testing.T) {
+	var mu sync.Mutex
 	var capturedBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
 		capturedBody = string(body)
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"access_token":"new-token","refresh_token":"new-refresh","expires_in":3600}`)
 	}))
@@ -1418,8 +1430,11 @@ func TestRefreshLocked_BC3SendsClientID(t *testing.T) {
 	err := m.refreshLocked(context.Background(), srv.URL, creds)
 	require.NoError(t, err)
 
-	assert.Contains(t, capturedBody, "client_id=bc3-client-id")
-	assert.Contains(t, capturedBody, "client_secret=bc3-client-secret")
+	mu.Lock()
+	body := capturedBody
+	mu.Unlock()
+	assert.Contains(t, body, "client_id=bc3-client-id")
+	assert.Contains(t, body, "client_secret=bc3-client-secret")
 }
 
 func TestRefreshLocked_BC3WithoutClientJSON(t *testing.T) {
@@ -1485,10 +1500,16 @@ func TestRefreshLocked_ClearsExpiresAtWhenServerOmits(t *testing.T) {
 }
 
 func TestRefreshLocked_EmptyOAuthTypeDefaultsToLaunchpad(t *testing.T) {
+	t.Setenv("BASECAMP_OAUTH_CLIENT_ID", "")
+	t.Setenv("BASECAMP_OAUTH_CLIENT_SECRET", "")
+
+	var mu sync.Mutex
 	var capturedBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
 		capturedBody = string(body)
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"access_token":"new-token","refresh_token":"new-refresh"}`)
 	}))
@@ -1516,9 +1537,12 @@ func TestRefreshLocked_EmptyOAuthTypeDefaultsToLaunchpad(t *testing.T) {
 	err := m.refreshLocked(context.Background(), srv.URL, creds)
 	require.NoError(t, err)
 
+	mu.Lock()
+	body := capturedBody
+	mu.Unlock()
 	// Should have used launchpad legacy format (type=refresh, not grant_type=refresh_token)
-	assert.Contains(t, capturedBody, "type=refresh")
-	assert.Contains(t, capturedBody, "client_id="+launchpadClientID)
+	assert.Contains(t, body, "type=refresh")
+	assert.Contains(t, body, "client_id="+launchpadClientID)
 }
 
 func TestLoginRejectsInvalidScope(t *testing.T) {


### PR DESCRIPTION
## Summary

- `refreshLocked` was sending `RefreshRequest` without `ClientID`/`ClientSecret`, causing "Missing client_id" errors from the token endpoint
- Resolves client credentials per OAuthType: BC3 loads from `client.json`, Launchpad uses env vars or built-in defaults
- Migrates old credentials: empty `OAuthType` defaults to `"launchpad"`, empty `TokenEndpoint` is derived for launchpad (hard error for bc3)
- Clears `ExpiresAt` to 0 when server omits `expires_in`, preserving the existing contract (`ExpiresAt==0` means non-expiring at `auth.go:93`)
- Surfaces the BC3 custom-redirect limitation explicitly: DCR credentials from custom-redirect logins are intentionally session-only (not persisted per `auth.go:659`), so refresh after restart fails with a clear diagnostic rather than a generic error

### Scope limitation

Default-redirect BC3 refresh is fixed. Custom-redirect BC3 refresh after process restart remains unsupported because DCR credentials are intentionally not persisted (they'd become stale without the redirect override). The error message now explains this clearly.

## Test plan

- [x] Auth token expiry with Launchpad → refresh succeeds (sends client_id) — `TestRefreshLocked_LaunchpadSendsClientID`
- [x] Auth token expiry with BC3 (default redirect) → refresh succeeds — `TestRefreshLocked_BC3SendsClientID`
- [x] Auth token expiry with BC3 (custom redirect, after restart) → clear error — `TestRefreshLocked_BC3WithoutClientJSON`
- [x] Old credentials without OAuthType → refresh works (defaults to launchpad) — `TestRefreshLocked_EmptyOAuthTypeDefaultsToLaunchpad`
- [x] Server omits expires_in → ExpiresAt cleared to 0 (no re-trigger loop) — `TestRefreshLocked_ClearsExpiresAtWhenServerOmits`
- [x] `bin/ci` passes
- [x] New unit tests: `TestRefreshLocked_*` (5 tests, all pass with `-race`)