### PR TITLE
Surface dock tools, app URLs, and project IDs in presenter output

### DIFF
--- a/internal/presenter/format.go
+++ b/internal/presenter/format.go
@@ -23,6 +23,8 @@ func FormatField(spec FieldSpec, key string, val any, locale Locale) string {
 		return formatPeople(val)
 	case "number":
 		return formatNumber(val, locale)
+	case "dock":
+		return formatDock(val)
 	default:
 		return formatText(val)
 	}
@@ -129,6 +131,39 @@ func formatPeople(val any) string {
 		}
 	}
 	return strings.Join(names, ", ")
+}
+
+// formatDock formats a project dock (array of tool maps) as a multi-line listing.
+func formatDock(val any) string {
+	arr, ok := val.([]any)
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+
+	var lines []string
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if enabled, ok := m["enabled"].(bool); ok && !enabled {
+			continue
+		}
+		title, _ := m["title"].(string)
+		name, _ := m["name"].(string)
+		id := formatText(m["id"])
+		if title == "" {
+			title = name
+		}
+		if name != "" && id != "" {
+			lines = append(lines, fmt.Sprintf("%s (%s, ID: %s)", title, name, id))
+		} else if name != "" {
+			lines = append(lines, fmt.Sprintf("%s (%s)", title, name))
+		} else {
+			lines = append(lines, title)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // formatPerson formats a single person object (map with "name" field).

--- a/internal/presenter/format_test.go
+++ b/internal/presenter/format_test.go
@@ -1,0 +1,53 @@
+package presenter
+
+import (
+	"testing"
+)
+
+func TestFormatDock(t *testing.T) {
+	dock := []any{
+		map[string]any{"name": "todoset", "title": "To-dos", "enabled": true, "id": float64(1)},
+		map[string]any{"name": "message_board", "title": "Message Board", "enabled": true, "id": float64(2)},
+	}
+
+	got := formatDock(dock)
+	want := "To-dos (todoset, ID: 1)\nMessage Board (message_board, ID: 2)"
+	if got != want {
+		t.Errorf("formatDock(enabled items) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDockSkipsDisabled(t *testing.T) {
+	dock := []any{
+		map[string]any{"name": "todoset", "title": "To-dos", "enabled": true, "id": float64(1)},
+		map[string]any{"name": "vault", "title": "Docs & Files", "enabled": false, "id": float64(3)},
+	}
+
+	got := formatDock(dock)
+	want := "To-dos (todoset, ID: 1)"
+	if got != want {
+		t.Errorf("formatDock(with disabled) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDockDefaultsEnabledWhenAbsent(t *testing.T) {
+	dock := []any{
+		map[string]any{"name": "todoset", "title": "To-dos", "id": float64(1)},
+		map[string]any{"name": "schedule", "title": "Schedule", "id": float64(2)},
+	}
+
+	got := formatDock(dock)
+	want := "To-dos (todoset, ID: 1)\nSchedule (schedule, ID: 2)"
+	if got != want {
+		t.Errorf("formatDock(no enabled field) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDockEmpty(t *testing.T) {
+	if got := formatDock([]any{}); got != "" {
+		t.Errorf("formatDock(empty) = %q, want empty", got)
+	}
+	if got := formatDock(nil); got != "" {
+		t.Errorf("formatDock(nil) = %q, want empty", got)
+	}
+}

--- a/internal/presenter/schemas/comment.yaml
+++ b/internal/presenter/schemas/comment.yaml
@@ -18,6 +18,10 @@ fields:
     role: detail
     format: person
 
+  app_url:
+    role: meta
+    format: text
+
   created_at:
     role: meta
     emphasis: muted
@@ -34,7 +38,7 @@ views:
     sections:
       - fields: [content]
       - heading: Metadata
-        fields: [id, created_at, creator]
+        fields: [id, app_url, created_at, creator]
 
 affordances:
   - action: update

--- a/internal/presenter/schemas/project.yaml
+++ b/internal/presenter/schemas/project.yaml
@@ -29,6 +29,14 @@ fields:
     role: detail
     format: text
 
+  dock:
+    role: body
+    format: dock
+
+  app_url:
+    role: meta
+    format: text
+
   created_at:
     role: meta
     emphasis: muted
@@ -36,7 +44,6 @@ fields:
 
   id:
     role: meta
-    emphasis: muted
 
 views:
   list:
@@ -46,8 +53,10 @@ views:
       - fields: [name, description]
       - heading: Info
         fields: [status, bookmarked]
+      - heading: Dock
+        fields: [dock]
       - heading: Metadata
-        fields: [id, created_at]
+        fields: [id, app_url, created_at]
   compact:
     show: [name, status]
     inline: true

--- a/internal/presenter/schemas/todo.yaml
+++ b/internal/presenter/schemas/todo.yaml
@@ -42,6 +42,10 @@ fields:
     format: people
     collapse: true
 
+  app_url:
+    role: meta
+    format: text
+
   created_at:
     role: meta
     emphasis: muted
@@ -63,7 +67,7 @@ views:
       - heading: Status
         fields: [completed, due_on, assignees]
       - heading: Metadata
-        fields: [id, created_at]
+        fields: [id, app_url, created_at]
   compact:
     show: [content, completed]
     inline: true

--- a/internal/presenter/schemas/todolist.yaml
+++ b/internal/presenter/schemas/todolist.yaml
@@ -37,6 +37,10 @@ fields:
     role: detail
     format: number
 
+  app_url:
+    role: meta
+    format: text
+
   created_at:
     role: meta
     emphasis: muted
@@ -55,4 +59,4 @@ views:
       - heading: Status
         fields: [completed, completed_ratio, comments_count]
       - heading: Metadata
-        fields: [id, created_at]
+        fields: [id, app_url, created_at]


### PR DESCRIPTION
## Summary
- surface project IDs more prominently in presenter output
- add dock rendering for enabled project tools
- include app URLs in project, todo, todolist, and comment schemas

## Testing
- [x] bin/ci

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dock section to Project details and surfaces plain-text `app_url` across schemas to make presenter output easier to navigate. Also shows Project IDs at normal weight for quick copy/paste.

- **New Features**
  - Project dock: new `dock` field + formatter lists enabled tools as "Title (name, ID: xxx)" in the Project detail view.
  - `app_url` added to Project, Todo, Todolist, and Comment schemas and shown in Metadata for terminals without link support.
  - Project `id` is no longer muted and is shown in Metadata for easier copying.

<sup>Written for commit cad083389356ca23d365be8b0ad639a6b7d80637. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->