### PR TITLE
Improve message board selection help text

### DIFF
--- a/internal/commands/messages.go
+++ b/internal/commands/messages.go
@@ -21,10 +21,13 @@ func NewMessagesCmd() *cobra.Command {
 	var messageBoard string
 
 	cmd := &cobra.Command{
-		Use:         "messages",
-		Aliases:     []string{"msgs"},
-		Short:       "Manage message board messages",
-		Long:        "List, show, create, and manage messages in a project's message board.",
+		Use:     "messages",
+		Aliases: []string{"msgs"},
+		Short:   "Manage message board messages",
+		Long: `List, show, create, and manage messages in a project's message board.
+
+Most projects have a single message board. If a project has multiple,
+use --message-board <id> to specify which one.`,
 		Annotations: map[string]string{"agent_notes": "Rich text content accepts Markdown — the CLI converts to HTML\nCross-project messages: basecamp recordings messages --json\nPinned messages appear at the top of the message board"},
 	}
 
@@ -513,7 +516,10 @@ func NewMessageCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "message <title> [body]",
 		Short: "Post a new message",
-		Long:  "Post a message to a project's message board. Shortcut for 'basecamp messages create'.",
+		Long: `Post a message to a project's message board. Shortcut for 'basecamp messages create'.
+
+Most projects have a single message board. If a project has multiple,
+use --message-board <id> to specify which one.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 


### PR DESCRIPTION
## Summary
- explain when --message-board is required for multi-board projects
- surface that guidance on both the parent messages command and the shortcut command

## Testing
- [x] bin/ci

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified help text for selecting a message board in the `messages` and `message` commands.
The help now explains that most projects have one board, and for multi-board projects you should pass `--message-board <id>`.

<sup>Written for commit 55d21cc26bc4dc974e16cf7d26cbfca9cb56a6ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->