### PR TITLE
Track skill version and auto-refresh after upgrade

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -136,11 +136,14 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
-		if app := appctx.FromContext(cmd.Context()); app != nil {
+		app := appctx.FromContext(cmd.Context())
+		if app != nil {
 			app.Close()
 		}
 		if commands.RefreshSkillsIfVersionChanged() {
-			fmt.Fprintf(os.Stderr, "Agent skill updated to match CLI %s\n", version.Version)
+			if app == nil || !app.IsMachineOutput() {
+				fmt.Fprintf(os.Stderr, "Agent skill updated to match CLI %s\n", version.Version)
+			}
 		}
 		return nil
 	}

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -932,7 +932,7 @@ func buildDoctorBreadcrumbs(checks []Check) []output.Breadcrumb {
 	var breadcrumbs []output.Breadcrumb
 
 	for _, c := range checks {
-		if c.Status != "fail" {
+		if c.Status != "fail" && c.Status != "warn" {
 			continue
 		}
 

--- a/internal/commands/doctor_test.go
+++ b/internal/commands/doctor_test.go
@@ -565,6 +565,88 @@ func TestCheckClaudeIntegrationIncludesSkillLink(t *testing.T) {
 	}
 }
 
+func TestCheckSkillVersion_UpToDate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("skill"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".installed-version"), []byte(version.Version), 0o644))
+
+	check := checkSkillVersion()
+	assert.Equal(t, "pass", check.Status)
+	if version.IsDev() {
+		assert.Contains(t, check.Message, "dev build")
+	} else {
+		assert.Contains(t, check.Message, "Up to date")
+	}
+}
+
+func TestCheckSkillVersion_Stale(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origVersion := version.Version
+	version.Version = "2.0.0"
+	defer func() { version.Version = origVersion }()
+
+	dir := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("skill"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".installed-version"), []byte("1.0.0"), 0o644))
+
+	check := checkSkillVersion()
+	assert.Equal(t, "warn", check.Status)
+	assert.Contains(t, check.Message, "Stale")
+	assert.Contains(t, check.Message, "1.0.0")
+	assert.Contains(t, check.Message, "2.0.0")
+	assert.Contains(t, check.Hint, "basecamp skill install")
+}
+
+func TestCheckSkillVersion_Untracked(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("skill"), 0o644))
+	// No .installed-version file
+
+	check := checkSkillVersion()
+	assert.Equal(t, "pass", check.Status)
+	assert.Contains(t, check.Message, "version not tracked")
+}
+
+func TestCheckSkillVersion_DevBuild(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origVersion := version.Version
+	version.Version = "dev"
+	defer func() { version.Version = origVersion }()
+
+	dir := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("skill"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".installed-version"), []byte("1.0.0"), 0o644))
+
+	check := checkSkillVersion()
+	assert.Equal(t, "pass", check.Status)
+	assert.Contains(t, check.Message, "dev build")
+	assert.Contains(t, check.Message, "1.0.0")
+}
+
+func TestBuildDoctorBreadcrumbs_SkillVersionWarn(t *testing.T) {
+	checks := []Check{
+		{Name: "Skill Version", Status: "warn"},
+	}
+
+	breadcrumbs := buildDoctorBreadcrumbs(checks)
+	require.Len(t, breadcrumbs, 1)
+	assert.Equal(t, "basecamp skill install", breadcrumbs[0].Cmd)
+}
+
 func TestCheckLegacyInstall_SkipsKeyringWhenNoKeyring(t *testing.T) {
 	t.Setenv("BASECAMP_NO_KEYRING", "1")
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())

--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -331,15 +331,19 @@ func RefreshSkillsIfVersionChanged() bool {
 	}
 
 	refreshed := false
-	if baselineSkillInstalled() {
+	needsRefresh := baselineSkillInstalled()
+	if needsRefresh {
 		if _, err := installSkillFiles(); err == nil {
 			refreshed = true
 		}
 	}
 
-	// Update sentinel (best-effort, directory may not exist yet)
-	_ = os.MkdirAll(filepath.Dir(sentinelPath), 0o755)             //nolint:gosec // G301: config dir
-	_ = os.WriteFile(sentinelPath, []byte(version.Version), 0o644) //nolint:gosec // G306: not a secret
+	// Update sentinel only when no refresh was needed or it succeeded.
+	// On transient failure, leave the sentinel stale so the next run retries.
+	if !needsRefresh || refreshed {
+		_ = os.MkdirAll(filepath.Dir(sentinelPath), 0o755)             //nolint:gosec // G301: config dir
+		_ = os.WriteFile(sentinelPath, []byte(version.Version), 0o644) //nolint:gosec // G306: not a secret
+	}
 
 	return refreshed
 }

--- a/internal/commands/skill_test.go
+++ b/internal/commands/skill_test.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/version"
 	"github.com/basecamp/basecamp-cli/skills"
 )
 
@@ -322,4 +326,149 @@ func TestSkillInstallNoClaude(t *testing.T) {
 	if _, err := os.Stat(claudeDir); err == nil {
 		t.Error("~/.claude should not be created when Claude is not detected")
 	}
+}
+
+func TestInstallSkillFilesStampsVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := installSkillFiles()
+	require.NoError(t, err)
+
+	versionFile := filepath.Join(home, ".agents", "skills", "basecamp", installedVersionFile)
+	got, err := os.ReadFile(versionFile)
+	require.NoError(t, err)
+	assert.Equal(t, version.Version, string(got))
+}
+
+func TestInstalledSkillVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No file → empty string
+	assert.Equal(t, "", installedSkillVersion())
+
+	// Create version file
+	dir := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, installedVersionFile), []byte("1.2.3\n"), 0o644))
+
+	assert.Equal(t, "1.2.3", installedSkillVersion())
+}
+
+func TestRefreshSkillsIfVersionChanged_SentinelMissing(t *testing.T) {
+	home := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	// Install baseline skill so refresh has something to update
+	_, err := installSkillFiles()
+	require.NoError(t, err)
+
+	// Save original version and set a non-dev version for testing
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	refreshed := RefreshSkillsIfVersionChanged()
+	assert.True(t, refreshed, "should refresh when sentinel is missing")
+
+	// Sentinel should now exist
+	sentinel, err := os.ReadFile(filepath.Join(configDir, "basecamp", ".last-run-version"))
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", string(sentinel))
+}
+
+func TestRefreshSkillsIfVersionChanged_SentinelMatches(t *testing.T) {
+	home := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	// Install skill and write matching sentinel
+	_, err := installSkillFiles()
+	require.NoError(t, err)
+	sentinelDir := filepath.Join(configDir, "basecamp")
+	require.NoError(t, os.MkdirAll(sentinelDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sentinelDir, ".last-run-version"), []byte("1.0.0"), 0o644))
+
+	refreshed := RefreshSkillsIfVersionChanged()
+	assert.False(t, refreshed, "should not refresh when sentinel matches")
+}
+
+func TestRefreshSkillsIfVersionChanged_SentinelMismatched(t *testing.T) {
+	home := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	origVersion := version.Version
+	version.Version = "2.0.0"
+	defer func() { version.Version = origVersion }()
+
+	// Install baseline skill and write old sentinel
+	_, err := installSkillFiles()
+	require.NoError(t, err)
+	sentinelDir := filepath.Join(configDir, "basecamp")
+	require.NoError(t, os.MkdirAll(sentinelDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sentinelDir, ".last-run-version"), []byte("1.0.0"), 0o644))
+
+	refreshed := RefreshSkillsIfVersionChanged()
+	assert.True(t, refreshed, "should refresh when sentinel mismatches")
+
+	// Sentinel should be updated
+	sentinel, err := os.ReadFile(filepath.Join(sentinelDir, ".last-run-version"))
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", string(sentinel))
+
+	// Installed version should be updated
+	assert.Equal(t, "2.0.0", installedSkillVersion())
+}
+
+func TestRefreshSkillsIfVersionChanged_SkipsDev(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "dev"
+	defer func() { version.Version = origVersion }()
+
+	refreshed := RefreshSkillsIfVersionChanged()
+	assert.False(t, refreshed, "should skip for dev builds")
+}
+
+func TestRefreshSkillsIfVersionChanged_NoSentinelUpdateOnFailure(t *testing.T) {
+	home := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+
+	origVersion := version.Version
+	version.Version = "3.0.0"
+	defer func() { version.Version = origVersion }()
+
+	// Install baseline skill, then make the skill file read-only
+	// so installSkillFiles() will fail on write
+	_, err := installSkillFiles()
+	require.NoError(t, err)
+
+	skillFile := filepath.Join(home, ".agents", "skills", "basecamp", "SKILL.md")
+	require.NoError(t, os.Chmod(skillFile, 0o444))
+	defer os.Chmod(skillFile, 0o644) //nolint:errcheck // cleanup
+
+	// Write old sentinel
+	sentinelDir := filepath.Join(configDir, "basecamp")
+	require.NoError(t, os.MkdirAll(sentinelDir, 0o755))
+	sentinelPath := filepath.Join(sentinelDir, ".last-run-version")
+	require.NoError(t, os.WriteFile(sentinelPath, []byte("2.0.0"), 0o644))
+
+	refreshed := RefreshSkillsIfVersionChanged()
+	assert.False(t, refreshed, "should not report refresh on failure")
+
+	// Sentinel should NOT be updated (so next run retries)
+	sentinel, err := os.ReadFile(sentinelPath)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", string(sentinel), "sentinel should remain unchanged on failure")
 }


### PR DESCRIPTION
## Summary

- `installSkillFiles()` and the wizard now stamp `.installed-version` alongside SKILL.md
- `RefreshSkillsIfVersionChanged()` compares `~/.config/basecamp/.last-run-version` sentinel against the running CLI version; on mismatch, silently refreshes the baseline skill and prints a one-line stderr notice
- Called from `PersistentPostRunE` — works for all upgrade paths (Homebrew, manual, go install)
- `basecamp doctor` gains a "Skill Version" check (up to date / stale / untracked / dev build) with breadcrumb to `basecamp skill install`

## Test plan

- [x] `basecamp skill install` → verify `.installed-version` exists at `~/.agents/skills/basecamp/`
- [x] Tamper `.last-run-version` to an old version → run any command → verify skill refreshed + notice printed
- [x] Match `.last-run-version` to current version → run command → no notice
- [x] `basecamp doctor` → verify "Skill Version" check appears
- [x] `bin/ci` passes