### PR TITLE
Don't truncate URLs in formatted output

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -2139,6 +2139,15 @@ func TestFormatCellDoesNotTruncateURLs(t *testing.T) {
 		result := formatCell(httpURL)
 		assert.Equal(t, httpURL, result)
 	})
+
+	t.Run("URL-like string with spaces is truncated", func(t *testing.T) {
+		// After newline collapsing, a value like "https://example.com\n(extra...)"
+		// becomes "https://example.com (extra...)" — not a real URL.
+		notURL := "https://example.com (extra text that makes this quite long)"
+		result := formatCell(notURL)
+		assert.Len(t, []rune(result), 40)
+		assert.True(t, strings.HasSuffix(result, "..."))
+	})
 }
 
 func TestStyledRenderObjectPreservesURLs(t *testing.T) {

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -735,7 +735,8 @@ func formatCell(val any) string {
 }
 
 func isURL(s string) bool {
-	return strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://")
+	return (strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://")) &&
+		!strings.ContainsRune(s, ' ')
 }
 
 // formatDateValue formats date fields in a human-readable way.


### PR DESCRIPTION
## Summary

- `formatCell` truncates any string over 40 runes, which destroys URL fields like `todolists_url` and `app_todolists_url` — a truncated URL can't be clicked, copied, or navigated
- Add `isURL()` helper to skip truncation for `http://` and `https://` prefixes
- Affects all four render paths (styled/markdown × object/table) since they all funnel through `formatCell`

## Test plan

- [x] Unit tests: long URL preserved, non-URL still truncated, short URL passthrough, http scheme
- [x] Regression tests: styled and markdown renderers preserve full URLs in both object and table views
- [x] `bin/ci` green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip truncation of http(s) URLs in formatted output so links stay usable across styled and markdown, for both object and table views.

- **Bug Fixes**
  - Update `formatCell` to skip truncation for `http://`/`https://` and reject values with spaces via `isURL()` to avoid false positives.
  - Applies to all render paths that funnel through `formatCell`.
  - Add tests: long URL preserved, non-URL truncated, short URL passthrough, whitespace-in-URL rejected, and styled/markdown object/table regressions.

<sup>Written for commit 8d3d5f875511dcbef26ff14be4dd86c046298ec0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

