### PR TITLE
Fix `campfire list` on multi-campfire projects

### DIFF
--- a/internal/commands/campfire.go
+++ b/internal/commands/campfire.go
@@ -144,12 +144,7 @@ func runCampfireList(cmd *cobra.Command, app *appctx.App, project, campfireID st
 	}
 
 	var projectData struct {
-		Dock []struct {
-			Name    string `json:"name"`
-			Title   string `json:"title"`
-			ID      int64  `json:"id"`
-			Enabled bool   `json:"enabled"`
-		} `json:"dock"`
+		Dock []DockTool `json:"dock"`
 	}
 	if err := json.Unmarshal(resp.Data, &projectData); err != nil {
 		return fmt.Errorf("failed to parse project: %w", err)

--- a/internal/commands/campfire_test.go
+++ b/internal/commands/campfire_test.go
@@ -330,7 +330,7 @@ func TestCampfireListMultipleCampfires(t *testing.T) {
 		Data []map[string]any `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	assert.Len(t, envelope.Data, 2)
+	require.Len(t, envelope.Data, 2)
 
 	titles := []string{envelope.Data[0]["title"].(string), envelope.Data[1]["title"].(string)}
 	assert.Contains(t, titles, "General")
@@ -350,7 +350,7 @@ func TestCampfireListWithCampfireFlag(t *testing.T) {
 		Data []map[string]any `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	assert.Len(t, envelope.Data, 1)
+	require.Len(t, envelope.Data, 1)
 	assert.Equal(t, "Engineering", envelope.Data[0]["title"])
 }
 


### PR DESCRIPTION
## Summary

- `campfire list --in <project>` failed with `CodeAmbiguous` on projects with multiple campfires because it routed through `getDockToolID`, which requires a single match
- Rewrite the project-scoped list path to fetch the dock directly and return all enabled chat entries (mirrors the `todosets list` pattern)
- Thread the `-c` flag into `newCampfireListCmd` so `campfire list -c <id>` works
- Update `agent_notes` to reflect that projects may have multiple campfires

Fixes [card](https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9666102800#__recording_9671001261)

## Design note

`campfire list` intentionally bypasses `getDockToolID` because listing must enumerate all chat dock entries in a project. Single-campfire commands (`messages`, `post`, `upload`, `line`, `delete`) still use the existing `getCampfireID` → `getDockToolID` disambiguation path, which requires `-c` when multiple campfires exist.

## Test plan

- [x] `bin/ci` green
- [x] `TestCampfireListMultipleCampfires` — 2 campfires returned, no ambiguous error
- [x] `TestCampfireListWithCampfireFlag` — `-c <id>` filters to single campfire
- [x] `TestCampfireListNoCampfires` — not-found error with "no campfire" hint
- [x] `TestCampfireListDisabledCampfire` — not-found error with "disabled" hint
- [x] Manual: `basecamp campfire list --in 37331921 --json` — returns both Fizzy campfires
- [x] Manual: `basecamp campfire list -c 9301300227 --in 37331921 --json` — returns only "Chatter"