### PR TITLE
Add paragraph spacing for blank lines in MarkdownToHTML

### DIFF
--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -25,7 +25,7 @@ func NewCommentsCmd() *cobra.Command {
 		Use:         "comments",
 		Short:       "List and manage comments",
 		Long:        "List, show, and update comments on items.",
-		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments\n@mentions supported: use @Name or @First.Last in content to create clickable mentions\nFor visible empty lines use <br><br> — Markdown blank lines become <p> tags which Basecamp renders without spacing"},
+		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments\n@mentions supported: use @Name or @First.Last in content to create clickable mentions"},
 	}
 
 	cmd.PersistentFlags().StringVarP(&project, "project", "p", "", "Project ID or name")

--- a/internal/commands/messages.go
+++ b/internal/commands/messages.go
@@ -29,7 +29,7 @@ func NewMessagesCmd() *cobra.Command {
 
 Most projects have a single message board. If a project has multiple,
 use --message-board <id> to specify which one.`,
-		Annotations: map[string]string{"agent_notes": "Rich text content accepts Markdown — the CLI converts to HTML\nCross-project messages: basecamp recordings messages --json\nPinned messages appear at the top of the message board\n@mentions supported: use @Name or @First.Last in content to create clickable mentions\nFor visible empty lines use <br><br> — Markdown blank lines become <p> tags which Basecamp renders without spacing"},
+		Annotations: map[string]string{"agent_notes": "Rich text content accepts Markdown — the CLI converts to HTML\nCross-project messages: basecamp recordings messages --json\nPinned messages appear at the top of the message board\n@mentions supported: use @Name or @First.Last in content to create clickable mentions"},
 	}
 
 	cmd.PersistentFlags().StringVarP(&project, "project", "p", "", "Project ID or name")

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -124,6 +124,13 @@ func MarkdownToHTML(md string) string {
 	var listType string // "ul" or "ol"
 	var pendingBreak bool
 
+	flushPendingBreak := func() {
+		if pendingBreak {
+			result.WriteString("<br>\n")
+			pendingBreak = false
+		}
+	}
+
 	flushList := func() {
 		if len(listItems) > 0 {
 			result.WriteString("<" + listType + ">\n")
@@ -158,10 +165,7 @@ func MarkdownToHTML(md string) string {
 			} else {
 				// Start code block
 				flushList()
-				if pendingBreak {
-					result.WriteString("<br>\n")
-					pendingBreak = false
-				}
+				flushPendingBreak()
 				inCodeBlock = true
 				codeBlockLang = after
 			}
@@ -180,10 +184,7 @@ func MarkdownToHTML(md string) string {
 		if ulMatch != nil {
 			if !inList || listType != "ul" {
 				flushList()
-				if pendingBreak {
-					result.WriteString("<br>\n")
-					pendingBreak = false
-				}
+				flushPendingBreak()
 				inList = true
 				listType = "ul"
 			}
@@ -194,10 +195,7 @@ func MarkdownToHTML(md string) string {
 		if olMatch != nil {
 			if !inList || listType != "ol" {
 				flushList()
-				if pendingBreak {
-					result.WriteString("<br>\n")
-					pendingBreak = false
-				}
+				flushPendingBreak()
 				inList = true
 				listType = "ol"
 			}
@@ -218,10 +216,7 @@ func MarkdownToHTML(md string) string {
 			continue
 		}
 
-		if pendingBreak {
-			result.WriteString("<br>\n")
-			pendingBreak = false
-		}
+		flushPendingBreak()
 
 		// Headings
 		if after, ok := strings.CutPrefix(line, "######"); ok {

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -147,6 +147,16 @@ func TestMarkdownToHTML(t *testing.T) {
 			input:    "\n\nHello",
 			expected: "<p>Hello</p>",
 		},
+		{
+			name:     "blank line before blockquote",
+			input:    "Intro\n\n> A quote",
+			expected: "<p>Intro</p>\n<br>\n<blockquote>A quote</blockquote>",
+		},
+		{
+			name:     "blank line before horizontal rule",
+			input:    "Intro\n\n---",
+			expected: "<p>Intro</p>\n<br>\n<hr>",
+		},
 	}
 
 	for _, tt := range tests {

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -75,8 +75,7 @@ Full CLI coverage: 130 endpoints across todos, cards, messages, files, schedule,
 3. **Comments are flat** - reply to parent recording, not to comments
 4. **Check context** via `.basecamp/config.json` before assuming project
 5. **Content fields accept Markdown and @mentions** — message body and comment content accept Markdown syntax; the CLI converts to HTML automatically. Use Markdown formatting (lists, bold, links, code blocks) for rich content. Use `@Name` or `@First.Last` to create clickable mentions (e.g., `@Jane.Smith`). For todos, documents, and cards, content is sent as-is — use plain text or HTML directly.
-6. **Line breaks in rich text** — Markdown blank lines become `<p>` tags, which Basecamp renders without visible spacing. For visible empty lines between paragraphs, use `<br><br>` instead of blank lines.
-7. **Project scope is mandatory for most commands** — via `--in <project>` or `.basecamp/config.json`. Cross-project exceptions: `basecamp reports assigned` for assigned work, `basecamp reports overdue` for overdue todos, `basecamp recordings <type>` for browsing by type.
+6. **Project scope is mandatory for most commands** — via `--in <project>` or `.basecamp/config.json`. Cross-project exceptions: `basecamp reports assigned` for assigned work, `basecamp reports overdue` for overdue todos, `basecamp recordings <type>` for browsing by type.
 
 ### Output Modes
 


### PR DESCRIPTION
## Summary

Basecamp's Trix editor does not render margins on `<p>` tags, so consecutive paragraphs produced by `MarkdownToHTML` appear visually merged with no spacing between them.

This made it impossible to create visible paragraph separation when writing Markdown content via the CLI — blank lines in the input were silently discarded.

### Changes

- Blank lines between content blocks now emit `<br>` for visible paragraph separation in Basecamp
- Multiple consecutive blank lines collapse to a single `<br>`, matching standard Markdown paragraph-break semantics
- Leading blank lines (before any content) are still ignored
- Works for all block transitions: paragraph→paragraph, heading→paragraph, paragraph→list, paragraph→code block

### Before

```
Input:  "First paragraph\n\nSecond paragraph"
Output: "<p>First paragraph</p>\n<p>Second paragraph</p>"
```
No visible spacing in Basecamp.

### After

```
Input:  "First paragraph\n\nSecond paragraph"
Output: "<p>First paragraph</p>\n<br>\n<p>Second paragraph</p>"
```
Visible paragraph separation in Basecamp.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add visible paragraph spacing in HTML output from `MarkdownToHTML` by inserting <br> for non-leading blank lines. Fixes merged paragraphs and block transitions in Basecamp’s Trix editor.

- **Bug Fixes**
  - Emit one <br> for non-leading blank lines; collapse multiples; ignore leading.
  - Apply before lists, code blocks, blockquotes, horizontal rules, and between headings and paragraphs.
  - Add tests for paragraphs, headings, lists, code blocks, blockquotes, hr, and edge cases.
  - Remove `<br><br>` workaround from CLI notes and `skills/basecamp/SKILL.md`; extract `flushPendingBreak()` helper.

<sup>Written for commit b267159ed178a70e88ae4eb2910496dc82504f08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

