### PR TITLE
Fix bash quoting bug in smoke_provision.sh

### DIFF
--- a/e2e/smoke/smoke_provision.sh
+++ b/e2e/smoke/smoke_provision.sh
@@ -62,61 +62,61 @@ QA_INBOX=$(enable_dock_tool "inbox") || QA_INBOX=""
 
 # Todolist
 out=$(basecamp todolists list -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-QA_TODOLIST=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+QA_TODOLIST=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
 if [[ -z "$QA_TODOLIST" ]]; then
   out=$(basecamp todolists create "Smoke Test List" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_TODOLIST=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+  QA_TODOLIST=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
 fi
 
 # Todo (needs todolist)
 QA_TODO=""
 if [[ -n "$QA_TODOLIST" ]]; then
   out=$(basecamp todos list -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_TODO=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+  QA_TODO=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
   if [[ -z "$QA_TODO" ]]; then
     out=$(basecamp todos create "Smoke test todo" --list "$QA_TODOLIST" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-    QA_TODO=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+    QA_TODO=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
   fi
 fi
 
 # Message (needs messageboard enabled)
 out=$(basecamp messages list -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-QA_MESSAGE=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+QA_MESSAGE=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
 if [[ -z "$QA_MESSAGE" && -n "$QA_MESSAGEBOARD" ]]; then
   out=$(basecamp messages create "Smoke test message" "Automated smoke test" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_MESSAGE=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+  QA_MESSAGE=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
 fi
 
 # Comment (needs todo)
 QA_COMMENT=""
 if [[ -n "$QA_TODO" ]]; then
   out=$(basecamp comments list "$QA_TODO" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_COMMENT=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+  QA_COMMENT=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
   if [[ -z "$QA_COMMENT" ]]; then
     out=$(basecamp comments create "$QA_TODO" "Smoke test comment" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-    QA_COMMENT=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+    QA_COMMENT=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
   fi
 fi
 
 # Upload
 out=$(basecamp uploads list -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-QA_UPLOAD=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+QA_UPLOAD=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
 if [[ -z "$QA_UPLOAD" ]]; then
   tmpfile=$(mktemp)
   echo "smoke test upload $(date +%s)" > "$tmpfile"
   out=$(basecamp uploads create "$tmpfile" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
   rm -f "$tmpfile"
-  QA_UPLOAD=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+  QA_UPLOAD=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
 fi
 
 # Card (needs cardtable)
 QA_CARD=""
 if [[ -n "$QA_CARDTABLE" ]]; then
   out=$(basecamp cards list --card-table "$QA_CARDTABLE" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_CARD=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+  QA_CARD=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
   if [[ -z "$QA_CARD" ]]; then
     out=$(basecamp cards create "Smoke card" --card-table "$QA_CARDTABLE" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-    QA_CARD=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+    QA_CARD=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
   fi
 fi
 
@@ -124,10 +124,10 @@ fi
 QA_COLUMN=""
 if [[ -n "$QA_CARDTABLE" ]]; then
   out=$(basecamp cards columns --card-table "$QA_CARDTABLE" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-  QA_COLUMN=$(echo "${out:-{}}" | jq -r '.data[0].id // empty')
+  QA_COLUMN=$(echo "${out:-"{}"}" | jq -r '.data[0].id // empty')
   if [[ -z "$QA_COLUMN" ]]; then
     out=$(basecamp cards column create "Smoke column" --card-table "$QA_CARDTABLE" -p "$QA_PROJECT" --json 2>/dev/null) || out=""
-    QA_COLUMN=$(echo "${out:-{}}" | jq -r '.data.id // empty')
+    QA_COLUMN=$(echo "${out:-"{}"}" | jq -r '.data.id // empty')
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Fix `${out:-{}}` → `${out:-"{}"}` in all 14 occurrences in `smoke_provision.sh`
- Bash parses `${out:-{}}` as `${out:-{}` (default `{`) + literal `}`, so when `out` is non-empty it appends a stray `}` producing invalid JSON that breaks jq under `set -eo pipefail`

## Test plan
- [x] `make check` passes (254 leaves, 0 uncovered)
- [x] `smoke_provision.sh` completes successfully against local dev (14 variables provisioned)
- [x] Full smoke suite runs with provisioning enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed bash default expansion in `e2e/smoke/smoke_provision.sh` by replacing 14 occurrences of `${out:-{}}` with `${out:-"{}"}` to prevent a stray `}` from corrupting JSON. This stops `jq` failures under `set -eo pipefail` and makes smoke provisioning reliable.

<sup>Written for commit e70479776c41b7726470f57219c800b72156621c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

