### PR TITLE
Add smoke test for messages publish command

### DIFF
--- a/e2e/smoke/smoke_messages_write.bats
+++ b/e2e/smoke/smoke_messages_write.bats
@@ -27,6 +27,24 @@ setup_file() {
   assert_json_not_null '.data.id'
 }
 
+@test "messages publish publishes a draft message" {
+  run_smoke basecamp messages create "Smoke draft $(date +%s)" \
+    "Draft body" --draft -p "$QA_PROJECT" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+  assert_json_not_null '.data.id'
+  local draft_id
+  draft_id=$(echo "$output" | jq -r '.data.id')
+
+  run_smoke basecamp messages publish "$draft_id" -p "$QA_PROJECT" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+
+  # Clean up: trash the published message
+  run_smoke basecamp messages trash "$draft_id" -p "$QA_PROJECT" --json
+  assert_success
+}
+
 @test "messages update updates a message" {
   local id_file="$BATS_FILE_TMPDIR/message_id"
   [[ -f "$id_file" ]] || mark_unverifiable "No message created in prior test"


### PR DESCRIPTION
## Summary

- Covers the smoke coverage gap from #294 — `messages publish` had no e2e test
- Creates a draft, publishes it, then trashes it for cleanup

## Test plan

- [ ] `bin/ci` passes (smoke coverage check no longer reports uncovered commands)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an end-to-end smoke test for `messages publish` to close the coverage gap from #294. The test creates a draft via `messages create --draft`, publishes it, then trashes it for cleanup.

<sup>Written for commit ed6fdb24a30cf7544a00520da8733d552aa83953. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

