### PR TITLE
Show -- separator in card creation help and add test coverage

### DIFF
--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -289,7 +289,7 @@ func newCardsCreateCmd(project, cardTable *string) *cobra.Command {
 		Short: "Create a new card",
 		Long:  "Create a new card in a project's card table.",
 		Example: `  basecamp cards create "My card" --in myproject
-  basecamp cards create -- "--title with dashes" --in myproject`,
+  basecamp cards create --in myproject -- "--title with dashes"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Show help when invoked with no title
 			if len(args) == 0 {
@@ -772,7 +772,7 @@ func NewCardCmd() *cobra.Command {
 		Short: "Create a new card",
 		Long:  "Create a card in a project's card table. Shortcut for 'basecamp cards create'.",
 		Example: `  basecamp card "My card" --in myproject
-  basecamp card -- "--title with dashes" --in myproject`,
+  basecamp card --in myproject -- "--title with dashes"`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Show help when invoked with no title

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -984,29 +984,39 @@ func TestCardsMovePositionNumericToMultiTableAmbiguous(t *testing.T) {
 // title pass through without being parsed as a flag.
 func TestCardsCreateDashSeparatorTitle(t *testing.T) {
 	app, _ := setupTestApp(t)
-	app.Config.ProjectID = "123"
+	// ProjectID intentionally empty — --in must be parsed for the command to
+	// proceed past project resolution.
 
 	cmd := NewCardsCmd()
 
 	err := executeCommand(cmd, app, "create", "--in", "123", "--", "--some-title")
 
-	// Will hit auth/API, but must NOT be "unknown flag"
-	if err != nil {
-		assert.NotContains(t, err.Error(), "unknown flag")
+	// No-network transport guarantees an error past arg parsing.
+	require.NotNil(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag")
+	assert.NotContains(t, err.Error(), "unknown shorthand")
+
+	var e *output.Error
+	if errors.As(err, &e) {
+		assert.NotEqual(t, "Project ID required", e.Message)
 	}
 }
 
 // TestCardShortcutDashSeparatorTitle verifies the same for the card shortcut.
 func TestCardShortcutDashSeparatorTitle(t *testing.T) {
 	app, _ := setupTestApp(t)
-	app.Config.ProjectID = "123"
 
 	cmd := NewCardCmd()
 
 	err := executeCommand(cmd, app, "--in", "123", "--", "--some-title")
 
-	if err != nil {
-		assert.NotContains(t, err.Error(), "unknown flag")
+	require.NotNil(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag")
+	assert.NotContains(t, err.Error(), "unknown shorthand")
+
+	var e *output.Error
+	if errors.As(err, &e) {
+		assert.NotEqual(t, "Project ID required", e.Message)
 	}
 }
 
@@ -1014,27 +1024,37 @@ func TestCardShortcutDashSeparatorTitle(t *testing.T) {
 // flags placed after the positional title must still be parsed.
 func TestCardsCreateFlagsAfterTitle(t *testing.T) {
 	app, _ := setupTestApp(t)
-	app.Config.ProjectID = "123"
+	// ProjectID intentionally empty — if --in after the title is NOT parsed,
+	// the command would fail with "Project ID required".
 
 	cmd := NewCardsCmd()
 
 	err := executeCommand(cmd, app, "create", "Normal title", "--in", "123")
 
-	if err != nil {
-		assert.NotContains(t, err.Error(), "unknown flag")
+	require.NotNil(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag")
+	assert.NotContains(t, err.Error(), "unknown shorthand")
+
+	var e *output.Error
+	if errors.As(err, &e) {
+		assert.NotEqual(t, "Project ID required", e.Message)
 	}
 }
 
 // TestCardShortcutFlagsAfterTitle guards the same for the card shortcut.
 func TestCardShortcutFlagsAfterTitle(t *testing.T) {
 	app, _ := setupTestApp(t)
-	app.Config.ProjectID = "123"
 
 	cmd := NewCardCmd()
 
 	err := executeCommand(cmd, app, "Normal title", "--in", "123")
 
-	if err != nil {
-		assert.NotContains(t, err.Error(), "unknown flag")
+	require.NotNil(t, err)
+	assert.NotContains(t, err.Error(), "unknown flag")
+	assert.NotContains(t, err.Error(), "unknown shorthand")
+
+	var e *output.Error
+	if errors.As(err, &e) {
+		assert.NotEqual(t, "Project ID required", e.Message)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `Example` fields to `cards create` and the `card` shortcut showing the `--` separator for titles that start with dashes (e.g. `--Deploy checklist`)
- Add four tests: two for the `--` separator path, two regression guards for flags-anywhere behavior

## Context

When a card title starts with `--`, Cobra interprets it as a flag. The POSIX `--` separator already works but wasn't discoverable from help output.

## Test plan

- [x] `make test` passes
- [x] `bin/ci` green
- [x] `basecamp cards create --help` and `basecamp card --help` show the new examples

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the POSIX `--` separator in `cards create` and `card` help so titles starting with dashes are treated as text, not flags. Place `--in` before `--` in examples, and add four tests covering dash-prefixed titles and flags-after-title parsing.

<sup>Written for commit 2f17351f331aba0e91cec1dceeee51b38df3f675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

