### PR TITLE
Return structured JSON help from bare group commands when --json is active

### DIFF
--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -386,6 +386,16 @@ load test_helper
   assert_output_contains "COMMANDS"
 }
 
+@test "messages --json shows structured JSON help" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  run basecamp messages --json
+  assert_success
+  assert_json_value '.command' 'messages'
+  assert_output_contains '"subcommands"'
+}
+
 @test "message without subject shows error" {
   create_credentials
   create_global_config '{"account_id": 99999, "project_id": 123}'

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -17,7 +17,12 @@ import (
 // and a consistent styled layout for every subcommand.
 func rootHelpFunc() func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		if agent, _ := cmd.Root().PersistentFlags().GetBool("agent"); agent {
+		pf := cmd.Root().PersistentFlags()
+		if agent, _ := pf.GetBool("agent"); agent {
+			emitAgentHelp(cmd)
+			return
+		}
+		if jsonFlag, _ := pf.GetBool("json"); jsonFlag {
 			emitAgentHelp(cmd)
 			return
 		}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -265,6 +265,49 @@ func TestAgentHelpProducesJSON(t *testing.T) {
 	assert.Contains(t, out, `"command"`)
 }
 
+func TestJSONHelpProducesStructuredJSON(t *testing.T) {
+	isolateHelpTest(t)
+
+	var buf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--help", "--json"})
+	_ = cmd.Execute()
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "{"), "json help should produce JSON, got: %s", out)
+	assert.Contains(t, out, `"command"`)
+}
+
+func TestBareGroupJSONHelpProducesJSON(t *testing.T) {
+	isolateHelpTest(t)
+
+	var buf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.AddCommand(commands.NewTodosCmd())
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"todos", "--json"})
+	_ = cmd.Execute()
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "{"), "bare group --json should produce JSON, got: %s", out)
+	assert.Contains(t, out, `"subcommands"`)
+}
+
+func TestBareGroupTextHelpUnchanged(t *testing.T) {
+	isolateHelpTest(t)
+
+	var buf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.AddCommand(commands.NewTodosCmd())
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"todos"})
+	_ = cmd.Execute()
+
+	out := buf.String()
+	assert.Contains(t, out, "COMMANDS")
+}
+
 func TestBareRootToleratesBadProfile(t *testing.T) {
 	// Bare basecamp should not error when profile env is broken.
 	// In non-TTY test environments the bare root falls through to quickstart


### PR DESCRIPTION
## Summary

- When `--json` is passed to a bare group command (`basecamp cards --json`, `basecamp messages --json`, etc.), the help function now emits structured JSON instead of plain text that breaks JSON parsers
- Extends the existing `--agent` help path in `rootHelpFunc()` to also trigger on `--json`, covering all bare group commands centrally
- Scoped to the explicit `--json` flag only — `--jq`, config-driven `format=json`, and non-TTY piped output retain existing behavior

## Test plan

- [x] `go test ./internal/cli/...` — 3 new unit tests (`TestJSONHelpProducesStructuredJSON`, `TestBareGroupJSONHelpProducesJSON`, `TestBareGroupTextHelpUnchanged`)
- [x] `make test-e2e` — 1 new e2e test (`messages --json shows structured JSON help`)
- [x] `bin/ci` — full CI suite passes (linter skipped locally due to parallel worktree contention; unit + e2e + vet all green)
- [x] Manual: `bin/basecamp cards --json` returns JSON with `"command":"cards","subcommands":[...]`
- [x] Manual: `bin/basecamp cards` still shows text help unchanged