### PR TITLE
Add e2e test coverage for --jq flag

### DIFF
--- a/e2e/core.bats
+++ b/e2e/core.bats
@@ -80,7 +80,7 @@ load test_helper
 @test "--jq extracts scalar" {
   run basecamp --jq '.data.auth.status'
   assert_success
-  assert_output_contains "unauthenticated"
+  [[ "$output" == "unauthenticated" ]]
 }
 
 

--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -113,6 +113,7 @@ load test_helper
 # JQ flag errors
 
 @test "--jq invalid expression shows error" {
+  create_credentials
   run basecamp --jq '.[invalid'
   assert_failure
   assert_json_value '.ok' 'false'
@@ -121,11 +122,12 @@ load test_helper
 }
 
 @test "--jq conflicts with --ids-only" {
+  create_credentials
   run basecamp --jq '.data' --ids-only
   assert_failure
   assert_json_value '.ok' 'false'
   assert_json_value '.code' 'usage'
-  assert_output_contains "cannot use --jq with --ids-only"
+  assert_json_value '.error' 'cannot use --jq with --ids-only'
 }
 
 


### PR DESCRIPTION
## Summary
- Add 2 success-path tests in `core.bats`: `--jq` implies `--json`, scalar extraction works cleanly
- Add 2 failure-path tests in `errors.bats`: invalid jq expression and `--jq`/`--ids-only` conflict both return structured usage errors

Locks in the behavior from #286.

## Test plan
- [x] `make test-e2e` — 289/289 pass
- [x] `make test` — all unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end tests for the --jq flag to lock in expected behavior and prevent regressions. Confirms that --jq implies --json, supports scalar extraction with exact-match output, and returns structured usage errors for invalid expressions and when combined with --ids-only; also tightens assertions and adds credentials setup in error tests.

<sup>Written for commit 6b9c289ed1d584c699f153f6187bcef56b1835ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

