### PR TITLE
Migrate step validation to SDK CardSteps().Get()

### DIFF
--- a/internal/commands/assign.go
+++ b/internal/commands/assign.go
@@ -27,18 +27,18 @@ func NewAssignCmd() *cobra.Command {
 		Short: "Assign someone to an item",
 		Long: `Assign a person to one or more to-dos, cards, or card steps.
 
-By default assigns to a to-do. Use --card or --step for other types.
+	By default assigns to a to-do. Use --card or --step for other types.
 
-Person can be:
-  - "me" for the current user
-  - A numeric person ID
-  - An email address (will be resolved to ID)
+	Person can be:
+	  - "me" for the current user
+	  - A numeric person ID
+	  - An email address (will be resolved to ID)
 
-Examples:
-  basecamp assign 123 --to me                     # Assign to-do
-  basecamp assign 123 456 --to me                  # Assign multiple to-dos
-  basecamp assign 456 --card --to me               # Assign card
-  basecamp assign 789 --step --to me               # Assign card step`,
+	Examples:
+	  basecamp assign 123 --to me                     # Assign to-do
+	  basecamp assign 123 456 --to me                  # Assign multiple to-dos
+	  basecamp assign 456 --card --to me               # Assign card
+	  basecamp assign 789 --step --to me               # Assign card step`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return missingArg(cmd, "<id|url>...")
@@ -76,18 +76,18 @@ func NewUnassignCmd() *cobra.Command {
 		Short: "Remove assignment",
 		Long: `Remove a person from one or more to-dos, cards, or card steps.
 
-By default unassigns from a to-do. Use --card or --step for other types.
+	By default unassigns from a to-do. Use --card or --step for other types.
 
-Person can be:
-  - "me" for the current user
-  - A numeric person ID
-  - An email address (will be resolved to ID)
+	Person can be:
+	  - "me" for the current user
+	  - A numeric person ID
+	  - An email address (will be resolved to ID)
 
-Examples:
-  basecamp unassign 123 --from me                     # Unassign from to-do
-  basecamp unassign 123 456 --from me                  # Unassign multiple to-dos
-  basecamp unassign 456 --card --from me               # Unassign from card
-  basecamp unassign 789 --step --from me               # Unassign from card step`,
+	Examples:
+	  basecamp unassign 123 --from me                     # Unassign from to-do
+	  basecamp unassign 123 456 --from me                  # Unassign multiple to-dos
+	  basecamp unassign 456 --card --from me               # Unassign from card
+	  basecamp unassign 789 --step --from me               # Unassign from card step`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return missingArg(cmd, "<id|url>...")
@@ -355,7 +355,7 @@ func assignOneItem(cmd *cobra.Command, app *appctx.App, itemID string, isCard, i
 		}
 		return doAssignCard(cmd, app, itemID, *assigneeID, *assigneeIDInt, resolvedProjectID, card)
 	case isStep:
-		step, err := validateStep(cmd, app, itemID, resolvedProjectID)
+		step, err := validateStep(cmd, app, itemID)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func unassignOneItem(cmd *cobra.Command, app *appctx.App, itemID string, isCard,
 		}
 		return doUnassignCard(cmd, app, itemID, *assigneeIDInt, resolvedProjectID, card)
 	case isStep:
-		step, err := validateStep(cmd, app, itemID, resolvedProjectID)
+		step, err := validateStep(cmd, app, itemID)
 		if err != nil {
 			return nil, err
 		}
@@ -512,21 +512,16 @@ func validateCard(cmd *cobra.Command, app *appctx.App, cardIDStr string) (*basec
 }
 
 // validateStep fetches a card step to verify it exists before showing the person picker.
-func validateStep(cmd *cobra.Command, app *appctx.App, stepIDStr, resolvedProjectID string) (*basecamp.CardStep, error) {
+func validateStep(cmd *cobra.Command, app *appctx.App, stepIDStr string) (*basecamp.CardStep, error) {
 	stepID, err := strconv.ParseInt(stepIDStr, 10, 64)
 	if err != nil {
 		return nil, output.ErrUsage("Invalid step ID")
 	}
-	stepPath := fmt.Sprintf("/buckets/%s/card_steps/%d.json", resolvedProjectID, stepID)
-	resp, err := app.Account().Get(cmd.Context(), stepPath)
+	step, err := app.Account().CardSteps().Get(cmd.Context(), stepID)
 	if err != nil {
 		return nil, notFoundOrConvert(err, "step", stepIDStr)
 	}
-	var step basecamp.CardStep
-	if err := resp.UnmarshalData(&step); err != nil {
-		return nil, fmt.Errorf("failed to parse step: %w", err)
-	}
-	return &step, nil
+	return step, nil
 }
 
 // notFoundOrConvert returns a friendly not-found error for the item type,

--- a/internal/commands/assign_test.go
+++ b/internal/commands/assign_test.go
@@ -402,6 +402,101 @@ func TestAssignCardRequiresAssigneeNonInteractive(t *testing.T) {
 	assert.Contains(t, e.Hint, "Use --to")
 }
 
+// stepPathTransport captures the request path for step-fetch calls.
+type stepPathTransport struct {
+	capturedPath string
+}
+
+func (s *stepPathTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	if req.Method == "GET" && strings.Contains(path, "/projects.json") {
+		body := `[{"id": 123, "name": "Test Project"}]`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     header,
+		}, nil
+	}
+
+	if req.Method == "GET" && strings.Contains(path, "card_tables/steps/") {
+		s.capturedPath = path
+		body := `{"id": 456, "title": "Test Step", "assignees": []}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     header,
+		}, nil
+	}
+
+	if req.Method == "GET" && strings.Contains(path, "/my/profile.json") {
+		body := `{"id": 999, "name": "Test User"}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     header,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected HTTP request: %s %s", req.Method, path)
+}
+
+func setupStepPathTestApp(t *testing.T, transport *stepPathTransport) *appctx.App {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	cfg := &config.Config{
+		AccountID: "99999",
+		ProjectID: "123",
+	}
+
+	authMgr := auth.NewManager(cfg, nil)
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &todosTestTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	nameResolver := names.NewResolver(sdkClient, authMgr, cfg.AccountID)
+
+	app := &appctx.App{
+		Config: cfg,
+		Auth:   authMgr,
+		SDK:    sdkClient,
+		Names:  nameResolver,
+		Output: output.New(output.Options{
+			Format: output.FormatJSON,
+			Writer: &bytes.Buffer{},
+		}),
+	}
+	app.Flags.JSON = true
+	return app
+}
+
+func TestValidateStepUsesSDKGet(t *testing.T) {
+	t.Run("assign", func(t *testing.T) {
+		transport := &stepPathTransport{}
+		app := setupStepPathTestApp(t, transport)
+
+		cmd := NewAssignCmd()
+		_ = executeAssignCommand(cmd, app, "456", "--step", "--to", "me", "-p", "123")
+
+		require.NotEmpty(t, transport.capturedPath, "step-fetch request was never made")
+		assert.Contains(t, transport.capturedPath, "card_tables/steps/456")
+	})
+
+	t.Run("unassign", func(t *testing.T) {
+		transport := &stepPathTransport{}
+		app := setupStepPathTestApp(t, transport)
+
+		cmd := NewUnassignCmd()
+		_ = executeAssignCommand(cmd, app, "456", "--step", "--from", "me", "-p", "123")
+
+		require.NotEmpty(t, transport.capturedPath, "step-fetch request was never made")
+		assert.Contains(t, transport.capturedPath, "card_tables/steps/456")
+	})
+}
+
 func TestUnassignStepRequiresAssigneeNonInteractive(t *testing.T) {
 	app := setupAssignGuardTestApp(t)
 


### PR DESCRIPTION
## Summary

- Replace raw HTTP call in `validateStep` with `CardSteps().Get()`, fixing the wrong endpoint path (`card_steps` → `card_tables/steps`) that caused 404 on every `assign --step` / `unassign --step`
- Drop unused `resolvedProjectID` parameter from `validateStep` (SDK method doesn't need it)
- Add `TestValidateStepUsesSDKGet` regression test with `/my/profile.json` stub for robustness

## Test plan

- [x] `TestValidateStepUsesSDKGet` passes for both assign and unassign
- [x] `bin/ci` green (all unit tests, 285 e2e tests, lint, surface snapshot, skill drift)