### PR TITLE
Fix url --help to show <url> as argument, not [parse]

### DIFF
--- a/.surface-breaking
+++ b/.surface-breaking
@@ -1,4 +1,6 @@
 ARG basecamp assign 00 <todo_id>
+ARG basecamp url 00 [parse]
+ARG basecamp url 01 <url>
 ARG basecamp unassign 00 <todo_id>
 ARG basecamp upload archive 00 <id|url>
 ARG basecamp upload doc create 00 <title>

--- a/e2e/url.bats
+++ b/e2e/url.bats
@@ -9,6 +9,8 @@ load test_helper
 @test "basecamp url --help shows help" {
   run basecamp url --help
   assert_success
+  assert_output_contains "<url>"
+  assert_output_not_contains "[parse]"
   assert_output_contains "parse"
 }
 

--- a/internal/commands/url.go
+++ b/internal/commands/url.go
@@ -25,7 +25,7 @@ type ParsedURL struct {
 // NewURLCmd creates the url command for parsing Basecamp URLs.
 func NewURLCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "url [parse] <url>",
+		Use:   "url <url>",
 		Short: "Parse Basecamp URLs",
 		Long: `Parse and work with Basecamp URLs.
 

--- a/internal/commands/url_test.go
+++ b/internal/commands/url_test.go
@@ -394,7 +394,7 @@ func TestURLParseBreadcrumbsForStep(t *testing.T) {
 func TestURLCmdCreation(t *testing.T) {
 	cmd := NewURLCmd()
 	require.NotNil(t, cmd, "NewURLCmd returned nil")
-	assert.Equal(t, "url [parse] <url>", cmd.Use)
+	assert.Equal(t, "url <url>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short, "command should have short description")
 
 	// Should have parse subcommand


### PR DESCRIPTION
## Summary
- Remove `[parse]` from the `url` command's `Use` field so help reads `url <url>` instead of `url [parse] <url>`
- The `parse` subcommand now appears only in the COMMANDS section where it belongs
- Update unit test assertion and strengthen e2e test to assert `<url>` present and `[parse]` absent

## Test plan
- [x] `go run ./cmd/basecamp url --help` shows `<url>`, not `[parse]`; `parse` listed under COMMANDS
- [x] `go test ./internal/commands -run TestURLCmdCreation` passes
- [x] All unit tests pass
- [x] All 290 e2e tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `basecamp url` help to show `url <url>` (not `url [parse] <url>`) and list `parse` only under COMMANDS. Drops `[parse]` from the command’s `Use`, updates `e2e/url.bats` and unit test assertions, and refreshes `.surface-breaking` to reflect `url <url>`.

<sup>Written for commit fd2d31bcbec147539be801db5a18f4722fafcf06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

