### PR TITLE
Include todolist group todos in `todos list`

### DIFF
--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -370,7 +370,7 @@ func runTodosList(cmd *cobra.Command, flags todosListFlags) error {
 
 	// If todolist is specified, list todos in that list
 	if todolist != "" {
-		return listTodosInList(cmd, app, project, todolist, flags.status, flags.limit, flags.page, flags.all, flags.sortField, flags.reverse)
+		return listTodosInList(cmd, app, project, todolist, flags.status, flags.limit, flags.all, flags.sortField, flags.reverse)
 	}
 
 	// --page is not meaningful when aggregating across todolists
@@ -488,7 +488,7 @@ func fetchTodosIncludingGroups(ctx context.Context, app *appctx.App, todolistID 
 	return result, totalCount, nil
 }
 
-func listTodosInList(cmd *cobra.Command, app *appctx.App, project, todolist, status string, limit, page int, all bool, sortField string, reverse bool) error {
+func listTodosInList(cmd *cobra.Command, app *appctx.App, project, todolist, status string, limit int, all bool, sortField string, reverse bool) error {
 	resolvedTodolist, _, err := app.Names.ResolveTodolist(cmd.Context(), todolist, project)
 	if err != nil {
 		return err
@@ -499,17 +499,8 @@ func listTodosInList(cmd *cobra.Command, app *appctx.App, project, todolist, sta
 		return output.ErrUsage("Invalid todolist ID")
 	}
 
-	// Reject --page for grouped todolists before doing any expensive
-	// todo fetches. The groups-list call is lightweight (metadata only).
-	if page > 0 {
-		groupsResult, err := app.Account().TodolistGroups().List(cmd.Context(), todolistID, nil)
-		if err != nil {
-			return convertSDKError(err)
-		}
-		if len(groupsResult.Groups) > 0 {
-			return output.ErrUsage("--page is not supported for todolists with groups; use --limit to cap results")
-		}
-	}
+	// --page 1 is the only valid value (runTodosList rejects 2+) and is the
+	// SDK default, so it's always a no-op — no special handling needed.
 
 	// Determine the SDK limit to pass through. fetchTodosIncludingGroups
 	// uses this for the no-groups fast path and for cross-list aggregation.

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -931,7 +931,7 @@ func (groupTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-// groupErrorTransport is like groupTodoTransport but returns HTTP 500 for
+// groupErrorTransport is like groupTodoTransport but returns HTTP 403 for
 // the /groups.json endpoint.
 type groupErrorTransport struct{}
 
@@ -1063,13 +1063,22 @@ func TestTodosListInListLimitCapsFlattened(t *testing.T) {
 	assert.NotEmpty(t, resp.Notice, "should include truncation notice")
 }
 
-func TestTodosListInListPageErrorsWithGroups(t *testing.T) {
-	app, _ := setupGroupTodoApp(t, groupTodoTransport{})
+func TestTodosListInListPageOneIsNoOp(t *testing.T) {
+	app, buf := setupGroupTodoApp(t, groupTodoTransport{})
 
 	cmd := NewTodosCmd()
+	// --page 1 is the only valid value (2+ rejected by runTodosList) and is
+	// the SDK default, so it succeeds even with grouped todolists.
 	err := executeTodosCommand(cmd, app, "list", "--list", "500", "--page", "1")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--page is not supported for todolists with groups")
+	require.NoError(t, err)
+
+	var resp struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	assert.Len(t, resp.Data, 3, "should return all todos including group todos")
 }
 
 func TestTodosListInListLimitPreservedCrossList(t *testing.T) {


### PR DESCRIPTION
## Summary

- Todos nested inside todolist groups (collapsible sections) were silently dropped from `todos list` output. This fix fetches group-nested todos and merges them with direct todos by position, matching the Basecamp UI ordering.
- Both the single-list path (`--list`) and cross-list aggregation path now include group todos.
- `--page` is rejected with an explicit error when groups are present (no meaningful page boundary after flattening). `--limit` is preserved: passed through to the SDK in the no-groups fast path and cross-list path, applied as a post-flatten cap when groups exist.

## Test plan

- [x] `TestTodosListInListMergesGroupTodosByPosition` — 3 todos returned in position order [1, 2, 3]
- [x] `TestTodosListAllIncludesGroupTodos` — cross-list aggregation includes group todos
- [x] `TestTodosListInListGroupErrorFails` — single-list mode hard-fails on group error
- [x] `TestTodosListAllGroupErrorSkipped` — cross-list mode skips group errors gracefully
- [x] `TestTodosListInListLimitCapsFlattened` — `--limit 2` with 3 total returns 2
- [x] `TestTodosListInListPageErrorsWithGroups` — `--page 1` with groups returns explicit error
- [x] `TestTodosListInListLimitPreservedCrossList` — `--limit` preserved in cross-list mode
- [x] Full CI green (`bin/ci`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `todos list` to include todos nested inside todolist groups and restores accurate truncation notices. Results match Basecamp UI ordering by merging group items with direct todos by top-level position in both single-list and cross-list modes.

- **Bug Fixes**
  - Restore correct total count and truncation notices; apply a 100-item default cap for grouped lists when no limit is set; honor `--limit`/`--all` and pass through in no-group and cross-list paths.
  - Accept `--page 1` as a no-op in single-list mode; reject `--page` in cross-list mode. Remove the duplicate groups fetch that previously did an early `--page` check.
  - Error policy: single-list hard-fails on group fetch errors; cross-list skips failures and continues.

<sup>Written for commit 9fe4246c3dd86e9ee14aed70f52d02a242e52d20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

