### PR TITLE
Fix dock ordering and add --all flag to `projects show`

### DIFF
--- a/.surface
+++ b/.surface
@@ -4388,6 +4388,7 @@ FLAG basecamp projects list --todolist type=string
 FLAG basecamp projects list --verbose type=count
 FLAG basecamp projects show --account type=string
 FLAG basecamp projects show --agent type=bool
+FLAG basecamp projects show --all type=bool
 FLAG basecamp projects show --cache-dir type=string
 FLAG basecamp projects show --count type=bool
 FLAG basecamp projects show --hints type=bool

--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -188,10 +188,12 @@ func updateProjectsCache(projects []basecamp.Project, cacheDir string) {
 }
 
 func newProjectsShowCmd() *cobra.Command {
-	return &cobra.Command{
+	var all bool
+
+	cmd := &cobra.Command{
 		Use:   "show <id>",
 		Short: "Show project details",
-		Long:  "Display detailed information about a project including its dock (the set of enabled tools: message board, to-dos, schedule, etc.).",
+		Long:  "Display detailed information about a project including its dock (the set of enabled tools: message board, to-dos, schedule, etc.).\n\nBy default only enabled tools are shown. Use --all to include disabled tools.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
@@ -214,6 +216,10 @@ func newProjectsShowCmd() *cobra.Command {
 				return convertSDKError(err)
 			}
 
+			if !all {
+				project.Dock = filterEnabledDock(project.Dock)
+			}
+
 			return app.OK(project,
 				output.WithEntity("project"),
 				output.WithBreadcrumbs(
@@ -231,6 +237,21 @@ func newProjectsShowCmd() *cobra.Command {
 			)
 		},
 	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Show all dock tools including disabled")
+
+	return cmd
+}
+
+// filterEnabledDock returns only the enabled dock items.
+func filterEnabledDock(dock []basecamp.DockItem) []basecamp.DockItem {
+	var enabled []basecamp.DockItem
+	for _, item := range dock {
+		if item.Enabled {
+			enabled = append(enabled, item)
+		}
+	}
+	return enabled
 }
 
 func newProjectsCreateCmd() *cobra.Command {

--- a/internal/presenter/format.go
+++ b/internal/presenter/format.go
@@ -155,35 +155,38 @@ func formatDock(val any) string {
 		return ""
 	}
 
-	// Filter to enabled items only.
-	var enabled []map[string]any
-	for _, m := range items {
-		if e, ok := m["enabled"].(bool); ok && !e {
-			continue
-		}
-		enabled = append(enabled, m)
-	}
-
 	// Sort by position so the output matches the web UI order.
-	sort.SliceStable(enabled, func(i, j int) bool {
-		return dockPosition(enabled[i]) < dockPosition(enabled[j])
+	// Enabled items (with positions) come first; disabled items sort to the end.
+	sort.SliceStable(items, func(i, j int) bool {
+		return dockPosition(items[i]) < dockPosition(items[j])
 	})
 
 	var lines []string
-	for _, m := range enabled {
+	for _, m := range items {
+		disabled := false
+		if e, ok := m["enabled"].(bool); ok && !e {
+			disabled = true
+		}
+
 		title, _ := m["title"].(string)
 		name, _ := m["name"].(string)
 		id := formatText(m["id"])
 		if title == "" {
 			title = name
 		}
+
+		var line string
 		if name != "" && id != "" {
-			lines = append(lines, fmt.Sprintf("%s (%s, ID: %s)", title, name, id))
+			line = fmt.Sprintf("%s (%s, ID: %s)", title, name, id)
 		} else if name != "" {
-			lines = append(lines, fmt.Sprintf("%s (%s)", title, name))
+			line = fmt.Sprintf("%s (%s)", title, name)
 		} else {
-			lines = append(lines, title)
+			line = title
 		}
+		if disabled {
+			line += " [disabled]"
+		}
+		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/presenter/format_test.go
+++ b/internal/presenter/format_test.go
@@ -18,14 +18,14 @@ func TestFormatDock(t *testing.T) {
 	}
 }
 
-func TestFormatDockSkipsDisabled(t *testing.T) {
+func TestFormatDockAnnotatesDisabled(t *testing.T) {
 	dock := []any{
-		map[string]any{"name": "todoset", "title": "To-dos", "enabled": true, "id": float64(1)},
+		map[string]any{"name": "todoset", "title": "To-dos", "enabled": true, "id": float64(1), "position": float64(1)},
 		map[string]any{"name": "vault", "title": "Docs & Files", "enabled": false, "id": float64(3)},
 	}
 
 	got := formatDock(dock)
-	want := "To-dos (todoset, ID: 1)"
+	want := "To-dos (todoset, ID: 1)\nDocs & Files (vault, ID: 3) [disabled]"
 	if got != want {
 		t.Errorf("formatDock(with disabled) = %q, want %q", got, want)
 	}
@@ -83,6 +83,20 @@ func TestFormatDockAcceptsMapSlice(t *testing.T) {
 	want := "To-dos (todoset, ID: 1)\nMessage Board (message_board, ID: 2)\nDocs & Files (vault, ID: 3)"
 	if got != want {
 		t.Errorf("formatDock([]map with json.Number) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDockDisabledSortAfterEnabled(t *testing.T) {
+	dock := []map[string]any{
+		{"name": "schedule", "title": "Schedule", "enabled": false, "id": json.Number("3")},
+		{"name": "todoset", "title": "To-dos", "enabled": true, "id": json.Number("1"), "position": json.Number("2")},
+		{"name": "message_board", "title": "Message Board", "enabled": true, "id": json.Number("2"), "position": json.Number("1")},
+	}
+
+	got := formatDock(dock)
+	want := "Message Board (message_board, ID: 2)\nTo-dos (todoset, ID: 1)\nSchedule (schedule, ID: 3) [disabled]"
+	if got != want {
+		t.Errorf("formatDock(disabled sort last) = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Sort dock items by their `position` field so the output matches the order configured in the Basecamp web UI
- Fixed `formatDock` to accept `[]map[string]any` (produced by `NormalizeData`) and `json.Number` position values — previously the function silently returned empty and fell through to a generic unsorted renderer
- Add `--all` flag to include disabled dock tools annotated with `[disabled]`, consistent with how `todos list` handles completed items