### PR TITLE
Show full content in detail views instead of truncating at 40 chars

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1264,6 +1264,76 @@ func TestRenderObjectOrdering(t *testing.T) {
 }
 
 // =============================================================================
+// renderObject Detail Value (no truncation) Tests
+// =============================================================================
+
+func TestRenderObjectDetailValueNotTruncated(t *testing.T) {
+	longContent := "This is a very long description that clearly exceeds the forty character truncation limit used by table cells"
+
+	t.Run("styled output preserves full content", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := New(Options{
+			Format: FormatStyled,
+			Writer: &buf,
+		})
+
+		data := map[string]any{
+			"id":          float64(1),
+			"description": longContent,
+		}
+
+		err := w.OK(data)
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, longContent,
+			"detail view should show full content without truncation")
+		assert.NotContains(t, output, "...",
+			"detail view should not contain truncation ellipsis")
+	})
+
+	t.Run("markdown output preserves full content", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := New(Options{
+			Format: FormatMarkdown,
+			Writer: &buf,
+		})
+
+		data := map[string]any{
+			"id":          float64(1),
+			"description": longContent,
+		}
+
+		err := w.OK(data)
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, longContent,
+			"markdown detail view should show full content without truncation")
+	})
+
+	t.Run("HTML content is converted to markdown", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := New(Options{
+			Format: FormatStyled,
+			Writer: &buf,
+		})
+
+		data := map[string]any{
+			"id":      float64(1),
+			"content": "<p>Status report with important details about the project</p>",
+		}
+
+		err := w.OK(data)
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, "Status report with important details about the project")
+		assert.NotContains(t, output, "<p>")
+	})
+}
+
+// =============================================================================
 // renderObject Header Humanization Tests
 // =============================================================================
 

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -796,8 +796,7 @@ func formatTableCell(key string, val any) string {
 // Date columns get human-readable formatting via formatDateValue.
 // Unlike formatCell, string values are not truncated — detail views show full content.
 func formatDetailValue(key string, val any) string {
-	isDateColumn := strings.HasSuffix(key, "_at") || strings.HasSuffix(key, "_on") || strings.HasSuffix(key, "_date")
-	if isDateColumn {
+	if isDateColumn(key) {
 		return formatDateValue(key, val)
 	}
 
@@ -821,11 +820,12 @@ func formatDetailValue(key string, val any) string {
 // formatDateValue formats date fields in a human-readable way.
 // For date columns (created_at, updated_at, due_on, due_date), it converts
 // ISO8601 timestamps to a more readable format.
-func formatDateValue(key string, val any) string {
-	// Check if this is a date column
-	isDateColumn := strings.HasSuffix(key, "_at") || strings.HasSuffix(key, "_on") || strings.HasSuffix(key, "_date")
+func isDateColumn(key string) bool {
+	return strings.HasSuffix(key, "_at") || strings.HasSuffix(key, "_on") || strings.HasSuffix(key, "_date")
+}
 
-	if !isDateColumn {
+func formatDateValue(key string, val any) string {
+	if !isDateColumn(key) {
 		return formatCell(val)
 	}
 


### PR DESCRIPTION
## Summary

- `basecamp show` truncates content/description fields to 40 characters because
  `renderObject` uses the same `formatCell` path as table rows
- Add `formatDetailValue` for detail (single-object) views that preserves full
  string content while keeping ANSI stripping, HTML→Markdown, and newline collapsing
- Table and list truncation unchanged — `formatCell` still caps at 40 chars

Before: `Content: **This message affects US Employees o...`
After: full content rendered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show full content in detail views (e.g., `basecamp show`) instead of truncating at 40 characters, so message bodies are fully readable while keeping existing formatting rules.

- **Bug Fixes**
  - Added `formatDetailValue` for detail views and use it in both styled and markdown renderers to preserve full strings.
  - Keeps ANSI stripping, HTML→Markdown conversion, and newline collapsing; date formatting unchanged via `formatDateValue` with new `isDateColumn` helper.
  - Table/list truncation unchanged (`formatCell` caps at 40 chars); added tests to verify no truncation and HTML→Markdown in detail views.

<sup>Written for commit e04384b0829959ea56dec4d33071f743c5df3120. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

