### PR TITLE
Add file upload command to SKILL.md

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -159,7 +159,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 | Add comment | `basecamp comment <recording_id> "Text" --in <project> --json` |
 | Search | `basecamp search "query" --json` |
 | Parse URL | `basecamp url parse "<url>" --json` |
-| Upload file | `basecamp files uploads create <file> [--vault <folder_id>] --in <project>` |
+| Upload file | `basecamp files uploads create <file> [--vault <folder_id>] --in <project> --json` |
 | Download file | `basecamp files download <id> --in <project>` |
 | Download inline attachment | `basecamp files download "https://storage.3.basecamp.com/.../download/report.pdf"` |
 | Watch timeline | `basecamp timeline --watch` |


### PR DESCRIPTION
## Summary

- The `basecamp files uploads create` command was missing from both the **Quick Reference** table and the **Files & Documents** resource section in `SKILL.md`
- Without this, AI agents guessed incorrect commands like `basecamp files upload`, which silently returned `null` without uploading anything
- Adds the upload command (with `--vault` for folder targeting) to both locations so agents use the correct command path

Before this update Claude failed to upload any files.  Afterwards it had no problems.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `basecamp files uploads create` command to `SKILL.md` (Quick Reference and Files & Documents), and update the Quick Reference to include `--json` and optional `--vault` (`[--vault <folder_id>]`). This prevents incorrect usage (e.g., `basecamp files upload`) that previously did nothing.

<sup>Written for commit 9c06231daa527b0185f65da982ea2e5f0e663bd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

