### PR TITLE
Add `todos update` command

### DIFF
--- a/.surface
+++ b/.surface
@@ -265,6 +265,7 @@ CMD basecamp todos show
 CMD basecamp todos sweep
 CMD basecamp todos trash
 CMD basecamp todos uncomplete
+CMD basecamp todos update
 CMD basecamp todosets
 CMD basecamp todosets list
 CMD basecamp todosets show
@@ -6156,6 +6157,33 @@ FLAG basecamp todos uncomplete --stats type=bool
 FLAG basecamp todos uncomplete --styled type=bool
 FLAG basecamp todos uncomplete --todolist type=string
 FLAG basecamp todos uncomplete --verbose type=count
+FLAG basecamp todos update --account type=string
+FLAG basecamp todos update --agent type=bool
+FLAG basecamp todos update --assignee type=string
+FLAG basecamp todos update --cache-dir type=string
+FLAG basecamp todos update --count type=bool
+FLAG basecamp todos update --description type=string
+FLAG basecamp todos update --due type=string
+FLAG basecamp todos update --hints type=bool
+FLAG basecamp todos update --ids-only type=bool
+FLAG basecamp todos update --in type=string
+FLAG basecamp todos update --jq type=string
+FLAG basecamp todos update --json type=bool
+FLAG basecamp todos update --markdown type=bool
+FLAG basecamp todos update --md type=bool
+FLAG basecamp todos update --no-hints type=bool
+FLAG basecamp todos update --no-stats type=bool
+FLAG basecamp todos update --notify type=bool
+FLAG basecamp todos update --profile type=string
+FLAG basecamp todos update --project type=string
+FLAG basecamp todos update --quiet type=bool
+FLAG basecamp todos update --starts-on type=string
+FLAG basecamp todos update --stats type=bool
+FLAG basecamp todos update --styled type=bool
+FLAG basecamp todos update --title type=string
+FLAG basecamp todos update --to type=string
+FLAG basecamp todos update --todolist type=string
+FLAG basecamp todos update --verbose type=count
 FLAG basecamp todosets --account type=string
 FLAG basecamp todosets --agent type=bool
 FLAG basecamp todosets --cache-dir type=string
@@ -7414,6 +7442,7 @@ SUB basecamp todos show
 SUB basecamp todos sweep
 SUB basecamp todos trash
 SUB basecamp todos uncomplete
+SUB basecamp todos update
 SUB basecamp todosets
 SUB basecamp todosets list
 SUB basecamp todosets show

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -22,7 +22,7 @@ Out-of-scope sections are excluded from parity totals and scripts: chatbots (dif
 |---------|-----------|-------------|--------|----------|-------|
 | **Core** |
 | projects | 9 | `projects` | ✅ | - | list, show, create, update, delete |
-| todos | 11 | `todos`, `todo`, `done`, `reopen` | ✅ | - | list, show, create, complete, uncomplete, position |
+| todos | 11 | `todos`, `todo`, `done`, `reopen` | ✅ | - | list, show, create, update, complete, uncomplete, position |
 | todolists | 8 | `todolists` | ✅ | - | list, show, create, update |
 | todosets | 3 | `todosets` | ✅ | - | Container for todolists, accessed via project dock |
 | todolist_groups | 8 | `todolistgroups` | ✅ | - | list, show, create, update, position |

--- a/e2e/smoke/smoke_todos_write.bats
+++ b/e2e/smoke/smoke_todos_write.bats
@@ -85,6 +85,17 @@ setup_file() {
   assert_json_value '.ok' 'true'
 }
 
+@test "todos update updates a todo" {
+  local id_file="$BATS_FILE_TMPDIR/direct_todo_id"
+  [[ -f "$id_file" ]] || mark_unverifiable "No direct todo created in prior test"
+  local todo_id
+  todo_id=$(<"$id_file")
+
+  run_smoke basecamp todos update "$todo_id" --title "Updated smoke todo $(date +%s)" -p "$QA_PROJECT" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
 @test "todos trash trashes a todo" {
   local id_file="$BATS_FILE_TMPDIR/direct_todo_id"
   [[ -f "$id_file" ]] || mark_unverifiable "No direct todo created in prior test"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
-	github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318172136-4784bb2fda18
+	github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318221909-49475983b9c8
 	github.com/basecamp/cli v0.1.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318172136-4784bb2fda18 h1:it4iTTmOKr4DFOdVGE7jVxNQ3lD9snwe8vYhVI8Soz4=
-github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318172136-4784bb2fda18/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
+github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318221909-49475983b9c8 h1:WsLan1O+1GWBSQEn+dTd63roBunjojffjaoKnQ4g33U=
+github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260318221909-49475983b9c8/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
 github.com/basecamp/cli v0.1.1 h1:FAF3M09xo1m7gJJXf38glCkT50ZUuvz+31f+c3R3zcc=
 github.com/basecamp/cli v0.1.1/go.mod h1:NTHe+keCTGI2qM5sMXdkUN0QgU3zGbwnBxcmg8vD5QU=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/commands/checkins.go
+++ b/internal/commands/checkins.go
@@ -344,8 +344,8 @@ Days format: comma-separated (0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat)`,
 				Schedule: &basecamp.QuestionSchedule{
 					Frequency: frequency,
 					Days:      daysArray,
-					Hour:      hour,
-					Minute:    minute,
+					Hour:      &hour,
+					Minute:    &minute,
 				},
 			}
 
@@ -457,8 +457,8 @@ You can pass either a question ID or a Basecamp URL:
 					if err != nil {
 						return output.ErrUsage("Invalid time format: " + timeOfDay)
 					}
-					schedule.Hour = hour
-					schedule.Minute = minute
+					schedule.Hour = &hour
+					schedule.Minute = &minute
 				}
 				if days != "" {
 					dayParts := strings.Split(days, ",")

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -35,7 +35,7 @@ func CommandCategories() []CommandCategory {
 			Name: "Core Commands",
 			Commands: []CommandInfo{
 				{Name: "projects", Category: "core", Description: "Manage projects", Actions: []string{"list", "show", "create", "update", "delete"}},
-				{Name: "todos", Category: "core", Description: "Manage to-dos", Actions: []string{"list", "show", "create", "complete", "uncomplete", "position", "trash", "archive", "restore"}},
+				{Name: "todos", Category: "core", Description: "Manage to-dos", Actions: []string{"list", "show", "create", "update", "complete", "uncomplete", "position", "trash", "archive", "restore"}},
 				{Name: "todolists", Category: "core", Description: "Manage to-do lists", Actions: []string{"list", "show", "create", "update", "trash", "archive", "restore"}},
 				{Name: "todosets", Category: "core", Description: "Manage to-do set containers", Actions: []string{"list", "show"}},
 				{Name: "todolistgroups", Category: "core", Description: "Manage to-do list groups", Actions: []string{"list", "show", "create", "update", "position"}},

--- a/internal/commands/schedule.go
+++ b/internal/commands/schedule.go
@@ -488,7 +488,7 @@ func runScheduleCreate(cmd *cobra.Command, app *appctx.App, project, scheduleID,
 		StartsAt:      startsAt,
 		EndsAt:        endsAt,
 		Description:   description,
-		AllDay:        allDay,
+		AllDay:        &allDay,
 		Notify:        notify,
 		Subscriptions: subs,
 	}
@@ -618,7 +618,7 @@ You can pass either an entry ID or a Basecamp URL:
 				hasChanges = true
 			}
 			if cmd.Flags().Changed("all-day") {
-				req.AllDay = allDay
+				req.AllDay = &allDay
 				hasChanges = true
 			}
 			if cmd.Flags().Changed("notify") {

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -49,6 +49,7 @@ func NewTodosCmd() *cobra.Command {
 		newTodosListCmd(),
 		newTodosShowCmd(),
 		newTodosCreateCmd(),
+		newTodosUpdateCmd(),
 		newTodosCompleteCmd(),
 		newTodosUncompleteCmd(),
 		newTodosSweepCmd(),
@@ -724,6 +725,11 @@ You can pass either a todo ID or a Basecamp URL:
 				output.WithEntity("todo"),
 				output.WithBreadcrumbs(
 					output.Breadcrumb{
+						Action:      "update",
+						Cmd:         fmt.Sprintf("basecamp todos update %d --title <title>", todoID),
+						Description: "Update this todo",
+					},
+					output.Breadcrumb{
 						Action:      "complete",
 						Cmd:         fmt.Sprintf("basecamp done %d", todoID),
 						Description: "Complete this todo",
@@ -913,6 +919,137 @@ func newTodosCreateCmd() *cobra.Command {
 	completer := completion.NewCompleter(nil)
 	_ = cmd.RegisterFlagCompletionFunc("project", completer.ProjectNameCompletion())
 	_ = cmd.RegisterFlagCompletionFunc("in", completer.ProjectNameCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("assignee", completer.PeopleNameCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("to", completer.PeopleNameCompletion())
+
+	return cmd
+}
+
+func newTodosUpdateCmd() *cobra.Command {
+	var title string
+	var description string
+	var assignee string
+	var due string
+	var startsOn string
+	var notify bool
+
+	cmd := &cobra.Command{
+		Use:   "update <id|url> [title]",
+		Short: "Update a todo",
+		Long: `Update an existing todo.
+
+You can pass either a todo ID or a Basecamp URL:
+  basecamp todos update 789 "New title"
+  basecamp todos update 789 --title "New title"
+  basecamp todos update 789 --due "next friday"
+  basecamp todos update https://3.basecamp.com/123/buckets/456/todos/789 --description "Details"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return missingArg(cmd, "<id|url>")
+			}
+
+			// Positional title: args[1:] joined
+			positionalTitle := strings.Join(args[1:], " ")
+
+			// Effective title: positional takes precedence over --title flag
+			effectiveTitle := title
+			if strings.TrimSpace(positionalTitle) != "" {
+				effectiveTitle = positionalTitle
+			}
+
+			// No-op guard: at least one effective field required
+			assigneeChanged := (cmd.Flags().Changed("assignee") || cmd.Flags().Changed("to")) && strings.TrimSpace(assignee) != ""
+			if strings.TrimSpace(effectiveTitle) == "" &&
+				strings.TrimSpace(description) == "" &&
+				strings.TrimSpace(due) == "" && strings.TrimSpace(startsOn) == "" &&
+				!assigneeChanged &&
+				(!cmd.Flags().Changed("notify") || !notify) {
+				return noChanges(cmd)
+			}
+
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			// Extract ID from URL if provided
+			todoIDStr := extractID(args[0])
+			todoID, err := strconv.ParseInt(todoIDStr, 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid todo ID")
+			}
+
+			req := &basecamp.UpdateTodoRequest{}
+			if effectiveTitle != "" {
+				req.Content = effectiveTitle
+			}
+			if description != "" {
+				descHTML := richtext.MarkdownToHTML(description)
+				descHTML, err = resolveLocalImages(cmd, app, descHTML)
+				if err != nil {
+					return err
+				}
+				req.Description = descHTML
+			}
+			if strings.TrimSpace(due) != "" {
+				if parsed := dateparse.Parse(due); parsed != "" {
+					req.DueOn = parsed
+				}
+			}
+			if strings.TrimSpace(startsOn) != "" {
+				if parsed := dateparse.Parse(startsOn); parsed != "" {
+					req.StartsOn = parsed
+				}
+			}
+			if assigneeChanged {
+				assigneeIDs, err := resolveAssigneeIDs(cmd.Context(), app, assignee)
+				if err != nil {
+					return err
+				}
+				req.AssigneeIDs = assigneeIDs
+			}
+			if cmd.Flags().Changed("notify") && notify {
+				req.Notify = true
+			}
+
+			todo, err := app.Account().Todos().Update(cmd.Context(), todoID, req)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(todo,
+				output.WithEntity("todo"),
+				output.WithSummary(fmt.Sprintf("Updated todo #%s", todoIDStr)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         fmt.Sprintf("basecamp todos show %s", todoIDStr),
+						Description: "View todo",
+					},
+					output.Breadcrumb{
+						Action:      "complete",
+						Cmd:         fmt.Sprintf("basecamp done %s", todoIDStr),
+						Description: "Complete todo",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVarP(&title, "title", "t", "", "Todo title (plain text)")
+	cmd.Flags().StringVar(&description, "description", "", "Extended description (Markdown)")
+	cmd.Flags().StringVar(&assignee, "assignee", "", "Assignees (names or IDs, comma-separated)")
+	cmd.Flags().StringVar(&assignee, "to", "", "Assignees (alias for --assignee)")
+	cmd.Flags().StringVarP(&due, "due", "d", "", "Due date (natural language or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&startsOn, "starts-on", "", "Start date (natural language or YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&notify, "notify", false, "Notify assignees")
+
+	// Register tab completion for assignee flags
+	completer := completion.NewCompleter(nil)
 	_ = cmd.RegisterFlagCompletionFunc("assignee", completer.PeopleNameCompletion())
 	_ = cmd.RegisterFlagCompletionFunc("to", completer.PeopleNameCompletion())
 

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -233,7 +234,7 @@ func TestReopenShowsHelpWithoutID(t *testing.T) {
 func TestTodosSubcommands(t *testing.T) {
 	cmd := NewTodosCmd()
 
-	expected := []string{"list", "show", "create", "complete", "uncomplete", "position"}
+	expected := []string{"list", "show", "create", "update", "complete", "uncomplete", "position"}
 	for _, name := range expected {
 		sub, _, err := cmd.Find([]string{name})
 		require.NoError(t, err, "expected subcommand %q to exist", name)
@@ -1346,6 +1347,173 @@ func TestSweepCommentLocalImageErrors(t *testing.T) {
 
 	cmd := NewTodosCmd()
 	err := executeTodosCommand(cmd, app, "sweep", "--overdue", "--comment", "![alt](./missing.png)")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing.png")
+}
+
+// =============================================================================
+// Todos Update Tests
+// =============================================================================
+
+// mockTodoUpdateTransport handles GET and PUT for todo update tests.
+type mockTodoUpdateTransport struct {
+	capturedBody []byte
+}
+
+func (t *mockTodoUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	if req.Method == "GET" {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     header,
+		}, nil
+	}
+
+	if req.Method == "PUT" {
+		if req.Body != nil {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, fmt.Errorf("reading request body: %w", err)
+			}
+			t.capturedBody = body
+			req.Body.Close()
+		}
+		mockResp := `{"id": 999, "title": "Updated", "status": "active", "completed": false}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(mockResp)),
+			Header:     header,
+		}, nil
+	}
+
+	return nil, errors.New("unexpected request")
+}
+
+func setupTodoUpdateApp(t *testing.T, transport http.RoundTripper) *appctx.App {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	cfg := &config.Config{
+		AccountID: "99999",
+	}
+
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &todosTestTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	authMgr := auth.NewManager(cfg, nil)
+	nameResolver := names.NewResolver(sdkClient, authMgr, cfg.AccountID)
+
+	return &appctx.App{
+		Config: cfg,
+		Auth:   authMgr,
+		SDK:    sdkClient,
+		Names:  nameResolver,
+		Output: output.New(output.Options{
+			Format: output.FormatJSON,
+			Writer: &bytes.Buffer{},
+		}),
+	}
+}
+
+func TestTodosUpdateShowsHelpWithoutID(t *testing.T) {
+	app, _ := setupTodosTestApp(t)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update")
+	require.NoError(t, err, "expected help output, not an error")
+}
+
+func TestTodosUpdateNoChangesShowsHelp(t *testing.T) {
+	app, _ := setupTodosTestApp(t)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "123")
+	// In non-machine mode (no format set), noChanges shows help → no error
+	assert.NoError(t, err)
+}
+
+func TestTodosUpdatePositionalTitle(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "New title")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	content, ok := body["content"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "New title", content)
+}
+
+func TestTodosUpdateFlagTitle(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "--title", "Flag title")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	content, ok := body["content"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "Flag title", content)
+}
+
+func TestTodosUpdatePositionalTitleTakesPrecedence(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "Positional", "--title", "Flag")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	content, ok := body["content"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "Positional", content)
+}
+
+func TestTodosUpdateDescriptionIsHTML(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "--description", "**bold** text")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	desc, ok := body["description"].(string)
+	require.True(t, ok)
+	assert.Contains(t, desc, "<strong>bold</strong>")
+}
+
+func TestTodosUpdateLocalImageErrors(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "--description", "![alt](./missing.png)")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing.png")
 }

--- a/internal/tui/workspace/views/schedule.go
+++ b/internal/tui/workspace/views/schedule.go
@@ -324,11 +324,12 @@ func (v *Schedule) dispatchCreate(summary, startDate, endDate string) tea.Cmd {
 	scope := v.session.Scope()
 	hub := v.session.Hub()
 	ctx := hub.ProjectContext()
+	allDay := true
 	req := &basecamp.CreateScheduleEntryRequest{
 		Summary:  summary,
 		StartsAt: startDate + "T00:00:00Z",
 		EndsAt:   endDate + "T00:00:00Z",
-		AllDay:   true,
+		AllDay:   &allDay,
 	}
 	return func() tea.Msg {
 		err := hub.CreateScheduleEntry(ctx, scope.AccountID, scope.ProjectID, scope.ToolID, req)

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,13 +1,13 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.6.1-0.20260318172136-4784bb2fda18",
-    "revision": "4784bb2fda18",
-    "updated_at": "2026-03-18T17:21:36Z"
+    "version": "v0.6.1-0.20260318221909-49475983b9c8",
+    "revision": "49475983b9c8",
+    "updated_at": "2026-03-18T22:19:09Z"
   },
   "api": {
     "repo": "basecamp/bc3",
-    "revision": "30169b756c949e67770df53fd18563e78dfa29bb",
+    "revision": "d57b6994a74f123aaf1fd685f993befb28a012fd",
     "synced_at": ""
   }
 }


### PR DESCRIPTION
## Summary

- Add `basecamp todos update <id|url> [title]` with flags: `--title`, `--description`, `--assignee`, `--due`, `--starts-on`, `--notify`
- Positional title takes precedence over `--title` flag (matches `cards steps update` pattern)
- Description pipeline: Markdown→HTML + local image resolution (matches `todos create`)
- Assignee supports comma-separated names/IDs via `resolveAssigneeIDs`; `--to` alias added
- Bump SDK to pick up fix for unsafe partial-update serialization in `TodosService.Update()` — fields now set conditionally, matching the cards pattern (basecamp/basecamp-sdk#201)
- Adapt checkins and schedule commands to SDK's new pointer types (`Hour`/`Minute` → `*int`, `AllDay` → `*bool`)

Triggered by https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9693937142

## Test plan

- [x] `bin/ci` passes (all checks: lint, vet, unit tests, e2e, catalog parity, surface snapshot, skill drift, smoke coverage, provenance)
- [x] Smoke: `basecamp todos update <id> "Updated title"` — title updated, confirmed via `todos show`
- [x] Smoke: `basecamp todos update <id> --title "Flag title"` — title updated
- [x] Smoke: `basecamp todos update <id> --due "next friday"` — due_on set to 2026-03-27, confirmed via `todos show`
- [x] Smoke: `basecamp todos update <id> --description "**bold**"` — HTML description persisted, confirmed via `todos show`