### PR TITLE
Bump SDK to fix empty ID array handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
-	github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260319050216-1c33ce43c305
+	github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320
 	github.com/basecamp/cli v0.1.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260319050216-1c33ce43c305 h1:NuMRr9mXUhSZAxxxLLfOAhiCTeYDlt/h7HaoarRLGjk=
-github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260319050216-1c33ce43c305/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
+github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320 h1:xHbqMcj57XgSb69wsy+dhTzZ+p3IYb/BnjisI9NF5c4=
+github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
 github.com/basecamp/cli v0.1.1 h1:FAF3M09xo1m7gJJXf38glCkT50ZUuvz+31f+c3R3zcc=
 github.com/basecamp/cli v0.1.1/go.mod h1:NTHe+keCTGI2qM5sMXdkUN0QgU3zGbwnBxcmg8vD5QU=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.6.1-0.20260319050216-1c33ce43c305",
-    "revision": "1c33ce43c305",
-    "updated_at": "2026-03-19T05:02:16Z"
+    "version": "v0.6.1-0.20260320103941-fe6154c8b320",
+    "revision": "fe6154c8b320",
+    "updated_at": "2026-03-20T10:39:41Z"
   },
   "api": {
     "repo": "basecamp/bc3",


### PR DESCRIPTION
## Summary
- Bumps `basecamp-sdk` to `fe6154c8b320` to pick up basecamp/basecamp-sdk#207
- Fixes `basecamp unassign` silently failing when removing the last assignee from a todo, card, or card step
- Same fix applies to clearing the last participant from a schedule entry

The SDK previously used `len(slice) > 0` to guard writing ID arrays into requests, which dropped empty slices (`[]int64{}`). The API interprets an absent field as "no change", so clearing the last assignee/participant had no effect. The SDK now uses `nil` checks, preserving three-way semantics: `nil` = don't change, `[]` = clear all, `[1,2]` = set specific IDs.

No CLI code changes needed — the fix is entirely in the SDK.

Ref: https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9696883477

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github.com/basecamp/basecamp-sdk/go` to fix empty ID array handling. Unassigning and clearing participants now correctly removes the last IDs.

- **Bug Fixes**
  - `basecamp unassign` removes the final assignee on todos, cards, and steps.
  - Clearing the last participant from schedule entries works.

- **Dependencies**
  - Bumped `github.com/basecamp/basecamp-sdk/go` to include the empty ID array fix.

<sup>Written for commit 5fbbfdcce896535e4b588d9c51532a0b83907c0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

