### PR TITLE
Refresh skills at all installed locations on CLI upgrade

### DIFF
--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -367,7 +367,10 @@ func refreshAllInstalledSkills() bool {
 
 		expanded := expandSkillPath(loc.Path)
 		if _, statErr := os.Stat(expanded); statErr != nil {
-			continue // not installed at this location
+			if !os.IsNotExist(statErr) {
+				failed++ // permission or IO error on a known location
+			}
+			continue
 		}
 
 		if writeErr := os.WriteFile(expanded, embedded, 0o644); writeErr == nil { //nolint:gosec // G306: Skill files are not secrets

--- a/internal/commands/skill_test.go
+++ b/internal/commands/skill_test.go
@@ -576,7 +576,7 @@ func TestRepairClaudeSkillLink_BrokenSymlink(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Create ~/.claude so DetectClaude returns true
+	// Ensure ~/.claude/skills exists so the symlink can be placed there
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755))
 
 	// Create baseline skill


### PR DESCRIPTION
## Summary

- `RefreshSkillsIfVersionChanged()` now updates the skill file at every known install location (Claude Code, OpenCode, Codex) — not just the baseline `~/.agents/` directory
- Broken Claude symlinks at `~/.claude/skills/basecamp` are detected and repaired automatically
- Project-relative paths are skipped since there is no reliable project root in the post-run hook

Previously, only `~/.agents/skills/basecamp/SKILL.md` was refreshed on upgrade. Users who installed the skill to `~/.claude/skills/basecamp/` (as a copy, not symlink), `~/.config/opencode/skill/basecamp/`, or `~/.codex/skills/basecamp/` would not get updates until they manually re-ran `basecamp skill install`.

## Test plan

- [x] `TestRefreshAllInstalledSkills_MultipleLocations` — installs to 3 locations, all get refreshed
- [x] `TestRefreshAllInstalledSkills_SkipsAbsentLocations` — doesn't create files at uninstalled locations
- [x] `TestRefreshAllInstalledSkills_SkipsProjectRelativePaths` — doesn't touch project-relative skills
- [x] `TestRepairClaudeSkillLink_BrokenSymlink` — broken symlink gets repaired
- [x] `TestRepairClaudeSkillLink_HealthySymlink` — healthy symlink is left alone