### PR TITLE
Add bats to make tools target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,6 +474,13 @@ tools:
 		else echo "Could not auto-install zizmor: https://docs.zizmor.sh/installation/" && exit 1; \
 		fi; \
 	}
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "Installing bats..."; \
+		if command -v brew >/dev/null 2>&1; then brew install bats-core; \
+		elif command -v pacman >/dev/null 2>&1; then sudo pacman -S --noconfirm bats; \
+		else echo "Could not auto-install bats: https://github.com/bats-core/bats-core#installation" && exit 1; \
+		fi; \
+	}
 
 
 # Run skill evals (requires ANTHROPIC_API_KEY and Ruby)


### PR DESCRIPTION
## Summary
- `make tools` now installs bats-core (via brew or pacman) if missing
- e2e tests require bats but it was the only dev dependency not covered by `make tools`

## Test plan
- [ ] Run `make tools` on a machine without bats — verify it gets installed
- [ ] Run `make test-e2e` after to confirm bats works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `make tools` to auto-install `bats-core` (via `brew` or `pacman`) if missing, so e2e tests run without manual setup. If neither is available, it exits with a helpful install link.

<sup>Written for commit bdd70c5070453c718cc4db6f77e7542e7d83ed11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

