### PR TITLE
Prepare CLI for SDK sync 2026-03-23

### DIFF
--- a/.surface
+++ b/.surface
@@ -1,422 +1,11 @@
-ARG basecamp account use 00 <id>
-ARG basecamp accounts use 00 <id>
-ARG basecamp api delete 00 <path>
-ARG basecamp api get 00 <path>
-ARG basecamp api post 00 <path>
-ARG basecamp api put 00 <path>
-ARG basecamp assign 00 <id|url>...
-ARG basecamp attach 00 <file>
-ARG basecamp attach 01 [<file2]
-ARG basecamp attachments list 00 <id|url>
-ARG basecamp bonfire layout load 00 <name>
-ARG basecamp bonfire layout save 00 <name>
-ARG basecamp bonfire layout save 01 <url>...
-ARG basecamp bonfire split 00 <room-url>
-ARG basecamp boost create 00 <id|url>
-ARG basecamp boost create 01 <content>
-ARG basecamp boost delete 00 <boost-id|url>
-ARG basecamp boost list 00 <id|url>
-ARG basecamp boost show 00 <boost-id|url>
-ARG basecamp boosts create 00 <id|url>
-ARG basecamp boosts create 01 <content>
-ARG basecamp boosts delete 00 <boost-id|url>
-ARG basecamp boosts list 00 <id|url>
-ARG basecamp boosts show 00 <boost-id|url>
-ARG basecamp campfire delete 00 <id|url>
-ARG basecamp campfire line 00 <id|url>
-ARG basecamp campfire post 00 <message>
-ARG basecamp campfire show 00 <id|url>
-ARG basecamp campfire upload 00 <file>
-ARG basecamp card 00 <title>
-ARG basecamp card 01 [body]
-ARG basecamp card move 00 <id|url>
-ARG basecamp card mv 00 <id|url>
-ARG basecamp card update 00 <id|url>
-ARG basecamp cards archive 00 <id|url>
-ARG basecamp cards column color 00 <id|url>
-ARG basecamp cards column create 00 <title>
-ARG basecamp cards column move 00 <id|url>
-ARG basecamp cards column no-on-hold 00 <id|url>
-ARG basecamp cards column on-hold 00 <id|url>
-ARG basecamp cards column show 00 <id|url>
-ARG basecamp cards column unwatch 00 <id|url>
-ARG basecamp cards column update 00 <id|url>
-ARG basecamp cards column watch 00 <id|url>
-ARG basecamp cards create 00 <title>
-ARG basecamp cards create 01 [body]
-ARG basecamp cards move 00 <id|url>
-ARG basecamp cards mv 00 <id|url>
-ARG basecamp cards restore 00 <id|url>
-ARG basecamp cards show 00 <id|url>
-ARG basecamp cards step complete 00 <step_id|url>
-ARG basecamp cards step create 00 <title>
-ARG basecamp cards step delete 00 <step_id|url>
-ARG basecamp cards step move 00 <step_id|url>
-ARG basecamp cards step uncomplete 00 <step_id|url>
-ARG basecamp cards step update 00 <step_id|url>
-ARG basecamp cards step update 01 [title]
-ARG basecamp cards steps 00 <card-id|url>
-ARG basecamp cards trash 00 <id|url>
-ARG basecamp cards update 00 <id|url>
-ARG basecamp chat delete 00 <id|url>
-ARG basecamp chat line 00 <id|url>
-ARG basecamp chat post 00 <message>
-ARG basecamp chat show 00 <id|url>
-ARG basecamp chat upload 00 <file>
-ARG basecamp checkin answer 00 <id|url>
-ARG basecamp checkin answer create 00 <question-id>
-ARG basecamp checkin answer create 01 <content>
-ARG basecamp checkin answer show 00 <id|url>
-ARG basecamp checkin answer update 00 <id|url>
-ARG basecamp checkin answer update 01 <content>
-ARG basecamp checkin answers 00 <question_id|url>
-ARG basecamp checkin question 00 <id|url>
-ARG basecamp checkin question create 00 <title>
-ARG basecamp checkin question show 00 <id|url>
-ARG basecamp checkin question update 00 <id|url>
-ARG basecamp checkin question update 01 [title]
-ARG basecamp checkins answer 00 <id|url>
-ARG basecamp checkins answer create 00 <question-id>
-ARG basecamp checkins answer create 01 <content>
-ARG basecamp checkins answer show 00 <id|url>
-ARG basecamp checkins answer update 00 <id|url>
-ARG basecamp checkins answer update 01 <content>
-ARG basecamp checkins answers 00 <question_id|url>
-ARG basecamp checkins question 00 <id|url>
-ARG basecamp checkins question create 00 <title>
-ARG basecamp checkins question show 00 <id|url>
-ARG basecamp checkins question update 00 <id|url>
-ARG basecamp checkins question update 01 [title]
-ARG basecamp comment 00 <id|url>
-ARG basecamp comment 01 <content>
-ARG basecamp comments archive 00 <id|url>
-ARG basecamp comments create 00 <id|url>
-ARG basecamp comments create 01 <content>
-ARG basecamp comments list 00 <id|url>
-ARG basecamp comments restore 00 <id|url>
-ARG basecamp comments show 00 <id|url>
-ARG basecamp comments trash 00 <id|url>
-ARG basecamp comments update 00 <id|url>
-ARG basecamp comments update 01 <content>
-ARG basecamp completion 00 [shell]
-ARG basecamp config set 00 <key>
-ARG basecamp config set 01 <value>
-ARG basecamp config trust 00 [path]
-ARG basecamp config unset 00 <key>
-ARG basecamp config untrust 00 [path]
-ARG basecamp docs archive 00 <id|url>
-ARG basecamp docs doc create 00 <title>
-ARG basecamp docs doc create 01 [content]
-ARG basecamp docs document create 00 <title>
-ARG basecamp docs document create 01 [content]
-ARG basecamp docs documents create 00 <title>
-ARG basecamp docs documents create 01 [content]
-ARG basecamp docs download 00 <upload-id|url>
-ARG basecamp docs folder create 00 <name>
-ARG basecamp docs folders create 00 <name>
-ARG basecamp docs restore 00 <id|url>
-ARG basecamp docs show 00 <id|url>
-ARG basecamp docs trash 00 <id|url>
-ARG basecamp docs update 00 <id|url>
-ARG basecamp docs upload create 00 <file>
-ARG basecamp docs uploads create 00 <file>
-ARG basecamp docs vault create 00 <name>
-ARG basecamp docs vaults create 00 <name>
-ARG basecamp documents archive 00 <id|url>
-ARG basecamp documents doc create 00 <title>
-ARG basecamp documents doc create 01 [content]
-ARG basecamp documents document create 00 <title>
-ARG basecamp documents document create 01 [content]
-ARG basecamp documents documents create 00 <title>
-ARG basecamp documents documents create 01 [content]
-ARG basecamp documents download 00 <upload-id|url>
-ARG basecamp documents folder create 00 <name>
-ARG basecamp documents folders create 00 <name>
-ARG basecamp documents restore 00 <id|url>
-ARG basecamp documents show 00 <id|url>
-ARG basecamp documents trash 00 <id|url>
-ARG basecamp documents update 00 <id|url>
-ARG basecamp documents upload create 00 <file>
-ARG basecamp documents uploads create 00 <file>
-ARG basecamp documents vault create 00 <name>
-ARG basecamp documents vaults create 00 <name>
-ARG basecamp done 00 <id|url>...
-ARG basecamp events 00 <id|url>
-ARG basecamp file archive 00 <id|url>
-ARG basecamp file doc create 00 <title>
-ARG basecamp file doc create 01 [content]
-ARG basecamp file document create 00 <title>
-ARG basecamp file document create 01 [content]
-ARG basecamp file documents create 00 <title>
-ARG basecamp file documents create 01 [content]
-ARG basecamp file download 00 <upload-id|url>
-ARG basecamp file folder create 00 <name>
-ARG basecamp file folders create 00 <name>
-ARG basecamp file restore 00 <id|url>
-ARG basecamp file show 00 <id|url>
-ARG basecamp file trash 00 <id|url>
-ARG basecamp file update 00 <id|url>
-ARG basecamp file upload create 00 <file>
-ARG basecamp file uploads create 00 <file>
-ARG basecamp file vault create 00 <name>
-ARG basecamp file vaults create 00 <name>
-ARG basecamp files archive 00 <id|url>
-ARG basecamp files doc create 00 <title>
-ARG basecamp files doc create 01 [content]
-ARG basecamp files document create 00 <title>
-ARG basecamp files document create 01 [content]
-ARG basecamp files documents create 00 <title>
-ARG basecamp files documents create 01 [content]
-ARG basecamp files download 00 <upload-id|url>
-ARG basecamp files folder create 00 <name>
-ARG basecamp files folders create 00 <name>
-ARG basecamp files restore 00 <id|url>
-ARG basecamp files show 00 <id|url>
-ARG basecamp files trash 00 <id|url>
-ARG basecamp files update 00 <id|url>
-ARG basecamp files upload create 00 <file>
-ARG basecamp files uploads create 00 <file>
-ARG basecamp files vault create 00 <name>
-ARG basecamp files vaults create 00 <name>
-ARG basecamp folders archive 00 <id|url>
-ARG basecamp folders doc create 00 <title>
-ARG basecamp folders doc create 01 [content]
-ARG basecamp folders document create 00 <title>
-ARG basecamp folders document create 01 [content]
-ARG basecamp folders documents create 00 <title>
-ARG basecamp folders documents create 01 [content]
-ARG basecamp folders download 00 <upload-id|url>
-ARG basecamp folders folder create 00 <name>
-ARG basecamp folders folders create 00 <name>
-ARG basecamp folders restore 00 <id|url>
-ARG basecamp folders show 00 <id|url>
-ARG basecamp folders trash 00 <id|url>
-ARG basecamp folders update 00 <id|url>
-ARG basecamp folders upload create 00 <file>
-ARG basecamp folders uploads create 00 <file>
-ARG basecamp folders vault create 00 <name>
-ARG basecamp folders vaults create 00 <name>
-ARG basecamp forwards replies 00 <forward_id|url>
-ARG basecamp forwards reply 00 <forward_id|url>
-ARG basecamp forwards reply 01 <reply_id|url>
-ARG basecamp forwards show 00 <id|url>
-ARG basecamp help 00 [command]
-ARG basecamp hillcharts track 00 <todolist-ids>
-ARG basecamp hillcharts untrack 00 <todolist-ids>
-ARG basecamp lineup create 00 <name>
-ARG basecamp lineup create 01 <date>
-ARG basecamp lineup delete 00 <id|url>
-ARG basecamp lineup update 00 <id|url>
-ARG basecamp lineup update 01 [name]
-ARG basecamp lineup update 02 [date]
-ARG basecamp message 00 <title>
-ARG basecamp message 01 [body]
-ARG basecamp messageboards show 00 [id]
-ARG basecamp messages archive 00 <id|url>
-ARG basecamp messages create 00 <title>
-ARG basecamp messages create 01 [body]
-ARG basecamp messages pin 00 <id|url>
-ARG basecamp messages publish 00 <id|url>
-ARG basecamp messages restore 00 <id|url>
-ARG basecamp messages show 00 <id|url>
-ARG basecamp messages trash 00 <id|url>
-ARG basecamp messages unpin 00 <id|url>
-ARG basecamp messages update 00 <id|url>
-ARG basecamp messagetypes create 00 <name>
-ARG basecamp messagetypes delete 00 <id>
-ARG basecamp messagetypes show 00 <id>
-ARG basecamp messagetypes update 00 <id>
-ARG basecamp msgs archive 00 <id|url>
-ARG basecamp msgs create 00 <title>
-ARG basecamp msgs create 01 [body]
-ARG basecamp msgs pin 00 <id|url>
-ARG basecamp msgs publish 00 <id|url>
-ARG basecamp msgs restore 00 <id|url>
-ARG basecamp msgs show 00 <id|url>
-ARG basecamp msgs trash 00 <id|url>
-ARG basecamp msgs unpin 00 <id|url>
-ARG basecamp msgs update 00 <id|url>
-ARG basecamp people add 00 <person-id>...
-ARG basecamp people remove 00 <person-id>...
-ARG basecamp people show 00 <id|name>
-ARG basecamp profile create 00 <name>
-ARG basecamp profile delete 00 <name>
-ARG basecamp profile set-default 00 <name>
-ARG basecamp profile show 00 [name]
-ARG basecamp project create 00 <name>
-ARG basecamp project delete 00 <id>
-ARG basecamp project show 00 <id>
-ARG basecamp project trash 00 <id>
-ARG basecamp project update 00 <id>
-ARG basecamp projects create 00 <name>
-ARG basecamp projects delete 00 <id>
-ARG basecamp projects show 00 <id>
-ARG basecamp projects trash 00 <id>
-ARG basecamp projects update 00 <id>
-ARG basecamp react 00 <content>
-ARG basecamp recordings 00 [type]
-ARG basecamp recordings active 00 <id|url>
-ARG basecamp recordings archive 00 <id|url>
-ARG basecamp recordings archived 00 <id|url>
-ARG basecamp recordings client-visibility 00 <id|url>
-ARG basecamp recordings list 00 [type]
-ARG basecamp recordings restore 00 <id|url>
-ARG basecamp recordings trash 00 <id|url>
-ARG basecamp recordings trashed 00 <id|url>
-ARG basecamp recordings visibility 00 <id|url>
-ARG basecamp reopen 00 <id|url>...
-ARG basecamp reports assigned 00 [person]
-ARG basecamp schedule create 00 <summary>
-ARG basecamp schedule show 00 <id|url>
-ARG basecamp schedule update 00 <id|url>
-ARG basecamp search 00 <query>
-ARG basecamp show 00 [type]
-ARG basecamp show 01 <id|url>
-ARG basecamp subscriptions add 00 <id|url>
-ARG basecamp subscriptions add 01 [person_ids]
-ARG basecamp subscriptions remove 00 <id|url>
-ARG basecamp subscriptions remove 01 [person_ids]
-ARG basecamp subscriptions show 00 <id|url>
-ARG basecamp subscriptions subscribe 00 <id|url>
-ARG basecamp subscriptions unsubscribe 00 <id|url>
-ARG basecamp templates construct 00 <template_id>
-ARG basecamp templates construction 00 <template_id>
-ARG basecamp templates construction 01 <construction_id>
-ARG basecamp templates create 00 <name>
-ARG basecamp templates delete 00 <id>
-ARG basecamp templates show 00 <id>
-ARG basecamp templates update 00 <id>
-ARG basecamp timeline 00 [me]
-ARG basecamp timesheet item 00 <id>
-ARG basecamp timesheet recording 00 <id>
-ARG basecamp tlgroup create 00 <name>
-ARG basecamp tlgroup move 00 <id>
-ARG basecamp tlgroup position 00 <id>
-ARG basecamp tlgroup rename 00 <id>
-ARG basecamp tlgroup rename 01 <name>
-ARG basecamp tlgroup show 00 <id>
-ARG basecamp tlgroup update 00 <id>
-ARG basecamp tlgroup update 01 <name>
-ARG basecamp tlgroups create 00 <name>
-ARG basecamp tlgroups move 00 <id>
-ARG basecamp tlgroups position 00 <id>
-ARG basecamp tlgroups rename 00 <id>
-ARG basecamp tlgroups rename 01 <name>
-ARG basecamp tlgroups show 00 <id>
-ARG basecamp tlgroups update 00 <id>
-ARG basecamp tlgroups update 01 <name>
-ARG basecamp todo 00 <content>
-ARG basecamp todolist archive 00 <id|url>
-ARG basecamp todolist create 00 <name>
-ARG basecamp todolist restore 00 <id|url>
-ARG basecamp todolist show 00 <id|url>
-ARG basecamp todolist trash 00 <id|url>
-ARG basecamp todolist update 00 <id|url>
-ARG basecamp todolistgroup create 00 <name>
-ARG basecamp todolistgroup move 00 <id>
-ARG basecamp todolistgroup position 00 <id>
-ARG basecamp todolistgroup rename 00 <id>
-ARG basecamp todolistgroup rename 01 <name>
-ARG basecamp todolistgroup show 00 <id>
-ARG basecamp todolistgroup update 00 <id>
-ARG basecamp todolistgroup update 01 <name>
-ARG basecamp todolistgroups create 00 <name>
-ARG basecamp todolistgroups move 00 <id>
-ARG basecamp todolistgroups position 00 <id>
-ARG basecamp todolistgroups rename 00 <id>
-ARG basecamp todolistgroups rename 01 <name>
-ARG basecamp todolistgroups show 00 <id>
-ARG basecamp todolistgroups update 00 <id>
-ARG basecamp todolistgroups update 01 <name>
-ARG basecamp todolists archive 00 <id|url>
-ARG basecamp todolists create 00 <name>
-ARG basecamp todolists restore 00 <id|url>
-ARG basecamp todolists show 00 <id|url>
-ARG basecamp todolists trash 00 <id|url>
-ARG basecamp todolists update 00 <id|url>
-ARG basecamp todos archive 00 <id|url>
-ARG basecamp todos complete 00 <id|url>...
-ARG basecamp todos create 00 <content>
-ARG basecamp todos move 00 <id|url>
-ARG basecamp todos position 00 <id|url>
-ARG basecamp todos reopen 00 <id|url>...
-ARG basecamp todos reorder 00 <id|url>
-ARG basecamp todos restore 00 <id|url>
-ARG basecamp todos show 00 <id|url>
-ARG basecamp todos trash 00 <id|url>
-ARG basecamp todos uncomplete 00 <id|url>...
-ARG basecamp todos update 00 <id|url>
-ARG basecamp todos update 01 [title]
-ARG basecamp todosets show 00 [id]
-ARG basecamp tools create 00 [title]
-ARG basecamp tools delete 00 <id>
-ARG basecamp tools disable 00 <id>
-ARG basecamp tools enable 00 <id>
-ARG basecamp tools move 00 <id>
-ARG basecamp tools rename 00 <id>
-ARG basecamp tools rename 01 <title>
-ARG basecamp tools reposition 00 <id>
-ARG basecamp tools show 00 <id>
-ARG basecamp tools trash 00 <id>
-ARG basecamp tools update 00 <id>
-ARG basecamp tools update 01 <title>
-ARG basecamp tui 00 [url]
-ARG basecamp unassign 00 <id|url>...
-ARG basecamp upload 00 <file>
-ARG basecamp uploads create 00 <file>
-ARG basecamp uploads show 00 <id|url>
-ARG basecamp url 00 <url>
-ARG basecamp url parse 00 <url>
-ARG basecamp vault archive 00 <id|url>
-ARG basecamp vault doc create 00 <title>
-ARG basecamp vault doc create 01 [content]
-ARG basecamp vault document create 00 <title>
-ARG basecamp vault document create 01 [content]
-ARG basecamp vault documents create 00 <title>
-ARG basecamp vault documents create 01 [content]
-ARG basecamp vault download 00 <upload-id|url>
-ARG basecamp vault folder create 00 <name>
-ARG basecamp vault folders create 00 <name>
-ARG basecamp vault restore 00 <id|url>
-ARG basecamp vault show 00 <id|url>
-ARG basecamp vault trash 00 <id|url>
-ARG basecamp vault update 00 <id|url>
-ARG basecamp vault upload create 00 <file>
-ARG basecamp vault uploads create 00 <file>
-ARG basecamp vault vault create 00 <name>
-ARG basecamp vault vaults create 00 <name>
-ARG basecamp vaults archive 00 <id|url>
-ARG basecamp vaults doc create 00 <title>
-ARG basecamp vaults doc create 01 [content]
-ARG basecamp vaults document create 00 <title>
-ARG basecamp vaults document create 01 [content]
-ARG basecamp vaults documents create 00 <title>
-ARG basecamp vaults documents create 01 [content]
-ARG basecamp vaults download 00 <upload-id|url>
-ARG basecamp vaults folder create 00 <name>
-ARG basecamp vaults folders create 00 <name>
-ARG basecamp vaults restore 00 <id|url>
-ARG basecamp vaults show 00 <id|url>
-ARG basecamp vaults trash 00 <id|url>
-ARG basecamp vaults update 00 <id|url>
-ARG basecamp vaults upload create 00 <file>
-ARG basecamp vaults uploads create 00 <file>
-ARG basecamp vaults vault create 00 <name>
-ARG basecamp vaults vaults create 00 <name>
-ARG basecamp webhook create 00 <url>
-ARG basecamp webhook delete 00 <id>
-ARG basecamp webhook show 00 <id>
-ARG basecamp webhook update 00 <id>
-ARG basecamp webhooks create 00 <url>
-ARG basecamp webhooks delete 00 <id>
-ARG basecamp webhooks show 00 <id>
-ARG basecamp webhooks update 00 <id>
 CMD basecamp
-CMD basecamp account
-CMD basecamp account list
-CMD basecamp account use
 CMD basecamp accounts
 CMD basecamp accounts list
+CMD basecamp accounts logo
+CMD basecamp accounts logo remove
+CMD basecamp accounts logo set
+CMD basecamp accounts rename
+CMD basecamp accounts show
 CMD basecamp accounts use
 CMD basecamp api
 CMD basecamp api delete
@@ -444,22 +33,8 @@ CMD basecamp boost create
 CMD basecamp boost delete
 CMD basecamp boost list
 CMD basecamp boost show
-CMD basecamp boosts
-CMD basecamp boosts create
-CMD basecamp boosts delete
-CMD basecamp boosts list
-CMD basecamp boosts show
-CMD basecamp campfire
-CMD basecamp campfire delete
-CMD basecamp campfire line
-CMD basecamp campfire list
-CMD basecamp campfire messages
-CMD basecamp campfire post
-CMD basecamp campfire show
-CMD basecamp campfire upload
 CMD basecamp card
 CMD basecamp card move
-CMD basecamp card mv
 CMD basecamp card update
 CMD basecamp cards
 CMD basecamp cards archive
@@ -477,7 +52,6 @@ CMD basecamp cards columns
 CMD basecamp cards create
 CMD basecamp cards list
 CMD basecamp cards move
-CMD basecamp cards mv
 CMD basecamp cards restore
 CMD basecamp cards show
 CMD basecamp cards step
@@ -496,19 +70,7 @@ CMD basecamp chat line
 CMD basecamp chat list
 CMD basecamp chat messages
 CMD basecamp chat post
-CMD basecamp chat show
 CMD basecamp chat upload
-CMD basecamp checkin
-CMD basecamp checkin answer
-CMD basecamp checkin answer create
-CMD basecamp checkin answer show
-CMD basecamp checkin answer update
-CMD basecamp checkin answers
-CMD basecamp checkin question
-CMD basecamp checkin question create
-CMD basecamp checkin question show
-CMD basecamp checkin question update
-CMD basecamp checkin questions
 CMD basecamp checkins
 CMD basecamp checkins answer
 CMD basecamp checkins answer create
@@ -520,7 +82,6 @@ CMD basecamp checkins question create
 CMD basecamp checkins question show
 CMD basecamp checkins question update
 CMD basecamp checkins questions
-CMD basecamp cmds
 CMD basecamp commands
 CMD basecamp comment
 CMD basecamp comments
@@ -548,19 +109,10 @@ CMD basecamp config unset
 CMD basecamp config untrust
 CMD basecamp docs
 CMD basecamp docs archive
-CMD basecamp docs doc
-CMD basecamp docs doc create
-CMD basecamp docs doc list
-CMD basecamp docs document
-CMD basecamp docs document create
-CMD basecamp docs document list
 CMD basecamp docs documents
 CMD basecamp docs documents create
 CMD basecamp docs documents list
 CMD basecamp docs download
-CMD basecamp docs folder
-CMD basecamp docs folder create
-CMD basecamp docs folder list
 CMD basecamp docs folders
 CMD basecamp docs folders create
 CMD basecamp docs folders list
@@ -569,106 +121,18 @@ CMD basecamp docs restore
 CMD basecamp docs show
 CMD basecamp docs trash
 CMD basecamp docs update
-CMD basecamp docs upload
-CMD basecamp docs upload create
-CMD basecamp docs upload list
 CMD basecamp docs uploads
 CMD basecamp docs uploads create
 CMD basecamp docs uploads list
-CMD basecamp docs vault
-CMD basecamp docs vault create
-CMD basecamp docs vault list
-CMD basecamp docs vaults
-CMD basecamp docs vaults create
-CMD basecamp docs vaults list
 CMD basecamp doctor
-CMD basecamp documents
-CMD basecamp documents archive
-CMD basecamp documents doc
-CMD basecamp documents doc create
-CMD basecamp documents doc list
-CMD basecamp documents document
-CMD basecamp documents document create
-CMD basecamp documents document list
-CMD basecamp documents documents
-CMD basecamp documents documents create
-CMD basecamp documents documents list
-CMD basecamp documents download
-CMD basecamp documents folder
-CMD basecamp documents folder create
-CMD basecamp documents folder list
-CMD basecamp documents folders
-CMD basecamp documents folders create
-CMD basecamp documents folders list
-CMD basecamp documents list
-CMD basecamp documents restore
-CMD basecamp documents show
-CMD basecamp documents trash
-CMD basecamp documents update
-CMD basecamp documents upload
-CMD basecamp documents upload create
-CMD basecamp documents upload list
-CMD basecamp documents uploads
-CMD basecamp documents uploads create
-CMD basecamp documents uploads list
-CMD basecamp documents vault
-CMD basecamp documents vault create
-CMD basecamp documents vault list
-CMD basecamp documents vaults
-CMD basecamp documents vaults create
-CMD basecamp documents vaults list
 CMD basecamp done
 CMD basecamp events
-CMD basecamp file
-CMD basecamp file archive
-CMD basecamp file doc
-CMD basecamp file doc create
-CMD basecamp file doc list
-CMD basecamp file document
-CMD basecamp file document create
-CMD basecamp file document list
-CMD basecamp file documents
-CMD basecamp file documents create
-CMD basecamp file documents list
-CMD basecamp file download
-CMD basecamp file folder
-CMD basecamp file folder create
-CMD basecamp file folder list
-CMD basecamp file folders
-CMD basecamp file folders create
-CMD basecamp file folders list
-CMD basecamp file list
-CMD basecamp file restore
-CMD basecamp file show
-CMD basecamp file trash
-CMD basecamp file update
-CMD basecamp file upload
-CMD basecamp file upload create
-CMD basecamp file upload list
-CMD basecamp file uploads
-CMD basecamp file uploads create
-CMD basecamp file uploads list
-CMD basecamp file vault
-CMD basecamp file vault create
-CMD basecamp file vault list
-CMD basecamp file vaults
-CMD basecamp file vaults create
-CMD basecamp file vaults list
 CMD basecamp files
 CMD basecamp files archive
-CMD basecamp files doc
-CMD basecamp files doc create
-CMD basecamp files doc list
-CMD basecamp files document
-CMD basecamp files document create
-CMD basecamp files document list
 CMD basecamp files documents
 CMD basecamp files documents create
 CMD basecamp files documents list
 CMD basecamp files download
-CMD basecamp files folder
-CMD basecamp files folder create
-CMD basecamp files folder list
 CMD basecamp files folders
 CMD basecamp files folders create
 CMD basecamp files folders list
@@ -677,59 +141,24 @@ CMD basecamp files restore
 CMD basecamp files show
 CMD basecamp files trash
 CMD basecamp files update
-CMD basecamp files upload
-CMD basecamp files upload create
-CMD basecamp files upload list
 CMD basecamp files uploads
 CMD basecamp files uploads create
 CMD basecamp files uploads list
-CMD basecamp files vault
-CMD basecamp files vault create
-CMD basecamp files vault list
-CMD basecamp files vaults
-CMD basecamp files vaults create
-CMD basecamp files vaults list
-CMD basecamp folders
-CMD basecamp folders archive
-CMD basecamp folders doc
-CMD basecamp folders doc create
-CMD basecamp folders doc list
-CMD basecamp folders document
-CMD basecamp folders document create
-CMD basecamp folders document list
-CMD basecamp folders documents
-CMD basecamp folders documents create
-CMD basecamp folders documents list
-CMD basecamp folders download
-CMD basecamp folders folder
-CMD basecamp folders folder create
-CMD basecamp folders folder list
-CMD basecamp folders folders
-CMD basecamp folders folders create
-CMD basecamp folders folders list
-CMD basecamp folders list
-CMD basecamp folders restore
-CMD basecamp folders show
-CMD basecamp folders trash
-CMD basecamp folders update
-CMD basecamp folders upload
-CMD basecamp folders upload create
-CMD basecamp folders upload list
-CMD basecamp folders uploads
-CMD basecamp folders uploads create
-CMD basecamp folders uploads list
-CMD basecamp folders vault
-CMD basecamp folders vault create
-CMD basecamp folders vault list
-CMD basecamp folders vaults
-CMD basecamp folders vaults create
-CMD basecamp folders vaults list
 CMD basecamp forwards
 CMD basecamp forwards inbox
 CMD basecamp forwards list
 CMD basecamp forwards replies
 CMD basecamp forwards reply
 CMD basecamp forwards show
+CMD basecamp gauges
+CMD basecamp gauges create
+CMD basecamp gauges delete
+CMD basecamp gauges disable
+CMD basecamp gauges enable
+CMD basecamp gauges list
+CMD basecamp gauges needles
+CMD basecamp gauges show
+CMD basecamp gauges update
 CMD basecamp help
 CMD basecamp hillcharts
 CMD basecamp hillcharts show
@@ -742,6 +171,7 @@ CMD basecamp lineup list
 CMD basecamp lineup update
 CMD basecamp login
 CMD basecamp logout
+CMD basecamp mcp
 CMD basecamp me
 CMD basecamp message
 CMD basecamp messageboards
@@ -764,21 +194,23 @@ CMD basecamp messagetypes list
 CMD basecamp messagetypes show
 CMD basecamp messagetypes update
 CMD basecamp migrate
-CMD basecamp msgs
-CMD basecamp msgs archive
-CMD basecamp msgs create
-CMD basecamp msgs list
-CMD basecamp msgs pin
-CMD basecamp msgs publish
-CMD basecamp msgs restore
-CMD basecamp msgs show
-CMD basecamp msgs trash
-CMD basecamp msgs unpin
-CMD basecamp msgs update
+CMD basecamp notifications
+CMD basecamp notifications list
+CMD basecamp notifications read
 CMD basecamp people
 CMD basecamp people add
 CMD basecamp people list
+CMD basecamp people out-of-office
+CMD basecamp people out-of-office disable
+CMD basecamp people out-of-office enable
+CMD basecamp people out-of-office show
 CMD basecamp people pingable
+CMD basecamp people preferences
+CMD basecamp people preferences show
+CMD basecamp people preferences update
+CMD basecamp people profile
+CMD basecamp people profile show
+CMD basecamp people profile update
 CMD basecamp people remove
 CMD basecamp people show
 CMD basecamp profile
@@ -787,35 +219,26 @@ CMD basecamp profile delete
 CMD basecamp profile list
 CMD basecamp profile set-default
 CMD basecamp profile show
-CMD basecamp project
-CMD basecamp project create
-CMD basecamp project delete
-CMD basecamp project list
-CMD basecamp project show
-CMD basecamp project trash
-CMD basecamp project update
 CMD basecamp projects
 CMD basecamp projects create
 CMD basecamp projects delete
 CMD basecamp projects list
 CMD basecamp projects show
-CMD basecamp projects trash
 CMD basecamp projects update
 CMD basecamp react
 CMD basecamp recordings
-CMD basecamp recordings active
 CMD basecamp recordings archive
-CMD basecamp recordings archived
-CMD basecamp recordings client-visibility
 CMD basecamp recordings list
 CMD basecamp recordings restore
 CMD basecamp recordings trash
-CMD basecamp recordings trashed
 CMD basecamp recordings visibility
 CMD basecamp reopen
 CMD basecamp reports
 CMD basecamp reports assignable
 CMD basecamp reports assigned
+CMD basecamp reports completed
+CMD basecamp reports due
+CMD basecamp reports mine
 CMD basecamp reports overdue
 CMD basecamp reports schedule
 CMD basecamp schedule
@@ -827,7 +250,6 @@ CMD basecamp schedule show
 CMD basecamp schedule update
 CMD basecamp search
 CMD basecamp search metadata
-CMD basecamp search types
 CMD basecamp setup
 CMD basecamp setup claude
 CMD basecamp show
@@ -851,47 +273,12 @@ CMD basecamp timeline
 CMD basecamp timesheet
 CMD basecamp timesheet item
 CMD basecamp timesheet project
-CMD basecamp timesheet recording
 CMD basecamp timesheet report
-CMD basecamp tlgroup
-CMD basecamp tlgroup create
-CMD basecamp tlgroup list
-CMD basecamp tlgroup move
-CMD basecamp tlgroup position
-CMD basecamp tlgroup rename
-CMD basecamp tlgroup show
-CMD basecamp tlgroup update
-CMD basecamp tlgroups
-CMD basecamp tlgroups create
-CMD basecamp tlgroups list
-CMD basecamp tlgroups move
-CMD basecamp tlgroups position
-CMD basecamp tlgroups rename
-CMD basecamp tlgroups show
-CMD basecamp tlgroups update
 CMD basecamp todo
-CMD basecamp todolist
-CMD basecamp todolist archive
-CMD basecamp todolist create
-CMD basecamp todolist list
-CMD basecamp todolist restore
-CMD basecamp todolist show
-CMD basecamp todolist trash
-CMD basecamp todolist update
-CMD basecamp todolistgroup
-CMD basecamp todolistgroup create
-CMD basecamp todolistgroup list
-CMD basecamp todolistgroup move
-CMD basecamp todolistgroup position
-CMD basecamp todolistgroup rename
-CMD basecamp todolistgroup show
-CMD basecamp todolistgroup update
 CMD basecamp todolistgroups
 CMD basecamp todolistgroups create
 CMD basecamp todolistgroups list
-CMD basecamp todolistgroups move
 CMD basecamp todolistgroups position
-CMD basecamp todolistgroups rename
 CMD basecamp todolistgroups show
 CMD basecamp todolistgroups update
 CMD basecamp todolists
@@ -907,10 +294,7 @@ CMD basecamp todos archive
 CMD basecamp todos complete
 CMD basecamp todos create
 CMD basecamp todos list
-CMD basecamp todos move
 CMD basecamp todos position
-CMD basecamp todos reopen
-CMD basecamp todos reorder
 CMD basecamp todos restore
 CMD basecamp todos show
 CMD basecamp todos sweep
@@ -922,11 +306,8 @@ CMD basecamp todosets list
 CMD basecamp todosets show
 CMD basecamp tools
 CMD basecamp tools create
-CMD basecamp tools delete
 CMD basecamp tools disable
 CMD basecamp tools enable
-CMD basecamp tools move
-CMD basecamp tools rename
 CMD basecamp tools reposition
 CMD basecamp tools show
 CMD basecamp tools trash
@@ -941,56 +322,12 @@ CMD basecamp uploads list
 CMD basecamp uploads show
 CMD basecamp url
 CMD basecamp url parse
-CMD basecamp vault
-CMD basecamp vault archive
-CMD basecamp vault doc
-CMD basecamp vault doc create
-CMD basecamp vault doc list
-CMD basecamp vault document
-CMD basecamp vault document create
-CMD basecamp vault document list
-CMD basecamp vault documents
-CMD basecamp vault documents create
-CMD basecamp vault documents list
-CMD basecamp vault download
-CMD basecamp vault folder
-CMD basecamp vault folder create
-CMD basecamp vault folder list
-CMD basecamp vault folders
-CMD basecamp vault folders create
-CMD basecamp vault folders list
-CMD basecamp vault list
-CMD basecamp vault restore
-CMD basecamp vault show
-CMD basecamp vault trash
-CMD basecamp vault update
-CMD basecamp vault upload
-CMD basecamp vault upload create
-CMD basecamp vault upload list
-CMD basecamp vault uploads
-CMD basecamp vault uploads create
-CMD basecamp vault uploads list
-CMD basecamp vault vault
-CMD basecamp vault vault create
-CMD basecamp vault vault list
-CMD basecamp vault vaults
-CMD basecamp vault vaults create
-CMD basecamp vault vaults list
 CMD basecamp vaults
 CMD basecamp vaults archive
-CMD basecamp vaults doc
-CMD basecamp vaults doc create
-CMD basecamp vaults doc list
-CMD basecamp vaults document
-CMD basecamp vaults document create
-CMD basecamp vaults document list
 CMD basecamp vaults documents
 CMD basecamp vaults documents create
 CMD basecamp vaults documents list
 CMD basecamp vaults download
-CMD basecamp vaults folder
-CMD basecamp vaults folder create
-CMD basecamp vaults folder list
 CMD basecamp vaults folders
 CMD basecamp vaults folders create
 CMD basecamp vaults folders list
@@ -999,25 +336,10 @@ CMD basecamp vaults restore
 CMD basecamp vaults show
 CMD basecamp vaults trash
 CMD basecamp vaults update
-CMD basecamp vaults upload
-CMD basecamp vaults upload create
-CMD basecamp vaults upload list
 CMD basecamp vaults uploads
 CMD basecamp vaults uploads create
 CMD basecamp vaults uploads list
-CMD basecamp vaults vault
-CMD basecamp vaults vault create
-CMD basecamp vaults vault list
-CMD basecamp vaults vaults
-CMD basecamp vaults vaults create
-CMD basecamp vaults vaults list
 CMD basecamp version
-CMD basecamp webhook
-CMD basecamp webhook create
-CMD basecamp webhook delete
-CMD basecamp webhook list
-CMD basecamp webhook show
-CMD basecamp webhook update
 CMD basecamp webhooks
 CMD basecamp webhooks create
 CMD basecamp webhooks delete
@@ -1028,7 +350,6 @@ FLAG basecamp --account type=string
 FLAG basecamp --agent type=bool
 FLAG basecamp --cache-dir type=string
 FLAG basecamp --count type=bool
-FLAG basecamp --help type=bool
 FLAG basecamp --hints type=bool
 FLAG basecamp --ids-only type=bool
 FLAG basecamp --in type=string
@@ -1045,79 +366,10 @@ FLAG basecamp --stats type=bool
 FLAG basecamp --styled type=bool
 FLAG basecamp --todolist type=string
 FLAG basecamp --verbose type=count
-FLAG basecamp --version type=bool
-FLAG basecamp account --account type=string
-FLAG basecamp account --agent type=bool
-FLAG basecamp account --cache-dir type=string
-FLAG basecamp account --count type=bool
-FLAG basecamp account --help type=bool
-FLAG basecamp account --hints type=bool
-FLAG basecamp account --ids-only type=bool
-FLAG basecamp account --in type=string
-FLAG basecamp account --jq type=string
-FLAG basecamp account --json type=bool
-FLAG basecamp account --markdown type=bool
-FLAG basecamp account --md type=bool
-FLAG basecamp account --no-hints type=bool
-FLAG basecamp account --no-stats type=bool
-FLAG basecamp account --profile type=string
-FLAG basecamp account --project type=string
-FLAG basecamp account --quiet type=bool
-FLAG basecamp account --stats type=bool
-FLAG basecamp account --styled type=bool
-FLAG basecamp account --todolist type=string
-FLAG basecamp account --verbose type=count
-FLAG basecamp account --version type=bool
-FLAG basecamp account list --account type=string
-FLAG basecamp account list --agent type=bool
-FLAG basecamp account list --cache-dir type=string
-FLAG basecamp account list --count type=bool
-FLAG basecamp account list --help type=bool
-FLAG basecamp account list --hints type=bool
-FLAG basecamp account list --ids-only type=bool
-FLAG basecamp account list --in type=string
-FLAG basecamp account list --jq type=string
-FLAG basecamp account list --json type=bool
-FLAG basecamp account list --markdown type=bool
-FLAG basecamp account list --md type=bool
-FLAG basecamp account list --no-hints type=bool
-FLAG basecamp account list --no-stats type=bool
-FLAG basecamp account list --profile type=string
-FLAG basecamp account list --project type=string
-FLAG basecamp account list --quiet type=bool
-FLAG basecamp account list --stats type=bool
-FLAG basecamp account list --styled type=bool
-FLAG basecamp account list --todolist type=string
-FLAG basecamp account list --verbose type=count
-FLAG basecamp account list --version type=bool
-FLAG basecamp account use --account type=string
-FLAG basecamp account use --agent type=bool
-FLAG basecamp account use --cache-dir type=string
-FLAG basecamp account use --count type=bool
-FLAG basecamp account use --help type=bool
-FLAG basecamp account use --hints type=bool
-FLAG basecamp account use --ids-only type=bool
-FLAG basecamp account use --in type=string
-FLAG basecamp account use --jq type=string
-FLAG basecamp account use --json type=bool
-FLAG basecamp account use --markdown type=bool
-FLAG basecamp account use --md type=bool
-FLAG basecamp account use --no-hints type=bool
-FLAG basecamp account use --no-stats type=bool
-FLAG basecamp account use --profile type=string
-FLAG basecamp account use --project type=string
-FLAG basecamp account use --quiet type=bool
-FLAG basecamp account use --scope type=string
-FLAG basecamp account use --stats type=bool
-FLAG basecamp account use --styled type=bool
-FLAG basecamp account use --todolist type=string
-FLAG basecamp account use --verbose type=count
-FLAG basecamp account use --version type=bool
 FLAG basecamp accounts --account type=string
 FLAG basecamp accounts --agent type=bool
 FLAG basecamp accounts --cache-dir type=string
 FLAG basecamp accounts --count type=bool
-FLAG basecamp accounts --help type=bool
 FLAG basecamp accounts --hints type=bool
 FLAG basecamp accounts --ids-only type=bool
 FLAG basecamp accounts --in type=string
@@ -1134,12 +386,10 @@ FLAG basecamp accounts --stats type=bool
 FLAG basecamp accounts --styled type=bool
 FLAG basecamp accounts --todolist type=string
 FLAG basecamp accounts --verbose type=count
-FLAG basecamp accounts --version type=bool
 FLAG basecamp accounts list --account type=string
 FLAG basecamp accounts list --agent type=bool
 FLAG basecamp accounts list --cache-dir type=string
 FLAG basecamp accounts list --count type=bool
-FLAG basecamp accounts list --help type=bool
 FLAG basecamp accounts list --hints type=bool
 FLAG basecamp accounts list --ids-only type=bool
 FLAG basecamp accounts list --in type=string
@@ -1156,12 +406,110 @@ FLAG basecamp accounts list --stats type=bool
 FLAG basecamp accounts list --styled type=bool
 FLAG basecamp accounts list --todolist type=string
 FLAG basecamp accounts list --verbose type=count
-FLAG basecamp accounts list --version type=bool
+FLAG basecamp accounts logo --account type=string
+FLAG basecamp accounts logo --agent type=bool
+FLAG basecamp accounts logo --cache-dir type=string
+FLAG basecamp accounts logo --count type=bool
+FLAG basecamp accounts logo --hints type=bool
+FLAG basecamp accounts logo --ids-only type=bool
+FLAG basecamp accounts logo --in type=string
+FLAG basecamp accounts logo --jq type=string
+FLAG basecamp accounts logo --json type=bool
+FLAG basecamp accounts logo --markdown type=bool
+FLAG basecamp accounts logo --md type=bool
+FLAG basecamp accounts logo --no-hints type=bool
+FLAG basecamp accounts logo --no-stats type=bool
+FLAG basecamp accounts logo --profile type=string
+FLAG basecamp accounts logo --project type=string
+FLAG basecamp accounts logo --quiet type=bool
+FLAG basecamp accounts logo --stats type=bool
+FLAG basecamp accounts logo --styled type=bool
+FLAG basecamp accounts logo --todolist type=string
+FLAG basecamp accounts logo --verbose type=count
+FLAG basecamp accounts logo remove --account type=string
+FLAG basecamp accounts logo remove --agent type=bool
+FLAG basecamp accounts logo remove --cache-dir type=string
+FLAG basecamp accounts logo remove --count type=bool
+FLAG basecamp accounts logo remove --hints type=bool
+FLAG basecamp accounts logo remove --ids-only type=bool
+FLAG basecamp accounts logo remove --in type=string
+FLAG basecamp accounts logo remove --jq type=string
+FLAG basecamp accounts logo remove --json type=bool
+FLAG basecamp accounts logo remove --markdown type=bool
+FLAG basecamp accounts logo remove --md type=bool
+FLAG basecamp accounts logo remove --no-hints type=bool
+FLAG basecamp accounts logo remove --no-stats type=bool
+FLAG basecamp accounts logo remove --profile type=string
+FLAG basecamp accounts logo remove --project type=string
+FLAG basecamp accounts logo remove --quiet type=bool
+FLAG basecamp accounts logo remove --stats type=bool
+FLAG basecamp accounts logo remove --styled type=bool
+FLAG basecamp accounts logo remove --todolist type=string
+FLAG basecamp accounts logo remove --verbose type=count
+FLAG basecamp accounts logo set --account type=string
+FLAG basecamp accounts logo set --agent type=bool
+FLAG basecamp accounts logo set --cache-dir type=string
+FLAG basecamp accounts logo set --count type=bool
+FLAG basecamp accounts logo set --hints type=bool
+FLAG basecamp accounts logo set --ids-only type=bool
+FLAG basecamp accounts logo set --in type=string
+FLAG basecamp accounts logo set --jq type=string
+FLAG basecamp accounts logo set --json type=bool
+FLAG basecamp accounts logo set --markdown type=bool
+FLAG basecamp accounts logo set --md type=bool
+FLAG basecamp accounts logo set --no-hints type=bool
+FLAG basecamp accounts logo set --no-stats type=bool
+FLAG basecamp accounts logo set --profile type=string
+FLAG basecamp accounts logo set --project type=string
+FLAG basecamp accounts logo set --quiet type=bool
+FLAG basecamp accounts logo set --stats type=bool
+FLAG basecamp accounts logo set --styled type=bool
+FLAG basecamp accounts logo set --todolist type=string
+FLAG basecamp accounts logo set --verbose type=count
+FLAG basecamp accounts rename --account type=string
+FLAG basecamp accounts rename --agent type=bool
+FLAG basecamp accounts rename --cache-dir type=string
+FLAG basecamp accounts rename --count type=bool
+FLAG basecamp accounts rename --hints type=bool
+FLAG basecamp accounts rename --ids-only type=bool
+FLAG basecamp accounts rename --in type=string
+FLAG basecamp accounts rename --jq type=string
+FLAG basecamp accounts rename --json type=bool
+FLAG basecamp accounts rename --markdown type=bool
+FLAG basecamp accounts rename --md type=bool
+FLAG basecamp accounts rename --no-hints type=bool
+FLAG basecamp accounts rename --no-stats type=bool
+FLAG basecamp accounts rename --profile type=string
+FLAG basecamp accounts rename --project type=string
+FLAG basecamp accounts rename --quiet type=bool
+FLAG basecamp accounts rename --stats type=bool
+FLAG basecamp accounts rename --styled type=bool
+FLAG basecamp accounts rename --todolist type=string
+FLAG basecamp accounts rename --verbose type=count
+FLAG basecamp accounts show --account type=string
+FLAG basecamp accounts show --agent type=bool
+FLAG basecamp accounts show --cache-dir type=string
+FLAG basecamp accounts show --count type=bool
+FLAG basecamp accounts show --hints type=bool
+FLAG basecamp accounts show --ids-only type=bool
+FLAG basecamp accounts show --in type=string
+FLAG basecamp accounts show --jq type=string
+FLAG basecamp accounts show --json type=bool
+FLAG basecamp accounts show --markdown type=bool
+FLAG basecamp accounts show --md type=bool
+FLAG basecamp accounts show --no-hints type=bool
+FLAG basecamp accounts show --no-stats type=bool
+FLAG basecamp accounts show --profile type=string
+FLAG basecamp accounts show --project type=string
+FLAG basecamp accounts show --quiet type=bool
+FLAG basecamp accounts show --stats type=bool
+FLAG basecamp accounts show --styled type=bool
+FLAG basecamp accounts show --todolist type=string
+FLAG basecamp accounts show --verbose type=count
 FLAG basecamp accounts use --account type=string
 FLAG basecamp accounts use --agent type=bool
 FLAG basecamp accounts use --cache-dir type=string
 FLAG basecamp accounts use --count type=bool
-FLAG basecamp accounts use --help type=bool
 FLAG basecamp accounts use --hints type=bool
 FLAG basecamp accounts use --ids-only type=bool
 FLAG basecamp accounts use --in type=string
@@ -1179,12 +527,10 @@ FLAG basecamp accounts use --stats type=bool
 FLAG basecamp accounts use --styled type=bool
 FLAG basecamp accounts use --todolist type=string
 FLAG basecamp accounts use --verbose type=count
-FLAG basecamp accounts use --version type=bool
 FLAG basecamp api --account type=string
 FLAG basecamp api --agent type=bool
 FLAG basecamp api --cache-dir type=string
 FLAG basecamp api --count type=bool
-FLAG basecamp api --help type=bool
 FLAG basecamp api --hints type=bool
 FLAG basecamp api --ids-only type=bool
 FLAG basecamp api --in type=string
@@ -1201,12 +547,10 @@ FLAG basecamp api --stats type=bool
 FLAG basecamp api --styled type=bool
 FLAG basecamp api --todolist type=string
 FLAG basecamp api --verbose type=count
-FLAG basecamp api --version type=bool
 FLAG basecamp api delete --account type=string
 FLAG basecamp api delete --agent type=bool
 FLAG basecamp api delete --cache-dir type=string
 FLAG basecamp api delete --count type=bool
-FLAG basecamp api delete --help type=bool
 FLAG basecamp api delete --hints type=bool
 FLAG basecamp api delete --ids-only type=bool
 FLAG basecamp api delete --in type=string
@@ -1223,12 +567,10 @@ FLAG basecamp api delete --stats type=bool
 FLAG basecamp api delete --styled type=bool
 FLAG basecamp api delete --todolist type=string
 FLAG basecamp api delete --verbose type=count
-FLAG basecamp api delete --version type=bool
 FLAG basecamp api get --account type=string
 FLAG basecamp api get --agent type=bool
 FLAG basecamp api get --cache-dir type=string
 FLAG basecamp api get --count type=bool
-FLAG basecamp api get --help type=bool
 FLAG basecamp api get --hints type=bool
 FLAG basecamp api get --ids-only type=bool
 FLAG basecamp api get --in type=string
@@ -1245,13 +587,11 @@ FLAG basecamp api get --stats type=bool
 FLAG basecamp api get --styled type=bool
 FLAG basecamp api get --todolist type=string
 FLAG basecamp api get --verbose type=count
-FLAG basecamp api get --version type=bool
 FLAG basecamp api post --account type=string
 FLAG basecamp api post --agent type=bool
 FLAG basecamp api post --cache-dir type=string
 FLAG basecamp api post --count type=bool
 FLAG basecamp api post --data type=string
-FLAG basecamp api post --help type=bool
 FLAG basecamp api post --hints type=bool
 FLAG basecamp api post --ids-only type=bool
 FLAG basecamp api post --in type=string
@@ -1268,13 +608,11 @@ FLAG basecamp api post --stats type=bool
 FLAG basecamp api post --styled type=bool
 FLAG basecamp api post --todolist type=string
 FLAG basecamp api post --verbose type=count
-FLAG basecamp api post --version type=bool
 FLAG basecamp api put --account type=string
 FLAG basecamp api put --agent type=bool
 FLAG basecamp api put --cache-dir type=string
 FLAG basecamp api put --count type=bool
 FLAG basecamp api put --data type=string
-FLAG basecamp api put --help type=bool
 FLAG basecamp api put --hints type=bool
 FLAG basecamp api put --ids-only type=bool
 FLAG basecamp api put --in type=string
@@ -1291,13 +629,11 @@ FLAG basecamp api put --stats type=bool
 FLAG basecamp api put --styled type=bool
 FLAG basecamp api put --todolist type=string
 FLAG basecamp api put --verbose type=count
-FLAG basecamp api put --version type=bool
 FLAG basecamp assign --account type=string
 FLAG basecamp assign --agent type=bool
 FLAG basecamp assign --cache-dir type=string
 FLAG basecamp assign --card type=bool
 FLAG basecamp assign --count type=bool
-FLAG basecamp assign --help type=bool
 FLAG basecamp assign --hints type=bool
 FLAG basecamp assign --ids-only type=bool
 FLAG basecamp assign --in type=string
@@ -1316,12 +652,10 @@ FLAG basecamp assign --styled type=bool
 FLAG basecamp assign --to type=string
 FLAG basecamp assign --todolist type=string
 FLAG basecamp assign --verbose type=count
-FLAG basecamp assign --version type=bool
 FLAG basecamp attach --account type=string
 FLAG basecamp attach --agent type=bool
 FLAG basecamp attach --cache-dir type=string
 FLAG basecamp attach --count type=bool
-FLAG basecamp attach --help type=bool
 FLAG basecamp attach --hints type=bool
 FLAG basecamp attach --ids-only type=bool
 FLAG basecamp attach --in type=string
@@ -1338,12 +672,10 @@ FLAG basecamp attach --stats type=bool
 FLAG basecamp attach --styled type=bool
 FLAG basecamp attach --todolist type=string
 FLAG basecamp attach --verbose type=count
-FLAG basecamp attach --version type=bool
 FLAG basecamp attachments --account type=string
 FLAG basecamp attachments --agent type=bool
 FLAG basecamp attachments --cache-dir type=string
 FLAG basecamp attachments --count type=bool
-FLAG basecamp attachments --help type=bool
 FLAG basecamp attachments --hints type=bool
 FLAG basecamp attachments --ids-only type=bool
 FLAG basecamp attachments --in type=string
@@ -1360,12 +692,10 @@ FLAG basecamp attachments --stats type=bool
 FLAG basecamp attachments --styled type=bool
 FLAG basecamp attachments --todolist type=string
 FLAG basecamp attachments --verbose type=count
-FLAG basecamp attachments --version type=bool
 FLAG basecamp attachments list --account type=string
 FLAG basecamp attachments list --agent type=bool
 FLAG basecamp attachments list --cache-dir type=string
 FLAG basecamp attachments list --count type=bool
-FLAG basecamp attachments list --help type=bool
 FLAG basecamp attachments list --hints type=bool
 FLAG basecamp attachments list --ids-only type=bool
 FLAG basecamp attachments list --in type=string
@@ -1383,12 +713,10 @@ FLAG basecamp attachments list --styled type=bool
 FLAG basecamp attachments list --todolist type=string
 FLAG basecamp attachments list --type type=string
 FLAG basecamp attachments list --verbose type=count
-FLAG basecamp attachments list --version type=bool
 FLAG basecamp auth --account type=string
 FLAG basecamp auth --agent type=bool
 FLAG basecamp auth --cache-dir type=string
 FLAG basecamp auth --count type=bool
-FLAG basecamp auth --help type=bool
 FLAG basecamp auth --hints type=bool
 FLAG basecamp auth --ids-only type=bool
 FLAG basecamp auth --in type=string
@@ -1405,13 +733,11 @@ FLAG basecamp auth --stats type=bool
 FLAG basecamp auth --styled type=bool
 FLAG basecamp auth --todolist type=string
 FLAG basecamp auth --verbose type=count
-FLAG basecamp auth --version type=bool
 FLAG basecamp auth login --account type=string
 FLAG basecamp auth login --agent type=bool
 FLAG basecamp auth login --cache-dir type=string
 FLAG basecamp auth login --count type=bool
 FLAG basecamp auth login --device-code type=bool
-FLAG basecamp auth login --help type=bool
 FLAG basecamp auth login --hints type=bool
 FLAG basecamp auth login --ids-only type=bool
 FLAG basecamp auth login --in type=string
@@ -1432,12 +758,10 @@ FLAG basecamp auth login --stats type=bool
 FLAG basecamp auth login --styled type=bool
 FLAG basecamp auth login --todolist type=string
 FLAG basecamp auth login --verbose type=count
-FLAG basecamp auth login --version type=bool
 FLAG basecamp auth logout --account type=string
 FLAG basecamp auth logout --agent type=bool
 FLAG basecamp auth logout --cache-dir type=string
 FLAG basecamp auth logout --count type=bool
-FLAG basecamp auth logout --help type=bool
 FLAG basecamp auth logout --hints type=bool
 FLAG basecamp auth logout --ids-only type=bool
 FLAG basecamp auth logout --in type=string
@@ -1454,12 +778,10 @@ FLAG basecamp auth logout --stats type=bool
 FLAG basecamp auth logout --styled type=bool
 FLAG basecamp auth logout --todolist type=string
 FLAG basecamp auth logout --verbose type=count
-FLAG basecamp auth logout --version type=bool
 FLAG basecamp auth refresh --account type=string
 FLAG basecamp auth refresh --agent type=bool
 FLAG basecamp auth refresh --cache-dir type=string
 FLAG basecamp auth refresh --count type=bool
-FLAG basecamp auth refresh --help type=bool
 FLAG basecamp auth refresh --hints type=bool
 FLAG basecamp auth refresh --ids-only type=bool
 FLAG basecamp auth refresh --in type=string
@@ -1476,12 +798,10 @@ FLAG basecamp auth refresh --stats type=bool
 FLAG basecamp auth refresh --styled type=bool
 FLAG basecamp auth refresh --todolist type=string
 FLAG basecamp auth refresh --verbose type=count
-FLAG basecamp auth refresh --version type=bool
 FLAG basecamp auth status --account type=string
 FLAG basecamp auth status --agent type=bool
 FLAG basecamp auth status --cache-dir type=string
 FLAG basecamp auth status --count type=bool
-FLAG basecamp auth status --help type=bool
 FLAG basecamp auth status --hints type=bool
 FLAG basecamp auth status --ids-only type=bool
 FLAG basecamp auth status --in type=string
@@ -1498,12 +818,10 @@ FLAG basecamp auth status --stats type=bool
 FLAG basecamp auth status --styled type=bool
 FLAG basecamp auth status --todolist type=string
 FLAG basecamp auth status --verbose type=count
-FLAG basecamp auth status --version type=bool
 FLAG basecamp auth token --account type=string
 FLAG basecamp auth token --agent type=bool
 FLAG basecamp auth token --cache-dir type=string
 FLAG basecamp auth token --count type=bool
-FLAG basecamp auth token --help type=bool
 FLAG basecamp auth token --hints type=bool
 FLAG basecamp auth token --ids-only type=bool
 FLAG basecamp auth token --in type=string
@@ -1521,12 +839,10 @@ FLAG basecamp auth token --stored type=bool
 FLAG basecamp auth token --styled type=bool
 FLAG basecamp auth token --todolist type=string
 FLAG basecamp auth token --verbose type=count
-FLAG basecamp auth token --version type=bool
 FLAG basecamp bonfire --account type=string
 FLAG basecamp bonfire --agent type=bool
 FLAG basecamp bonfire --cache-dir type=string
 FLAG basecamp bonfire --count type=bool
-FLAG basecamp bonfire --help type=bool
 FLAG basecamp bonfire --hints type=bool
 FLAG basecamp bonfire --ids-only type=bool
 FLAG basecamp bonfire --in type=string
@@ -1543,12 +859,10 @@ FLAG basecamp bonfire --stats type=bool
 FLAG basecamp bonfire --styled type=bool
 FLAG basecamp bonfire --todolist type=string
 FLAG basecamp bonfire --verbose type=count
-FLAG basecamp bonfire --version type=bool
 FLAG basecamp bonfire layout --account type=string
 FLAG basecamp bonfire layout --agent type=bool
 FLAG basecamp bonfire layout --cache-dir type=string
 FLAG basecamp bonfire layout --count type=bool
-FLAG basecamp bonfire layout --help type=bool
 FLAG basecamp bonfire layout --hints type=bool
 FLAG basecamp bonfire layout --ids-only type=bool
 FLAG basecamp bonfire layout --in type=string
@@ -1565,12 +879,10 @@ FLAG basecamp bonfire layout --stats type=bool
 FLAG basecamp bonfire layout --styled type=bool
 FLAG basecamp bonfire layout --todolist type=string
 FLAG basecamp bonfire layout --verbose type=count
-FLAG basecamp bonfire layout --version type=bool
 FLAG basecamp bonfire layout list --account type=string
 FLAG basecamp bonfire layout list --agent type=bool
 FLAG basecamp bonfire layout list --cache-dir type=string
 FLAG basecamp bonfire layout list --count type=bool
-FLAG basecamp bonfire layout list --help type=bool
 FLAG basecamp bonfire layout list --hints type=bool
 FLAG basecamp bonfire layout list --ids-only type=bool
 FLAG basecamp bonfire layout list --in type=string
@@ -1587,12 +899,10 @@ FLAG basecamp bonfire layout list --stats type=bool
 FLAG basecamp bonfire layout list --styled type=bool
 FLAG basecamp bonfire layout list --todolist type=string
 FLAG basecamp bonfire layout list --verbose type=count
-FLAG basecamp bonfire layout list --version type=bool
 FLAG basecamp bonfire layout load --account type=string
 FLAG basecamp bonfire layout load --agent type=bool
 FLAG basecamp bonfire layout load --cache-dir type=string
 FLAG basecamp bonfire layout load --count type=bool
-FLAG basecamp bonfire layout load --help type=bool
 FLAG basecamp bonfire layout load --hints type=bool
 FLAG basecamp bonfire layout load --ids-only type=bool
 FLAG basecamp bonfire layout load --in type=string
@@ -1609,12 +919,10 @@ FLAG basecamp bonfire layout load --stats type=bool
 FLAG basecamp bonfire layout load --styled type=bool
 FLAG basecamp bonfire layout load --todolist type=string
 FLAG basecamp bonfire layout load --verbose type=count
-FLAG basecamp bonfire layout load --version type=bool
 FLAG basecamp bonfire layout save --account type=string
 FLAG basecamp bonfire layout save --agent type=bool
 FLAG basecamp bonfire layout save --cache-dir type=string
 FLAG basecamp bonfire layout save --count type=bool
-FLAG basecamp bonfire layout save --help type=bool
 FLAG basecamp bonfire layout save --hints type=bool
 FLAG basecamp bonfire layout save --ids-only type=bool
 FLAG basecamp bonfire layout save --in type=string
@@ -1631,12 +939,10 @@ FLAG basecamp bonfire layout save --stats type=bool
 FLAG basecamp bonfire layout save --styled type=bool
 FLAG basecamp bonfire layout save --todolist type=string
 FLAG basecamp bonfire layout save --verbose type=count
-FLAG basecamp bonfire layout save --version type=bool
 FLAG basecamp bonfire split --account type=string
 FLAG basecamp bonfire split --agent type=bool
 FLAG basecamp bonfire split --cache-dir type=string
 FLAG basecamp bonfire split --count type=bool
-FLAG basecamp bonfire split --help type=bool
 FLAG basecamp bonfire split --hints type=bool
 FLAG basecamp bonfire split --ids-only type=bool
 FLAG basecamp bonfire split --in type=string
@@ -1653,12 +959,10 @@ FLAG basecamp bonfire split --stats type=bool
 FLAG basecamp bonfire split --styled type=bool
 FLAG basecamp bonfire split --todolist type=string
 FLAG basecamp bonfire split --verbose type=count
-FLAG basecamp bonfire split --version type=bool
 FLAG basecamp boost --account type=string
 FLAG basecamp boost --agent type=bool
 FLAG basecamp boost --cache-dir type=string
 FLAG basecamp boost --count type=bool
-FLAG basecamp boost --help type=bool
 FLAG basecamp boost --hints type=bool
 FLAG basecamp boost --ids-only type=bool
 FLAG basecamp boost --in type=string
@@ -1675,13 +979,11 @@ FLAG basecamp boost --stats type=bool
 FLAG basecamp boost --styled type=bool
 FLAG basecamp boost --todolist type=string
 FLAG basecamp boost --verbose type=count
-FLAG basecamp boost --version type=bool
 FLAG basecamp boost create --account type=string
 FLAG basecamp boost create --agent type=bool
 FLAG basecamp boost create --cache-dir type=string
 FLAG basecamp boost create --count type=bool
 FLAG basecamp boost create --event type=string
-FLAG basecamp boost create --help type=bool
 FLAG basecamp boost create --hints type=bool
 FLAG basecamp boost create --ids-only type=bool
 FLAG basecamp boost create --in type=string
@@ -1698,12 +1000,10 @@ FLAG basecamp boost create --stats type=bool
 FLAG basecamp boost create --styled type=bool
 FLAG basecamp boost create --todolist type=string
 FLAG basecamp boost create --verbose type=count
-FLAG basecamp boost create --version type=bool
 FLAG basecamp boost delete --account type=string
 FLAG basecamp boost delete --agent type=bool
 FLAG basecamp boost delete --cache-dir type=string
 FLAG basecamp boost delete --count type=bool
-FLAG basecamp boost delete --help type=bool
 FLAG basecamp boost delete --hints type=bool
 FLAG basecamp boost delete --ids-only type=bool
 FLAG basecamp boost delete --in type=string
@@ -1720,13 +1020,11 @@ FLAG basecamp boost delete --stats type=bool
 FLAG basecamp boost delete --styled type=bool
 FLAG basecamp boost delete --todolist type=string
 FLAG basecamp boost delete --verbose type=count
-FLAG basecamp boost delete --version type=bool
 FLAG basecamp boost list --account type=string
 FLAG basecamp boost list --agent type=bool
 FLAG basecamp boost list --cache-dir type=string
 FLAG basecamp boost list --count type=bool
 FLAG basecamp boost list --event type=string
-FLAG basecamp boost list --help type=bool
 FLAG basecamp boost list --hints type=bool
 FLAG basecamp boost list --ids-only type=bool
 FLAG basecamp boost list --in type=string
@@ -1743,12 +1041,10 @@ FLAG basecamp boost list --stats type=bool
 FLAG basecamp boost list --styled type=bool
 FLAG basecamp boost list --todolist type=string
 FLAG basecamp boost list --verbose type=count
-FLAG basecamp boost list --version type=bool
 FLAG basecamp boost show --account type=string
 FLAG basecamp boost show --agent type=bool
 FLAG basecamp boost show --cache-dir type=string
 FLAG basecamp boost show --count type=bool
-FLAG basecamp boost show --help type=bool
 FLAG basecamp boost show --hints type=bool
 FLAG basecamp boost show --ids-only type=bool
 FLAG basecamp boost show --in type=string
@@ -1765,309 +1061,6 @@ FLAG basecamp boost show --stats type=bool
 FLAG basecamp boost show --styled type=bool
 FLAG basecamp boost show --todolist type=string
 FLAG basecamp boost show --verbose type=count
-FLAG basecamp boost show --version type=bool
-FLAG basecamp boosts --account type=string
-FLAG basecamp boosts --agent type=bool
-FLAG basecamp boosts --cache-dir type=string
-FLAG basecamp boosts --count type=bool
-FLAG basecamp boosts --help type=bool
-FLAG basecamp boosts --hints type=bool
-FLAG basecamp boosts --ids-only type=bool
-FLAG basecamp boosts --in type=string
-FLAG basecamp boosts --jq type=string
-FLAG basecamp boosts --json type=bool
-FLAG basecamp boosts --markdown type=bool
-FLAG basecamp boosts --md type=bool
-FLAG basecamp boosts --no-hints type=bool
-FLAG basecamp boosts --no-stats type=bool
-FLAG basecamp boosts --profile type=string
-FLAG basecamp boosts --project type=string
-FLAG basecamp boosts --quiet type=bool
-FLAG basecamp boosts --stats type=bool
-FLAG basecamp boosts --styled type=bool
-FLAG basecamp boosts --todolist type=string
-FLAG basecamp boosts --verbose type=count
-FLAG basecamp boosts --version type=bool
-FLAG basecamp boosts create --account type=string
-FLAG basecamp boosts create --agent type=bool
-FLAG basecamp boosts create --cache-dir type=string
-FLAG basecamp boosts create --count type=bool
-FLAG basecamp boosts create --event type=string
-FLAG basecamp boosts create --help type=bool
-FLAG basecamp boosts create --hints type=bool
-FLAG basecamp boosts create --ids-only type=bool
-FLAG basecamp boosts create --in type=string
-FLAG basecamp boosts create --jq type=string
-FLAG basecamp boosts create --json type=bool
-FLAG basecamp boosts create --markdown type=bool
-FLAG basecamp boosts create --md type=bool
-FLAG basecamp boosts create --no-hints type=bool
-FLAG basecamp boosts create --no-stats type=bool
-FLAG basecamp boosts create --profile type=string
-FLAG basecamp boosts create --project type=string
-FLAG basecamp boosts create --quiet type=bool
-FLAG basecamp boosts create --stats type=bool
-FLAG basecamp boosts create --styled type=bool
-FLAG basecamp boosts create --todolist type=string
-FLAG basecamp boosts create --verbose type=count
-FLAG basecamp boosts create --version type=bool
-FLAG basecamp boosts delete --account type=string
-FLAG basecamp boosts delete --agent type=bool
-FLAG basecamp boosts delete --cache-dir type=string
-FLAG basecamp boosts delete --count type=bool
-FLAG basecamp boosts delete --help type=bool
-FLAG basecamp boosts delete --hints type=bool
-FLAG basecamp boosts delete --ids-only type=bool
-FLAG basecamp boosts delete --in type=string
-FLAG basecamp boosts delete --jq type=string
-FLAG basecamp boosts delete --json type=bool
-FLAG basecamp boosts delete --markdown type=bool
-FLAG basecamp boosts delete --md type=bool
-FLAG basecamp boosts delete --no-hints type=bool
-FLAG basecamp boosts delete --no-stats type=bool
-FLAG basecamp boosts delete --profile type=string
-FLAG basecamp boosts delete --project type=string
-FLAG basecamp boosts delete --quiet type=bool
-FLAG basecamp boosts delete --stats type=bool
-FLAG basecamp boosts delete --styled type=bool
-FLAG basecamp boosts delete --todolist type=string
-FLAG basecamp boosts delete --verbose type=count
-FLAG basecamp boosts delete --version type=bool
-FLAG basecamp boosts list --account type=string
-FLAG basecamp boosts list --agent type=bool
-FLAG basecamp boosts list --cache-dir type=string
-FLAG basecamp boosts list --count type=bool
-FLAG basecamp boosts list --event type=string
-FLAG basecamp boosts list --help type=bool
-FLAG basecamp boosts list --hints type=bool
-FLAG basecamp boosts list --ids-only type=bool
-FLAG basecamp boosts list --in type=string
-FLAG basecamp boosts list --jq type=string
-FLAG basecamp boosts list --json type=bool
-FLAG basecamp boosts list --markdown type=bool
-FLAG basecamp boosts list --md type=bool
-FLAG basecamp boosts list --no-hints type=bool
-FLAG basecamp boosts list --no-stats type=bool
-FLAG basecamp boosts list --profile type=string
-FLAG basecamp boosts list --project type=string
-FLAG basecamp boosts list --quiet type=bool
-FLAG basecamp boosts list --stats type=bool
-FLAG basecamp boosts list --styled type=bool
-FLAG basecamp boosts list --todolist type=string
-FLAG basecamp boosts list --verbose type=count
-FLAG basecamp boosts list --version type=bool
-FLAG basecamp boosts show --account type=string
-FLAG basecamp boosts show --agent type=bool
-FLAG basecamp boosts show --cache-dir type=string
-FLAG basecamp boosts show --count type=bool
-FLAG basecamp boosts show --help type=bool
-FLAG basecamp boosts show --hints type=bool
-FLAG basecamp boosts show --ids-only type=bool
-FLAG basecamp boosts show --in type=string
-FLAG basecamp boosts show --jq type=string
-FLAG basecamp boosts show --json type=bool
-FLAG basecamp boosts show --markdown type=bool
-FLAG basecamp boosts show --md type=bool
-FLAG basecamp boosts show --no-hints type=bool
-FLAG basecamp boosts show --no-stats type=bool
-FLAG basecamp boosts show --profile type=string
-FLAG basecamp boosts show --project type=string
-FLAG basecamp boosts show --quiet type=bool
-FLAG basecamp boosts show --stats type=bool
-FLAG basecamp boosts show --styled type=bool
-FLAG basecamp boosts show --todolist type=string
-FLAG basecamp boosts show --verbose type=count
-FLAG basecamp boosts show --version type=bool
-FLAG basecamp campfire --account type=string
-FLAG basecamp campfire --agent type=bool
-FLAG basecamp campfire --cache-dir type=string
-FLAG basecamp campfire --count type=bool
-FLAG basecamp campfire --help type=bool
-FLAG basecamp campfire --hints type=bool
-FLAG basecamp campfire --ids-only type=bool
-FLAG basecamp campfire --in type=string
-FLAG basecamp campfire --jq type=string
-FLAG basecamp campfire --json type=bool
-FLAG basecamp campfire --markdown type=bool
-FLAG basecamp campfire --md type=bool
-FLAG basecamp campfire --no-hints type=bool
-FLAG basecamp campfire --no-stats type=bool
-FLAG basecamp campfire --profile type=string
-FLAG basecamp campfire --project type=string
-FLAG basecamp campfire --quiet type=bool
-FLAG basecamp campfire --room type=string
-FLAG basecamp campfire --stats type=bool
-FLAG basecamp campfire --styled type=bool
-FLAG basecamp campfire --todolist type=string
-FLAG basecamp campfire --verbose type=count
-FLAG basecamp campfire --version type=bool
-FLAG basecamp campfire delete --account type=string
-FLAG basecamp campfire delete --agent type=bool
-FLAG basecamp campfire delete --cache-dir type=string
-FLAG basecamp campfire delete --count type=bool
-FLAG basecamp campfire delete --force type=bool
-FLAG basecamp campfire delete --help type=bool
-FLAG basecamp campfire delete --hints type=bool
-FLAG basecamp campfire delete --ids-only type=bool
-FLAG basecamp campfire delete --in type=string
-FLAG basecamp campfire delete --jq type=string
-FLAG basecamp campfire delete --json type=bool
-FLAG basecamp campfire delete --markdown type=bool
-FLAG basecamp campfire delete --md type=bool
-FLAG basecamp campfire delete --no-hints type=bool
-FLAG basecamp campfire delete --no-stats type=bool
-FLAG basecamp campfire delete --profile type=string
-FLAG basecamp campfire delete --project type=string
-FLAG basecamp campfire delete --quiet type=bool
-FLAG basecamp campfire delete --room type=string
-FLAG basecamp campfire delete --stats type=bool
-FLAG basecamp campfire delete --styled type=bool
-FLAG basecamp campfire delete --todolist type=string
-FLAG basecamp campfire delete --verbose type=count
-FLAG basecamp campfire delete --version type=bool
-FLAG basecamp campfire line --account type=string
-FLAG basecamp campfire line --agent type=bool
-FLAG basecamp campfire line --cache-dir type=string
-FLAG basecamp campfire line --count type=bool
-FLAG basecamp campfire line --help type=bool
-FLAG basecamp campfire line --hints type=bool
-FLAG basecamp campfire line --ids-only type=bool
-FLAG basecamp campfire line --in type=string
-FLAG basecamp campfire line --jq type=string
-FLAG basecamp campfire line --json type=bool
-FLAG basecamp campfire line --markdown type=bool
-FLAG basecamp campfire line --md type=bool
-FLAG basecamp campfire line --no-hints type=bool
-FLAG basecamp campfire line --no-stats type=bool
-FLAG basecamp campfire line --profile type=string
-FLAG basecamp campfire line --project type=string
-FLAG basecamp campfire line --quiet type=bool
-FLAG basecamp campfire line --room type=string
-FLAG basecamp campfire line --stats type=bool
-FLAG basecamp campfire line --styled type=bool
-FLAG basecamp campfire line --todolist type=string
-FLAG basecamp campfire line --verbose type=count
-FLAG basecamp campfire line --version type=bool
-FLAG basecamp campfire list --account type=string
-FLAG basecamp campfire list --agent type=bool
-FLAG basecamp campfire list --all type=bool
-FLAG basecamp campfire list --cache-dir type=string
-FLAG basecamp campfire list --count type=bool
-FLAG basecamp campfire list --help type=bool
-FLAG basecamp campfire list --hints type=bool
-FLAG basecamp campfire list --ids-only type=bool
-FLAG basecamp campfire list --in type=string
-FLAG basecamp campfire list --jq type=string
-FLAG basecamp campfire list --json type=bool
-FLAG basecamp campfire list --markdown type=bool
-FLAG basecamp campfire list --md type=bool
-FLAG basecamp campfire list --no-hints type=bool
-FLAG basecamp campfire list --no-stats type=bool
-FLAG basecamp campfire list --profile type=string
-FLAG basecamp campfire list --project type=string
-FLAG basecamp campfire list --quiet type=bool
-FLAG basecamp campfire list --room type=string
-FLAG basecamp campfire list --stats type=bool
-FLAG basecamp campfire list --styled type=bool
-FLAG basecamp campfire list --todolist type=string
-FLAG basecamp campfire list --verbose type=count
-FLAG basecamp campfire list --version type=bool
-FLAG basecamp campfire messages --account type=string
-FLAG basecamp campfire messages --agent type=bool
-FLAG basecamp campfire messages --cache-dir type=string
-FLAG basecamp campfire messages --count type=bool
-FLAG basecamp campfire messages --help type=bool
-FLAG basecamp campfire messages --hints type=bool
-FLAG basecamp campfire messages --ids-only type=bool
-FLAG basecamp campfire messages --in type=string
-FLAG basecamp campfire messages --jq type=string
-FLAG basecamp campfire messages --json type=bool
-FLAG basecamp campfire messages --limit type=int
-FLAG basecamp campfire messages --markdown type=bool
-FLAG basecamp campfire messages --md type=bool
-FLAG basecamp campfire messages --no-hints type=bool
-FLAG basecamp campfire messages --no-stats type=bool
-FLAG basecamp campfire messages --profile type=string
-FLAG basecamp campfire messages --project type=string
-FLAG basecamp campfire messages --quiet type=bool
-FLAG basecamp campfire messages --room type=string
-FLAG basecamp campfire messages --stats type=bool
-FLAG basecamp campfire messages --styled type=bool
-FLAG basecamp campfire messages --todolist type=string
-FLAG basecamp campfire messages --verbose type=count
-FLAG basecamp campfire messages --version type=bool
-FLAG basecamp campfire post --account type=string
-FLAG basecamp campfire post --agent type=bool
-FLAG basecamp campfire post --attach type=stringArray
-FLAG basecamp campfire post --cache-dir type=string
-FLAG basecamp campfire post --content type=string
-FLAG basecamp campfire post --content-type type=string
-FLAG basecamp campfire post --count type=bool
-FLAG basecamp campfire post --help type=bool
-FLAG basecamp campfire post --hints type=bool
-FLAG basecamp campfire post --ids-only type=bool
-FLAG basecamp campfire post --in type=string
-FLAG basecamp campfire post --jq type=string
-FLAG basecamp campfire post --json type=bool
-FLAG basecamp campfire post --markdown type=bool
-FLAG basecamp campfire post --md type=bool
-FLAG basecamp campfire post --no-hints type=bool
-FLAG basecamp campfire post --no-stats type=bool
-FLAG basecamp campfire post --profile type=string
-FLAG basecamp campfire post --project type=string
-FLAG basecamp campfire post --quiet type=bool
-FLAG basecamp campfire post --room type=string
-FLAG basecamp campfire post --stats type=bool
-FLAG basecamp campfire post --styled type=bool
-FLAG basecamp campfire post --todolist type=string
-FLAG basecamp campfire post --verbose type=count
-FLAG basecamp campfire post --version type=bool
-FLAG basecamp campfire show --account type=string
-FLAG basecamp campfire show --agent type=bool
-FLAG basecamp campfire show --cache-dir type=string
-FLAG basecamp campfire show --count type=bool
-FLAG basecamp campfire show --help type=bool
-FLAG basecamp campfire show --hints type=bool
-FLAG basecamp campfire show --ids-only type=bool
-FLAG basecamp campfire show --in type=string
-FLAG basecamp campfire show --jq type=string
-FLAG basecamp campfire show --json type=bool
-FLAG basecamp campfire show --markdown type=bool
-FLAG basecamp campfire show --md type=bool
-FLAG basecamp campfire show --no-hints type=bool
-FLAG basecamp campfire show --no-stats type=bool
-FLAG basecamp campfire show --profile type=string
-FLAG basecamp campfire show --project type=string
-FLAG basecamp campfire show --quiet type=bool
-FLAG basecamp campfire show --room type=string
-FLAG basecamp campfire show --stats type=bool
-FLAG basecamp campfire show --styled type=bool
-FLAG basecamp campfire show --todolist type=string
-FLAG basecamp campfire show --verbose type=count
-FLAG basecamp campfire show --version type=bool
-FLAG basecamp campfire upload --account type=string
-FLAG basecamp campfire upload --agent type=bool
-FLAG basecamp campfire upload --cache-dir type=string
-FLAG basecamp campfire upload --count type=bool
-FLAG basecamp campfire upload --help type=bool
-FLAG basecamp campfire upload --hints type=bool
-FLAG basecamp campfire upload --ids-only type=bool
-FLAG basecamp campfire upload --in type=string
-FLAG basecamp campfire upload --jq type=string
-FLAG basecamp campfire upload --json type=bool
-FLAG basecamp campfire upload --markdown type=bool
-FLAG basecamp campfire upload --md type=bool
-FLAG basecamp campfire upload --no-hints type=bool
-FLAG basecamp campfire upload --no-stats type=bool
-FLAG basecamp campfire upload --profile type=string
-FLAG basecamp campfire upload --project type=string
-FLAG basecamp campfire upload --quiet type=bool
-FLAG basecamp campfire upload --room type=string
-FLAG basecamp campfire upload --stats type=bool
-FLAG basecamp campfire upload --styled type=bool
-FLAG basecamp campfire upload --todolist type=string
-FLAG basecamp campfire upload --verbose type=count
-FLAG basecamp campfire upload --version type=bool
 FLAG basecamp card --account type=string
 FLAG basecamp card --agent type=bool
 FLAG basecamp card --assignee type=string
@@ -2076,7 +1069,6 @@ FLAG basecamp card --cache-dir type=string
 FLAG basecamp card --card-table type=string
 FLAG basecamp card --column type=string
 FLAG basecamp card --count type=bool
-FLAG basecamp card --help type=bool
 FLAG basecamp card --hints type=bool
 FLAG basecamp card --ids-only type=bool
 FLAG basecamp card --in type=string
@@ -2094,13 +1086,11 @@ FLAG basecamp card --styled type=bool
 FLAG basecamp card --to type=string
 FLAG basecamp card --todolist type=string
 FLAG basecamp card --verbose type=count
-FLAG basecamp card --version type=bool
 FLAG basecamp card move --account type=string
 FLAG basecamp card move --agent type=bool
 FLAG basecamp card move --cache-dir type=string
 FLAG basecamp card move --card-table type=string
 FLAG basecamp card move --count type=bool
-FLAG basecamp card move --help type=bool
 FLAG basecamp card move --hints type=bool
 FLAG basecamp card move --ids-only type=bool
 FLAG basecamp card move --in type=string
@@ -2121,34 +1111,6 @@ FLAG basecamp card move --styled type=bool
 FLAG basecamp card move --to type=string
 FLAG basecamp card move --todolist type=string
 FLAG basecamp card move --verbose type=count
-FLAG basecamp card move --version type=bool
-FLAG basecamp card mv --account type=string
-FLAG basecamp card mv --agent type=bool
-FLAG basecamp card mv --cache-dir type=string
-FLAG basecamp card mv --card-table type=string
-FLAG basecamp card mv --count type=bool
-FLAG basecamp card mv --help type=bool
-FLAG basecamp card mv --hints type=bool
-FLAG basecamp card mv --ids-only type=bool
-FLAG basecamp card mv --in type=string
-FLAG basecamp card mv --jq type=string
-FLAG basecamp card mv --json type=bool
-FLAG basecamp card mv --markdown type=bool
-FLAG basecamp card mv --md type=bool
-FLAG basecamp card mv --no-hints type=bool
-FLAG basecamp card mv --no-stats type=bool
-FLAG basecamp card mv --on-hold type=bool
-FLAG basecamp card mv --pos type=int
-FLAG basecamp card mv --position type=int
-FLAG basecamp card mv --profile type=string
-FLAG basecamp card mv --project type=string
-FLAG basecamp card mv --quiet type=bool
-FLAG basecamp card mv --stats type=bool
-FLAG basecamp card mv --styled type=bool
-FLAG basecamp card mv --to type=string
-FLAG basecamp card mv --todolist type=string
-FLAG basecamp card mv --verbose type=count
-FLAG basecamp card mv --version type=bool
 FLAG basecamp card update --account type=string
 FLAG basecamp card update --agent type=bool
 FLAG basecamp card update --assignee type=string
@@ -2158,7 +1120,6 @@ FLAG basecamp card update --cache-dir type=string
 FLAG basecamp card update --card-table type=string
 FLAG basecamp card update --count type=bool
 FLAG basecamp card update --due type=string
-FLAG basecamp card update --help type=bool
 FLAG basecamp card update --hints type=bool
 FLAG basecamp card update --ids-only type=bool
 FLAG basecamp card update --in type=string
@@ -2176,13 +1137,11 @@ FLAG basecamp card update --styled type=bool
 FLAG basecamp card update --title type=string
 FLAG basecamp card update --todolist type=string
 FLAG basecamp card update --verbose type=count
-FLAG basecamp card update --version type=bool
 FLAG basecamp cards --account type=string
 FLAG basecamp cards --agent type=bool
 FLAG basecamp cards --cache-dir type=string
 FLAG basecamp cards --card-table type=string
 FLAG basecamp cards --count type=bool
-FLAG basecamp cards --help type=bool
 FLAG basecamp cards --hints type=bool
 FLAG basecamp cards --ids-only type=bool
 FLAG basecamp cards --in type=string
@@ -2199,13 +1158,11 @@ FLAG basecamp cards --stats type=bool
 FLAG basecamp cards --styled type=bool
 FLAG basecamp cards --todolist type=string
 FLAG basecamp cards --verbose type=count
-FLAG basecamp cards --version type=bool
 FLAG basecamp cards archive --account type=string
 FLAG basecamp cards archive --agent type=bool
 FLAG basecamp cards archive --cache-dir type=string
 FLAG basecamp cards archive --card-table type=string
 FLAG basecamp cards archive --count type=bool
-FLAG basecamp cards archive --help type=bool
 FLAG basecamp cards archive --hints type=bool
 FLAG basecamp cards archive --ids-only type=bool
 FLAG basecamp cards archive --in type=string
@@ -2222,13 +1179,11 @@ FLAG basecamp cards archive --stats type=bool
 FLAG basecamp cards archive --styled type=bool
 FLAG basecamp cards archive --todolist type=string
 FLAG basecamp cards archive --verbose type=count
-FLAG basecamp cards archive --version type=bool
 FLAG basecamp cards column --account type=string
 FLAG basecamp cards column --agent type=bool
 FLAG basecamp cards column --cache-dir type=string
 FLAG basecamp cards column --card-table type=string
 FLAG basecamp cards column --count type=bool
-FLAG basecamp cards column --help type=bool
 FLAG basecamp cards column --hints type=bool
 FLAG basecamp cards column --ids-only type=bool
 FLAG basecamp cards column --in type=string
@@ -2245,14 +1200,12 @@ FLAG basecamp cards column --stats type=bool
 FLAG basecamp cards column --styled type=bool
 FLAG basecamp cards column --todolist type=string
 FLAG basecamp cards column --verbose type=count
-FLAG basecamp cards column --version type=bool
 FLAG basecamp cards column color --account type=string
 FLAG basecamp cards column color --agent type=bool
 FLAG basecamp cards column color --cache-dir type=string
 FLAG basecamp cards column color --card-table type=string
 FLAG basecamp cards column color --color type=string
 FLAG basecamp cards column color --count type=bool
-FLAG basecamp cards column color --help type=bool
 FLAG basecamp cards column color --hints type=bool
 FLAG basecamp cards column color --ids-only type=bool
 FLAG basecamp cards column color --in type=string
@@ -2269,14 +1222,12 @@ FLAG basecamp cards column color --stats type=bool
 FLAG basecamp cards column color --styled type=bool
 FLAG basecamp cards column color --todolist type=string
 FLAG basecamp cards column color --verbose type=count
-FLAG basecamp cards column color --version type=bool
 FLAG basecamp cards column create --account type=string
 FLAG basecamp cards column create --agent type=bool
 FLAG basecamp cards column create --cache-dir type=string
 FLAG basecamp cards column create --card-table type=string
 FLAG basecamp cards column create --count type=bool
 FLAG basecamp cards column create --description type=string
-FLAG basecamp cards column create --help type=bool
 FLAG basecamp cards column create --hints type=bool
 FLAG basecamp cards column create --ids-only type=bool
 FLAG basecamp cards column create --in type=string
@@ -2293,13 +1244,11 @@ FLAG basecamp cards column create --stats type=bool
 FLAG basecamp cards column create --styled type=bool
 FLAG basecamp cards column create --todolist type=string
 FLAG basecamp cards column create --verbose type=count
-FLAG basecamp cards column create --version type=bool
 FLAG basecamp cards column move --account type=string
 FLAG basecamp cards column move --agent type=bool
 FLAG basecamp cards column move --cache-dir type=string
 FLAG basecamp cards column move --card-table type=string
 FLAG basecamp cards column move --count type=bool
-FLAG basecamp cards column move --help type=bool
 FLAG basecamp cards column move --hints type=bool
 FLAG basecamp cards column move --ids-only type=bool
 FLAG basecamp cards column move --in type=string
@@ -2318,13 +1267,11 @@ FLAG basecamp cards column move --stats type=bool
 FLAG basecamp cards column move --styled type=bool
 FLAG basecamp cards column move --todolist type=string
 FLAG basecamp cards column move --verbose type=count
-FLAG basecamp cards column move --version type=bool
 FLAG basecamp cards column no-on-hold --account type=string
 FLAG basecamp cards column no-on-hold --agent type=bool
 FLAG basecamp cards column no-on-hold --cache-dir type=string
 FLAG basecamp cards column no-on-hold --card-table type=string
 FLAG basecamp cards column no-on-hold --count type=bool
-FLAG basecamp cards column no-on-hold --help type=bool
 FLAG basecamp cards column no-on-hold --hints type=bool
 FLAG basecamp cards column no-on-hold --ids-only type=bool
 FLAG basecamp cards column no-on-hold --in type=string
@@ -2341,13 +1288,11 @@ FLAG basecamp cards column no-on-hold --stats type=bool
 FLAG basecamp cards column no-on-hold --styled type=bool
 FLAG basecamp cards column no-on-hold --todolist type=string
 FLAG basecamp cards column no-on-hold --verbose type=count
-FLAG basecamp cards column no-on-hold --version type=bool
 FLAG basecamp cards column on-hold --account type=string
 FLAG basecamp cards column on-hold --agent type=bool
 FLAG basecamp cards column on-hold --cache-dir type=string
 FLAG basecamp cards column on-hold --card-table type=string
 FLAG basecamp cards column on-hold --count type=bool
-FLAG basecamp cards column on-hold --help type=bool
 FLAG basecamp cards column on-hold --hints type=bool
 FLAG basecamp cards column on-hold --ids-only type=bool
 FLAG basecamp cards column on-hold --in type=string
@@ -2364,13 +1309,11 @@ FLAG basecamp cards column on-hold --stats type=bool
 FLAG basecamp cards column on-hold --styled type=bool
 FLAG basecamp cards column on-hold --todolist type=string
 FLAG basecamp cards column on-hold --verbose type=count
-FLAG basecamp cards column on-hold --version type=bool
 FLAG basecamp cards column show --account type=string
 FLAG basecamp cards column show --agent type=bool
 FLAG basecamp cards column show --cache-dir type=string
 FLAG basecamp cards column show --card-table type=string
 FLAG basecamp cards column show --count type=bool
-FLAG basecamp cards column show --help type=bool
 FLAG basecamp cards column show --hints type=bool
 FLAG basecamp cards column show --ids-only type=bool
 FLAG basecamp cards column show --in type=string
@@ -2387,13 +1330,11 @@ FLAG basecamp cards column show --stats type=bool
 FLAG basecamp cards column show --styled type=bool
 FLAG basecamp cards column show --todolist type=string
 FLAG basecamp cards column show --verbose type=count
-FLAG basecamp cards column show --version type=bool
 FLAG basecamp cards column unwatch --account type=string
 FLAG basecamp cards column unwatch --agent type=bool
 FLAG basecamp cards column unwatch --cache-dir type=string
 FLAG basecamp cards column unwatch --card-table type=string
 FLAG basecamp cards column unwatch --count type=bool
-FLAG basecamp cards column unwatch --help type=bool
 FLAG basecamp cards column unwatch --hints type=bool
 FLAG basecamp cards column unwatch --ids-only type=bool
 FLAG basecamp cards column unwatch --in type=string
@@ -2410,14 +1351,12 @@ FLAG basecamp cards column unwatch --stats type=bool
 FLAG basecamp cards column unwatch --styled type=bool
 FLAG basecamp cards column unwatch --todolist type=string
 FLAG basecamp cards column unwatch --verbose type=count
-FLAG basecamp cards column unwatch --version type=bool
 FLAG basecamp cards column update --account type=string
 FLAG basecamp cards column update --agent type=bool
 FLAG basecamp cards column update --cache-dir type=string
 FLAG basecamp cards column update --card-table type=string
 FLAG basecamp cards column update --count type=bool
 FLAG basecamp cards column update --description type=string
-FLAG basecamp cards column update --help type=bool
 FLAG basecamp cards column update --hints type=bool
 FLAG basecamp cards column update --ids-only type=bool
 FLAG basecamp cards column update --in type=string
@@ -2435,13 +1374,11 @@ FLAG basecamp cards column update --styled type=bool
 FLAG basecamp cards column update --title type=string
 FLAG basecamp cards column update --todolist type=string
 FLAG basecamp cards column update --verbose type=count
-FLAG basecamp cards column update --version type=bool
 FLAG basecamp cards column watch --account type=string
 FLAG basecamp cards column watch --agent type=bool
 FLAG basecamp cards column watch --cache-dir type=string
 FLAG basecamp cards column watch --card-table type=string
 FLAG basecamp cards column watch --count type=bool
-FLAG basecamp cards column watch --help type=bool
 FLAG basecamp cards column watch --hints type=bool
 FLAG basecamp cards column watch --ids-only type=bool
 FLAG basecamp cards column watch --in type=string
@@ -2458,13 +1395,11 @@ FLAG basecamp cards column watch --stats type=bool
 FLAG basecamp cards column watch --styled type=bool
 FLAG basecamp cards column watch --todolist type=string
 FLAG basecamp cards column watch --verbose type=count
-FLAG basecamp cards column watch --version type=bool
 FLAG basecamp cards columns --account type=string
 FLAG basecamp cards columns --agent type=bool
 FLAG basecamp cards columns --cache-dir type=string
 FLAG basecamp cards columns --card-table type=string
 FLAG basecamp cards columns --count type=bool
-FLAG basecamp cards columns --help type=bool
 FLAG basecamp cards columns --hints type=bool
 FLAG basecamp cards columns --ids-only type=bool
 FLAG basecamp cards columns --in type=string
@@ -2481,7 +1416,6 @@ FLAG basecamp cards columns --stats type=bool
 FLAG basecamp cards columns --styled type=bool
 FLAG basecamp cards columns --todolist type=string
 FLAG basecamp cards columns --verbose type=count
-FLAG basecamp cards columns --version type=bool
 FLAG basecamp cards create --account type=string
 FLAG basecamp cards create --agent type=bool
 FLAG basecamp cards create --assignee type=string
@@ -2490,7 +1424,6 @@ FLAG basecamp cards create --cache-dir type=string
 FLAG basecamp cards create --card-table type=string
 FLAG basecamp cards create --column type=string
 FLAG basecamp cards create --count type=bool
-FLAG basecamp cards create --help type=bool
 FLAG basecamp cards create --hints type=bool
 FLAG basecamp cards create --ids-only type=bool
 FLAG basecamp cards create --in type=string
@@ -2508,7 +1441,6 @@ FLAG basecamp cards create --styled type=bool
 FLAG basecamp cards create --to type=string
 FLAG basecamp cards create --todolist type=string
 FLAG basecamp cards create --verbose type=count
-FLAG basecamp cards create --version type=bool
 FLAG basecamp cards list --account type=string
 FLAG basecamp cards list --agent type=bool
 FLAG basecamp cards list --all type=bool
@@ -2516,7 +1448,6 @@ FLAG basecamp cards list --cache-dir type=string
 FLAG basecamp cards list --card-table type=string
 FLAG basecamp cards list --column type=string
 FLAG basecamp cards list --count type=bool
-FLAG basecamp cards list --help type=bool
 FLAG basecamp cards list --hints type=bool
 FLAG basecamp cards list --ids-only type=bool
 FLAG basecamp cards list --in type=string
@@ -2537,13 +1468,11 @@ FLAG basecamp cards list --stats type=bool
 FLAG basecamp cards list --styled type=bool
 FLAG basecamp cards list --todolist type=string
 FLAG basecamp cards list --verbose type=count
-FLAG basecamp cards list --version type=bool
 FLAG basecamp cards move --account type=string
 FLAG basecamp cards move --agent type=bool
 FLAG basecamp cards move --cache-dir type=string
 FLAG basecamp cards move --card-table type=string
 FLAG basecamp cards move --count type=bool
-FLAG basecamp cards move --help type=bool
 FLAG basecamp cards move --hints type=bool
 FLAG basecamp cards move --ids-only type=bool
 FLAG basecamp cards move --in type=string
@@ -2564,40 +1493,11 @@ FLAG basecamp cards move --styled type=bool
 FLAG basecamp cards move --to type=string
 FLAG basecamp cards move --todolist type=string
 FLAG basecamp cards move --verbose type=count
-FLAG basecamp cards move --version type=bool
-FLAG basecamp cards mv --account type=string
-FLAG basecamp cards mv --agent type=bool
-FLAG basecamp cards mv --cache-dir type=string
-FLAG basecamp cards mv --card-table type=string
-FLAG basecamp cards mv --count type=bool
-FLAG basecamp cards mv --help type=bool
-FLAG basecamp cards mv --hints type=bool
-FLAG basecamp cards mv --ids-only type=bool
-FLAG basecamp cards mv --in type=string
-FLAG basecamp cards mv --jq type=string
-FLAG basecamp cards mv --json type=bool
-FLAG basecamp cards mv --markdown type=bool
-FLAG basecamp cards mv --md type=bool
-FLAG basecamp cards mv --no-hints type=bool
-FLAG basecamp cards mv --no-stats type=bool
-FLAG basecamp cards mv --on-hold type=bool
-FLAG basecamp cards mv --pos type=int
-FLAG basecamp cards mv --position type=int
-FLAG basecamp cards mv --profile type=string
-FLAG basecamp cards mv --project type=string
-FLAG basecamp cards mv --quiet type=bool
-FLAG basecamp cards mv --stats type=bool
-FLAG basecamp cards mv --styled type=bool
-FLAG basecamp cards mv --to type=string
-FLAG basecamp cards mv --todolist type=string
-FLAG basecamp cards mv --verbose type=count
-FLAG basecamp cards mv --version type=bool
 FLAG basecamp cards restore --account type=string
 FLAG basecamp cards restore --agent type=bool
 FLAG basecamp cards restore --cache-dir type=string
 FLAG basecamp cards restore --card-table type=string
 FLAG basecamp cards restore --count type=bool
-FLAG basecamp cards restore --help type=bool
 FLAG basecamp cards restore --hints type=bool
 FLAG basecamp cards restore --ids-only type=bool
 FLAG basecamp cards restore --in type=string
@@ -2614,13 +1514,11 @@ FLAG basecamp cards restore --stats type=bool
 FLAG basecamp cards restore --styled type=bool
 FLAG basecamp cards restore --todolist type=string
 FLAG basecamp cards restore --verbose type=count
-FLAG basecamp cards restore --version type=bool
 FLAG basecamp cards show --account type=string
 FLAG basecamp cards show --agent type=bool
 FLAG basecamp cards show --cache-dir type=string
 FLAG basecamp cards show --card-table type=string
 FLAG basecamp cards show --count type=bool
-FLAG basecamp cards show --help type=bool
 FLAG basecamp cards show --hints type=bool
 FLAG basecamp cards show --ids-only type=bool
 FLAG basecamp cards show --in type=string
@@ -2637,13 +1535,11 @@ FLAG basecamp cards show --stats type=bool
 FLAG basecamp cards show --styled type=bool
 FLAG basecamp cards show --todolist type=string
 FLAG basecamp cards show --verbose type=count
-FLAG basecamp cards show --version type=bool
 FLAG basecamp cards step --account type=string
 FLAG basecamp cards step --agent type=bool
 FLAG basecamp cards step --cache-dir type=string
 FLAG basecamp cards step --card-table type=string
 FLAG basecamp cards step --count type=bool
-FLAG basecamp cards step --help type=bool
 FLAG basecamp cards step --hints type=bool
 FLAG basecamp cards step --ids-only type=bool
 FLAG basecamp cards step --in type=string
@@ -2660,13 +1556,11 @@ FLAG basecamp cards step --stats type=bool
 FLAG basecamp cards step --styled type=bool
 FLAG basecamp cards step --todolist type=string
 FLAG basecamp cards step --verbose type=count
-FLAG basecamp cards step --version type=bool
 FLAG basecamp cards step complete --account type=string
 FLAG basecamp cards step complete --agent type=bool
 FLAG basecamp cards step complete --cache-dir type=string
 FLAG basecamp cards step complete --card-table type=string
 FLAG basecamp cards step complete --count type=bool
-FLAG basecamp cards step complete --help type=bool
 FLAG basecamp cards step complete --hints type=bool
 FLAG basecamp cards step complete --ids-only type=bool
 FLAG basecamp cards step complete --in type=string
@@ -2683,7 +1577,6 @@ FLAG basecamp cards step complete --stats type=bool
 FLAG basecamp cards step complete --styled type=bool
 FLAG basecamp cards step complete --todolist type=string
 FLAG basecamp cards step complete --verbose type=count
-FLAG basecamp cards step complete --version type=bool
 FLAG basecamp cards step create --account type=string
 FLAG basecamp cards step create --agent type=bool
 FLAG basecamp cards step create --assignees type=string
@@ -2692,7 +1585,6 @@ FLAG basecamp cards step create --card type=string
 FLAG basecamp cards step create --card-table type=string
 FLAG basecamp cards step create --count type=bool
 FLAG basecamp cards step create --due type=string
-FLAG basecamp cards step create --help type=bool
 FLAG basecamp cards step create --hints type=bool
 FLAG basecamp cards step create --ids-only type=bool
 FLAG basecamp cards step create --in type=string
@@ -2709,13 +1601,11 @@ FLAG basecamp cards step create --stats type=bool
 FLAG basecamp cards step create --styled type=bool
 FLAG basecamp cards step create --todolist type=string
 FLAG basecamp cards step create --verbose type=count
-FLAG basecamp cards step create --version type=bool
 FLAG basecamp cards step delete --account type=string
 FLAG basecamp cards step delete --agent type=bool
 FLAG basecamp cards step delete --cache-dir type=string
 FLAG basecamp cards step delete --card-table type=string
 FLAG basecamp cards step delete --count type=bool
-FLAG basecamp cards step delete --help type=bool
 FLAG basecamp cards step delete --hints type=bool
 FLAG basecamp cards step delete --ids-only type=bool
 FLAG basecamp cards step delete --in type=string
@@ -2732,14 +1622,12 @@ FLAG basecamp cards step delete --stats type=bool
 FLAG basecamp cards step delete --styled type=bool
 FLAG basecamp cards step delete --todolist type=string
 FLAG basecamp cards step delete --verbose type=count
-FLAG basecamp cards step delete --version type=bool
 FLAG basecamp cards step move --account type=string
 FLAG basecamp cards step move --agent type=bool
 FLAG basecamp cards step move --cache-dir type=string
 FLAG basecamp cards step move --card type=string
 FLAG basecamp cards step move --card-table type=string
 FLAG basecamp cards step move --count type=bool
-FLAG basecamp cards step move --help type=bool
 FLAG basecamp cards step move --hints type=bool
 FLAG basecamp cards step move --ids-only type=bool
 FLAG basecamp cards step move --in type=string
@@ -2758,13 +1646,11 @@ FLAG basecamp cards step move --stats type=bool
 FLAG basecamp cards step move --styled type=bool
 FLAG basecamp cards step move --todolist type=string
 FLAG basecamp cards step move --verbose type=count
-FLAG basecamp cards step move --version type=bool
 FLAG basecamp cards step uncomplete --account type=string
 FLAG basecamp cards step uncomplete --agent type=bool
 FLAG basecamp cards step uncomplete --cache-dir type=string
 FLAG basecamp cards step uncomplete --card-table type=string
 FLAG basecamp cards step uncomplete --count type=bool
-FLAG basecamp cards step uncomplete --help type=bool
 FLAG basecamp cards step uncomplete --hints type=bool
 FLAG basecamp cards step uncomplete --ids-only type=bool
 FLAG basecamp cards step uncomplete --in type=string
@@ -2781,7 +1667,6 @@ FLAG basecamp cards step uncomplete --stats type=bool
 FLAG basecamp cards step uncomplete --styled type=bool
 FLAG basecamp cards step uncomplete --todolist type=string
 FLAG basecamp cards step uncomplete --verbose type=count
-FLAG basecamp cards step uncomplete --version type=bool
 FLAG basecamp cards step update --account type=string
 FLAG basecamp cards step update --agent type=bool
 FLAG basecamp cards step update --assignees type=string
@@ -2789,7 +1674,6 @@ FLAG basecamp cards step update --cache-dir type=string
 FLAG basecamp cards step update --card-table type=string
 FLAG basecamp cards step update --count type=bool
 FLAG basecamp cards step update --due type=string
-FLAG basecamp cards step update --help type=bool
 FLAG basecamp cards step update --hints type=bool
 FLAG basecamp cards step update --ids-only type=bool
 FLAG basecamp cards step update --in type=string
@@ -2806,14 +1690,12 @@ FLAG basecamp cards step update --stats type=bool
 FLAG basecamp cards step update --styled type=bool
 FLAG basecamp cards step update --todolist type=string
 FLAG basecamp cards step update --verbose type=count
-FLAG basecamp cards step update --version type=bool
 FLAG basecamp cards steps --account type=string
 FLAG basecamp cards steps --agent type=bool
 FLAG basecamp cards steps --cache-dir type=string
 FLAG basecamp cards steps --card type=string
 FLAG basecamp cards steps --card-table type=string
 FLAG basecamp cards steps --count type=bool
-FLAG basecamp cards steps --help type=bool
 FLAG basecamp cards steps --hints type=bool
 FLAG basecamp cards steps --ids-only type=bool
 FLAG basecamp cards steps --in type=string
@@ -2830,13 +1712,11 @@ FLAG basecamp cards steps --stats type=bool
 FLAG basecamp cards steps --styled type=bool
 FLAG basecamp cards steps --todolist type=string
 FLAG basecamp cards steps --verbose type=count
-FLAG basecamp cards steps --version type=bool
 FLAG basecamp cards trash --account type=string
 FLAG basecamp cards trash --agent type=bool
 FLAG basecamp cards trash --cache-dir type=string
 FLAG basecamp cards trash --card-table type=string
 FLAG basecamp cards trash --count type=bool
-FLAG basecamp cards trash --help type=bool
 FLAG basecamp cards trash --hints type=bool
 FLAG basecamp cards trash --ids-only type=bool
 FLAG basecamp cards trash --in type=string
@@ -2853,7 +1733,6 @@ FLAG basecamp cards trash --stats type=bool
 FLAG basecamp cards trash --styled type=bool
 FLAG basecamp cards trash --todolist type=string
 FLAG basecamp cards trash --verbose type=count
-FLAG basecamp cards trash --version type=bool
 FLAG basecamp cards update --account type=string
 FLAG basecamp cards update --agent type=bool
 FLAG basecamp cards update --assignee type=string
@@ -2863,7 +1742,6 @@ FLAG basecamp cards update --cache-dir type=string
 FLAG basecamp cards update --card-table type=string
 FLAG basecamp cards update --count type=bool
 FLAG basecamp cards update --due type=string
-FLAG basecamp cards update --help type=bool
 FLAG basecamp cards update --hints type=bool
 FLAG basecamp cards update --ids-only type=bool
 FLAG basecamp cards update --in type=string
@@ -2881,12 +1759,10 @@ FLAG basecamp cards update --styled type=bool
 FLAG basecamp cards update --title type=string
 FLAG basecamp cards update --todolist type=string
 FLAG basecamp cards update --verbose type=count
-FLAG basecamp cards update --version type=bool
 FLAG basecamp chat --account type=string
 FLAG basecamp chat --agent type=bool
 FLAG basecamp chat --cache-dir type=string
 FLAG basecamp chat --count type=bool
-FLAG basecamp chat --help type=bool
 FLAG basecamp chat --hints type=bool
 FLAG basecamp chat --ids-only type=bool
 FLAG basecamp chat --in type=string
@@ -2904,13 +1780,11 @@ FLAG basecamp chat --stats type=bool
 FLAG basecamp chat --styled type=bool
 FLAG basecamp chat --todolist type=string
 FLAG basecamp chat --verbose type=count
-FLAG basecamp chat --version type=bool
 FLAG basecamp chat delete --account type=string
 FLAG basecamp chat delete --agent type=bool
 FLAG basecamp chat delete --cache-dir type=string
 FLAG basecamp chat delete --count type=bool
 FLAG basecamp chat delete --force type=bool
-FLAG basecamp chat delete --help type=bool
 FLAG basecamp chat delete --hints type=bool
 FLAG basecamp chat delete --ids-only type=bool
 FLAG basecamp chat delete --in type=string
@@ -2928,12 +1802,10 @@ FLAG basecamp chat delete --stats type=bool
 FLAG basecamp chat delete --styled type=bool
 FLAG basecamp chat delete --todolist type=string
 FLAG basecamp chat delete --verbose type=count
-FLAG basecamp chat delete --version type=bool
 FLAG basecamp chat line --account type=string
 FLAG basecamp chat line --agent type=bool
 FLAG basecamp chat line --cache-dir type=string
 FLAG basecamp chat line --count type=bool
-FLAG basecamp chat line --help type=bool
 FLAG basecamp chat line --hints type=bool
 FLAG basecamp chat line --ids-only type=bool
 FLAG basecamp chat line --in type=string
@@ -2951,13 +1823,11 @@ FLAG basecamp chat line --stats type=bool
 FLAG basecamp chat line --styled type=bool
 FLAG basecamp chat line --todolist type=string
 FLAG basecamp chat line --verbose type=count
-FLAG basecamp chat line --version type=bool
 FLAG basecamp chat list --account type=string
 FLAG basecamp chat list --agent type=bool
 FLAG basecamp chat list --all type=bool
 FLAG basecamp chat list --cache-dir type=string
 FLAG basecamp chat list --count type=bool
-FLAG basecamp chat list --help type=bool
 FLAG basecamp chat list --hints type=bool
 FLAG basecamp chat list --ids-only type=bool
 FLAG basecamp chat list --in type=string
@@ -2975,12 +1845,10 @@ FLAG basecamp chat list --stats type=bool
 FLAG basecamp chat list --styled type=bool
 FLAG basecamp chat list --todolist type=string
 FLAG basecamp chat list --verbose type=count
-FLAG basecamp chat list --version type=bool
 FLAG basecamp chat messages --account type=string
 FLAG basecamp chat messages --agent type=bool
 FLAG basecamp chat messages --cache-dir type=string
 FLAG basecamp chat messages --count type=bool
-FLAG basecamp chat messages --help type=bool
 FLAG basecamp chat messages --hints type=bool
 FLAG basecamp chat messages --ids-only type=bool
 FLAG basecamp chat messages --in type=string
@@ -2999,7 +1867,6 @@ FLAG basecamp chat messages --stats type=bool
 FLAG basecamp chat messages --styled type=bool
 FLAG basecamp chat messages --todolist type=string
 FLAG basecamp chat messages --verbose type=count
-FLAG basecamp chat messages --version type=bool
 FLAG basecamp chat post --account type=string
 FLAG basecamp chat post --agent type=bool
 FLAG basecamp chat post --attach type=stringArray
@@ -3007,7 +1874,6 @@ FLAG basecamp chat post --cache-dir type=string
 FLAG basecamp chat post --content type=string
 FLAG basecamp chat post --content-type type=string
 FLAG basecamp chat post --count type=bool
-FLAG basecamp chat post --help type=bool
 FLAG basecamp chat post --hints type=bool
 FLAG basecamp chat post --ids-only type=bool
 FLAG basecamp chat post --in type=string
@@ -3025,35 +1891,10 @@ FLAG basecamp chat post --stats type=bool
 FLAG basecamp chat post --styled type=bool
 FLAG basecamp chat post --todolist type=string
 FLAG basecamp chat post --verbose type=count
-FLAG basecamp chat post --version type=bool
-FLAG basecamp chat show --account type=string
-FLAG basecamp chat show --agent type=bool
-FLAG basecamp chat show --cache-dir type=string
-FLAG basecamp chat show --count type=bool
-FLAG basecamp chat show --help type=bool
-FLAG basecamp chat show --hints type=bool
-FLAG basecamp chat show --ids-only type=bool
-FLAG basecamp chat show --in type=string
-FLAG basecamp chat show --jq type=string
-FLAG basecamp chat show --json type=bool
-FLAG basecamp chat show --markdown type=bool
-FLAG basecamp chat show --md type=bool
-FLAG basecamp chat show --no-hints type=bool
-FLAG basecamp chat show --no-stats type=bool
-FLAG basecamp chat show --profile type=string
-FLAG basecamp chat show --project type=string
-FLAG basecamp chat show --quiet type=bool
-FLAG basecamp chat show --room type=string
-FLAG basecamp chat show --stats type=bool
-FLAG basecamp chat show --styled type=bool
-FLAG basecamp chat show --todolist type=string
-FLAG basecamp chat show --verbose type=count
-FLAG basecamp chat show --version type=bool
 FLAG basecamp chat upload --account type=string
 FLAG basecamp chat upload --agent type=bool
 FLAG basecamp chat upload --cache-dir type=string
 FLAG basecamp chat upload --count type=bool
-FLAG basecamp chat upload --help type=bool
 FLAG basecamp chat upload --hints type=bool
 FLAG basecamp chat upload --ids-only type=bool
 FLAG basecamp chat upload --in type=string
@@ -3071,279 +1912,10 @@ FLAG basecamp chat upload --stats type=bool
 FLAG basecamp chat upload --styled type=bool
 FLAG basecamp chat upload --todolist type=string
 FLAG basecamp chat upload --verbose type=count
-FLAG basecamp chat upload --version type=bool
-FLAG basecamp checkin --account type=string
-FLAG basecamp checkin --agent type=bool
-FLAG basecamp checkin --cache-dir type=string
-FLAG basecamp checkin --count type=bool
-FLAG basecamp checkin --help type=bool
-FLAG basecamp checkin --hints type=bool
-FLAG basecamp checkin --ids-only type=bool
-FLAG basecamp checkin --in type=string
-FLAG basecamp checkin --jq type=string
-FLAG basecamp checkin --json type=bool
-FLAG basecamp checkin --markdown type=bool
-FLAG basecamp checkin --md type=bool
-FLAG basecamp checkin --no-hints type=bool
-FLAG basecamp checkin --no-stats type=bool
-FLAG basecamp checkin --profile type=string
-FLAG basecamp checkin --project type=string
-FLAG basecamp checkin --questionnaire type=string
-FLAG basecamp checkin --quiet type=bool
-FLAG basecamp checkin --stats type=bool
-FLAG basecamp checkin --styled type=bool
-FLAG basecamp checkin --todolist type=string
-FLAG basecamp checkin --verbose type=count
-FLAG basecamp checkin --version type=bool
-FLAG basecamp checkin answer --account type=string
-FLAG basecamp checkin answer --agent type=bool
-FLAG basecamp checkin answer --cache-dir type=string
-FLAG basecamp checkin answer --count type=bool
-FLAG basecamp checkin answer --help type=bool
-FLAG basecamp checkin answer --hints type=bool
-FLAG basecamp checkin answer --ids-only type=bool
-FLAG basecamp checkin answer --in type=string
-FLAG basecamp checkin answer --jq type=string
-FLAG basecamp checkin answer --json type=bool
-FLAG basecamp checkin answer --markdown type=bool
-FLAG basecamp checkin answer --md type=bool
-FLAG basecamp checkin answer --no-hints type=bool
-FLAG basecamp checkin answer --no-stats type=bool
-FLAG basecamp checkin answer --profile type=string
-FLAG basecamp checkin answer --project type=string
-FLAG basecamp checkin answer --questionnaire type=string
-FLAG basecamp checkin answer --quiet type=bool
-FLAG basecamp checkin answer --stats type=bool
-FLAG basecamp checkin answer --styled type=bool
-FLAG basecamp checkin answer --todolist type=string
-FLAG basecamp checkin answer --verbose type=count
-FLAG basecamp checkin answer --version type=bool
-FLAG basecamp checkin answer create --account type=string
-FLAG basecamp checkin answer create --agent type=bool
-FLAG basecamp checkin answer create --attach type=stringArray
-FLAG basecamp checkin answer create --cache-dir type=string
-FLAG basecamp checkin answer create --count type=bool
-FLAG basecamp checkin answer create --date type=string
-FLAG basecamp checkin answer create --help type=bool
-FLAG basecamp checkin answer create --hints type=bool
-FLAG basecamp checkin answer create --ids-only type=bool
-FLAG basecamp checkin answer create --in type=string
-FLAG basecamp checkin answer create --jq type=string
-FLAG basecamp checkin answer create --json type=bool
-FLAG basecamp checkin answer create --markdown type=bool
-FLAG basecamp checkin answer create --md type=bool
-FLAG basecamp checkin answer create --no-hints type=bool
-FLAG basecamp checkin answer create --no-stats type=bool
-FLAG basecamp checkin answer create --profile type=string
-FLAG basecamp checkin answer create --project type=string
-FLAG basecamp checkin answer create --questionnaire type=string
-FLAG basecamp checkin answer create --quiet type=bool
-FLAG basecamp checkin answer create --stats type=bool
-FLAG basecamp checkin answer create --styled type=bool
-FLAG basecamp checkin answer create --todolist type=string
-FLAG basecamp checkin answer create --verbose type=count
-FLAG basecamp checkin answer create --version type=bool
-FLAG basecamp checkin answer show --account type=string
-FLAG basecamp checkin answer show --agent type=bool
-FLAG basecamp checkin answer show --cache-dir type=string
-FLAG basecamp checkin answer show --count type=bool
-FLAG basecamp checkin answer show --help type=bool
-FLAG basecamp checkin answer show --hints type=bool
-FLAG basecamp checkin answer show --ids-only type=bool
-FLAG basecamp checkin answer show --in type=string
-FLAG basecamp checkin answer show --jq type=string
-FLAG basecamp checkin answer show --json type=bool
-FLAG basecamp checkin answer show --markdown type=bool
-FLAG basecamp checkin answer show --md type=bool
-FLAG basecamp checkin answer show --no-hints type=bool
-FLAG basecamp checkin answer show --no-stats type=bool
-FLAG basecamp checkin answer show --profile type=string
-FLAG basecamp checkin answer show --project type=string
-FLAG basecamp checkin answer show --questionnaire type=string
-FLAG basecamp checkin answer show --quiet type=bool
-FLAG basecamp checkin answer show --stats type=bool
-FLAG basecamp checkin answer show --styled type=bool
-FLAG basecamp checkin answer show --todolist type=string
-FLAG basecamp checkin answer show --verbose type=count
-FLAG basecamp checkin answer show --version type=bool
-FLAG basecamp checkin answer update --account type=string
-FLAG basecamp checkin answer update --agent type=bool
-FLAG basecamp checkin answer update --cache-dir type=string
-FLAG basecamp checkin answer update --count type=bool
-FLAG basecamp checkin answer update --help type=bool
-FLAG basecamp checkin answer update --hints type=bool
-FLAG basecamp checkin answer update --ids-only type=bool
-FLAG basecamp checkin answer update --in type=string
-FLAG basecamp checkin answer update --jq type=string
-FLAG basecamp checkin answer update --json type=bool
-FLAG basecamp checkin answer update --markdown type=bool
-FLAG basecamp checkin answer update --md type=bool
-FLAG basecamp checkin answer update --no-hints type=bool
-FLAG basecamp checkin answer update --no-stats type=bool
-FLAG basecamp checkin answer update --profile type=string
-FLAG basecamp checkin answer update --project type=string
-FLAG basecamp checkin answer update --questionnaire type=string
-FLAG basecamp checkin answer update --quiet type=bool
-FLAG basecamp checkin answer update --stats type=bool
-FLAG basecamp checkin answer update --styled type=bool
-FLAG basecamp checkin answer update --todolist type=string
-FLAG basecamp checkin answer update --verbose type=count
-FLAG basecamp checkin answer update --version type=bool
-FLAG basecamp checkin answers --account type=string
-FLAG basecamp checkin answers --agent type=bool
-FLAG basecamp checkin answers --all type=bool
-FLAG basecamp checkin answers --cache-dir type=string
-FLAG basecamp checkin answers --count type=bool
-FLAG basecamp checkin answers --help type=bool
-FLAG basecamp checkin answers --hints type=bool
-FLAG basecamp checkin answers --ids-only type=bool
-FLAG basecamp checkin answers --in type=string
-FLAG basecamp checkin answers --jq type=string
-FLAG basecamp checkin answers --json type=bool
-FLAG basecamp checkin answers --limit type=int
-FLAG basecamp checkin answers --markdown type=bool
-FLAG basecamp checkin answers --md type=bool
-FLAG basecamp checkin answers --no-hints type=bool
-FLAG basecamp checkin answers --no-stats type=bool
-FLAG basecamp checkin answers --page type=int
-FLAG basecamp checkin answers --profile type=string
-FLAG basecamp checkin answers --project type=string
-FLAG basecamp checkin answers --questionnaire type=string
-FLAG basecamp checkin answers --quiet type=bool
-FLAG basecamp checkin answers --stats type=bool
-FLAG basecamp checkin answers --styled type=bool
-FLAG basecamp checkin answers --todolist type=string
-FLAG basecamp checkin answers --verbose type=count
-FLAG basecamp checkin answers --version type=bool
-FLAG basecamp checkin question --account type=string
-FLAG basecamp checkin question --agent type=bool
-FLAG basecamp checkin question --cache-dir type=string
-FLAG basecamp checkin question --count type=bool
-FLAG basecamp checkin question --help type=bool
-FLAG basecamp checkin question --hints type=bool
-FLAG basecamp checkin question --ids-only type=bool
-FLAG basecamp checkin question --in type=string
-FLAG basecamp checkin question --jq type=string
-FLAG basecamp checkin question --json type=bool
-FLAG basecamp checkin question --markdown type=bool
-FLAG basecamp checkin question --md type=bool
-FLAG basecamp checkin question --no-hints type=bool
-FLAG basecamp checkin question --no-stats type=bool
-FLAG basecamp checkin question --profile type=string
-FLAG basecamp checkin question --project type=string
-FLAG basecamp checkin question --questionnaire type=string
-FLAG basecamp checkin question --quiet type=bool
-FLAG basecamp checkin question --stats type=bool
-FLAG basecamp checkin question --styled type=bool
-FLAG basecamp checkin question --todolist type=string
-FLAG basecamp checkin question --verbose type=count
-FLAG basecamp checkin question --version type=bool
-FLAG basecamp checkin question create --account type=string
-FLAG basecamp checkin question create --agent type=bool
-FLAG basecamp checkin question create --cache-dir type=string
-FLAG basecamp checkin question create --count type=bool
-FLAG basecamp checkin question create --days type=string
-FLAG basecamp checkin question create --frequency type=string
-FLAG basecamp checkin question create --help type=bool
-FLAG basecamp checkin question create --hints type=bool
-FLAG basecamp checkin question create --ids-only type=bool
-FLAG basecamp checkin question create --in type=string
-FLAG basecamp checkin question create --jq type=string
-FLAG basecamp checkin question create --json type=bool
-FLAG basecamp checkin question create --markdown type=bool
-FLAG basecamp checkin question create --md type=bool
-FLAG basecamp checkin question create --no-hints type=bool
-FLAG basecamp checkin question create --no-stats type=bool
-FLAG basecamp checkin question create --profile type=string
-FLAG basecamp checkin question create --project type=string
-FLAG basecamp checkin question create --questionnaire type=string
-FLAG basecamp checkin question create --quiet type=bool
-FLAG basecamp checkin question create --stats type=bool
-FLAG basecamp checkin question create --styled type=bool
-FLAG basecamp checkin question create --time type=string
-FLAG basecamp checkin question create --todolist type=string
-FLAG basecamp checkin question create --verbose type=count
-FLAG basecamp checkin question create --version type=bool
-FLAG basecamp checkin question show --account type=string
-FLAG basecamp checkin question show --agent type=bool
-FLAG basecamp checkin question show --cache-dir type=string
-FLAG basecamp checkin question show --count type=bool
-FLAG basecamp checkin question show --help type=bool
-FLAG basecamp checkin question show --hints type=bool
-FLAG basecamp checkin question show --ids-only type=bool
-FLAG basecamp checkin question show --in type=string
-FLAG basecamp checkin question show --jq type=string
-FLAG basecamp checkin question show --json type=bool
-FLAG basecamp checkin question show --markdown type=bool
-FLAG basecamp checkin question show --md type=bool
-FLAG basecamp checkin question show --no-hints type=bool
-FLAG basecamp checkin question show --no-stats type=bool
-FLAG basecamp checkin question show --profile type=string
-FLAG basecamp checkin question show --project type=string
-FLAG basecamp checkin question show --questionnaire type=string
-FLAG basecamp checkin question show --quiet type=bool
-FLAG basecamp checkin question show --stats type=bool
-FLAG basecamp checkin question show --styled type=bool
-FLAG basecamp checkin question show --todolist type=string
-FLAG basecamp checkin question show --verbose type=count
-FLAG basecamp checkin question show --version type=bool
-FLAG basecamp checkin question update --account type=string
-FLAG basecamp checkin question update --agent type=bool
-FLAG basecamp checkin question update --cache-dir type=string
-FLAG basecamp checkin question update --count type=bool
-FLAG basecamp checkin question update --days type=string
-FLAG basecamp checkin question update --frequency type=string
-FLAG basecamp checkin question update --help type=bool
-FLAG basecamp checkin question update --hints type=bool
-FLAG basecamp checkin question update --ids-only type=bool
-FLAG basecamp checkin question update --in type=string
-FLAG basecamp checkin question update --jq type=string
-FLAG basecamp checkin question update --json type=bool
-FLAG basecamp checkin question update --markdown type=bool
-FLAG basecamp checkin question update --md type=bool
-FLAG basecamp checkin question update --no-hints type=bool
-FLAG basecamp checkin question update --no-stats type=bool
-FLAG basecamp checkin question update --profile type=string
-FLAG basecamp checkin question update --project type=string
-FLAG basecamp checkin question update --questionnaire type=string
-FLAG basecamp checkin question update --quiet type=bool
-FLAG basecamp checkin question update --stats type=bool
-FLAG basecamp checkin question update --styled type=bool
-FLAG basecamp checkin question update --time type=string
-FLAG basecamp checkin question update --todolist type=string
-FLAG basecamp checkin question update --verbose type=count
-FLAG basecamp checkin question update --version type=bool
-FLAG basecamp checkin questions --account type=string
-FLAG basecamp checkin questions --agent type=bool
-FLAG basecamp checkin questions --all type=bool
-FLAG basecamp checkin questions --cache-dir type=string
-FLAG basecamp checkin questions --count type=bool
-FLAG basecamp checkin questions --help type=bool
-FLAG basecamp checkin questions --hints type=bool
-FLAG basecamp checkin questions --ids-only type=bool
-FLAG basecamp checkin questions --in type=string
-FLAG basecamp checkin questions --jq type=string
-FLAG basecamp checkin questions --json type=bool
-FLAG basecamp checkin questions --limit type=int
-FLAG basecamp checkin questions --markdown type=bool
-FLAG basecamp checkin questions --md type=bool
-FLAG basecamp checkin questions --no-hints type=bool
-FLAG basecamp checkin questions --no-stats type=bool
-FLAG basecamp checkin questions --page type=int
-FLAG basecamp checkin questions --profile type=string
-FLAG basecamp checkin questions --project type=string
-FLAG basecamp checkin questions --questionnaire type=string
-FLAG basecamp checkin questions --quiet type=bool
-FLAG basecamp checkin questions --stats type=bool
-FLAG basecamp checkin questions --styled type=bool
-FLAG basecamp checkin questions --todolist type=string
-FLAG basecamp checkin questions --verbose type=count
-FLAG basecamp checkin questions --version type=bool
 FLAG basecamp checkins --account type=string
 FLAG basecamp checkins --agent type=bool
 FLAG basecamp checkins --cache-dir type=string
 FLAG basecamp checkins --count type=bool
-FLAG basecamp checkins --help type=bool
 FLAG basecamp checkins --hints type=bool
 FLAG basecamp checkins --ids-only type=bool
 FLAG basecamp checkins --in type=string
@@ -3361,12 +1933,10 @@ FLAG basecamp checkins --stats type=bool
 FLAG basecamp checkins --styled type=bool
 FLAG basecamp checkins --todolist type=string
 FLAG basecamp checkins --verbose type=count
-FLAG basecamp checkins --version type=bool
 FLAG basecamp checkins answer --account type=string
 FLAG basecamp checkins answer --agent type=bool
 FLAG basecamp checkins answer --cache-dir type=string
 FLAG basecamp checkins answer --count type=bool
-FLAG basecamp checkins answer --help type=bool
 FLAG basecamp checkins answer --hints type=bool
 FLAG basecamp checkins answer --ids-only type=bool
 FLAG basecamp checkins answer --in type=string
@@ -3384,14 +1954,12 @@ FLAG basecamp checkins answer --stats type=bool
 FLAG basecamp checkins answer --styled type=bool
 FLAG basecamp checkins answer --todolist type=string
 FLAG basecamp checkins answer --verbose type=count
-FLAG basecamp checkins answer --version type=bool
 FLAG basecamp checkins answer create --account type=string
 FLAG basecamp checkins answer create --agent type=bool
 FLAG basecamp checkins answer create --attach type=stringArray
 FLAG basecamp checkins answer create --cache-dir type=string
 FLAG basecamp checkins answer create --count type=bool
 FLAG basecamp checkins answer create --date type=string
-FLAG basecamp checkins answer create --help type=bool
 FLAG basecamp checkins answer create --hints type=bool
 FLAG basecamp checkins answer create --ids-only type=bool
 FLAG basecamp checkins answer create --in type=string
@@ -3409,12 +1977,10 @@ FLAG basecamp checkins answer create --stats type=bool
 FLAG basecamp checkins answer create --styled type=bool
 FLAG basecamp checkins answer create --todolist type=string
 FLAG basecamp checkins answer create --verbose type=count
-FLAG basecamp checkins answer create --version type=bool
 FLAG basecamp checkins answer show --account type=string
 FLAG basecamp checkins answer show --agent type=bool
 FLAG basecamp checkins answer show --cache-dir type=string
 FLAG basecamp checkins answer show --count type=bool
-FLAG basecamp checkins answer show --help type=bool
 FLAG basecamp checkins answer show --hints type=bool
 FLAG basecamp checkins answer show --ids-only type=bool
 FLAG basecamp checkins answer show --in type=string
@@ -3432,12 +1998,10 @@ FLAG basecamp checkins answer show --stats type=bool
 FLAG basecamp checkins answer show --styled type=bool
 FLAG basecamp checkins answer show --todolist type=string
 FLAG basecamp checkins answer show --verbose type=count
-FLAG basecamp checkins answer show --version type=bool
 FLAG basecamp checkins answer update --account type=string
 FLAG basecamp checkins answer update --agent type=bool
 FLAG basecamp checkins answer update --cache-dir type=string
 FLAG basecamp checkins answer update --count type=bool
-FLAG basecamp checkins answer update --help type=bool
 FLAG basecamp checkins answer update --hints type=bool
 FLAG basecamp checkins answer update --ids-only type=bool
 FLAG basecamp checkins answer update --in type=string
@@ -3455,13 +2019,11 @@ FLAG basecamp checkins answer update --stats type=bool
 FLAG basecamp checkins answer update --styled type=bool
 FLAG basecamp checkins answer update --todolist type=string
 FLAG basecamp checkins answer update --verbose type=count
-FLAG basecamp checkins answer update --version type=bool
 FLAG basecamp checkins answers --account type=string
 FLAG basecamp checkins answers --agent type=bool
 FLAG basecamp checkins answers --all type=bool
 FLAG basecamp checkins answers --cache-dir type=string
 FLAG basecamp checkins answers --count type=bool
-FLAG basecamp checkins answers --help type=bool
 FLAG basecamp checkins answers --hints type=bool
 FLAG basecamp checkins answers --ids-only type=bool
 FLAG basecamp checkins answers --in type=string
@@ -3481,12 +2043,10 @@ FLAG basecamp checkins answers --stats type=bool
 FLAG basecamp checkins answers --styled type=bool
 FLAG basecamp checkins answers --todolist type=string
 FLAG basecamp checkins answers --verbose type=count
-FLAG basecamp checkins answers --version type=bool
 FLAG basecamp checkins question --account type=string
 FLAG basecamp checkins question --agent type=bool
 FLAG basecamp checkins question --cache-dir type=string
 FLAG basecamp checkins question --count type=bool
-FLAG basecamp checkins question --help type=bool
 FLAG basecamp checkins question --hints type=bool
 FLAG basecamp checkins question --ids-only type=bool
 FLAG basecamp checkins question --in type=string
@@ -3504,14 +2064,12 @@ FLAG basecamp checkins question --stats type=bool
 FLAG basecamp checkins question --styled type=bool
 FLAG basecamp checkins question --todolist type=string
 FLAG basecamp checkins question --verbose type=count
-FLAG basecamp checkins question --version type=bool
 FLAG basecamp checkins question create --account type=string
 FLAG basecamp checkins question create --agent type=bool
 FLAG basecamp checkins question create --cache-dir type=string
 FLAG basecamp checkins question create --count type=bool
 FLAG basecamp checkins question create --days type=string
 FLAG basecamp checkins question create --frequency type=string
-FLAG basecamp checkins question create --help type=bool
 FLAG basecamp checkins question create --hints type=bool
 FLAG basecamp checkins question create --ids-only type=bool
 FLAG basecamp checkins question create --in type=string
@@ -3530,12 +2088,10 @@ FLAG basecamp checkins question create --styled type=bool
 FLAG basecamp checkins question create --time type=string
 FLAG basecamp checkins question create --todolist type=string
 FLAG basecamp checkins question create --verbose type=count
-FLAG basecamp checkins question create --version type=bool
 FLAG basecamp checkins question show --account type=string
 FLAG basecamp checkins question show --agent type=bool
 FLAG basecamp checkins question show --cache-dir type=string
 FLAG basecamp checkins question show --count type=bool
-FLAG basecamp checkins question show --help type=bool
 FLAG basecamp checkins question show --hints type=bool
 FLAG basecamp checkins question show --ids-only type=bool
 FLAG basecamp checkins question show --in type=string
@@ -3553,14 +2109,12 @@ FLAG basecamp checkins question show --stats type=bool
 FLAG basecamp checkins question show --styled type=bool
 FLAG basecamp checkins question show --todolist type=string
 FLAG basecamp checkins question show --verbose type=count
-FLAG basecamp checkins question show --version type=bool
 FLAG basecamp checkins question update --account type=string
 FLAG basecamp checkins question update --agent type=bool
 FLAG basecamp checkins question update --cache-dir type=string
 FLAG basecamp checkins question update --count type=bool
 FLAG basecamp checkins question update --days type=string
 FLAG basecamp checkins question update --frequency type=string
-FLAG basecamp checkins question update --help type=bool
 FLAG basecamp checkins question update --hints type=bool
 FLAG basecamp checkins question update --ids-only type=bool
 FLAG basecamp checkins question update --in type=string
@@ -3579,13 +2133,11 @@ FLAG basecamp checkins question update --styled type=bool
 FLAG basecamp checkins question update --time type=string
 FLAG basecamp checkins question update --todolist type=string
 FLAG basecamp checkins question update --verbose type=count
-FLAG basecamp checkins question update --version type=bool
 FLAG basecamp checkins questions --account type=string
 FLAG basecamp checkins questions --agent type=bool
 FLAG basecamp checkins questions --all type=bool
 FLAG basecamp checkins questions --cache-dir type=string
 FLAG basecamp checkins questions --count type=bool
-FLAG basecamp checkins questions --help type=bool
 FLAG basecamp checkins questions --hints type=bool
 FLAG basecamp checkins questions --ids-only type=bool
 FLAG basecamp checkins questions --in type=string
@@ -3605,34 +2157,10 @@ FLAG basecamp checkins questions --stats type=bool
 FLAG basecamp checkins questions --styled type=bool
 FLAG basecamp checkins questions --todolist type=string
 FLAG basecamp checkins questions --verbose type=count
-FLAG basecamp checkins questions --version type=bool
-FLAG basecamp cmds --account type=string
-FLAG basecamp cmds --agent type=bool
-FLAG basecamp cmds --cache-dir type=string
-FLAG basecamp cmds --count type=bool
-FLAG basecamp cmds --help type=bool
-FLAG basecamp cmds --hints type=bool
-FLAG basecamp cmds --ids-only type=bool
-FLAG basecamp cmds --in type=string
-FLAG basecamp cmds --jq type=string
-FLAG basecamp cmds --json type=bool
-FLAG basecamp cmds --markdown type=bool
-FLAG basecamp cmds --md type=bool
-FLAG basecamp cmds --no-hints type=bool
-FLAG basecamp cmds --no-stats type=bool
-FLAG basecamp cmds --profile type=string
-FLAG basecamp cmds --project type=string
-FLAG basecamp cmds --quiet type=bool
-FLAG basecamp cmds --stats type=bool
-FLAG basecamp cmds --styled type=bool
-FLAG basecamp cmds --todolist type=string
-FLAG basecamp cmds --verbose type=count
-FLAG basecamp cmds --version type=bool
 FLAG basecamp commands --account type=string
 FLAG basecamp commands --agent type=bool
 FLAG basecamp commands --cache-dir type=string
 FLAG basecamp commands --count type=bool
-FLAG basecamp commands --help type=bool
 FLAG basecamp commands --hints type=bool
 FLAG basecamp commands --ids-only type=bool
 FLAG basecamp commands --in type=string
@@ -3649,14 +2177,12 @@ FLAG basecamp commands --stats type=bool
 FLAG basecamp commands --styled type=bool
 FLAG basecamp commands --todolist type=string
 FLAG basecamp commands --verbose type=count
-FLAG basecamp commands --version type=bool
 FLAG basecamp comment --account type=string
 FLAG basecamp comment --agent type=bool
 FLAG basecamp comment --attach type=stringArray
 FLAG basecamp comment --cache-dir type=string
 FLAG basecamp comment --count type=bool
 FLAG basecamp comment --edit type=bool
-FLAG basecamp comment --help type=bool
 FLAG basecamp comment --hints type=bool
 FLAG basecamp comment --ids-only type=bool
 FLAG basecamp comment --in type=string
@@ -3673,12 +2199,10 @@ FLAG basecamp comment --stats type=bool
 FLAG basecamp comment --styled type=bool
 FLAG basecamp comment --todolist type=string
 FLAG basecamp comment --verbose type=count
-FLAG basecamp comment --version type=bool
 FLAG basecamp comments --account type=string
 FLAG basecamp comments --agent type=bool
 FLAG basecamp comments --cache-dir type=string
 FLAG basecamp comments --count type=bool
-FLAG basecamp comments --help type=bool
 FLAG basecamp comments --hints type=bool
 FLAG basecamp comments --ids-only type=bool
 FLAG basecamp comments --in type=string
@@ -3695,12 +2219,10 @@ FLAG basecamp comments --stats type=bool
 FLAG basecamp comments --styled type=bool
 FLAG basecamp comments --todolist type=string
 FLAG basecamp comments --verbose type=count
-FLAG basecamp comments --version type=bool
 FLAG basecamp comments archive --account type=string
 FLAG basecamp comments archive --agent type=bool
 FLAG basecamp comments archive --cache-dir type=string
 FLAG basecamp comments archive --count type=bool
-FLAG basecamp comments archive --help type=bool
 FLAG basecamp comments archive --hints type=bool
 FLAG basecamp comments archive --ids-only type=bool
 FLAG basecamp comments archive --in type=string
@@ -3717,14 +2239,12 @@ FLAG basecamp comments archive --stats type=bool
 FLAG basecamp comments archive --styled type=bool
 FLAG basecamp comments archive --todolist type=string
 FLAG basecamp comments archive --verbose type=count
-FLAG basecamp comments archive --version type=bool
 FLAG basecamp comments create --account type=string
 FLAG basecamp comments create --agent type=bool
 FLAG basecamp comments create --attach type=stringArray
 FLAG basecamp comments create --cache-dir type=string
 FLAG basecamp comments create --count type=bool
 FLAG basecamp comments create --edit type=bool
-FLAG basecamp comments create --help type=bool
 FLAG basecamp comments create --hints type=bool
 FLAG basecamp comments create --ids-only type=bool
 FLAG basecamp comments create --in type=string
@@ -3741,13 +2261,11 @@ FLAG basecamp comments create --stats type=bool
 FLAG basecamp comments create --styled type=bool
 FLAG basecamp comments create --todolist type=string
 FLAG basecamp comments create --verbose type=count
-FLAG basecamp comments create --version type=bool
 FLAG basecamp comments list --account type=string
 FLAG basecamp comments list --agent type=bool
 FLAG basecamp comments list --all type=bool
 FLAG basecamp comments list --cache-dir type=string
 FLAG basecamp comments list --count type=bool
-FLAG basecamp comments list --help type=bool
 FLAG basecamp comments list --hints type=bool
 FLAG basecamp comments list --ids-only type=bool
 FLAG basecamp comments list --in type=string
@@ -3766,12 +2284,10 @@ FLAG basecamp comments list --stats type=bool
 FLAG basecamp comments list --styled type=bool
 FLAG basecamp comments list --todolist type=string
 FLAG basecamp comments list --verbose type=count
-FLAG basecamp comments list --version type=bool
 FLAG basecamp comments restore --account type=string
 FLAG basecamp comments restore --agent type=bool
 FLAG basecamp comments restore --cache-dir type=string
 FLAG basecamp comments restore --count type=bool
-FLAG basecamp comments restore --help type=bool
 FLAG basecamp comments restore --hints type=bool
 FLAG basecamp comments restore --ids-only type=bool
 FLAG basecamp comments restore --in type=string
@@ -3788,12 +2304,10 @@ FLAG basecamp comments restore --stats type=bool
 FLAG basecamp comments restore --styled type=bool
 FLAG basecamp comments restore --todolist type=string
 FLAG basecamp comments restore --verbose type=count
-FLAG basecamp comments restore --version type=bool
 FLAG basecamp comments show --account type=string
 FLAG basecamp comments show --agent type=bool
 FLAG basecamp comments show --cache-dir type=string
 FLAG basecamp comments show --count type=bool
-FLAG basecamp comments show --help type=bool
 FLAG basecamp comments show --hints type=bool
 FLAG basecamp comments show --ids-only type=bool
 FLAG basecamp comments show --in type=string
@@ -3810,12 +2324,10 @@ FLAG basecamp comments show --stats type=bool
 FLAG basecamp comments show --styled type=bool
 FLAG basecamp comments show --todolist type=string
 FLAG basecamp comments show --verbose type=count
-FLAG basecamp comments show --version type=bool
 FLAG basecamp comments trash --account type=string
 FLAG basecamp comments trash --agent type=bool
 FLAG basecamp comments trash --cache-dir type=string
 FLAG basecamp comments trash --count type=bool
-FLAG basecamp comments trash --help type=bool
 FLAG basecamp comments trash --hints type=bool
 FLAG basecamp comments trash --ids-only type=bool
 FLAG basecamp comments trash --in type=string
@@ -3832,12 +2344,10 @@ FLAG basecamp comments trash --stats type=bool
 FLAG basecamp comments trash --styled type=bool
 FLAG basecamp comments trash --todolist type=string
 FLAG basecamp comments trash --verbose type=count
-FLAG basecamp comments trash --version type=bool
 FLAG basecamp comments update --account type=string
 FLAG basecamp comments update --agent type=bool
 FLAG basecamp comments update --cache-dir type=string
 FLAG basecamp comments update --count type=bool
-FLAG basecamp comments update --help type=bool
 FLAG basecamp comments update --hints type=bool
 FLAG basecamp comments update --ids-only type=bool
 FLAG basecamp comments update --in type=string
@@ -3854,12 +2364,10 @@ FLAG basecamp comments update --stats type=bool
 FLAG basecamp comments update --styled type=bool
 FLAG basecamp comments update --todolist type=string
 FLAG basecamp comments update --verbose type=count
-FLAG basecamp comments update --version type=bool
 FLAG basecamp completion --account type=string
 FLAG basecamp completion --agent type=bool
 FLAG basecamp completion --cache-dir type=string
 FLAG basecamp completion --count type=bool
-FLAG basecamp completion --help type=bool
 FLAG basecamp completion --hints type=bool
 FLAG basecamp completion --ids-only type=bool
 FLAG basecamp completion --in type=string
@@ -3876,12 +2384,10 @@ FLAG basecamp completion --stats type=bool
 FLAG basecamp completion --styled type=bool
 FLAG basecamp completion --todolist type=string
 FLAG basecamp completion --verbose type=count
-FLAG basecamp completion --version type=bool
 FLAG basecamp completion bash --account type=string
 FLAG basecamp completion bash --agent type=bool
 FLAG basecamp completion bash --cache-dir type=string
 FLAG basecamp completion bash --count type=bool
-FLAG basecamp completion bash --help type=bool
 FLAG basecamp completion bash --hints type=bool
 FLAG basecamp completion bash --ids-only type=bool
 FLAG basecamp completion bash --in type=string
@@ -3898,12 +2404,10 @@ FLAG basecamp completion bash --stats type=bool
 FLAG basecamp completion bash --styled type=bool
 FLAG basecamp completion bash --todolist type=string
 FLAG basecamp completion bash --verbose type=count
-FLAG basecamp completion bash --version type=bool
 FLAG basecamp completion fish --account type=string
 FLAG basecamp completion fish --agent type=bool
 FLAG basecamp completion fish --cache-dir type=string
 FLAG basecamp completion fish --count type=bool
-FLAG basecamp completion fish --help type=bool
 FLAG basecamp completion fish --hints type=bool
 FLAG basecamp completion fish --ids-only type=bool
 FLAG basecamp completion fish --in type=string
@@ -3920,12 +2424,10 @@ FLAG basecamp completion fish --stats type=bool
 FLAG basecamp completion fish --styled type=bool
 FLAG basecamp completion fish --todolist type=string
 FLAG basecamp completion fish --verbose type=count
-FLAG basecamp completion fish --version type=bool
 FLAG basecamp completion powershell --account type=string
 FLAG basecamp completion powershell --agent type=bool
 FLAG basecamp completion powershell --cache-dir type=string
 FLAG basecamp completion powershell --count type=bool
-FLAG basecamp completion powershell --help type=bool
 FLAG basecamp completion powershell --hints type=bool
 FLAG basecamp completion powershell --ids-only type=bool
 FLAG basecamp completion powershell --in type=string
@@ -3942,12 +2444,10 @@ FLAG basecamp completion powershell --stats type=bool
 FLAG basecamp completion powershell --styled type=bool
 FLAG basecamp completion powershell --todolist type=string
 FLAG basecamp completion powershell --verbose type=count
-FLAG basecamp completion powershell --version type=bool
 FLAG basecamp completion refresh --account type=string
 FLAG basecamp completion refresh --agent type=bool
 FLAG basecamp completion refresh --cache-dir type=string
 FLAG basecamp completion refresh --count type=bool
-FLAG basecamp completion refresh --help type=bool
 FLAG basecamp completion refresh --hints type=bool
 FLAG basecamp completion refresh --ids-only type=bool
 FLAG basecamp completion refresh --in type=string
@@ -3964,12 +2464,10 @@ FLAG basecamp completion refresh --stats type=bool
 FLAG basecamp completion refresh --styled type=bool
 FLAG basecamp completion refresh --todolist type=string
 FLAG basecamp completion refresh --verbose type=count
-FLAG basecamp completion refresh --version type=bool
 FLAG basecamp completion status --account type=string
 FLAG basecamp completion status --agent type=bool
 FLAG basecamp completion status --cache-dir type=string
 FLAG basecamp completion status --count type=bool
-FLAG basecamp completion status --help type=bool
 FLAG basecamp completion status --hints type=bool
 FLAG basecamp completion status --ids-only type=bool
 FLAG basecamp completion status --in type=string
@@ -3986,12 +2484,10 @@ FLAG basecamp completion status --stats type=bool
 FLAG basecamp completion status --styled type=bool
 FLAG basecamp completion status --todolist type=string
 FLAG basecamp completion status --verbose type=count
-FLAG basecamp completion status --version type=bool
 FLAG basecamp completion zsh --account type=string
 FLAG basecamp completion zsh --agent type=bool
 FLAG basecamp completion zsh --cache-dir type=string
 FLAG basecamp completion zsh --count type=bool
-FLAG basecamp completion zsh --help type=bool
 FLAG basecamp completion zsh --hints type=bool
 FLAG basecamp completion zsh --ids-only type=bool
 FLAG basecamp completion zsh --in type=string
@@ -4008,12 +2504,10 @@ FLAG basecamp completion zsh --stats type=bool
 FLAG basecamp completion zsh --styled type=bool
 FLAG basecamp completion zsh --todolist type=string
 FLAG basecamp completion zsh --verbose type=count
-FLAG basecamp completion zsh --version type=bool
 FLAG basecamp config --account type=string
 FLAG basecamp config --agent type=bool
 FLAG basecamp config --cache-dir type=string
 FLAG basecamp config --count type=bool
-FLAG basecamp config --help type=bool
 FLAG basecamp config --hints type=bool
 FLAG basecamp config --ids-only type=bool
 FLAG basecamp config --in type=string
@@ -4030,12 +2524,10 @@ FLAG basecamp config --stats type=bool
 FLAG basecamp config --styled type=bool
 FLAG basecamp config --todolist type=string
 FLAG basecamp config --verbose type=count
-FLAG basecamp config --version type=bool
 FLAG basecamp config init --account type=string
 FLAG basecamp config init --agent type=bool
 FLAG basecamp config init --cache-dir type=string
 FLAG basecamp config init --count type=bool
-FLAG basecamp config init --help type=bool
 FLAG basecamp config init --hints type=bool
 FLAG basecamp config init --ids-only type=bool
 FLAG basecamp config init --in type=string
@@ -4052,12 +2544,10 @@ FLAG basecamp config init --stats type=bool
 FLAG basecamp config init --styled type=bool
 FLAG basecamp config init --todolist type=string
 FLAG basecamp config init --verbose type=count
-FLAG basecamp config init --version type=bool
 FLAG basecamp config project --account type=string
 FLAG basecamp config project --agent type=bool
 FLAG basecamp config project --cache-dir type=string
 FLAG basecamp config project --count type=bool
-FLAG basecamp config project --help type=bool
 FLAG basecamp config project --hints type=bool
 FLAG basecamp config project --ids-only type=bool
 FLAG basecamp config project --in type=string
@@ -4074,13 +2564,11 @@ FLAG basecamp config project --stats type=bool
 FLAG basecamp config project --styled type=bool
 FLAG basecamp config project --todolist type=string
 FLAG basecamp config project --verbose type=count
-FLAG basecamp config project --version type=bool
 FLAG basecamp config set --account type=string
 FLAG basecamp config set --agent type=bool
 FLAG basecamp config set --cache-dir type=string
 FLAG basecamp config set --count type=bool
 FLAG basecamp config set --global type=bool
-FLAG basecamp config set --help type=bool
 FLAG basecamp config set --hints type=bool
 FLAG basecamp config set --ids-only type=bool
 FLAG basecamp config set --in type=string
@@ -4097,12 +2585,10 @@ FLAG basecamp config set --stats type=bool
 FLAG basecamp config set --styled type=bool
 FLAG basecamp config set --todolist type=string
 FLAG basecamp config set --verbose type=count
-FLAG basecamp config set --version type=bool
 FLAG basecamp config show --account type=string
 FLAG basecamp config show --agent type=bool
 FLAG basecamp config show --cache-dir type=string
 FLAG basecamp config show --count type=bool
-FLAG basecamp config show --help type=bool
 FLAG basecamp config show --hints type=bool
 FLAG basecamp config show --ids-only type=bool
 FLAG basecamp config show --in type=string
@@ -4119,12 +2605,10 @@ FLAG basecamp config show --stats type=bool
 FLAG basecamp config show --styled type=bool
 FLAG basecamp config show --todolist type=string
 FLAG basecamp config show --verbose type=count
-FLAG basecamp config show --version type=bool
 FLAG basecamp config trust --account type=string
 FLAG basecamp config trust --agent type=bool
 FLAG basecamp config trust --cache-dir type=string
 FLAG basecamp config trust --count type=bool
-FLAG basecamp config trust --help type=bool
 FLAG basecamp config trust --hints type=bool
 FLAG basecamp config trust --ids-only type=bool
 FLAG basecamp config trust --in type=string
@@ -4142,13 +2626,11 @@ FLAG basecamp config trust --stats type=bool
 FLAG basecamp config trust --styled type=bool
 FLAG basecamp config trust --todolist type=string
 FLAG basecamp config trust --verbose type=count
-FLAG basecamp config trust --version type=bool
 FLAG basecamp config unset --account type=string
 FLAG basecamp config unset --agent type=bool
 FLAG basecamp config unset --cache-dir type=string
 FLAG basecamp config unset --count type=bool
 FLAG basecamp config unset --global type=bool
-FLAG basecamp config unset --help type=bool
 FLAG basecamp config unset --hints type=bool
 FLAG basecamp config unset --ids-only type=bool
 FLAG basecamp config unset --in type=string
@@ -4165,12 +2647,10 @@ FLAG basecamp config unset --stats type=bool
 FLAG basecamp config unset --styled type=bool
 FLAG basecamp config unset --todolist type=string
 FLAG basecamp config unset --verbose type=count
-FLAG basecamp config unset --version type=bool
 FLAG basecamp config untrust --account type=string
 FLAG basecamp config untrust --agent type=bool
 FLAG basecamp config untrust --cache-dir type=string
 FLAG basecamp config untrust --count type=bool
-FLAG basecamp config untrust --help type=bool
 FLAG basecamp config untrust --hints type=bool
 FLAG basecamp config untrust --ids-only type=bool
 FLAG basecamp config untrust --in type=string
@@ -4187,13 +2667,11 @@ FLAG basecamp config untrust --stats type=bool
 FLAG basecamp config untrust --styled type=bool
 FLAG basecamp config untrust --todolist type=string
 FLAG basecamp config untrust --verbose type=count
-FLAG basecamp config untrust --version type=bool
 FLAG basecamp docs --account type=string
 FLAG basecamp docs --agent type=bool
 FLAG basecamp docs --cache-dir type=string
 FLAG basecamp docs --count type=bool
 FLAG basecamp docs --folder type=string
-FLAG basecamp docs --help type=bool
 FLAG basecamp docs --hints type=bool
 FLAG basecamp docs --ids-only type=bool
 FLAG basecamp docs --in type=string
@@ -4211,13 +2689,11 @@ FLAG basecamp docs --styled type=bool
 FLAG basecamp docs --todolist type=string
 FLAG basecamp docs --vault type=string
 FLAG basecamp docs --verbose type=count
-FLAG basecamp docs --version type=bool
 FLAG basecamp docs archive --account type=string
 FLAG basecamp docs archive --agent type=bool
 FLAG basecamp docs archive --cache-dir type=string
 FLAG basecamp docs archive --count type=bool
 FLAG basecamp docs archive --folder type=string
-FLAG basecamp docs archive --help type=bool
 FLAG basecamp docs archive --hints type=bool
 FLAG basecamp docs archive --ids-only type=bool
 FLAG basecamp docs archive --in type=string
@@ -4235,178 +2711,12 @@ FLAG basecamp docs archive --styled type=bool
 FLAG basecamp docs archive --todolist type=string
 FLAG basecamp docs archive --vault type=string
 FLAG basecamp docs archive --verbose type=count
-FLAG basecamp docs archive --version type=bool
-FLAG basecamp docs doc --account type=string
-FLAG basecamp docs doc --agent type=bool
-FLAG basecamp docs doc --all type=bool
-FLAG basecamp docs doc --cache-dir type=string
-FLAG basecamp docs doc --count type=bool
-FLAG basecamp docs doc --folder type=string
-FLAG basecamp docs doc --help type=bool
-FLAG basecamp docs doc --hints type=bool
-FLAG basecamp docs doc --ids-only type=bool
-FLAG basecamp docs doc --in type=string
-FLAG basecamp docs doc --jq type=string
-FLAG basecamp docs doc --json type=bool
-FLAG basecamp docs doc --limit type=int
-FLAG basecamp docs doc --markdown type=bool
-FLAG basecamp docs doc --md type=bool
-FLAG basecamp docs doc --no-hints type=bool
-FLAG basecamp docs doc --no-stats type=bool
-FLAG basecamp docs doc --page type=int
-FLAG basecamp docs doc --profile type=string
-FLAG basecamp docs doc --project type=string
-FLAG basecamp docs doc --quiet type=bool
-FLAG basecamp docs doc --stats type=bool
-FLAG basecamp docs doc --styled type=bool
-FLAG basecamp docs doc --todolist type=string
-FLAG basecamp docs doc --vault type=string
-FLAG basecamp docs doc --verbose type=count
-FLAG basecamp docs doc --version type=bool
-FLAG basecamp docs doc create --account type=string
-FLAG basecamp docs doc create --agent type=bool
-FLAG basecamp docs doc create --attach type=stringArray
-FLAG basecamp docs doc create --cache-dir type=string
-FLAG basecamp docs doc create --count type=bool
-FLAG basecamp docs doc create --draft type=bool
-FLAG basecamp docs doc create --folder type=string
-FLAG basecamp docs doc create --help type=bool
-FLAG basecamp docs doc create --hints type=bool
-FLAG basecamp docs doc create --ids-only type=bool
-FLAG basecamp docs doc create --in type=string
-FLAG basecamp docs doc create --jq type=string
-FLAG basecamp docs doc create --json type=bool
-FLAG basecamp docs doc create --markdown type=bool
-FLAG basecamp docs doc create --md type=bool
-FLAG basecamp docs doc create --no-hints type=bool
-FLAG basecamp docs doc create --no-stats type=bool
-FLAG basecamp docs doc create --no-subscribe type=bool
-FLAG basecamp docs doc create --profile type=string
-FLAG basecamp docs doc create --project type=string
-FLAG basecamp docs doc create --quiet type=bool
-FLAG basecamp docs doc create --stats type=bool
-FLAG basecamp docs doc create --styled type=bool
-FLAG basecamp docs doc create --subscribe type=string
-FLAG basecamp docs doc create --todolist type=string
-FLAG basecamp docs doc create --vault type=string
-FLAG basecamp docs doc create --verbose type=count
-FLAG basecamp docs doc create --version type=bool
-FLAG basecamp docs doc list --account type=string
-FLAG basecamp docs doc list --agent type=bool
-FLAG basecamp docs doc list --all type=bool
-FLAG basecamp docs doc list --cache-dir type=string
-FLAG basecamp docs doc list --count type=bool
-FLAG basecamp docs doc list --folder type=string
-FLAG basecamp docs doc list --help type=bool
-FLAG basecamp docs doc list --hints type=bool
-FLAG basecamp docs doc list --ids-only type=bool
-FLAG basecamp docs doc list --in type=string
-FLAG basecamp docs doc list --jq type=string
-FLAG basecamp docs doc list --json type=bool
-FLAG basecamp docs doc list --limit type=int
-FLAG basecamp docs doc list --markdown type=bool
-FLAG basecamp docs doc list --md type=bool
-FLAG basecamp docs doc list --no-hints type=bool
-FLAG basecamp docs doc list --no-stats type=bool
-FLAG basecamp docs doc list --page type=int
-FLAG basecamp docs doc list --profile type=string
-FLAG basecamp docs doc list --project type=string
-FLAG basecamp docs doc list --quiet type=bool
-FLAG basecamp docs doc list --stats type=bool
-FLAG basecamp docs doc list --styled type=bool
-FLAG basecamp docs doc list --todolist type=string
-FLAG basecamp docs doc list --vault type=string
-FLAG basecamp docs doc list --verbose type=count
-FLAG basecamp docs doc list --version type=bool
-FLAG basecamp docs document --account type=string
-FLAG basecamp docs document --agent type=bool
-FLAG basecamp docs document --all type=bool
-FLAG basecamp docs document --cache-dir type=string
-FLAG basecamp docs document --count type=bool
-FLAG basecamp docs document --folder type=string
-FLAG basecamp docs document --help type=bool
-FLAG basecamp docs document --hints type=bool
-FLAG basecamp docs document --ids-only type=bool
-FLAG basecamp docs document --in type=string
-FLAG basecamp docs document --jq type=string
-FLAG basecamp docs document --json type=bool
-FLAG basecamp docs document --limit type=int
-FLAG basecamp docs document --markdown type=bool
-FLAG basecamp docs document --md type=bool
-FLAG basecamp docs document --no-hints type=bool
-FLAG basecamp docs document --no-stats type=bool
-FLAG basecamp docs document --page type=int
-FLAG basecamp docs document --profile type=string
-FLAG basecamp docs document --project type=string
-FLAG basecamp docs document --quiet type=bool
-FLAG basecamp docs document --stats type=bool
-FLAG basecamp docs document --styled type=bool
-FLAG basecamp docs document --todolist type=string
-FLAG basecamp docs document --vault type=string
-FLAG basecamp docs document --verbose type=count
-FLAG basecamp docs document --version type=bool
-FLAG basecamp docs document create --account type=string
-FLAG basecamp docs document create --agent type=bool
-FLAG basecamp docs document create --attach type=stringArray
-FLAG basecamp docs document create --cache-dir type=string
-FLAG basecamp docs document create --count type=bool
-FLAG basecamp docs document create --draft type=bool
-FLAG basecamp docs document create --folder type=string
-FLAG basecamp docs document create --help type=bool
-FLAG basecamp docs document create --hints type=bool
-FLAG basecamp docs document create --ids-only type=bool
-FLAG basecamp docs document create --in type=string
-FLAG basecamp docs document create --jq type=string
-FLAG basecamp docs document create --json type=bool
-FLAG basecamp docs document create --markdown type=bool
-FLAG basecamp docs document create --md type=bool
-FLAG basecamp docs document create --no-hints type=bool
-FLAG basecamp docs document create --no-stats type=bool
-FLAG basecamp docs document create --no-subscribe type=bool
-FLAG basecamp docs document create --profile type=string
-FLAG basecamp docs document create --project type=string
-FLAG basecamp docs document create --quiet type=bool
-FLAG basecamp docs document create --stats type=bool
-FLAG basecamp docs document create --styled type=bool
-FLAG basecamp docs document create --subscribe type=string
-FLAG basecamp docs document create --todolist type=string
-FLAG basecamp docs document create --vault type=string
-FLAG basecamp docs document create --verbose type=count
-FLAG basecamp docs document create --version type=bool
-FLAG basecamp docs document list --account type=string
-FLAG basecamp docs document list --agent type=bool
-FLAG basecamp docs document list --all type=bool
-FLAG basecamp docs document list --cache-dir type=string
-FLAG basecamp docs document list --count type=bool
-FLAG basecamp docs document list --folder type=string
-FLAG basecamp docs document list --help type=bool
-FLAG basecamp docs document list --hints type=bool
-FLAG basecamp docs document list --ids-only type=bool
-FLAG basecamp docs document list --in type=string
-FLAG basecamp docs document list --jq type=string
-FLAG basecamp docs document list --json type=bool
-FLAG basecamp docs document list --limit type=int
-FLAG basecamp docs document list --markdown type=bool
-FLAG basecamp docs document list --md type=bool
-FLAG basecamp docs document list --no-hints type=bool
-FLAG basecamp docs document list --no-stats type=bool
-FLAG basecamp docs document list --page type=int
-FLAG basecamp docs document list --profile type=string
-FLAG basecamp docs document list --project type=string
-FLAG basecamp docs document list --quiet type=bool
-FLAG basecamp docs document list --stats type=bool
-FLAG basecamp docs document list --styled type=bool
-FLAG basecamp docs document list --todolist type=string
-FLAG basecamp docs document list --vault type=string
-FLAG basecamp docs document list --verbose type=count
-FLAG basecamp docs document list --version type=bool
 FLAG basecamp docs documents --account type=string
 FLAG basecamp docs documents --agent type=bool
 FLAG basecamp docs documents --all type=bool
 FLAG basecamp docs documents --cache-dir type=string
 FLAG basecamp docs documents --count type=bool
 FLAG basecamp docs documents --folder type=string
-FLAG basecamp docs documents --help type=bool
 FLAG basecamp docs documents --hints type=bool
 FLAG basecamp docs documents --ids-only type=bool
 FLAG basecamp docs documents --in type=string
@@ -4426,7 +2736,6 @@ FLAG basecamp docs documents --styled type=bool
 FLAG basecamp docs documents --todolist type=string
 FLAG basecamp docs documents --vault type=string
 FLAG basecamp docs documents --verbose type=count
-FLAG basecamp docs documents --version type=bool
 FLAG basecamp docs documents create --account type=string
 FLAG basecamp docs documents create --agent type=bool
 FLAG basecamp docs documents create --attach type=stringArray
@@ -4434,7 +2743,6 @@ FLAG basecamp docs documents create --cache-dir type=string
 FLAG basecamp docs documents create --count type=bool
 FLAG basecamp docs documents create --draft type=bool
 FLAG basecamp docs documents create --folder type=string
-FLAG basecamp docs documents create --help type=bool
 FLAG basecamp docs documents create --hints type=bool
 FLAG basecamp docs documents create --ids-only type=bool
 FLAG basecamp docs documents create --in type=string
@@ -4454,14 +2762,12 @@ FLAG basecamp docs documents create --subscribe type=string
 FLAG basecamp docs documents create --todolist type=string
 FLAG basecamp docs documents create --vault type=string
 FLAG basecamp docs documents create --verbose type=count
-FLAG basecamp docs documents create --version type=bool
 FLAG basecamp docs documents list --account type=string
 FLAG basecamp docs documents list --agent type=bool
 FLAG basecamp docs documents list --all type=bool
 FLAG basecamp docs documents list --cache-dir type=string
 FLAG basecamp docs documents list --count type=bool
 FLAG basecamp docs documents list --folder type=string
-FLAG basecamp docs documents list --help type=bool
 FLAG basecamp docs documents list --hints type=bool
 FLAG basecamp docs documents list --ids-only type=bool
 FLAG basecamp docs documents list --in type=string
@@ -4481,13 +2787,11 @@ FLAG basecamp docs documents list --styled type=bool
 FLAG basecamp docs documents list --todolist type=string
 FLAG basecamp docs documents list --vault type=string
 FLAG basecamp docs documents list --verbose type=count
-FLAG basecamp docs documents list --version type=bool
 FLAG basecamp docs download --account type=string
 FLAG basecamp docs download --agent type=bool
 FLAG basecamp docs download --cache-dir type=string
 FLAG basecamp docs download --count type=bool
 FLAG basecamp docs download --folder type=string
-FLAG basecamp docs download --help type=bool
 FLAG basecamp docs download --hints type=bool
 FLAG basecamp docs download --ids-only type=bool
 FLAG basecamp docs download --in type=string
@@ -4506,92 +2810,12 @@ FLAG basecamp docs download --styled type=bool
 FLAG basecamp docs download --todolist type=string
 FLAG basecamp docs download --vault type=string
 FLAG basecamp docs download --verbose type=count
-FLAG basecamp docs download --version type=bool
-FLAG basecamp docs folder --account type=string
-FLAG basecamp docs folder --agent type=bool
-FLAG basecamp docs folder --all type=bool
-FLAG basecamp docs folder --cache-dir type=string
-FLAG basecamp docs folder --count type=bool
-FLAG basecamp docs folder --folder type=string
-FLAG basecamp docs folder --help type=bool
-FLAG basecamp docs folder --hints type=bool
-FLAG basecamp docs folder --ids-only type=bool
-FLAG basecamp docs folder --in type=string
-FLAG basecamp docs folder --jq type=string
-FLAG basecamp docs folder --json type=bool
-FLAG basecamp docs folder --limit type=int
-FLAG basecamp docs folder --markdown type=bool
-FLAG basecamp docs folder --md type=bool
-FLAG basecamp docs folder --no-hints type=bool
-FLAG basecamp docs folder --no-stats type=bool
-FLAG basecamp docs folder --page type=int
-FLAG basecamp docs folder --profile type=string
-FLAG basecamp docs folder --project type=string
-FLAG basecamp docs folder --quiet type=bool
-FLAG basecamp docs folder --stats type=bool
-FLAG basecamp docs folder --styled type=bool
-FLAG basecamp docs folder --todolist type=string
-FLAG basecamp docs folder --vault type=string
-FLAG basecamp docs folder --verbose type=count
-FLAG basecamp docs folder --version type=bool
-FLAG basecamp docs folder create --account type=string
-FLAG basecamp docs folder create --agent type=bool
-FLAG basecamp docs folder create --cache-dir type=string
-FLAG basecamp docs folder create --count type=bool
-FLAG basecamp docs folder create --folder type=string
-FLAG basecamp docs folder create --help type=bool
-FLAG basecamp docs folder create --hints type=bool
-FLAG basecamp docs folder create --ids-only type=bool
-FLAG basecamp docs folder create --in type=string
-FLAG basecamp docs folder create --jq type=string
-FLAG basecamp docs folder create --json type=bool
-FLAG basecamp docs folder create --markdown type=bool
-FLAG basecamp docs folder create --md type=bool
-FLAG basecamp docs folder create --no-hints type=bool
-FLAG basecamp docs folder create --no-stats type=bool
-FLAG basecamp docs folder create --profile type=string
-FLAG basecamp docs folder create --project type=string
-FLAG basecamp docs folder create --quiet type=bool
-FLAG basecamp docs folder create --stats type=bool
-FLAG basecamp docs folder create --styled type=bool
-FLAG basecamp docs folder create --todolist type=string
-FLAG basecamp docs folder create --vault type=string
-FLAG basecamp docs folder create --verbose type=count
-FLAG basecamp docs folder create --version type=bool
-FLAG basecamp docs folder list --account type=string
-FLAG basecamp docs folder list --agent type=bool
-FLAG basecamp docs folder list --all type=bool
-FLAG basecamp docs folder list --cache-dir type=string
-FLAG basecamp docs folder list --count type=bool
-FLAG basecamp docs folder list --folder type=string
-FLAG basecamp docs folder list --help type=bool
-FLAG basecamp docs folder list --hints type=bool
-FLAG basecamp docs folder list --ids-only type=bool
-FLAG basecamp docs folder list --in type=string
-FLAG basecamp docs folder list --jq type=string
-FLAG basecamp docs folder list --json type=bool
-FLAG basecamp docs folder list --limit type=int
-FLAG basecamp docs folder list --markdown type=bool
-FLAG basecamp docs folder list --md type=bool
-FLAG basecamp docs folder list --no-hints type=bool
-FLAG basecamp docs folder list --no-stats type=bool
-FLAG basecamp docs folder list --page type=int
-FLAG basecamp docs folder list --profile type=string
-FLAG basecamp docs folder list --project type=string
-FLAG basecamp docs folder list --quiet type=bool
-FLAG basecamp docs folder list --stats type=bool
-FLAG basecamp docs folder list --styled type=bool
-FLAG basecamp docs folder list --todolist type=string
-FLAG basecamp docs folder list --vault type=string
-FLAG basecamp docs folder list --verbose type=count
-FLAG basecamp docs folder list --version type=bool
 FLAG basecamp docs folders --account type=string
 FLAG basecamp docs folders --agent type=bool
 FLAG basecamp docs folders --all type=bool
 FLAG basecamp docs folders --cache-dir type=string
 FLAG basecamp docs folders --count type=bool
 FLAG basecamp docs folders --folder type=string
-FLAG basecamp docs folders --help type=bool
 FLAG basecamp docs folders --hints type=bool
 FLAG basecamp docs folders --ids-only type=bool
 FLAG basecamp docs folders --in type=string
@@ -4611,13 +2835,11 @@ FLAG basecamp docs folders --styled type=bool
 FLAG basecamp docs folders --todolist type=string
 FLAG basecamp docs folders --vault type=string
 FLAG basecamp docs folders --verbose type=count
-FLAG basecamp docs folders --version type=bool
 FLAG basecamp docs folders create --account type=string
 FLAG basecamp docs folders create --agent type=bool
 FLAG basecamp docs folders create --cache-dir type=string
 FLAG basecamp docs folders create --count type=bool
 FLAG basecamp docs folders create --folder type=string
-FLAG basecamp docs folders create --help type=bool
 FLAG basecamp docs folders create --hints type=bool
 FLAG basecamp docs folders create --ids-only type=bool
 FLAG basecamp docs folders create --in type=string
@@ -4635,14 +2857,12 @@ FLAG basecamp docs folders create --styled type=bool
 FLAG basecamp docs folders create --todolist type=string
 FLAG basecamp docs folders create --vault type=string
 FLAG basecamp docs folders create --verbose type=count
-FLAG basecamp docs folders create --version type=bool
 FLAG basecamp docs folders list --account type=string
 FLAG basecamp docs folders list --agent type=bool
 FLAG basecamp docs folders list --all type=bool
 FLAG basecamp docs folders list --cache-dir type=string
 FLAG basecamp docs folders list --count type=bool
 FLAG basecamp docs folders list --folder type=string
-FLAG basecamp docs folders list --help type=bool
 FLAG basecamp docs folders list --hints type=bool
 FLAG basecamp docs folders list --ids-only type=bool
 FLAG basecamp docs folders list --in type=string
@@ -4662,13 +2882,11 @@ FLAG basecamp docs folders list --styled type=bool
 FLAG basecamp docs folders list --todolist type=string
 FLAG basecamp docs folders list --vault type=string
 FLAG basecamp docs folders list --verbose type=count
-FLAG basecamp docs folders list --version type=bool
 FLAG basecamp docs list --account type=string
 FLAG basecamp docs list --agent type=bool
 FLAG basecamp docs list --cache-dir type=string
 FLAG basecamp docs list --count type=bool
 FLAG basecamp docs list --folder type=string
-FLAG basecamp docs list --help type=bool
 FLAG basecamp docs list --hints type=bool
 FLAG basecamp docs list --ids-only type=bool
 FLAG basecamp docs list --in type=string
@@ -4686,13 +2904,11 @@ FLAG basecamp docs list --styled type=bool
 FLAG basecamp docs list --todolist type=string
 FLAG basecamp docs list --vault type=string
 FLAG basecamp docs list --verbose type=count
-FLAG basecamp docs list --version type=bool
 FLAG basecamp docs restore --account type=string
 FLAG basecamp docs restore --agent type=bool
 FLAG basecamp docs restore --cache-dir type=string
 FLAG basecamp docs restore --count type=bool
 FLAG basecamp docs restore --folder type=string
-FLAG basecamp docs restore --help type=bool
 FLAG basecamp docs restore --hints type=bool
 FLAG basecamp docs restore --ids-only type=bool
 FLAG basecamp docs restore --in type=string
@@ -4710,13 +2926,11 @@ FLAG basecamp docs restore --styled type=bool
 FLAG basecamp docs restore --todolist type=string
 FLAG basecamp docs restore --vault type=string
 FLAG basecamp docs restore --verbose type=count
-FLAG basecamp docs restore --version type=bool
 FLAG basecamp docs show --account type=string
 FLAG basecamp docs show --agent type=bool
 FLAG basecamp docs show --cache-dir type=string
 FLAG basecamp docs show --count type=bool
 FLAG basecamp docs show --folder type=string
-FLAG basecamp docs show --help type=bool
 FLAG basecamp docs show --hints type=bool
 FLAG basecamp docs show --ids-only type=bool
 FLAG basecamp docs show --in type=string
@@ -4735,13 +2949,11 @@ FLAG basecamp docs show --todolist type=string
 FLAG basecamp docs show --type type=string
 FLAG basecamp docs show --vault type=string
 FLAG basecamp docs show --verbose type=count
-FLAG basecamp docs show --version type=bool
 FLAG basecamp docs trash --account type=string
 FLAG basecamp docs trash --agent type=bool
 FLAG basecamp docs trash --cache-dir type=string
 FLAG basecamp docs trash --count type=bool
 FLAG basecamp docs trash --folder type=string
-FLAG basecamp docs trash --help type=bool
 FLAG basecamp docs trash --hints type=bool
 FLAG basecamp docs trash --ids-only type=bool
 FLAG basecamp docs trash --in type=string
@@ -4759,14 +2971,12 @@ FLAG basecamp docs trash --styled type=bool
 FLAG basecamp docs trash --todolist type=string
 FLAG basecamp docs trash --vault type=string
 FLAG basecamp docs trash --verbose type=count
-FLAG basecamp docs trash --version type=bool
 FLAG basecamp docs update --account type=string
 FLAG basecamp docs update --agent type=bool
 FLAG basecamp docs update --cache-dir type=string
 FLAG basecamp docs update --content type=string
 FLAG basecamp docs update --count type=bool
 FLAG basecamp docs update --folder type=string
-FLAG basecamp docs update --help type=bool
 FLAG basecamp docs update --hints type=bool
 FLAG basecamp docs update --ids-only type=bool
 FLAG basecamp docs update --in type=string
@@ -4786,93 +2996,12 @@ FLAG basecamp docs update --todolist type=string
 FLAG basecamp docs update --type type=string
 FLAG basecamp docs update --vault type=string
 FLAG basecamp docs update --verbose type=count
-FLAG basecamp docs update --version type=bool
-FLAG basecamp docs upload --account type=string
-FLAG basecamp docs upload --agent type=bool
-FLAG basecamp docs upload --all type=bool
-FLAG basecamp docs upload --cache-dir type=string
-FLAG basecamp docs upload --count type=bool
-FLAG basecamp docs upload --folder type=string
-FLAG basecamp docs upload --help type=bool
-FLAG basecamp docs upload --hints type=bool
-FLAG basecamp docs upload --ids-only type=bool
-FLAG basecamp docs upload --in type=string
-FLAG basecamp docs upload --jq type=string
-FLAG basecamp docs upload --json type=bool
-FLAG basecamp docs upload --limit type=int
-FLAG basecamp docs upload --markdown type=bool
-FLAG basecamp docs upload --md type=bool
-FLAG basecamp docs upload --no-hints type=bool
-FLAG basecamp docs upload --no-stats type=bool
-FLAG basecamp docs upload --page type=int
-FLAG basecamp docs upload --profile type=string
-FLAG basecamp docs upload --project type=string
-FLAG basecamp docs upload --quiet type=bool
-FLAG basecamp docs upload --stats type=bool
-FLAG basecamp docs upload --styled type=bool
-FLAG basecamp docs upload --todolist type=string
-FLAG basecamp docs upload --vault type=string
-FLAG basecamp docs upload --verbose type=count
-FLAG basecamp docs upload --version type=bool
-FLAG basecamp docs upload create --account type=string
-FLAG basecamp docs upload create --agent type=bool
-FLAG basecamp docs upload create --cache-dir type=string
-FLAG basecamp docs upload create --count type=bool
-FLAG basecamp docs upload create --description type=string
-FLAG basecamp docs upload create --folder type=string
-FLAG basecamp docs upload create --help type=bool
-FLAG basecamp docs upload create --hints type=bool
-FLAG basecamp docs upload create --ids-only type=bool
-FLAG basecamp docs upload create --in type=string
-FLAG basecamp docs upload create --jq type=string
-FLAG basecamp docs upload create --json type=bool
-FLAG basecamp docs upload create --markdown type=bool
-FLAG basecamp docs upload create --md type=bool
-FLAG basecamp docs upload create --no-hints type=bool
-FLAG basecamp docs upload create --no-stats type=bool
-FLAG basecamp docs upload create --profile type=string
-FLAG basecamp docs upload create --project type=string
-FLAG basecamp docs upload create --quiet type=bool
-FLAG basecamp docs upload create --stats type=bool
-FLAG basecamp docs upload create --styled type=bool
-FLAG basecamp docs upload create --todolist type=string
-FLAG basecamp docs upload create --vault type=string
-FLAG basecamp docs upload create --verbose type=count
-FLAG basecamp docs upload create --version type=bool
-FLAG basecamp docs upload list --account type=string
-FLAG basecamp docs upload list --agent type=bool
-FLAG basecamp docs upload list --all type=bool
-FLAG basecamp docs upload list --cache-dir type=string
-FLAG basecamp docs upload list --count type=bool
-FLAG basecamp docs upload list --folder type=string
-FLAG basecamp docs upload list --help type=bool
-FLAG basecamp docs upload list --hints type=bool
-FLAG basecamp docs upload list --ids-only type=bool
-FLAG basecamp docs upload list --in type=string
-FLAG basecamp docs upload list --jq type=string
-FLAG basecamp docs upload list --json type=bool
-FLAG basecamp docs upload list --limit type=int
-FLAG basecamp docs upload list --markdown type=bool
-FLAG basecamp docs upload list --md type=bool
-FLAG basecamp docs upload list --no-hints type=bool
-FLAG basecamp docs upload list --no-stats type=bool
-FLAG basecamp docs upload list --page type=int
-FLAG basecamp docs upload list --profile type=string
-FLAG basecamp docs upload list --project type=string
-FLAG basecamp docs upload list --quiet type=bool
-FLAG basecamp docs upload list --stats type=bool
-FLAG basecamp docs upload list --styled type=bool
-FLAG basecamp docs upload list --todolist type=string
-FLAG basecamp docs upload list --vault type=string
-FLAG basecamp docs upload list --verbose type=count
-FLAG basecamp docs upload list --version type=bool
 FLAG basecamp docs uploads --account type=string
 FLAG basecamp docs uploads --agent type=bool
 FLAG basecamp docs uploads --all type=bool
 FLAG basecamp docs uploads --cache-dir type=string
 FLAG basecamp docs uploads --count type=bool
 FLAG basecamp docs uploads --folder type=string
-FLAG basecamp docs uploads --help type=bool
 FLAG basecamp docs uploads --hints type=bool
 FLAG basecamp docs uploads --ids-only type=bool
 FLAG basecamp docs uploads --in type=string
@@ -4892,14 +3021,12 @@ FLAG basecamp docs uploads --styled type=bool
 FLAG basecamp docs uploads --todolist type=string
 FLAG basecamp docs uploads --vault type=string
 FLAG basecamp docs uploads --verbose type=count
-FLAG basecamp docs uploads --version type=bool
 FLAG basecamp docs uploads create --account type=string
 FLAG basecamp docs uploads create --agent type=bool
 FLAG basecamp docs uploads create --cache-dir type=string
 FLAG basecamp docs uploads create --count type=bool
 FLAG basecamp docs uploads create --description type=string
 FLAG basecamp docs uploads create --folder type=string
-FLAG basecamp docs uploads create --help type=bool
 FLAG basecamp docs uploads create --hints type=bool
 FLAG basecamp docs uploads create --ids-only type=bool
 FLAG basecamp docs uploads create --in type=string
@@ -4917,14 +3044,12 @@ FLAG basecamp docs uploads create --styled type=bool
 FLAG basecamp docs uploads create --todolist type=string
 FLAG basecamp docs uploads create --vault type=string
 FLAG basecamp docs uploads create --verbose type=count
-FLAG basecamp docs uploads create --version type=bool
 FLAG basecamp docs uploads list --account type=string
 FLAG basecamp docs uploads list --agent type=bool
 FLAG basecamp docs uploads list --all type=bool
 FLAG basecamp docs uploads list --cache-dir type=string
 FLAG basecamp docs uploads list --count type=bool
 FLAG basecamp docs uploads list --folder type=string
-FLAG basecamp docs uploads list --help type=bool
 FLAG basecamp docs uploads list --hints type=bool
 FLAG basecamp docs uploads list --ids-only type=bool
 FLAG basecamp docs uploads list --in type=string
@@ -4944,168 +3069,10 @@ FLAG basecamp docs uploads list --styled type=bool
 FLAG basecamp docs uploads list --todolist type=string
 FLAG basecamp docs uploads list --vault type=string
 FLAG basecamp docs uploads list --verbose type=count
-FLAG basecamp docs uploads list --version type=bool
-FLAG basecamp docs vault --account type=string
-FLAG basecamp docs vault --agent type=bool
-FLAG basecamp docs vault --all type=bool
-FLAG basecamp docs vault --cache-dir type=string
-FLAG basecamp docs vault --count type=bool
-FLAG basecamp docs vault --folder type=string
-FLAG basecamp docs vault --help type=bool
-FLAG basecamp docs vault --hints type=bool
-FLAG basecamp docs vault --ids-only type=bool
-FLAG basecamp docs vault --in type=string
-FLAG basecamp docs vault --jq type=string
-FLAG basecamp docs vault --json type=bool
-FLAG basecamp docs vault --limit type=int
-FLAG basecamp docs vault --markdown type=bool
-FLAG basecamp docs vault --md type=bool
-FLAG basecamp docs vault --no-hints type=bool
-FLAG basecamp docs vault --no-stats type=bool
-FLAG basecamp docs vault --page type=int
-FLAG basecamp docs vault --profile type=string
-FLAG basecamp docs vault --project type=string
-FLAG basecamp docs vault --quiet type=bool
-FLAG basecamp docs vault --stats type=bool
-FLAG basecamp docs vault --styled type=bool
-FLAG basecamp docs vault --todolist type=string
-FLAG basecamp docs vault --vault type=string
-FLAG basecamp docs vault --verbose type=count
-FLAG basecamp docs vault --version type=bool
-FLAG basecamp docs vault create --account type=string
-FLAG basecamp docs vault create --agent type=bool
-FLAG basecamp docs vault create --cache-dir type=string
-FLAG basecamp docs vault create --count type=bool
-FLAG basecamp docs vault create --folder type=string
-FLAG basecamp docs vault create --help type=bool
-FLAG basecamp docs vault create --hints type=bool
-FLAG basecamp docs vault create --ids-only type=bool
-FLAG basecamp docs vault create --in type=string
-FLAG basecamp docs vault create --jq type=string
-FLAG basecamp docs vault create --json type=bool
-FLAG basecamp docs vault create --markdown type=bool
-FLAG basecamp docs vault create --md type=bool
-FLAG basecamp docs vault create --no-hints type=bool
-FLAG basecamp docs vault create --no-stats type=bool
-FLAG basecamp docs vault create --profile type=string
-FLAG basecamp docs vault create --project type=string
-FLAG basecamp docs vault create --quiet type=bool
-FLAG basecamp docs vault create --stats type=bool
-FLAG basecamp docs vault create --styled type=bool
-FLAG basecamp docs vault create --todolist type=string
-FLAG basecamp docs vault create --vault type=string
-FLAG basecamp docs vault create --verbose type=count
-FLAG basecamp docs vault create --version type=bool
-FLAG basecamp docs vault list --account type=string
-FLAG basecamp docs vault list --agent type=bool
-FLAG basecamp docs vault list --all type=bool
-FLAG basecamp docs vault list --cache-dir type=string
-FLAG basecamp docs vault list --count type=bool
-FLAG basecamp docs vault list --folder type=string
-FLAG basecamp docs vault list --help type=bool
-FLAG basecamp docs vault list --hints type=bool
-FLAG basecamp docs vault list --ids-only type=bool
-FLAG basecamp docs vault list --in type=string
-FLAG basecamp docs vault list --jq type=string
-FLAG basecamp docs vault list --json type=bool
-FLAG basecamp docs vault list --limit type=int
-FLAG basecamp docs vault list --markdown type=bool
-FLAG basecamp docs vault list --md type=bool
-FLAG basecamp docs vault list --no-hints type=bool
-FLAG basecamp docs vault list --no-stats type=bool
-FLAG basecamp docs vault list --page type=int
-FLAG basecamp docs vault list --profile type=string
-FLAG basecamp docs vault list --project type=string
-FLAG basecamp docs vault list --quiet type=bool
-FLAG basecamp docs vault list --stats type=bool
-FLAG basecamp docs vault list --styled type=bool
-FLAG basecamp docs vault list --todolist type=string
-FLAG basecamp docs vault list --vault type=string
-FLAG basecamp docs vault list --verbose type=count
-FLAG basecamp docs vault list --version type=bool
-FLAG basecamp docs vaults --account type=string
-FLAG basecamp docs vaults --agent type=bool
-FLAG basecamp docs vaults --all type=bool
-FLAG basecamp docs vaults --cache-dir type=string
-FLAG basecamp docs vaults --count type=bool
-FLAG basecamp docs vaults --folder type=string
-FLAG basecamp docs vaults --help type=bool
-FLAG basecamp docs vaults --hints type=bool
-FLAG basecamp docs vaults --ids-only type=bool
-FLAG basecamp docs vaults --in type=string
-FLAG basecamp docs vaults --jq type=string
-FLAG basecamp docs vaults --json type=bool
-FLAG basecamp docs vaults --limit type=int
-FLAG basecamp docs vaults --markdown type=bool
-FLAG basecamp docs vaults --md type=bool
-FLAG basecamp docs vaults --no-hints type=bool
-FLAG basecamp docs vaults --no-stats type=bool
-FLAG basecamp docs vaults --page type=int
-FLAG basecamp docs vaults --profile type=string
-FLAG basecamp docs vaults --project type=string
-FLAG basecamp docs vaults --quiet type=bool
-FLAG basecamp docs vaults --stats type=bool
-FLAG basecamp docs vaults --styled type=bool
-FLAG basecamp docs vaults --todolist type=string
-FLAG basecamp docs vaults --vault type=string
-FLAG basecamp docs vaults --verbose type=count
-FLAG basecamp docs vaults --version type=bool
-FLAG basecamp docs vaults create --account type=string
-FLAG basecamp docs vaults create --agent type=bool
-FLAG basecamp docs vaults create --cache-dir type=string
-FLAG basecamp docs vaults create --count type=bool
-FLAG basecamp docs vaults create --folder type=string
-FLAG basecamp docs vaults create --help type=bool
-FLAG basecamp docs vaults create --hints type=bool
-FLAG basecamp docs vaults create --ids-only type=bool
-FLAG basecamp docs vaults create --in type=string
-FLAG basecamp docs vaults create --jq type=string
-FLAG basecamp docs vaults create --json type=bool
-FLAG basecamp docs vaults create --markdown type=bool
-FLAG basecamp docs vaults create --md type=bool
-FLAG basecamp docs vaults create --no-hints type=bool
-FLAG basecamp docs vaults create --no-stats type=bool
-FLAG basecamp docs vaults create --profile type=string
-FLAG basecamp docs vaults create --project type=string
-FLAG basecamp docs vaults create --quiet type=bool
-FLAG basecamp docs vaults create --stats type=bool
-FLAG basecamp docs vaults create --styled type=bool
-FLAG basecamp docs vaults create --todolist type=string
-FLAG basecamp docs vaults create --vault type=string
-FLAG basecamp docs vaults create --verbose type=count
-FLAG basecamp docs vaults create --version type=bool
-FLAG basecamp docs vaults list --account type=string
-FLAG basecamp docs vaults list --agent type=bool
-FLAG basecamp docs vaults list --all type=bool
-FLAG basecamp docs vaults list --cache-dir type=string
-FLAG basecamp docs vaults list --count type=bool
-FLAG basecamp docs vaults list --folder type=string
-FLAG basecamp docs vaults list --help type=bool
-FLAG basecamp docs vaults list --hints type=bool
-FLAG basecamp docs vaults list --ids-only type=bool
-FLAG basecamp docs vaults list --in type=string
-FLAG basecamp docs vaults list --jq type=string
-FLAG basecamp docs vaults list --json type=bool
-FLAG basecamp docs vaults list --limit type=int
-FLAG basecamp docs vaults list --markdown type=bool
-FLAG basecamp docs vaults list --md type=bool
-FLAG basecamp docs vaults list --no-hints type=bool
-FLAG basecamp docs vaults list --no-stats type=bool
-FLAG basecamp docs vaults list --page type=int
-FLAG basecamp docs vaults list --profile type=string
-FLAG basecamp docs vaults list --project type=string
-FLAG basecamp docs vaults list --quiet type=bool
-FLAG basecamp docs vaults list --stats type=bool
-FLAG basecamp docs vaults list --styled type=bool
-FLAG basecamp docs vaults list --todolist type=string
-FLAG basecamp docs vaults list --vault type=string
-FLAG basecamp docs vaults list --verbose type=count
-FLAG basecamp docs vaults list --version type=bool
 FLAG basecamp doctor --account type=string
 FLAG basecamp doctor --agent type=bool
 FLAG basecamp doctor --cache-dir type=string
 FLAG basecamp doctor --count type=bool
-FLAG basecamp doctor --help type=bool
 FLAG basecamp doctor --hints type=bool
 FLAG basecamp doctor --ids-only type=bool
 FLAG basecamp doctor --in type=string
@@ -5122,925 +3089,10 @@ FLAG basecamp doctor --stats type=bool
 FLAG basecamp doctor --styled type=bool
 FLAG basecamp doctor --todolist type=string
 FLAG basecamp doctor --verbose type=bool
-FLAG basecamp doctor --version type=bool
-FLAG basecamp documents --account type=string
-FLAG basecamp documents --agent type=bool
-FLAG basecamp documents --cache-dir type=string
-FLAG basecamp documents --count type=bool
-FLAG basecamp documents --folder type=string
-FLAG basecamp documents --help type=bool
-FLAG basecamp documents --hints type=bool
-FLAG basecamp documents --ids-only type=bool
-FLAG basecamp documents --in type=string
-FLAG basecamp documents --jq type=string
-FLAG basecamp documents --json type=bool
-FLAG basecamp documents --markdown type=bool
-FLAG basecamp documents --md type=bool
-FLAG basecamp documents --no-hints type=bool
-FLAG basecamp documents --no-stats type=bool
-FLAG basecamp documents --profile type=string
-FLAG basecamp documents --project type=string
-FLAG basecamp documents --quiet type=bool
-FLAG basecamp documents --stats type=bool
-FLAG basecamp documents --styled type=bool
-FLAG basecamp documents --todolist type=string
-FLAG basecamp documents --vault type=string
-FLAG basecamp documents --verbose type=count
-FLAG basecamp documents --version type=bool
-FLAG basecamp documents archive --account type=string
-FLAG basecamp documents archive --agent type=bool
-FLAG basecamp documents archive --cache-dir type=string
-FLAG basecamp documents archive --count type=bool
-FLAG basecamp documents archive --folder type=string
-FLAG basecamp documents archive --help type=bool
-FLAG basecamp documents archive --hints type=bool
-FLAG basecamp documents archive --ids-only type=bool
-FLAG basecamp documents archive --in type=string
-FLAG basecamp documents archive --jq type=string
-FLAG basecamp documents archive --json type=bool
-FLAG basecamp documents archive --markdown type=bool
-FLAG basecamp documents archive --md type=bool
-FLAG basecamp documents archive --no-hints type=bool
-FLAG basecamp documents archive --no-stats type=bool
-FLAG basecamp documents archive --profile type=string
-FLAG basecamp documents archive --project type=string
-FLAG basecamp documents archive --quiet type=bool
-FLAG basecamp documents archive --stats type=bool
-FLAG basecamp documents archive --styled type=bool
-FLAG basecamp documents archive --todolist type=string
-FLAG basecamp documents archive --vault type=string
-FLAG basecamp documents archive --verbose type=count
-FLAG basecamp documents archive --version type=bool
-FLAG basecamp documents doc --account type=string
-FLAG basecamp documents doc --agent type=bool
-FLAG basecamp documents doc --all type=bool
-FLAG basecamp documents doc --cache-dir type=string
-FLAG basecamp documents doc --count type=bool
-FLAG basecamp documents doc --folder type=string
-FLAG basecamp documents doc --help type=bool
-FLAG basecamp documents doc --hints type=bool
-FLAG basecamp documents doc --ids-only type=bool
-FLAG basecamp documents doc --in type=string
-FLAG basecamp documents doc --jq type=string
-FLAG basecamp documents doc --json type=bool
-FLAG basecamp documents doc --limit type=int
-FLAG basecamp documents doc --markdown type=bool
-FLAG basecamp documents doc --md type=bool
-FLAG basecamp documents doc --no-hints type=bool
-FLAG basecamp documents doc --no-stats type=bool
-FLAG basecamp documents doc --page type=int
-FLAG basecamp documents doc --profile type=string
-FLAG basecamp documents doc --project type=string
-FLAG basecamp documents doc --quiet type=bool
-FLAG basecamp documents doc --stats type=bool
-FLAG basecamp documents doc --styled type=bool
-FLAG basecamp documents doc --todolist type=string
-FLAG basecamp documents doc --vault type=string
-FLAG basecamp documents doc --verbose type=count
-FLAG basecamp documents doc --version type=bool
-FLAG basecamp documents doc create --account type=string
-FLAG basecamp documents doc create --agent type=bool
-FLAG basecamp documents doc create --attach type=stringArray
-FLAG basecamp documents doc create --cache-dir type=string
-FLAG basecamp documents doc create --count type=bool
-FLAG basecamp documents doc create --draft type=bool
-FLAG basecamp documents doc create --folder type=string
-FLAG basecamp documents doc create --help type=bool
-FLAG basecamp documents doc create --hints type=bool
-FLAG basecamp documents doc create --ids-only type=bool
-FLAG basecamp documents doc create --in type=string
-FLAG basecamp documents doc create --jq type=string
-FLAG basecamp documents doc create --json type=bool
-FLAG basecamp documents doc create --markdown type=bool
-FLAG basecamp documents doc create --md type=bool
-FLAG basecamp documents doc create --no-hints type=bool
-FLAG basecamp documents doc create --no-stats type=bool
-FLAG basecamp documents doc create --no-subscribe type=bool
-FLAG basecamp documents doc create --profile type=string
-FLAG basecamp documents doc create --project type=string
-FLAG basecamp documents doc create --quiet type=bool
-FLAG basecamp documents doc create --stats type=bool
-FLAG basecamp documents doc create --styled type=bool
-FLAG basecamp documents doc create --subscribe type=string
-FLAG basecamp documents doc create --todolist type=string
-FLAG basecamp documents doc create --vault type=string
-FLAG basecamp documents doc create --verbose type=count
-FLAG basecamp documents doc create --version type=bool
-FLAG basecamp documents doc list --account type=string
-FLAG basecamp documents doc list --agent type=bool
-FLAG basecamp documents doc list --all type=bool
-FLAG basecamp documents doc list --cache-dir type=string
-FLAG basecamp documents doc list --count type=bool
-FLAG basecamp documents doc list --folder type=string
-FLAG basecamp documents doc list --help type=bool
-FLAG basecamp documents doc list --hints type=bool
-FLAG basecamp documents doc list --ids-only type=bool
-FLAG basecamp documents doc list --in type=string
-FLAG basecamp documents doc list --jq type=string
-FLAG basecamp documents doc list --json type=bool
-FLAG basecamp documents doc list --limit type=int
-FLAG basecamp documents doc list --markdown type=bool
-FLAG basecamp documents doc list --md type=bool
-FLAG basecamp documents doc list --no-hints type=bool
-FLAG basecamp documents doc list --no-stats type=bool
-FLAG basecamp documents doc list --page type=int
-FLAG basecamp documents doc list --profile type=string
-FLAG basecamp documents doc list --project type=string
-FLAG basecamp documents doc list --quiet type=bool
-FLAG basecamp documents doc list --stats type=bool
-FLAG basecamp documents doc list --styled type=bool
-FLAG basecamp documents doc list --todolist type=string
-FLAG basecamp documents doc list --vault type=string
-FLAG basecamp documents doc list --verbose type=count
-FLAG basecamp documents doc list --version type=bool
-FLAG basecamp documents document --account type=string
-FLAG basecamp documents document --agent type=bool
-FLAG basecamp documents document --all type=bool
-FLAG basecamp documents document --cache-dir type=string
-FLAG basecamp documents document --count type=bool
-FLAG basecamp documents document --folder type=string
-FLAG basecamp documents document --help type=bool
-FLAG basecamp documents document --hints type=bool
-FLAG basecamp documents document --ids-only type=bool
-FLAG basecamp documents document --in type=string
-FLAG basecamp documents document --jq type=string
-FLAG basecamp documents document --json type=bool
-FLAG basecamp documents document --limit type=int
-FLAG basecamp documents document --markdown type=bool
-FLAG basecamp documents document --md type=bool
-FLAG basecamp documents document --no-hints type=bool
-FLAG basecamp documents document --no-stats type=bool
-FLAG basecamp documents document --page type=int
-FLAG basecamp documents document --profile type=string
-FLAG basecamp documents document --project type=string
-FLAG basecamp documents document --quiet type=bool
-FLAG basecamp documents document --stats type=bool
-FLAG basecamp documents document --styled type=bool
-FLAG basecamp documents document --todolist type=string
-FLAG basecamp documents document --vault type=string
-FLAG basecamp documents document --verbose type=count
-FLAG basecamp documents document --version type=bool
-FLAG basecamp documents document create --account type=string
-FLAG basecamp documents document create --agent type=bool
-FLAG basecamp documents document create --attach type=stringArray
-FLAG basecamp documents document create --cache-dir type=string
-FLAG basecamp documents document create --count type=bool
-FLAG basecamp documents document create --draft type=bool
-FLAG basecamp documents document create --folder type=string
-FLAG basecamp documents document create --help type=bool
-FLAG basecamp documents document create --hints type=bool
-FLAG basecamp documents document create --ids-only type=bool
-FLAG basecamp documents document create --in type=string
-FLAG basecamp documents document create --jq type=string
-FLAG basecamp documents document create --json type=bool
-FLAG basecamp documents document create --markdown type=bool
-FLAG basecamp documents document create --md type=bool
-FLAG basecamp documents document create --no-hints type=bool
-FLAG basecamp documents document create --no-stats type=bool
-FLAG basecamp documents document create --no-subscribe type=bool
-FLAG basecamp documents document create --profile type=string
-FLAG basecamp documents document create --project type=string
-FLAG basecamp documents document create --quiet type=bool
-FLAG basecamp documents document create --stats type=bool
-FLAG basecamp documents document create --styled type=bool
-FLAG basecamp documents document create --subscribe type=string
-FLAG basecamp documents document create --todolist type=string
-FLAG basecamp documents document create --vault type=string
-FLAG basecamp documents document create --verbose type=count
-FLAG basecamp documents document create --version type=bool
-FLAG basecamp documents document list --account type=string
-FLAG basecamp documents document list --agent type=bool
-FLAG basecamp documents document list --all type=bool
-FLAG basecamp documents document list --cache-dir type=string
-FLAG basecamp documents document list --count type=bool
-FLAG basecamp documents document list --folder type=string
-FLAG basecamp documents document list --help type=bool
-FLAG basecamp documents document list --hints type=bool
-FLAG basecamp documents document list --ids-only type=bool
-FLAG basecamp documents document list --in type=string
-FLAG basecamp documents document list --jq type=string
-FLAG basecamp documents document list --json type=bool
-FLAG basecamp documents document list --limit type=int
-FLAG basecamp documents document list --markdown type=bool
-FLAG basecamp documents document list --md type=bool
-FLAG basecamp documents document list --no-hints type=bool
-FLAG basecamp documents document list --no-stats type=bool
-FLAG basecamp documents document list --page type=int
-FLAG basecamp documents document list --profile type=string
-FLAG basecamp documents document list --project type=string
-FLAG basecamp documents document list --quiet type=bool
-FLAG basecamp documents document list --stats type=bool
-FLAG basecamp documents document list --styled type=bool
-FLAG basecamp documents document list --todolist type=string
-FLAG basecamp documents document list --vault type=string
-FLAG basecamp documents document list --verbose type=count
-FLAG basecamp documents document list --version type=bool
-FLAG basecamp documents documents --account type=string
-FLAG basecamp documents documents --agent type=bool
-FLAG basecamp documents documents --all type=bool
-FLAG basecamp documents documents --cache-dir type=string
-FLAG basecamp documents documents --count type=bool
-FLAG basecamp documents documents --folder type=string
-FLAG basecamp documents documents --help type=bool
-FLAG basecamp documents documents --hints type=bool
-FLAG basecamp documents documents --ids-only type=bool
-FLAG basecamp documents documents --in type=string
-FLAG basecamp documents documents --jq type=string
-FLAG basecamp documents documents --json type=bool
-FLAG basecamp documents documents --limit type=int
-FLAG basecamp documents documents --markdown type=bool
-FLAG basecamp documents documents --md type=bool
-FLAG basecamp documents documents --no-hints type=bool
-FLAG basecamp documents documents --no-stats type=bool
-FLAG basecamp documents documents --page type=int
-FLAG basecamp documents documents --profile type=string
-FLAG basecamp documents documents --project type=string
-FLAG basecamp documents documents --quiet type=bool
-FLAG basecamp documents documents --stats type=bool
-FLAG basecamp documents documents --styled type=bool
-FLAG basecamp documents documents --todolist type=string
-FLAG basecamp documents documents --vault type=string
-FLAG basecamp documents documents --verbose type=count
-FLAG basecamp documents documents --version type=bool
-FLAG basecamp documents documents create --account type=string
-FLAG basecamp documents documents create --agent type=bool
-FLAG basecamp documents documents create --attach type=stringArray
-FLAG basecamp documents documents create --cache-dir type=string
-FLAG basecamp documents documents create --count type=bool
-FLAG basecamp documents documents create --draft type=bool
-FLAG basecamp documents documents create --folder type=string
-FLAG basecamp documents documents create --help type=bool
-FLAG basecamp documents documents create --hints type=bool
-FLAG basecamp documents documents create --ids-only type=bool
-FLAG basecamp documents documents create --in type=string
-FLAG basecamp documents documents create --jq type=string
-FLAG basecamp documents documents create --json type=bool
-FLAG basecamp documents documents create --markdown type=bool
-FLAG basecamp documents documents create --md type=bool
-FLAG basecamp documents documents create --no-hints type=bool
-FLAG basecamp documents documents create --no-stats type=bool
-FLAG basecamp documents documents create --no-subscribe type=bool
-FLAG basecamp documents documents create --profile type=string
-FLAG basecamp documents documents create --project type=string
-FLAG basecamp documents documents create --quiet type=bool
-FLAG basecamp documents documents create --stats type=bool
-FLAG basecamp documents documents create --styled type=bool
-FLAG basecamp documents documents create --subscribe type=string
-FLAG basecamp documents documents create --todolist type=string
-FLAG basecamp documents documents create --vault type=string
-FLAG basecamp documents documents create --verbose type=count
-FLAG basecamp documents documents create --version type=bool
-FLAG basecamp documents documents list --account type=string
-FLAG basecamp documents documents list --agent type=bool
-FLAG basecamp documents documents list --all type=bool
-FLAG basecamp documents documents list --cache-dir type=string
-FLAG basecamp documents documents list --count type=bool
-FLAG basecamp documents documents list --folder type=string
-FLAG basecamp documents documents list --help type=bool
-FLAG basecamp documents documents list --hints type=bool
-FLAG basecamp documents documents list --ids-only type=bool
-FLAG basecamp documents documents list --in type=string
-FLAG basecamp documents documents list --jq type=string
-FLAG basecamp documents documents list --json type=bool
-FLAG basecamp documents documents list --limit type=int
-FLAG basecamp documents documents list --markdown type=bool
-FLAG basecamp documents documents list --md type=bool
-FLAG basecamp documents documents list --no-hints type=bool
-FLAG basecamp documents documents list --no-stats type=bool
-FLAG basecamp documents documents list --page type=int
-FLAG basecamp documents documents list --profile type=string
-FLAG basecamp documents documents list --project type=string
-FLAG basecamp documents documents list --quiet type=bool
-FLAG basecamp documents documents list --stats type=bool
-FLAG basecamp documents documents list --styled type=bool
-FLAG basecamp documents documents list --todolist type=string
-FLAG basecamp documents documents list --vault type=string
-FLAG basecamp documents documents list --verbose type=count
-FLAG basecamp documents documents list --version type=bool
-FLAG basecamp documents download --account type=string
-FLAG basecamp documents download --agent type=bool
-FLAG basecamp documents download --cache-dir type=string
-FLAG basecamp documents download --count type=bool
-FLAG basecamp documents download --folder type=string
-FLAG basecamp documents download --help type=bool
-FLAG basecamp documents download --hints type=bool
-FLAG basecamp documents download --ids-only type=bool
-FLAG basecamp documents download --in type=string
-FLAG basecamp documents download --jq type=string
-FLAG basecamp documents download --json type=bool
-FLAG basecamp documents download --markdown type=bool
-FLAG basecamp documents download --md type=bool
-FLAG basecamp documents download --no-hints type=bool
-FLAG basecamp documents download --no-stats type=bool
-FLAG basecamp documents download --out type=string
-FLAG basecamp documents download --profile type=string
-FLAG basecamp documents download --project type=string
-FLAG basecamp documents download --quiet type=bool
-FLAG basecamp documents download --stats type=bool
-FLAG basecamp documents download --styled type=bool
-FLAG basecamp documents download --todolist type=string
-FLAG basecamp documents download --vault type=string
-FLAG basecamp documents download --verbose type=count
-FLAG basecamp documents download --version type=bool
-FLAG basecamp documents folder --account type=string
-FLAG basecamp documents folder --agent type=bool
-FLAG basecamp documents folder --all type=bool
-FLAG basecamp documents folder --cache-dir type=string
-FLAG basecamp documents folder --count type=bool
-FLAG basecamp documents folder --folder type=string
-FLAG basecamp documents folder --help type=bool
-FLAG basecamp documents folder --hints type=bool
-FLAG basecamp documents folder --ids-only type=bool
-FLAG basecamp documents folder --in type=string
-FLAG basecamp documents folder --jq type=string
-FLAG basecamp documents folder --json type=bool
-FLAG basecamp documents folder --limit type=int
-FLAG basecamp documents folder --markdown type=bool
-FLAG basecamp documents folder --md type=bool
-FLAG basecamp documents folder --no-hints type=bool
-FLAG basecamp documents folder --no-stats type=bool
-FLAG basecamp documents folder --page type=int
-FLAG basecamp documents folder --profile type=string
-FLAG basecamp documents folder --project type=string
-FLAG basecamp documents folder --quiet type=bool
-FLAG basecamp documents folder --stats type=bool
-FLAG basecamp documents folder --styled type=bool
-FLAG basecamp documents folder --todolist type=string
-FLAG basecamp documents folder --vault type=string
-FLAG basecamp documents folder --verbose type=count
-FLAG basecamp documents folder --version type=bool
-FLAG basecamp documents folder create --account type=string
-FLAG basecamp documents folder create --agent type=bool
-FLAG basecamp documents folder create --cache-dir type=string
-FLAG basecamp documents folder create --count type=bool
-FLAG basecamp documents folder create --folder type=string
-FLAG basecamp documents folder create --help type=bool
-FLAG basecamp documents folder create --hints type=bool
-FLAG basecamp documents folder create --ids-only type=bool
-FLAG basecamp documents folder create --in type=string
-FLAG basecamp documents folder create --jq type=string
-FLAG basecamp documents folder create --json type=bool
-FLAG basecamp documents folder create --markdown type=bool
-FLAG basecamp documents folder create --md type=bool
-FLAG basecamp documents folder create --no-hints type=bool
-FLAG basecamp documents folder create --no-stats type=bool
-FLAG basecamp documents folder create --profile type=string
-FLAG basecamp documents folder create --project type=string
-FLAG basecamp documents folder create --quiet type=bool
-FLAG basecamp documents folder create --stats type=bool
-FLAG basecamp documents folder create --styled type=bool
-FLAG basecamp documents folder create --todolist type=string
-FLAG basecamp documents folder create --vault type=string
-FLAG basecamp documents folder create --verbose type=count
-FLAG basecamp documents folder create --version type=bool
-FLAG basecamp documents folder list --account type=string
-FLAG basecamp documents folder list --agent type=bool
-FLAG basecamp documents folder list --all type=bool
-FLAG basecamp documents folder list --cache-dir type=string
-FLAG basecamp documents folder list --count type=bool
-FLAG basecamp documents folder list --folder type=string
-FLAG basecamp documents folder list --help type=bool
-FLAG basecamp documents folder list --hints type=bool
-FLAG basecamp documents folder list --ids-only type=bool
-FLAG basecamp documents folder list --in type=string
-FLAG basecamp documents folder list --jq type=string
-FLAG basecamp documents folder list --json type=bool
-FLAG basecamp documents folder list --limit type=int
-FLAG basecamp documents folder list --markdown type=bool
-FLAG basecamp documents folder list --md type=bool
-FLAG basecamp documents folder list --no-hints type=bool
-FLAG basecamp documents folder list --no-stats type=bool
-FLAG basecamp documents folder list --page type=int
-FLAG basecamp documents folder list --profile type=string
-FLAG basecamp documents folder list --project type=string
-FLAG basecamp documents folder list --quiet type=bool
-FLAG basecamp documents folder list --stats type=bool
-FLAG basecamp documents folder list --styled type=bool
-FLAG basecamp documents folder list --todolist type=string
-FLAG basecamp documents folder list --vault type=string
-FLAG basecamp documents folder list --verbose type=count
-FLAG basecamp documents folder list --version type=bool
-FLAG basecamp documents folders --account type=string
-FLAG basecamp documents folders --agent type=bool
-FLAG basecamp documents folders --all type=bool
-FLAG basecamp documents folders --cache-dir type=string
-FLAG basecamp documents folders --count type=bool
-FLAG basecamp documents folders --folder type=string
-FLAG basecamp documents folders --help type=bool
-FLAG basecamp documents folders --hints type=bool
-FLAG basecamp documents folders --ids-only type=bool
-FLAG basecamp documents folders --in type=string
-FLAG basecamp documents folders --jq type=string
-FLAG basecamp documents folders --json type=bool
-FLAG basecamp documents folders --limit type=int
-FLAG basecamp documents folders --markdown type=bool
-FLAG basecamp documents folders --md type=bool
-FLAG basecamp documents folders --no-hints type=bool
-FLAG basecamp documents folders --no-stats type=bool
-FLAG basecamp documents folders --page type=int
-FLAG basecamp documents folders --profile type=string
-FLAG basecamp documents folders --project type=string
-FLAG basecamp documents folders --quiet type=bool
-FLAG basecamp documents folders --stats type=bool
-FLAG basecamp documents folders --styled type=bool
-FLAG basecamp documents folders --todolist type=string
-FLAG basecamp documents folders --vault type=string
-FLAG basecamp documents folders --verbose type=count
-FLAG basecamp documents folders --version type=bool
-FLAG basecamp documents folders create --account type=string
-FLAG basecamp documents folders create --agent type=bool
-FLAG basecamp documents folders create --cache-dir type=string
-FLAG basecamp documents folders create --count type=bool
-FLAG basecamp documents folders create --folder type=string
-FLAG basecamp documents folders create --help type=bool
-FLAG basecamp documents folders create --hints type=bool
-FLAG basecamp documents folders create --ids-only type=bool
-FLAG basecamp documents folders create --in type=string
-FLAG basecamp documents folders create --jq type=string
-FLAG basecamp documents folders create --json type=bool
-FLAG basecamp documents folders create --markdown type=bool
-FLAG basecamp documents folders create --md type=bool
-FLAG basecamp documents folders create --no-hints type=bool
-FLAG basecamp documents folders create --no-stats type=bool
-FLAG basecamp documents folders create --profile type=string
-FLAG basecamp documents folders create --project type=string
-FLAG basecamp documents folders create --quiet type=bool
-FLAG basecamp documents folders create --stats type=bool
-FLAG basecamp documents folders create --styled type=bool
-FLAG basecamp documents folders create --todolist type=string
-FLAG basecamp documents folders create --vault type=string
-FLAG basecamp documents folders create --verbose type=count
-FLAG basecamp documents folders create --version type=bool
-FLAG basecamp documents folders list --account type=string
-FLAG basecamp documents folders list --agent type=bool
-FLAG basecamp documents folders list --all type=bool
-FLAG basecamp documents folders list --cache-dir type=string
-FLAG basecamp documents folders list --count type=bool
-FLAG basecamp documents folders list --folder type=string
-FLAG basecamp documents folders list --help type=bool
-FLAG basecamp documents folders list --hints type=bool
-FLAG basecamp documents folders list --ids-only type=bool
-FLAG basecamp documents folders list --in type=string
-FLAG basecamp documents folders list --jq type=string
-FLAG basecamp documents folders list --json type=bool
-FLAG basecamp documents folders list --limit type=int
-FLAG basecamp documents folders list --markdown type=bool
-FLAG basecamp documents folders list --md type=bool
-FLAG basecamp documents folders list --no-hints type=bool
-FLAG basecamp documents folders list --no-stats type=bool
-FLAG basecamp documents folders list --page type=int
-FLAG basecamp documents folders list --profile type=string
-FLAG basecamp documents folders list --project type=string
-FLAG basecamp documents folders list --quiet type=bool
-FLAG basecamp documents folders list --stats type=bool
-FLAG basecamp documents folders list --styled type=bool
-FLAG basecamp documents folders list --todolist type=string
-FLAG basecamp documents folders list --vault type=string
-FLAG basecamp documents folders list --verbose type=count
-FLAG basecamp documents folders list --version type=bool
-FLAG basecamp documents list --account type=string
-FLAG basecamp documents list --agent type=bool
-FLAG basecamp documents list --cache-dir type=string
-FLAG basecamp documents list --count type=bool
-FLAG basecamp documents list --folder type=string
-FLAG basecamp documents list --help type=bool
-FLAG basecamp documents list --hints type=bool
-FLAG basecamp documents list --ids-only type=bool
-FLAG basecamp documents list --in type=string
-FLAG basecamp documents list --jq type=string
-FLAG basecamp documents list --json type=bool
-FLAG basecamp documents list --markdown type=bool
-FLAG basecamp documents list --md type=bool
-FLAG basecamp documents list --no-hints type=bool
-FLAG basecamp documents list --no-stats type=bool
-FLAG basecamp documents list --profile type=string
-FLAG basecamp documents list --project type=string
-FLAG basecamp documents list --quiet type=bool
-FLAG basecamp documents list --stats type=bool
-FLAG basecamp documents list --styled type=bool
-FLAG basecamp documents list --todolist type=string
-FLAG basecamp documents list --vault type=string
-FLAG basecamp documents list --verbose type=count
-FLAG basecamp documents list --version type=bool
-FLAG basecamp documents restore --account type=string
-FLAG basecamp documents restore --agent type=bool
-FLAG basecamp documents restore --cache-dir type=string
-FLAG basecamp documents restore --count type=bool
-FLAG basecamp documents restore --folder type=string
-FLAG basecamp documents restore --help type=bool
-FLAG basecamp documents restore --hints type=bool
-FLAG basecamp documents restore --ids-only type=bool
-FLAG basecamp documents restore --in type=string
-FLAG basecamp documents restore --jq type=string
-FLAG basecamp documents restore --json type=bool
-FLAG basecamp documents restore --markdown type=bool
-FLAG basecamp documents restore --md type=bool
-FLAG basecamp documents restore --no-hints type=bool
-FLAG basecamp documents restore --no-stats type=bool
-FLAG basecamp documents restore --profile type=string
-FLAG basecamp documents restore --project type=string
-FLAG basecamp documents restore --quiet type=bool
-FLAG basecamp documents restore --stats type=bool
-FLAG basecamp documents restore --styled type=bool
-FLAG basecamp documents restore --todolist type=string
-FLAG basecamp documents restore --vault type=string
-FLAG basecamp documents restore --verbose type=count
-FLAG basecamp documents restore --version type=bool
-FLAG basecamp documents show --account type=string
-FLAG basecamp documents show --agent type=bool
-FLAG basecamp documents show --cache-dir type=string
-FLAG basecamp documents show --count type=bool
-FLAG basecamp documents show --folder type=string
-FLAG basecamp documents show --help type=bool
-FLAG basecamp documents show --hints type=bool
-FLAG basecamp documents show --ids-only type=bool
-FLAG basecamp documents show --in type=string
-FLAG basecamp documents show --jq type=string
-FLAG basecamp documents show --json type=bool
-FLAG basecamp documents show --markdown type=bool
-FLAG basecamp documents show --md type=bool
-FLAG basecamp documents show --no-hints type=bool
-FLAG basecamp documents show --no-stats type=bool
-FLAG basecamp documents show --profile type=string
-FLAG basecamp documents show --project type=string
-FLAG basecamp documents show --quiet type=bool
-FLAG basecamp documents show --stats type=bool
-FLAG basecamp documents show --styled type=bool
-FLAG basecamp documents show --todolist type=string
-FLAG basecamp documents show --type type=string
-FLAG basecamp documents show --vault type=string
-FLAG basecamp documents show --verbose type=count
-FLAG basecamp documents show --version type=bool
-FLAG basecamp documents trash --account type=string
-FLAG basecamp documents trash --agent type=bool
-FLAG basecamp documents trash --cache-dir type=string
-FLAG basecamp documents trash --count type=bool
-FLAG basecamp documents trash --folder type=string
-FLAG basecamp documents trash --help type=bool
-FLAG basecamp documents trash --hints type=bool
-FLAG basecamp documents trash --ids-only type=bool
-FLAG basecamp documents trash --in type=string
-FLAG basecamp documents trash --jq type=string
-FLAG basecamp documents trash --json type=bool
-FLAG basecamp documents trash --markdown type=bool
-FLAG basecamp documents trash --md type=bool
-FLAG basecamp documents trash --no-hints type=bool
-FLAG basecamp documents trash --no-stats type=bool
-FLAG basecamp documents trash --profile type=string
-FLAG basecamp documents trash --project type=string
-FLAG basecamp documents trash --quiet type=bool
-FLAG basecamp documents trash --stats type=bool
-FLAG basecamp documents trash --styled type=bool
-FLAG basecamp documents trash --todolist type=string
-FLAG basecamp documents trash --vault type=string
-FLAG basecamp documents trash --verbose type=count
-FLAG basecamp documents trash --version type=bool
-FLAG basecamp documents update --account type=string
-FLAG basecamp documents update --agent type=bool
-FLAG basecamp documents update --cache-dir type=string
-FLAG basecamp documents update --content type=string
-FLAG basecamp documents update --count type=bool
-FLAG basecamp documents update --folder type=string
-FLAG basecamp documents update --help type=bool
-FLAG basecamp documents update --hints type=bool
-FLAG basecamp documents update --ids-only type=bool
-FLAG basecamp documents update --in type=string
-FLAG basecamp documents update --jq type=string
-FLAG basecamp documents update --json type=bool
-FLAG basecamp documents update --markdown type=bool
-FLAG basecamp documents update --md type=bool
-FLAG basecamp documents update --no-hints type=bool
-FLAG basecamp documents update --no-stats type=bool
-FLAG basecamp documents update --profile type=string
-FLAG basecamp documents update --project type=string
-FLAG basecamp documents update --quiet type=bool
-FLAG basecamp documents update --stats type=bool
-FLAG basecamp documents update --styled type=bool
-FLAG basecamp documents update --title type=string
-FLAG basecamp documents update --todolist type=string
-FLAG basecamp documents update --type type=string
-FLAG basecamp documents update --vault type=string
-FLAG basecamp documents update --verbose type=count
-FLAG basecamp documents update --version type=bool
-FLAG basecamp documents upload --account type=string
-FLAG basecamp documents upload --agent type=bool
-FLAG basecamp documents upload --all type=bool
-FLAG basecamp documents upload --cache-dir type=string
-FLAG basecamp documents upload --count type=bool
-FLAG basecamp documents upload --folder type=string
-FLAG basecamp documents upload --help type=bool
-FLAG basecamp documents upload --hints type=bool
-FLAG basecamp documents upload --ids-only type=bool
-FLAG basecamp documents upload --in type=string
-FLAG basecamp documents upload --jq type=string
-FLAG basecamp documents upload --json type=bool
-FLAG basecamp documents upload --limit type=int
-FLAG basecamp documents upload --markdown type=bool
-FLAG basecamp documents upload --md type=bool
-FLAG basecamp documents upload --no-hints type=bool
-FLAG basecamp documents upload --no-stats type=bool
-FLAG basecamp documents upload --page type=int
-FLAG basecamp documents upload --profile type=string
-FLAG basecamp documents upload --project type=string
-FLAG basecamp documents upload --quiet type=bool
-FLAG basecamp documents upload --stats type=bool
-FLAG basecamp documents upload --styled type=bool
-FLAG basecamp documents upload --todolist type=string
-FLAG basecamp documents upload --vault type=string
-FLAG basecamp documents upload --verbose type=count
-FLAG basecamp documents upload --version type=bool
-FLAG basecamp documents upload create --account type=string
-FLAG basecamp documents upload create --agent type=bool
-FLAG basecamp documents upload create --cache-dir type=string
-FLAG basecamp documents upload create --count type=bool
-FLAG basecamp documents upload create --description type=string
-FLAG basecamp documents upload create --folder type=string
-FLAG basecamp documents upload create --help type=bool
-FLAG basecamp documents upload create --hints type=bool
-FLAG basecamp documents upload create --ids-only type=bool
-FLAG basecamp documents upload create --in type=string
-FLAG basecamp documents upload create --jq type=string
-FLAG basecamp documents upload create --json type=bool
-FLAG basecamp documents upload create --markdown type=bool
-FLAG basecamp documents upload create --md type=bool
-FLAG basecamp documents upload create --no-hints type=bool
-FLAG basecamp documents upload create --no-stats type=bool
-FLAG basecamp documents upload create --profile type=string
-FLAG basecamp documents upload create --project type=string
-FLAG basecamp documents upload create --quiet type=bool
-FLAG basecamp documents upload create --stats type=bool
-FLAG basecamp documents upload create --styled type=bool
-FLAG basecamp documents upload create --todolist type=string
-FLAG basecamp documents upload create --vault type=string
-FLAG basecamp documents upload create --verbose type=count
-FLAG basecamp documents upload create --version type=bool
-FLAG basecamp documents upload list --account type=string
-FLAG basecamp documents upload list --agent type=bool
-FLAG basecamp documents upload list --all type=bool
-FLAG basecamp documents upload list --cache-dir type=string
-FLAG basecamp documents upload list --count type=bool
-FLAG basecamp documents upload list --folder type=string
-FLAG basecamp documents upload list --help type=bool
-FLAG basecamp documents upload list --hints type=bool
-FLAG basecamp documents upload list --ids-only type=bool
-FLAG basecamp documents upload list --in type=string
-FLAG basecamp documents upload list --jq type=string
-FLAG basecamp documents upload list --json type=bool
-FLAG basecamp documents upload list --limit type=int
-FLAG basecamp documents upload list --markdown type=bool
-FLAG basecamp documents upload list --md type=bool
-FLAG basecamp documents upload list --no-hints type=bool
-FLAG basecamp documents upload list --no-stats type=bool
-FLAG basecamp documents upload list --page type=int
-FLAG basecamp documents upload list --profile type=string
-FLAG basecamp documents upload list --project type=string
-FLAG basecamp documents upload list --quiet type=bool
-FLAG basecamp documents upload list --stats type=bool
-FLAG basecamp documents upload list --styled type=bool
-FLAG basecamp documents upload list --todolist type=string
-FLAG basecamp documents upload list --vault type=string
-FLAG basecamp documents upload list --verbose type=count
-FLAG basecamp documents upload list --version type=bool
-FLAG basecamp documents uploads --account type=string
-FLAG basecamp documents uploads --agent type=bool
-FLAG basecamp documents uploads --all type=bool
-FLAG basecamp documents uploads --cache-dir type=string
-FLAG basecamp documents uploads --count type=bool
-FLAG basecamp documents uploads --folder type=string
-FLAG basecamp documents uploads --help type=bool
-FLAG basecamp documents uploads --hints type=bool
-FLAG basecamp documents uploads --ids-only type=bool
-FLAG basecamp documents uploads --in type=string
-FLAG basecamp documents uploads --jq type=string
-FLAG basecamp documents uploads --json type=bool
-FLAG basecamp documents uploads --limit type=int
-FLAG basecamp documents uploads --markdown type=bool
-FLAG basecamp documents uploads --md type=bool
-FLAG basecamp documents uploads --no-hints type=bool
-FLAG basecamp documents uploads --no-stats type=bool
-FLAG basecamp documents uploads --page type=int
-FLAG basecamp documents uploads --profile type=string
-FLAG basecamp documents uploads --project type=string
-FLAG basecamp documents uploads --quiet type=bool
-FLAG basecamp documents uploads --stats type=bool
-FLAG basecamp documents uploads --styled type=bool
-FLAG basecamp documents uploads --todolist type=string
-FLAG basecamp documents uploads --vault type=string
-FLAG basecamp documents uploads --verbose type=count
-FLAG basecamp documents uploads --version type=bool
-FLAG basecamp documents uploads create --account type=string
-FLAG basecamp documents uploads create --agent type=bool
-FLAG basecamp documents uploads create --cache-dir type=string
-FLAG basecamp documents uploads create --count type=bool
-FLAG basecamp documents uploads create --description type=string
-FLAG basecamp documents uploads create --folder type=string
-FLAG basecamp documents uploads create --help type=bool
-FLAG basecamp documents uploads create --hints type=bool
-FLAG basecamp documents uploads create --ids-only type=bool
-FLAG basecamp documents uploads create --in type=string
-FLAG basecamp documents uploads create --jq type=string
-FLAG basecamp documents uploads create --json type=bool
-FLAG basecamp documents uploads create --markdown type=bool
-FLAG basecamp documents uploads create --md type=bool
-FLAG basecamp documents uploads create --no-hints type=bool
-FLAG basecamp documents uploads create --no-stats type=bool
-FLAG basecamp documents uploads create --profile type=string
-FLAG basecamp documents uploads create --project type=string
-FLAG basecamp documents uploads create --quiet type=bool
-FLAG basecamp documents uploads create --stats type=bool
-FLAG basecamp documents uploads create --styled type=bool
-FLAG basecamp documents uploads create --todolist type=string
-FLAG basecamp documents uploads create --vault type=string
-FLAG basecamp documents uploads create --verbose type=count
-FLAG basecamp documents uploads create --version type=bool
-FLAG basecamp documents uploads list --account type=string
-FLAG basecamp documents uploads list --agent type=bool
-FLAG basecamp documents uploads list --all type=bool
-FLAG basecamp documents uploads list --cache-dir type=string
-FLAG basecamp documents uploads list --count type=bool
-FLAG basecamp documents uploads list --folder type=string
-FLAG basecamp documents uploads list --help type=bool
-FLAG basecamp documents uploads list --hints type=bool
-FLAG basecamp documents uploads list --ids-only type=bool
-FLAG basecamp documents uploads list --in type=string
-FLAG basecamp documents uploads list --jq type=string
-FLAG basecamp documents uploads list --json type=bool
-FLAG basecamp documents uploads list --limit type=int
-FLAG basecamp documents uploads list --markdown type=bool
-FLAG basecamp documents uploads list --md type=bool
-FLAG basecamp documents uploads list --no-hints type=bool
-FLAG basecamp documents uploads list --no-stats type=bool
-FLAG basecamp documents uploads list --page type=int
-FLAG basecamp documents uploads list --profile type=string
-FLAG basecamp documents uploads list --project type=string
-FLAG basecamp documents uploads list --quiet type=bool
-FLAG basecamp documents uploads list --stats type=bool
-FLAG basecamp documents uploads list --styled type=bool
-FLAG basecamp documents uploads list --todolist type=string
-FLAG basecamp documents uploads list --vault type=string
-FLAG basecamp documents uploads list --verbose type=count
-FLAG basecamp documents uploads list --version type=bool
-FLAG basecamp documents vault --account type=string
-FLAG basecamp documents vault --agent type=bool
-FLAG basecamp documents vault --all type=bool
-FLAG basecamp documents vault --cache-dir type=string
-FLAG basecamp documents vault --count type=bool
-FLAG basecamp documents vault --folder type=string
-FLAG basecamp documents vault --help type=bool
-FLAG basecamp documents vault --hints type=bool
-FLAG basecamp documents vault --ids-only type=bool
-FLAG basecamp documents vault --in type=string
-FLAG basecamp documents vault --jq type=string
-FLAG basecamp documents vault --json type=bool
-FLAG basecamp documents vault --limit type=int
-FLAG basecamp documents vault --markdown type=bool
-FLAG basecamp documents vault --md type=bool
-FLAG basecamp documents vault --no-hints type=bool
-FLAG basecamp documents vault --no-stats type=bool
-FLAG basecamp documents vault --page type=int
-FLAG basecamp documents vault --profile type=string
-FLAG basecamp documents vault --project type=string
-FLAG basecamp documents vault --quiet type=bool
-FLAG basecamp documents vault --stats type=bool
-FLAG basecamp documents vault --styled type=bool
-FLAG basecamp documents vault --todolist type=string
-FLAG basecamp documents vault --vault type=string
-FLAG basecamp documents vault --verbose type=count
-FLAG basecamp documents vault --version type=bool
-FLAG basecamp documents vault create --account type=string
-FLAG basecamp documents vault create --agent type=bool
-FLAG basecamp documents vault create --cache-dir type=string
-FLAG basecamp documents vault create --count type=bool
-FLAG basecamp documents vault create --folder type=string
-FLAG basecamp documents vault create --help type=bool
-FLAG basecamp documents vault create --hints type=bool
-FLAG basecamp documents vault create --ids-only type=bool
-FLAG basecamp documents vault create --in type=string
-FLAG basecamp documents vault create --jq type=string
-FLAG basecamp documents vault create --json type=bool
-FLAG basecamp documents vault create --markdown type=bool
-FLAG basecamp documents vault create --md type=bool
-FLAG basecamp documents vault create --no-hints type=bool
-FLAG basecamp documents vault create --no-stats type=bool
-FLAG basecamp documents vault create --profile type=string
-FLAG basecamp documents vault create --project type=string
-FLAG basecamp documents vault create --quiet type=bool
-FLAG basecamp documents vault create --stats type=bool
-FLAG basecamp documents vault create --styled type=bool
-FLAG basecamp documents vault create --todolist type=string
-FLAG basecamp documents vault create --vault type=string
-FLAG basecamp documents vault create --verbose type=count
-FLAG basecamp documents vault create --version type=bool
-FLAG basecamp documents vault list --account type=string
-FLAG basecamp documents vault list --agent type=bool
-FLAG basecamp documents vault list --all type=bool
-FLAG basecamp documents vault list --cache-dir type=string
-FLAG basecamp documents vault list --count type=bool
-FLAG basecamp documents vault list --folder type=string
-FLAG basecamp documents vault list --help type=bool
-FLAG basecamp documents vault list --hints type=bool
-FLAG basecamp documents vault list --ids-only type=bool
-FLAG basecamp documents vault list --in type=string
-FLAG basecamp documents vault list --jq type=string
-FLAG basecamp documents vault list --json type=bool
-FLAG basecamp documents vault list --limit type=int
-FLAG basecamp documents vault list --markdown type=bool
-FLAG basecamp documents vault list --md type=bool
-FLAG basecamp documents vault list --no-hints type=bool
-FLAG basecamp documents vault list --no-stats type=bool
-FLAG basecamp documents vault list --page type=int
-FLAG basecamp documents vault list --profile type=string
-FLAG basecamp documents vault list --project type=string
-FLAG basecamp documents vault list --quiet type=bool
-FLAG basecamp documents vault list --stats type=bool
-FLAG basecamp documents vault list --styled type=bool
-FLAG basecamp documents vault list --todolist type=string
-FLAG basecamp documents vault list --vault type=string
-FLAG basecamp documents vault list --verbose type=count
-FLAG basecamp documents vault list --version type=bool
-FLAG basecamp documents vaults --account type=string
-FLAG basecamp documents vaults --agent type=bool
-FLAG basecamp documents vaults --all type=bool
-FLAG basecamp documents vaults --cache-dir type=string
-FLAG basecamp documents vaults --count type=bool
-FLAG basecamp documents vaults --folder type=string
-FLAG basecamp documents vaults --help type=bool
-FLAG basecamp documents vaults --hints type=bool
-FLAG basecamp documents vaults --ids-only type=bool
-FLAG basecamp documents vaults --in type=string
-FLAG basecamp documents vaults --jq type=string
-FLAG basecamp documents vaults --json type=bool
-FLAG basecamp documents vaults --limit type=int
-FLAG basecamp documents vaults --markdown type=bool
-FLAG basecamp documents vaults --md type=bool
-FLAG basecamp documents vaults --no-hints type=bool
-FLAG basecamp documents vaults --no-stats type=bool
-FLAG basecamp documents vaults --page type=int
-FLAG basecamp documents vaults --profile type=string
-FLAG basecamp documents vaults --project type=string
-FLAG basecamp documents vaults --quiet type=bool
-FLAG basecamp documents vaults --stats type=bool
-FLAG basecamp documents vaults --styled type=bool
-FLAG basecamp documents vaults --todolist type=string
-FLAG basecamp documents vaults --vault type=string
-FLAG basecamp documents vaults --verbose type=count
-FLAG basecamp documents vaults --version type=bool
-FLAG basecamp documents vaults create --account type=string
-FLAG basecamp documents vaults create --agent type=bool
-FLAG basecamp documents vaults create --cache-dir type=string
-FLAG basecamp documents vaults create --count type=bool
-FLAG basecamp documents vaults create --folder type=string
-FLAG basecamp documents vaults create --help type=bool
-FLAG basecamp documents vaults create --hints type=bool
-FLAG basecamp documents vaults create --ids-only type=bool
-FLAG basecamp documents vaults create --in type=string
-FLAG basecamp documents vaults create --jq type=string
-FLAG basecamp documents vaults create --json type=bool
-FLAG basecamp documents vaults create --markdown type=bool
-FLAG basecamp documents vaults create --md type=bool
-FLAG basecamp documents vaults create --no-hints type=bool
-FLAG basecamp documents vaults create --no-stats type=bool
-FLAG basecamp documents vaults create --profile type=string
-FLAG basecamp documents vaults create --project type=string
-FLAG basecamp documents vaults create --quiet type=bool
-FLAG basecamp documents vaults create --stats type=bool
-FLAG basecamp documents vaults create --styled type=bool
-FLAG basecamp documents vaults create --todolist type=string
-FLAG basecamp documents vaults create --vault type=string
-FLAG basecamp documents vaults create --verbose type=count
-FLAG basecamp documents vaults create --version type=bool
-FLAG basecamp documents vaults list --account type=string
-FLAG basecamp documents vaults list --agent type=bool
-FLAG basecamp documents vaults list --all type=bool
-FLAG basecamp documents vaults list --cache-dir type=string
-FLAG basecamp documents vaults list --count type=bool
-FLAG basecamp documents vaults list --folder type=string
-FLAG basecamp documents vaults list --help type=bool
-FLAG basecamp documents vaults list --hints type=bool
-FLAG basecamp documents vaults list --ids-only type=bool
-FLAG basecamp documents vaults list --in type=string
-FLAG basecamp documents vaults list --jq type=string
-FLAG basecamp documents vaults list --json type=bool
-FLAG basecamp documents vaults list --limit type=int
-FLAG basecamp documents vaults list --markdown type=bool
-FLAG basecamp documents vaults list --md type=bool
-FLAG basecamp documents vaults list --no-hints type=bool
-FLAG basecamp documents vaults list --no-stats type=bool
-FLAG basecamp documents vaults list --page type=int
-FLAG basecamp documents vaults list --profile type=string
-FLAG basecamp documents vaults list --project type=string
-FLAG basecamp documents vaults list --quiet type=bool
-FLAG basecamp documents vaults list --stats type=bool
-FLAG basecamp documents vaults list --styled type=bool
-FLAG basecamp documents vaults list --todolist type=string
-FLAG basecamp documents vaults list --vault type=string
-FLAG basecamp documents vaults list --verbose type=count
-FLAG basecamp documents vaults list --version type=bool
 FLAG basecamp done --account type=string
 FLAG basecamp done --agent type=bool
 FLAG basecamp done --cache-dir type=string
 FLAG basecamp done --count type=bool
-FLAG basecamp done --help type=bool
 FLAG basecamp done --hints type=bool
 FLAG basecamp done --ids-only type=bool
 FLAG basecamp done --in type=string
@@ -6057,13 +3109,11 @@ FLAG basecamp done --stats type=bool
 FLAG basecamp done --styled type=bool
 FLAG basecamp done --todolist type=string
 FLAG basecamp done --verbose type=count
-FLAG basecamp done --version type=bool
 FLAG basecamp events --account type=string
 FLAG basecamp events --agent type=bool
 FLAG basecamp events --all type=bool
 FLAG basecamp events --cache-dir type=string
 FLAG basecamp events --count type=bool
-FLAG basecamp events --help type=bool
 FLAG basecamp events --hints type=bool
 FLAG basecamp events --ids-only type=bool
 FLAG basecamp events --in type=string
@@ -6082,926 +3132,11 @@ FLAG basecamp events --stats type=bool
 FLAG basecamp events --styled type=bool
 FLAG basecamp events --todolist type=string
 FLAG basecamp events --verbose type=count
-FLAG basecamp events --version type=bool
-FLAG basecamp file --account type=string
-FLAG basecamp file --agent type=bool
-FLAG basecamp file --cache-dir type=string
-FLAG basecamp file --count type=bool
-FLAG basecamp file --folder type=string
-FLAG basecamp file --help type=bool
-FLAG basecamp file --hints type=bool
-FLAG basecamp file --ids-only type=bool
-FLAG basecamp file --in type=string
-FLAG basecamp file --jq type=string
-FLAG basecamp file --json type=bool
-FLAG basecamp file --markdown type=bool
-FLAG basecamp file --md type=bool
-FLAG basecamp file --no-hints type=bool
-FLAG basecamp file --no-stats type=bool
-FLAG basecamp file --profile type=string
-FLAG basecamp file --project type=string
-FLAG basecamp file --quiet type=bool
-FLAG basecamp file --stats type=bool
-FLAG basecamp file --styled type=bool
-FLAG basecamp file --todolist type=string
-FLAG basecamp file --vault type=string
-FLAG basecamp file --verbose type=count
-FLAG basecamp file --version type=bool
-FLAG basecamp file archive --account type=string
-FLAG basecamp file archive --agent type=bool
-FLAG basecamp file archive --cache-dir type=string
-FLAG basecamp file archive --count type=bool
-FLAG basecamp file archive --folder type=string
-FLAG basecamp file archive --help type=bool
-FLAG basecamp file archive --hints type=bool
-FLAG basecamp file archive --ids-only type=bool
-FLAG basecamp file archive --in type=string
-FLAG basecamp file archive --jq type=string
-FLAG basecamp file archive --json type=bool
-FLAG basecamp file archive --markdown type=bool
-FLAG basecamp file archive --md type=bool
-FLAG basecamp file archive --no-hints type=bool
-FLAG basecamp file archive --no-stats type=bool
-FLAG basecamp file archive --profile type=string
-FLAG basecamp file archive --project type=string
-FLAG basecamp file archive --quiet type=bool
-FLAG basecamp file archive --stats type=bool
-FLAG basecamp file archive --styled type=bool
-FLAG basecamp file archive --todolist type=string
-FLAG basecamp file archive --vault type=string
-FLAG basecamp file archive --verbose type=count
-FLAG basecamp file archive --version type=bool
-FLAG basecamp file doc --account type=string
-FLAG basecamp file doc --agent type=bool
-FLAG basecamp file doc --all type=bool
-FLAG basecamp file doc --cache-dir type=string
-FLAG basecamp file doc --count type=bool
-FLAG basecamp file doc --folder type=string
-FLAG basecamp file doc --help type=bool
-FLAG basecamp file doc --hints type=bool
-FLAG basecamp file doc --ids-only type=bool
-FLAG basecamp file doc --in type=string
-FLAG basecamp file doc --jq type=string
-FLAG basecamp file doc --json type=bool
-FLAG basecamp file doc --limit type=int
-FLAG basecamp file doc --markdown type=bool
-FLAG basecamp file doc --md type=bool
-FLAG basecamp file doc --no-hints type=bool
-FLAG basecamp file doc --no-stats type=bool
-FLAG basecamp file doc --page type=int
-FLAG basecamp file doc --profile type=string
-FLAG basecamp file doc --project type=string
-FLAG basecamp file doc --quiet type=bool
-FLAG basecamp file doc --stats type=bool
-FLAG basecamp file doc --styled type=bool
-FLAG basecamp file doc --todolist type=string
-FLAG basecamp file doc --vault type=string
-FLAG basecamp file doc --verbose type=count
-FLAG basecamp file doc --version type=bool
-FLAG basecamp file doc create --account type=string
-FLAG basecamp file doc create --agent type=bool
-FLAG basecamp file doc create --attach type=stringArray
-FLAG basecamp file doc create --cache-dir type=string
-FLAG basecamp file doc create --count type=bool
-FLAG basecamp file doc create --draft type=bool
-FLAG basecamp file doc create --folder type=string
-FLAG basecamp file doc create --help type=bool
-FLAG basecamp file doc create --hints type=bool
-FLAG basecamp file doc create --ids-only type=bool
-FLAG basecamp file doc create --in type=string
-FLAG basecamp file doc create --jq type=string
-FLAG basecamp file doc create --json type=bool
-FLAG basecamp file doc create --markdown type=bool
-FLAG basecamp file doc create --md type=bool
-FLAG basecamp file doc create --no-hints type=bool
-FLAG basecamp file doc create --no-stats type=bool
-FLAG basecamp file doc create --no-subscribe type=bool
-FLAG basecamp file doc create --profile type=string
-FLAG basecamp file doc create --project type=string
-FLAG basecamp file doc create --quiet type=bool
-FLAG basecamp file doc create --stats type=bool
-FLAG basecamp file doc create --styled type=bool
-FLAG basecamp file doc create --subscribe type=string
-FLAG basecamp file doc create --todolist type=string
-FLAG basecamp file doc create --vault type=string
-FLAG basecamp file doc create --verbose type=count
-FLAG basecamp file doc create --version type=bool
-FLAG basecamp file doc list --account type=string
-FLAG basecamp file doc list --agent type=bool
-FLAG basecamp file doc list --all type=bool
-FLAG basecamp file doc list --cache-dir type=string
-FLAG basecamp file doc list --count type=bool
-FLAG basecamp file doc list --folder type=string
-FLAG basecamp file doc list --help type=bool
-FLAG basecamp file doc list --hints type=bool
-FLAG basecamp file doc list --ids-only type=bool
-FLAG basecamp file doc list --in type=string
-FLAG basecamp file doc list --jq type=string
-FLAG basecamp file doc list --json type=bool
-FLAG basecamp file doc list --limit type=int
-FLAG basecamp file doc list --markdown type=bool
-FLAG basecamp file doc list --md type=bool
-FLAG basecamp file doc list --no-hints type=bool
-FLAG basecamp file doc list --no-stats type=bool
-FLAG basecamp file doc list --page type=int
-FLAG basecamp file doc list --profile type=string
-FLAG basecamp file doc list --project type=string
-FLAG basecamp file doc list --quiet type=bool
-FLAG basecamp file doc list --stats type=bool
-FLAG basecamp file doc list --styled type=bool
-FLAG basecamp file doc list --todolist type=string
-FLAG basecamp file doc list --vault type=string
-FLAG basecamp file doc list --verbose type=count
-FLAG basecamp file doc list --version type=bool
-FLAG basecamp file document --account type=string
-FLAG basecamp file document --agent type=bool
-FLAG basecamp file document --all type=bool
-FLAG basecamp file document --cache-dir type=string
-FLAG basecamp file document --count type=bool
-FLAG basecamp file document --folder type=string
-FLAG basecamp file document --help type=bool
-FLAG basecamp file document --hints type=bool
-FLAG basecamp file document --ids-only type=bool
-FLAG basecamp file document --in type=string
-FLAG basecamp file document --jq type=string
-FLAG basecamp file document --json type=bool
-FLAG basecamp file document --limit type=int
-FLAG basecamp file document --markdown type=bool
-FLAG basecamp file document --md type=bool
-FLAG basecamp file document --no-hints type=bool
-FLAG basecamp file document --no-stats type=bool
-FLAG basecamp file document --page type=int
-FLAG basecamp file document --profile type=string
-FLAG basecamp file document --project type=string
-FLAG basecamp file document --quiet type=bool
-FLAG basecamp file document --stats type=bool
-FLAG basecamp file document --styled type=bool
-FLAG basecamp file document --todolist type=string
-FLAG basecamp file document --vault type=string
-FLAG basecamp file document --verbose type=count
-FLAG basecamp file document --version type=bool
-FLAG basecamp file document create --account type=string
-FLAG basecamp file document create --agent type=bool
-FLAG basecamp file document create --attach type=stringArray
-FLAG basecamp file document create --cache-dir type=string
-FLAG basecamp file document create --count type=bool
-FLAG basecamp file document create --draft type=bool
-FLAG basecamp file document create --folder type=string
-FLAG basecamp file document create --help type=bool
-FLAG basecamp file document create --hints type=bool
-FLAG basecamp file document create --ids-only type=bool
-FLAG basecamp file document create --in type=string
-FLAG basecamp file document create --jq type=string
-FLAG basecamp file document create --json type=bool
-FLAG basecamp file document create --markdown type=bool
-FLAG basecamp file document create --md type=bool
-FLAG basecamp file document create --no-hints type=bool
-FLAG basecamp file document create --no-stats type=bool
-FLAG basecamp file document create --no-subscribe type=bool
-FLAG basecamp file document create --profile type=string
-FLAG basecamp file document create --project type=string
-FLAG basecamp file document create --quiet type=bool
-FLAG basecamp file document create --stats type=bool
-FLAG basecamp file document create --styled type=bool
-FLAG basecamp file document create --subscribe type=string
-FLAG basecamp file document create --todolist type=string
-FLAG basecamp file document create --vault type=string
-FLAG basecamp file document create --verbose type=count
-FLAG basecamp file document create --version type=bool
-FLAG basecamp file document list --account type=string
-FLAG basecamp file document list --agent type=bool
-FLAG basecamp file document list --all type=bool
-FLAG basecamp file document list --cache-dir type=string
-FLAG basecamp file document list --count type=bool
-FLAG basecamp file document list --folder type=string
-FLAG basecamp file document list --help type=bool
-FLAG basecamp file document list --hints type=bool
-FLAG basecamp file document list --ids-only type=bool
-FLAG basecamp file document list --in type=string
-FLAG basecamp file document list --jq type=string
-FLAG basecamp file document list --json type=bool
-FLAG basecamp file document list --limit type=int
-FLAG basecamp file document list --markdown type=bool
-FLAG basecamp file document list --md type=bool
-FLAG basecamp file document list --no-hints type=bool
-FLAG basecamp file document list --no-stats type=bool
-FLAG basecamp file document list --page type=int
-FLAG basecamp file document list --profile type=string
-FLAG basecamp file document list --project type=string
-FLAG basecamp file document list --quiet type=bool
-FLAG basecamp file document list --stats type=bool
-FLAG basecamp file document list --styled type=bool
-FLAG basecamp file document list --todolist type=string
-FLAG basecamp file document list --vault type=string
-FLAG basecamp file document list --verbose type=count
-FLAG basecamp file document list --version type=bool
-FLAG basecamp file documents --account type=string
-FLAG basecamp file documents --agent type=bool
-FLAG basecamp file documents --all type=bool
-FLAG basecamp file documents --cache-dir type=string
-FLAG basecamp file documents --count type=bool
-FLAG basecamp file documents --folder type=string
-FLAG basecamp file documents --help type=bool
-FLAG basecamp file documents --hints type=bool
-FLAG basecamp file documents --ids-only type=bool
-FLAG basecamp file documents --in type=string
-FLAG basecamp file documents --jq type=string
-FLAG basecamp file documents --json type=bool
-FLAG basecamp file documents --limit type=int
-FLAG basecamp file documents --markdown type=bool
-FLAG basecamp file documents --md type=bool
-FLAG basecamp file documents --no-hints type=bool
-FLAG basecamp file documents --no-stats type=bool
-FLAG basecamp file documents --page type=int
-FLAG basecamp file documents --profile type=string
-FLAG basecamp file documents --project type=string
-FLAG basecamp file documents --quiet type=bool
-FLAG basecamp file documents --stats type=bool
-FLAG basecamp file documents --styled type=bool
-FLAG basecamp file documents --todolist type=string
-FLAG basecamp file documents --vault type=string
-FLAG basecamp file documents --verbose type=count
-FLAG basecamp file documents --version type=bool
-FLAG basecamp file documents create --account type=string
-FLAG basecamp file documents create --agent type=bool
-FLAG basecamp file documents create --attach type=stringArray
-FLAG basecamp file documents create --cache-dir type=string
-FLAG basecamp file documents create --count type=bool
-FLAG basecamp file documents create --draft type=bool
-FLAG basecamp file documents create --folder type=string
-FLAG basecamp file documents create --help type=bool
-FLAG basecamp file documents create --hints type=bool
-FLAG basecamp file documents create --ids-only type=bool
-FLAG basecamp file documents create --in type=string
-FLAG basecamp file documents create --jq type=string
-FLAG basecamp file documents create --json type=bool
-FLAG basecamp file documents create --markdown type=bool
-FLAG basecamp file documents create --md type=bool
-FLAG basecamp file documents create --no-hints type=bool
-FLAG basecamp file documents create --no-stats type=bool
-FLAG basecamp file documents create --no-subscribe type=bool
-FLAG basecamp file documents create --profile type=string
-FLAG basecamp file documents create --project type=string
-FLAG basecamp file documents create --quiet type=bool
-FLAG basecamp file documents create --stats type=bool
-FLAG basecamp file documents create --styled type=bool
-FLAG basecamp file documents create --subscribe type=string
-FLAG basecamp file documents create --todolist type=string
-FLAG basecamp file documents create --vault type=string
-FLAG basecamp file documents create --verbose type=count
-FLAG basecamp file documents create --version type=bool
-FLAG basecamp file documents list --account type=string
-FLAG basecamp file documents list --agent type=bool
-FLAG basecamp file documents list --all type=bool
-FLAG basecamp file documents list --cache-dir type=string
-FLAG basecamp file documents list --count type=bool
-FLAG basecamp file documents list --folder type=string
-FLAG basecamp file documents list --help type=bool
-FLAG basecamp file documents list --hints type=bool
-FLAG basecamp file documents list --ids-only type=bool
-FLAG basecamp file documents list --in type=string
-FLAG basecamp file documents list --jq type=string
-FLAG basecamp file documents list --json type=bool
-FLAG basecamp file documents list --limit type=int
-FLAG basecamp file documents list --markdown type=bool
-FLAG basecamp file documents list --md type=bool
-FLAG basecamp file documents list --no-hints type=bool
-FLAG basecamp file documents list --no-stats type=bool
-FLAG basecamp file documents list --page type=int
-FLAG basecamp file documents list --profile type=string
-FLAG basecamp file documents list --project type=string
-FLAG basecamp file documents list --quiet type=bool
-FLAG basecamp file documents list --stats type=bool
-FLAG basecamp file documents list --styled type=bool
-FLAG basecamp file documents list --todolist type=string
-FLAG basecamp file documents list --vault type=string
-FLAG basecamp file documents list --verbose type=count
-FLAG basecamp file documents list --version type=bool
-FLAG basecamp file download --account type=string
-FLAG basecamp file download --agent type=bool
-FLAG basecamp file download --cache-dir type=string
-FLAG basecamp file download --count type=bool
-FLAG basecamp file download --folder type=string
-FLAG basecamp file download --help type=bool
-FLAG basecamp file download --hints type=bool
-FLAG basecamp file download --ids-only type=bool
-FLAG basecamp file download --in type=string
-FLAG basecamp file download --jq type=string
-FLAG basecamp file download --json type=bool
-FLAG basecamp file download --markdown type=bool
-FLAG basecamp file download --md type=bool
-FLAG basecamp file download --no-hints type=bool
-FLAG basecamp file download --no-stats type=bool
-FLAG basecamp file download --out type=string
-FLAG basecamp file download --profile type=string
-FLAG basecamp file download --project type=string
-FLAG basecamp file download --quiet type=bool
-FLAG basecamp file download --stats type=bool
-FLAG basecamp file download --styled type=bool
-FLAG basecamp file download --todolist type=string
-FLAG basecamp file download --vault type=string
-FLAG basecamp file download --verbose type=count
-FLAG basecamp file download --version type=bool
-FLAG basecamp file folder --account type=string
-FLAG basecamp file folder --agent type=bool
-FLAG basecamp file folder --all type=bool
-FLAG basecamp file folder --cache-dir type=string
-FLAG basecamp file folder --count type=bool
-FLAG basecamp file folder --folder type=string
-FLAG basecamp file folder --help type=bool
-FLAG basecamp file folder --hints type=bool
-FLAG basecamp file folder --ids-only type=bool
-FLAG basecamp file folder --in type=string
-FLAG basecamp file folder --jq type=string
-FLAG basecamp file folder --json type=bool
-FLAG basecamp file folder --limit type=int
-FLAG basecamp file folder --markdown type=bool
-FLAG basecamp file folder --md type=bool
-FLAG basecamp file folder --no-hints type=bool
-FLAG basecamp file folder --no-stats type=bool
-FLAG basecamp file folder --page type=int
-FLAG basecamp file folder --profile type=string
-FLAG basecamp file folder --project type=string
-FLAG basecamp file folder --quiet type=bool
-FLAG basecamp file folder --stats type=bool
-FLAG basecamp file folder --styled type=bool
-FLAG basecamp file folder --todolist type=string
-FLAG basecamp file folder --vault type=string
-FLAG basecamp file folder --verbose type=count
-FLAG basecamp file folder --version type=bool
-FLAG basecamp file folder create --account type=string
-FLAG basecamp file folder create --agent type=bool
-FLAG basecamp file folder create --cache-dir type=string
-FLAG basecamp file folder create --count type=bool
-FLAG basecamp file folder create --folder type=string
-FLAG basecamp file folder create --help type=bool
-FLAG basecamp file folder create --hints type=bool
-FLAG basecamp file folder create --ids-only type=bool
-FLAG basecamp file folder create --in type=string
-FLAG basecamp file folder create --jq type=string
-FLAG basecamp file folder create --json type=bool
-FLAG basecamp file folder create --markdown type=bool
-FLAG basecamp file folder create --md type=bool
-FLAG basecamp file folder create --no-hints type=bool
-FLAG basecamp file folder create --no-stats type=bool
-FLAG basecamp file folder create --profile type=string
-FLAG basecamp file folder create --project type=string
-FLAG basecamp file folder create --quiet type=bool
-FLAG basecamp file folder create --stats type=bool
-FLAG basecamp file folder create --styled type=bool
-FLAG basecamp file folder create --todolist type=string
-FLAG basecamp file folder create --vault type=string
-FLAG basecamp file folder create --verbose type=count
-FLAG basecamp file folder create --version type=bool
-FLAG basecamp file folder list --account type=string
-FLAG basecamp file folder list --agent type=bool
-FLAG basecamp file folder list --all type=bool
-FLAG basecamp file folder list --cache-dir type=string
-FLAG basecamp file folder list --count type=bool
-FLAG basecamp file folder list --folder type=string
-FLAG basecamp file folder list --help type=bool
-FLAG basecamp file folder list --hints type=bool
-FLAG basecamp file folder list --ids-only type=bool
-FLAG basecamp file folder list --in type=string
-FLAG basecamp file folder list --jq type=string
-FLAG basecamp file folder list --json type=bool
-FLAG basecamp file folder list --limit type=int
-FLAG basecamp file folder list --markdown type=bool
-FLAG basecamp file folder list --md type=bool
-FLAG basecamp file folder list --no-hints type=bool
-FLAG basecamp file folder list --no-stats type=bool
-FLAG basecamp file folder list --page type=int
-FLAG basecamp file folder list --profile type=string
-FLAG basecamp file folder list --project type=string
-FLAG basecamp file folder list --quiet type=bool
-FLAG basecamp file folder list --stats type=bool
-FLAG basecamp file folder list --styled type=bool
-FLAG basecamp file folder list --todolist type=string
-FLAG basecamp file folder list --vault type=string
-FLAG basecamp file folder list --verbose type=count
-FLAG basecamp file folder list --version type=bool
-FLAG basecamp file folders --account type=string
-FLAG basecamp file folders --agent type=bool
-FLAG basecamp file folders --all type=bool
-FLAG basecamp file folders --cache-dir type=string
-FLAG basecamp file folders --count type=bool
-FLAG basecamp file folders --folder type=string
-FLAG basecamp file folders --help type=bool
-FLAG basecamp file folders --hints type=bool
-FLAG basecamp file folders --ids-only type=bool
-FLAG basecamp file folders --in type=string
-FLAG basecamp file folders --jq type=string
-FLAG basecamp file folders --json type=bool
-FLAG basecamp file folders --limit type=int
-FLAG basecamp file folders --markdown type=bool
-FLAG basecamp file folders --md type=bool
-FLAG basecamp file folders --no-hints type=bool
-FLAG basecamp file folders --no-stats type=bool
-FLAG basecamp file folders --page type=int
-FLAG basecamp file folders --profile type=string
-FLAG basecamp file folders --project type=string
-FLAG basecamp file folders --quiet type=bool
-FLAG basecamp file folders --stats type=bool
-FLAG basecamp file folders --styled type=bool
-FLAG basecamp file folders --todolist type=string
-FLAG basecamp file folders --vault type=string
-FLAG basecamp file folders --verbose type=count
-FLAG basecamp file folders --version type=bool
-FLAG basecamp file folders create --account type=string
-FLAG basecamp file folders create --agent type=bool
-FLAG basecamp file folders create --cache-dir type=string
-FLAG basecamp file folders create --count type=bool
-FLAG basecamp file folders create --folder type=string
-FLAG basecamp file folders create --help type=bool
-FLAG basecamp file folders create --hints type=bool
-FLAG basecamp file folders create --ids-only type=bool
-FLAG basecamp file folders create --in type=string
-FLAG basecamp file folders create --jq type=string
-FLAG basecamp file folders create --json type=bool
-FLAG basecamp file folders create --markdown type=bool
-FLAG basecamp file folders create --md type=bool
-FLAG basecamp file folders create --no-hints type=bool
-FLAG basecamp file folders create --no-stats type=bool
-FLAG basecamp file folders create --profile type=string
-FLAG basecamp file folders create --project type=string
-FLAG basecamp file folders create --quiet type=bool
-FLAG basecamp file folders create --stats type=bool
-FLAG basecamp file folders create --styled type=bool
-FLAG basecamp file folders create --todolist type=string
-FLAG basecamp file folders create --vault type=string
-FLAG basecamp file folders create --verbose type=count
-FLAG basecamp file folders create --version type=bool
-FLAG basecamp file folders list --account type=string
-FLAG basecamp file folders list --agent type=bool
-FLAG basecamp file folders list --all type=bool
-FLAG basecamp file folders list --cache-dir type=string
-FLAG basecamp file folders list --count type=bool
-FLAG basecamp file folders list --folder type=string
-FLAG basecamp file folders list --help type=bool
-FLAG basecamp file folders list --hints type=bool
-FLAG basecamp file folders list --ids-only type=bool
-FLAG basecamp file folders list --in type=string
-FLAG basecamp file folders list --jq type=string
-FLAG basecamp file folders list --json type=bool
-FLAG basecamp file folders list --limit type=int
-FLAG basecamp file folders list --markdown type=bool
-FLAG basecamp file folders list --md type=bool
-FLAG basecamp file folders list --no-hints type=bool
-FLAG basecamp file folders list --no-stats type=bool
-FLAG basecamp file folders list --page type=int
-FLAG basecamp file folders list --profile type=string
-FLAG basecamp file folders list --project type=string
-FLAG basecamp file folders list --quiet type=bool
-FLAG basecamp file folders list --stats type=bool
-FLAG basecamp file folders list --styled type=bool
-FLAG basecamp file folders list --todolist type=string
-FLAG basecamp file folders list --vault type=string
-FLAG basecamp file folders list --verbose type=count
-FLAG basecamp file folders list --version type=bool
-FLAG basecamp file list --account type=string
-FLAG basecamp file list --agent type=bool
-FLAG basecamp file list --cache-dir type=string
-FLAG basecamp file list --count type=bool
-FLAG basecamp file list --folder type=string
-FLAG basecamp file list --help type=bool
-FLAG basecamp file list --hints type=bool
-FLAG basecamp file list --ids-only type=bool
-FLAG basecamp file list --in type=string
-FLAG basecamp file list --jq type=string
-FLAG basecamp file list --json type=bool
-FLAG basecamp file list --markdown type=bool
-FLAG basecamp file list --md type=bool
-FLAG basecamp file list --no-hints type=bool
-FLAG basecamp file list --no-stats type=bool
-FLAG basecamp file list --profile type=string
-FLAG basecamp file list --project type=string
-FLAG basecamp file list --quiet type=bool
-FLAG basecamp file list --stats type=bool
-FLAG basecamp file list --styled type=bool
-FLAG basecamp file list --todolist type=string
-FLAG basecamp file list --vault type=string
-FLAG basecamp file list --verbose type=count
-FLAG basecamp file list --version type=bool
-FLAG basecamp file restore --account type=string
-FLAG basecamp file restore --agent type=bool
-FLAG basecamp file restore --cache-dir type=string
-FLAG basecamp file restore --count type=bool
-FLAG basecamp file restore --folder type=string
-FLAG basecamp file restore --help type=bool
-FLAG basecamp file restore --hints type=bool
-FLAG basecamp file restore --ids-only type=bool
-FLAG basecamp file restore --in type=string
-FLAG basecamp file restore --jq type=string
-FLAG basecamp file restore --json type=bool
-FLAG basecamp file restore --markdown type=bool
-FLAG basecamp file restore --md type=bool
-FLAG basecamp file restore --no-hints type=bool
-FLAG basecamp file restore --no-stats type=bool
-FLAG basecamp file restore --profile type=string
-FLAG basecamp file restore --project type=string
-FLAG basecamp file restore --quiet type=bool
-FLAG basecamp file restore --stats type=bool
-FLAG basecamp file restore --styled type=bool
-FLAG basecamp file restore --todolist type=string
-FLAG basecamp file restore --vault type=string
-FLAG basecamp file restore --verbose type=count
-FLAG basecamp file restore --version type=bool
-FLAG basecamp file show --account type=string
-FLAG basecamp file show --agent type=bool
-FLAG basecamp file show --cache-dir type=string
-FLAG basecamp file show --count type=bool
-FLAG basecamp file show --folder type=string
-FLAG basecamp file show --help type=bool
-FLAG basecamp file show --hints type=bool
-FLAG basecamp file show --ids-only type=bool
-FLAG basecamp file show --in type=string
-FLAG basecamp file show --jq type=string
-FLAG basecamp file show --json type=bool
-FLAG basecamp file show --markdown type=bool
-FLAG basecamp file show --md type=bool
-FLAG basecamp file show --no-hints type=bool
-FLAG basecamp file show --no-stats type=bool
-FLAG basecamp file show --profile type=string
-FLAG basecamp file show --project type=string
-FLAG basecamp file show --quiet type=bool
-FLAG basecamp file show --stats type=bool
-FLAG basecamp file show --styled type=bool
-FLAG basecamp file show --todolist type=string
-FLAG basecamp file show --type type=string
-FLAG basecamp file show --vault type=string
-FLAG basecamp file show --verbose type=count
-FLAG basecamp file show --version type=bool
-FLAG basecamp file trash --account type=string
-FLAG basecamp file trash --agent type=bool
-FLAG basecamp file trash --cache-dir type=string
-FLAG basecamp file trash --count type=bool
-FLAG basecamp file trash --folder type=string
-FLAG basecamp file trash --help type=bool
-FLAG basecamp file trash --hints type=bool
-FLAG basecamp file trash --ids-only type=bool
-FLAG basecamp file trash --in type=string
-FLAG basecamp file trash --jq type=string
-FLAG basecamp file trash --json type=bool
-FLAG basecamp file trash --markdown type=bool
-FLAG basecamp file trash --md type=bool
-FLAG basecamp file trash --no-hints type=bool
-FLAG basecamp file trash --no-stats type=bool
-FLAG basecamp file trash --profile type=string
-FLAG basecamp file trash --project type=string
-FLAG basecamp file trash --quiet type=bool
-FLAG basecamp file trash --stats type=bool
-FLAG basecamp file trash --styled type=bool
-FLAG basecamp file trash --todolist type=string
-FLAG basecamp file trash --vault type=string
-FLAG basecamp file trash --verbose type=count
-FLAG basecamp file trash --version type=bool
-FLAG basecamp file update --account type=string
-FLAG basecamp file update --agent type=bool
-FLAG basecamp file update --cache-dir type=string
-FLAG basecamp file update --content type=string
-FLAG basecamp file update --count type=bool
-FLAG basecamp file update --folder type=string
-FLAG basecamp file update --help type=bool
-FLAG basecamp file update --hints type=bool
-FLAG basecamp file update --ids-only type=bool
-FLAG basecamp file update --in type=string
-FLAG basecamp file update --jq type=string
-FLAG basecamp file update --json type=bool
-FLAG basecamp file update --markdown type=bool
-FLAG basecamp file update --md type=bool
-FLAG basecamp file update --no-hints type=bool
-FLAG basecamp file update --no-stats type=bool
-FLAG basecamp file update --profile type=string
-FLAG basecamp file update --project type=string
-FLAG basecamp file update --quiet type=bool
-FLAG basecamp file update --stats type=bool
-FLAG basecamp file update --styled type=bool
-FLAG basecamp file update --title type=string
-FLAG basecamp file update --todolist type=string
-FLAG basecamp file update --type type=string
-FLAG basecamp file update --vault type=string
-FLAG basecamp file update --verbose type=count
-FLAG basecamp file update --version type=bool
-FLAG basecamp file upload --account type=string
-FLAG basecamp file upload --agent type=bool
-FLAG basecamp file upload --all type=bool
-FLAG basecamp file upload --cache-dir type=string
-FLAG basecamp file upload --count type=bool
-FLAG basecamp file upload --folder type=string
-FLAG basecamp file upload --help type=bool
-FLAG basecamp file upload --hints type=bool
-FLAG basecamp file upload --ids-only type=bool
-FLAG basecamp file upload --in type=string
-FLAG basecamp file upload --jq type=string
-FLAG basecamp file upload --json type=bool
-FLAG basecamp file upload --limit type=int
-FLAG basecamp file upload --markdown type=bool
-FLAG basecamp file upload --md type=bool
-FLAG basecamp file upload --no-hints type=bool
-FLAG basecamp file upload --no-stats type=bool
-FLAG basecamp file upload --page type=int
-FLAG basecamp file upload --profile type=string
-FLAG basecamp file upload --project type=string
-FLAG basecamp file upload --quiet type=bool
-FLAG basecamp file upload --stats type=bool
-FLAG basecamp file upload --styled type=bool
-FLAG basecamp file upload --todolist type=string
-FLAG basecamp file upload --vault type=string
-FLAG basecamp file upload --verbose type=count
-FLAG basecamp file upload --version type=bool
-FLAG basecamp file upload create --account type=string
-FLAG basecamp file upload create --agent type=bool
-FLAG basecamp file upload create --cache-dir type=string
-FLAG basecamp file upload create --count type=bool
-FLAG basecamp file upload create --description type=string
-FLAG basecamp file upload create --folder type=string
-FLAG basecamp file upload create --help type=bool
-FLAG basecamp file upload create --hints type=bool
-FLAG basecamp file upload create --ids-only type=bool
-FLAG basecamp file upload create --in type=string
-FLAG basecamp file upload create --jq type=string
-FLAG basecamp file upload create --json type=bool
-FLAG basecamp file upload create --markdown type=bool
-FLAG basecamp file upload create --md type=bool
-FLAG basecamp file upload create --no-hints type=bool
-FLAG basecamp file upload create --no-stats type=bool
-FLAG basecamp file upload create --profile type=string
-FLAG basecamp file upload create --project type=string
-FLAG basecamp file upload create --quiet type=bool
-FLAG basecamp file upload create --stats type=bool
-FLAG basecamp file upload create --styled type=bool
-FLAG basecamp file upload create --todolist type=string
-FLAG basecamp file upload create --vault type=string
-FLAG basecamp file upload create --verbose type=count
-FLAG basecamp file upload create --version type=bool
-FLAG basecamp file upload list --account type=string
-FLAG basecamp file upload list --agent type=bool
-FLAG basecamp file upload list --all type=bool
-FLAG basecamp file upload list --cache-dir type=string
-FLAG basecamp file upload list --count type=bool
-FLAG basecamp file upload list --folder type=string
-FLAG basecamp file upload list --help type=bool
-FLAG basecamp file upload list --hints type=bool
-FLAG basecamp file upload list --ids-only type=bool
-FLAG basecamp file upload list --in type=string
-FLAG basecamp file upload list --jq type=string
-FLAG basecamp file upload list --json type=bool
-FLAG basecamp file upload list --limit type=int
-FLAG basecamp file upload list --markdown type=bool
-FLAG basecamp file upload list --md type=bool
-FLAG basecamp file upload list --no-hints type=bool
-FLAG basecamp file upload list --no-stats type=bool
-FLAG basecamp file upload list --page type=int
-FLAG basecamp file upload list --profile type=string
-FLAG basecamp file upload list --project type=string
-FLAG basecamp file upload list --quiet type=bool
-FLAG basecamp file upload list --stats type=bool
-FLAG basecamp file upload list --styled type=bool
-FLAG basecamp file upload list --todolist type=string
-FLAG basecamp file upload list --vault type=string
-FLAG basecamp file upload list --verbose type=count
-FLAG basecamp file upload list --version type=bool
-FLAG basecamp file uploads --account type=string
-FLAG basecamp file uploads --agent type=bool
-FLAG basecamp file uploads --all type=bool
-FLAG basecamp file uploads --cache-dir type=string
-FLAG basecamp file uploads --count type=bool
-FLAG basecamp file uploads --folder type=string
-FLAG basecamp file uploads --help type=bool
-FLAG basecamp file uploads --hints type=bool
-FLAG basecamp file uploads --ids-only type=bool
-FLAG basecamp file uploads --in type=string
-FLAG basecamp file uploads --jq type=string
-FLAG basecamp file uploads --json type=bool
-FLAG basecamp file uploads --limit type=int
-FLAG basecamp file uploads --markdown type=bool
-FLAG basecamp file uploads --md type=bool
-FLAG basecamp file uploads --no-hints type=bool
-FLAG basecamp file uploads --no-stats type=bool
-FLAG basecamp file uploads --page type=int
-FLAG basecamp file uploads --profile type=string
-FLAG basecamp file uploads --project type=string
-FLAG basecamp file uploads --quiet type=bool
-FLAG basecamp file uploads --stats type=bool
-FLAG basecamp file uploads --styled type=bool
-FLAG basecamp file uploads --todolist type=string
-FLAG basecamp file uploads --vault type=string
-FLAG basecamp file uploads --verbose type=count
-FLAG basecamp file uploads --version type=bool
-FLAG basecamp file uploads create --account type=string
-FLAG basecamp file uploads create --agent type=bool
-FLAG basecamp file uploads create --cache-dir type=string
-FLAG basecamp file uploads create --count type=bool
-FLAG basecamp file uploads create --description type=string
-FLAG basecamp file uploads create --folder type=string
-FLAG basecamp file uploads create --help type=bool
-FLAG basecamp file uploads create --hints type=bool
-FLAG basecamp file uploads create --ids-only type=bool
-FLAG basecamp file uploads create --in type=string
-FLAG basecamp file uploads create --jq type=string
-FLAG basecamp file uploads create --json type=bool
-FLAG basecamp file uploads create --markdown type=bool
-FLAG basecamp file uploads create --md type=bool
-FLAG basecamp file uploads create --no-hints type=bool
-FLAG basecamp file uploads create --no-stats type=bool
-FLAG basecamp file uploads create --profile type=string
-FLAG basecamp file uploads create --project type=string
-FLAG basecamp file uploads create --quiet type=bool
-FLAG basecamp file uploads create --stats type=bool
-FLAG basecamp file uploads create --styled type=bool
-FLAG basecamp file uploads create --todolist type=string
-FLAG basecamp file uploads create --vault type=string
-FLAG basecamp file uploads create --verbose type=count
-FLAG basecamp file uploads create --version type=bool
-FLAG basecamp file uploads list --account type=string
-FLAG basecamp file uploads list --agent type=bool
-FLAG basecamp file uploads list --all type=bool
-FLAG basecamp file uploads list --cache-dir type=string
-FLAG basecamp file uploads list --count type=bool
-FLAG basecamp file uploads list --folder type=string
-FLAG basecamp file uploads list --help type=bool
-FLAG basecamp file uploads list --hints type=bool
-FLAG basecamp file uploads list --ids-only type=bool
-FLAG basecamp file uploads list --in type=string
-FLAG basecamp file uploads list --jq type=string
-FLAG basecamp file uploads list --json type=bool
-FLAG basecamp file uploads list --limit type=int
-FLAG basecamp file uploads list --markdown type=bool
-FLAG basecamp file uploads list --md type=bool
-FLAG basecamp file uploads list --no-hints type=bool
-FLAG basecamp file uploads list --no-stats type=bool
-FLAG basecamp file uploads list --page type=int
-FLAG basecamp file uploads list --profile type=string
-FLAG basecamp file uploads list --project type=string
-FLAG basecamp file uploads list --quiet type=bool
-FLAG basecamp file uploads list --stats type=bool
-FLAG basecamp file uploads list --styled type=bool
-FLAG basecamp file uploads list --todolist type=string
-FLAG basecamp file uploads list --vault type=string
-FLAG basecamp file uploads list --verbose type=count
-FLAG basecamp file uploads list --version type=bool
-FLAG basecamp file vault --account type=string
-FLAG basecamp file vault --agent type=bool
-FLAG basecamp file vault --all type=bool
-FLAG basecamp file vault --cache-dir type=string
-FLAG basecamp file vault --count type=bool
-FLAG basecamp file vault --folder type=string
-FLAG basecamp file vault --help type=bool
-FLAG basecamp file vault --hints type=bool
-FLAG basecamp file vault --ids-only type=bool
-FLAG basecamp file vault --in type=string
-FLAG basecamp file vault --jq type=string
-FLAG basecamp file vault --json type=bool
-FLAG basecamp file vault --limit type=int
-FLAG basecamp file vault --markdown type=bool
-FLAG basecamp file vault --md type=bool
-FLAG basecamp file vault --no-hints type=bool
-FLAG basecamp file vault --no-stats type=bool
-FLAG basecamp file vault --page type=int
-FLAG basecamp file vault --profile type=string
-FLAG basecamp file vault --project type=string
-FLAG basecamp file vault --quiet type=bool
-FLAG basecamp file vault --stats type=bool
-FLAG basecamp file vault --styled type=bool
-FLAG basecamp file vault --todolist type=string
-FLAG basecamp file vault --vault type=string
-FLAG basecamp file vault --verbose type=count
-FLAG basecamp file vault --version type=bool
-FLAG basecamp file vault create --account type=string
-FLAG basecamp file vault create --agent type=bool
-FLAG basecamp file vault create --cache-dir type=string
-FLAG basecamp file vault create --count type=bool
-FLAG basecamp file vault create --folder type=string
-FLAG basecamp file vault create --help type=bool
-FLAG basecamp file vault create --hints type=bool
-FLAG basecamp file vault create --ids-only type=bool
-FLAG basecamp file vault create --in type=string
-FLAG basecamp file vault create --jq type=string
-FLAG basecamp file vault create --json type=bool
-FLAG basecamp file vault create --markdown type=bool
-FLAG basecamp file vault create --md type=bool
-FLAG basecamp file vault create --no-hints type=bool
-FLAG basecamp file vault create --no-stats type=bool
-FLAG basecamp file vault create --profile type=string
-FLAG basecamp file vault create --project type=string
-FLAG basecamp file vault create --quiet type=bool
-FLAG basecamp file vault create --stats type=bool
-FLAG basecamp file vault create --styled type=bool
-FLAG basecamp file vault create --todolist type=string
-FLAG basecamp file vault create --vault type=string
-FLAG basecamp file vault create --verbose type=count
-FLAG basecamp file vault create --version type=bool
-FLAG basecamp file vault list --account type=string
-FLAG basecamp file vault list --agent type=bool
-FLAG basecamp file vault list --all type=bool
-FLAG basecamp file vault list --cache-dir type=string
-FLAG basecamp file vault list --count type=bool
-FLAG basecamp file vault list --folder type=string
-FLAG basecamp file vault list --help type=bool
-FLAG basecamp file vault list --hints type=bool
-FLAG basecamp file vault list --ids-only type=bool
-FLAG basecamp file vault list --in type=string
-FLAG basecamp file vault list --jq type=string
-FLAG basecamp file vault list --json type=bool
-FLAG basecamp file vault list --limit type=int
-FLAG basecamp file vault list --markdown type=bool
-FLAG basecamp file vault list --md type=bool
-FLAG basecamp file vault list --no-hints type=bool
-FLAG basecamp file vault list --no-stats type=bool
-FLAG basecamp file vault list --page type=int
-FLAG basecamp file vault list --profile type=string
-FLAG basecamp file vault list --project type=string
-FLAG basecamp file vault list --quiet type=bool
-FLAG basecamp file vault list --stats type=bool
-FLAG basecamp file vault list --styled type=bool
-FLAG basecamp file vault list --todolist type=string
-FLAG basecamp file vault list --vault type=string
-FLAG basecamp file vault list --verbose type=count
-FLAG basecamp file vault list --version type=bool
-FLAG basecamp file vaults --account type=string
-FLAG basecamp file vaults --agent type=bool
-FLAG basecamp file vaults --all type=bool
-FLAG basecamp file vaults --cache-dir type=string
-FLAG basecamp file vaults --count type=bool
-FLAG basecamp file vaults --folder type=string
-FLAG basecamp file vaults --help type=bool
-FLAG basecamp file vaults --hints type=bool
-FLAG basecamp file vaults --ids-only type=bool
-FLAG basecamp file vaults --in type=string
-FLAG basecamp file vaults --jq type=string
-FLAG basecamp file vaults --json type=bool
-FLAG basecamp file vaults --limit type=int
-FLAG basecamp file vaults --markdown type=bool
-FLAG basecamp file vaults --md type=bool
-FLAG basecamp file vaults --no-hints type=bool
-FLAG basecamp file vaults --no-stats type=bool
-FLAG basecamp file vaults --page type=int
-FLAG basecamp file vaults --profile type=string
-FLAG basecamp file vaults --project type=string
-FLAG basecamp file vaults --quiet type=bool
-FLAG basecamp file vaults --stats type=bool
-FLAG basecamp file vaults --styled type=bool
-FLAG basecamp file vaults --todolist type=string
-FLAG basecamp file vaults --vault type=string
-FLAG basecamp file vaults --verbose type=count
-FLAG basecamp file vaults --version type=bool
-FLAG basecamp file vaults create --account type=string
-FLAG basecamp file vaults create --agent type=bool
-FLAG basecamp file vaults create --cache-dir type=string
-FLAG basecamp file vaults create --count type=bool
-FLAG basecamp file vaults create --folder type=string
-FLAG basecamp file vaults create --help type=bool
-FLAG basecamp file vaults create --hints type=bool
-FLAG basecamp file vaults create --ids-only type=bool
-FLAG basecamp file vaults create --in type=string
-FLAG basecamp file vaults create --jq type=string
-FLAG basecamp file vaults create --json type=bool
-FLAG basecamp file vaults create --markdown type=bool
-FLAG basecamp file vaults create --md type=bool
-FLAG basecamp file vaults create --no-hints type=bool
-FLAG basecamp file vaults create --no-stats type=bool
-FLAG basecamp file vaults create --profile type=string
-FLAG basecamp file vaults create --project type=string
-FLAG basecamp file vaults create --quiet type=bool
-FLAG basecamp file vaults create --stats type=bool
-FLAG basecamp file vaults create --styled type=bool
-FLAG basecamp file vaults create --todolist type=string
-FLAG basecamp file vaults create --vault type=string
-FLAG basecamp file vaults create --verbose type=count
-FLAG basecamp file vaults create --version type=bool
-FLAG basecamp file vaults list --account type=string
-FLAG basecamp file vaults list --agent type=bool
-FLAG basecamp file vaults list --all type=bool
-FLAG basecamp file vaults list --cache-dir type=string
-FLAG basecamp file vaults list --count type=bool
-FLAG basecamp file vaults list --folder type=string
-FLAG basecamp file vaults list --help type=bool
-FLAG basecamp file vaults list --hints type=bool
-FLAG basecamp file vaults list --ids-only type=bool
-FLAG basecamp file vaults list --in type=string
-FLAG basecamp file vaults list --jq type=string
-FLAG basecamp file vaults list --json type=bool
-FLAG basecamp file vaults list --limit type=int
-FLAG basecamp file vaults list --markdown type=bool
-FLAG basecamp file vaults list --md type=bool
-FLAG basecamp file vaults list --no-hints type=bool
-FLAG basecamp file vaults list --no-stats type=bool
-FLAG basecamp file vaults list --page type=int
-FLAG basecamp file vaults list --profile type=string
-FLAG basecamp file vaults list --project type=string
-FLAG basecamp file vaults list --quiet type=bool
-FLAG basecamp file vaults list --stats type=bool
-FLAG basecamp file vaults list --styled type=bool
-FLAG basecamp file vaults list --todolist type=string
-FLAG basecamp file vaults list --vault type=string
-FLAG basecamp file vaults list --verbose type=count
-FLAG basecamp file vaults list --version type=bool
 FLAG basecamp files --account type=string
 FLAG basecamp files --agent type=bool
 FLAG basecamp files --cache-dir type=string
 FLAG basecamp files --count type=bool
 FLAG basecamp files --folder type=string
-FLAG basecamp files --help type=bool
 FLAG basecamp files --hints type=bool
 FLAG basecamp files --ids-only type=bool
 FLAG basecamp files --in type=string
@@ -7019,13 +3154,11 @@ FLAG basecamp files --styled type=bool
 FLAG basecamp files --todolist type=string
 FLAG basecamp files --vault type=string
 FLAG basecamp files --verbose type=count
-FLAG basecamp files --version type=bool
 FLAG basecamp files archive --account type=string
 FLAG basecamp files archive --agent type=bool
 FLAG basecamp files archive --cache-dir type=string
 FLAG basecamp files archive --count type=bool
 FLAG basecamp files archive --folder type=string
-FLAG basecamp files archive --help type=bool
 FLAG basecamp files archive --hints type=bool
 FLAG basecamp files archive --ids-only type=bool
 FLAG basecamp files archive --in type=string
@@ -7043,178 +3176,12 @@ FLAG basecamp files archive --styled type=bool
 FLAG basecamp files archive --todolist type=string
 FLAG basecamp files archive --vault type=string
 FLAG basecamp files archive --verbose type=count
-FLAG basecamp files archive --version type=bool
-FLAG basecamp files doc --account type=string
-FLAG basecamp files doc --agent type=bool
-FLAG basecamp files doc --all type=bool
-FLAG basecamp files doc --cache-dir type=string
-FLAG basecamp files doc --count type=bool
-FLAG basecamp files doc --folder type=string
-FLAG basecamp files doc --help type=bool
-FLAG basecamp files doc --hints type=bool
-FLAG basecamp files doc --ids-only type=bool
-FLAG basecamp files doc --in type=string
-FLAG basecamp files doc --jq type=string
-FLAG basecamp files doc --json type=bool
-FLAG basecamp files doc --limit type=int
-FLAG basecamp files doc --markdown type=bool
-FLAG basecamp files doc --md type=bool
-FLAG basecamp files doc --no-hints type=bool
-FLAG basecamp files doc --no-stats type=bool
-FLAG basecamp files doc --page type=int
-FLAG basecamp files doc --profile type=string
-FLAG basecamp files doc --project type=string
-FLAG basecamp files doc --quiet type=bool
-FLAG basecamp files doc --stats type=bool
-FLAG basecamp files doc --styled type=bool
-FLAG basecamp files doc --todolist type=string
-FLAG basecamp files doc --vault type=string
-FLAG basecamp files doc --verbose type=count
-FLAG basecamp files doc --version type=bool
-FLAG basecamp files doc create --account type=string
-FLAG basecamp files doc create --agent type=bool
-FLAG basecamp files doc create --attach type=stringArray
-FLAG basecamp files doc create --cache-dir type=string
-FLAG basecamp files doc create --count type=bool
-FLAG basecamp files doc create --draft type=bool
-FLAG basecamp files doc create --folder type=string
-FLAG basecamp files doc create --help type=bool
-FLAG basecamp files doc create --hints type=bool
-FLAG basecamp files doc create --ids-only type=bool
-FLAG basecamp files doc create --in type=string
-FLAG basecamp files doc create --jq type=string
-FLAG basecamp files doc create --json type=bool
-FLAG basecamp files doc create --markdown type=bool
-FLAG basecamp files doc create --md type=bool
-FLAG basecamp files doc create --no-hints type=bool
-FLAG basecamp files doc create --no-stats type=bool
-FLAG basecamp files doc create --no-subscribe type=bool
-FLAG basecamp files doc create --profile type=string
-FLAG basecamp files doc create --project type=string
-FLAG basecamp files doc create --quiet type=bool
-FLAG basecamp files doc create --stats type=bool
-FLAG basecamp files doc create --styled type=bool
-FLAG basecamp files doc create --subscribe type=string
-FLAG basecamp files doc create --todolist type=string
-FLAG basecamp files doc create --vault type=string
-FLAG basecamp files doc create --verbose type=count
-FLAG basecamp files doc create --version type=bool
-FLAG basecamp files doc list --account type=string
-FLAG basecamp files doc list --agent type=bool
-FLAG basecamp files doc list --all type=bool
-FLAG basecamp files doc list --cache-dir type=string
-FLAG basecamp files doc list --count type=bool
-FLAG basecamp files doc list --folder type=string
-FLAG basecamp files doc list --help type=bool
-FLAG basecamp files doc list --hints type=bool
-FLAG basecamp files doc list --ids-only type=bool
-FLAG basecamp files doc list --in type=string
-FLAG basecamp files doc list --jq type=string
-FLAG basecamp files doc list --json type=bool
-FLAG basecamp files doc list --limit type=int
-FLAG basecamp files doc list --markdown type=bool
-FLAG basecamp files doc list --md type=bool
-FLAG basecamp files doc list --no-hints type=bool
-FLAG basecamp files doc list --no-stats type=bool
-FLAG basecamp files doc list --page type=int
-FLAG basecamp files doc list --profile type=string
-FLAG basecamp files doc list --project type=string
-FLAG basecamp files doc list --quiet type=bool
-FLAG basecamp files doc list --stats type=bool
-FLAG basecamp files doc list --styled type=bool
-FLAG basecamp files doc list --todolist type=string
-FLAG basecamp files doc list --vault type=string
-FLAG basecamp files doc list --verbose type=count
-FLAG basecamp files doc list --version type=bool
-FLAG basecamp files document --account type=string
-FLAG basecamp files document --agent type=bool
-FLAG basecamp files document --all type=bool
-FLAG basecamp files document --cache-dir type=string
-FLAG basecamp files document --count type=bool
-FLAG basecamp files document --folder type=string
-FLAG basecamp files document --help type=bool
-FLAG basecamp files document --hints type=bool
-FLAG basecamp files document --ids-only type=bool
-FLAG basecamp files document --in type=string
-FLAG basecamp files document --jq type=string
-FLAG basecamp files document --json type=bool
-FLAG basecamp files document --limit type=int
-FLAG basecamp files document --markdown type=bool
-FLAG basecamp files document --md type=bool
-FLAG basecamp files document --no-hints type=bool
-FLAG basecamp files document --no-stats type=bool
-FLAG basecamp files document --page type=int
-FLAG basecamp files document --profile type=string
-FLAG basecamp files document --project type=string
-FLAG basecamp files document --quiet type=bool
-FLAG basecamp files document --stats type=bool
-FLAG basecamp files document --styled type=bool
-FLAG basecamp files document --todolist type=string
-FLAG basecamp files document --vault type=string
-FLAG basecamp files document --verbose type=count
-FLAG basecamp files document --version type=bool
-FLAG basecamp files document create --account type=string
-FLAG basecamp files document create --agent type=bool
-FLAG basecamp files document create --attach type=stringArray
-FLAG basecamp files document create --cache-dir type=string
-FLAG basecamp files document create --count type=bool
-FLAG basecamp files document create --draft type=bool
-FLAG basecamp files document create --folder type=string
-FLAG basecamp files document create --help type=bool
-FLAG basecamp files document create --hints type=bool
-FLAG basecamp files document create --ids-only type=bool
-FLAG basecamp files document create --in type=string
-FLAG basecamp files document create --jq type=string
-FLAG basecamp files document create --json type=bool
-FLAG basecamp files document create --markdown type=bool
-FLAG basecamp files document create --md type=bool
-FLAG basecamp files document create --no-hints type=bool
-FLAG basecamp files document create --no-stats type=bool
-FLAG basecamp files document create --no-subscribe type=bool
-FLAG basecamp files document create --profile type=string
-FLAG basecamp files document create --project type=string
-FLAG basecamp files document create --quiet type=bool
-FLAG basecamp files document create --stats type=bool
-FLAG basecamp files document create --styled type=bool
-FLAG basecamp files document create --subscribe type=string
-FLAG basecamp files document create --todolist type=string
-FLAG basecamp files document create --vault type=string
-FLAG basecamp files document create --verbose type=count
-FLAG basecamp files document create --version type=bool
-FLAG basecamp files document list --account type=string
-FLAG basecamp files document list --agent type=bool
-FLAG basecamp files document list --all type=bool
-FLAG basecamp files document list --cache-dir type=string
-FLAG basecamp files document list --count type=bool
-FLAG basecamp files document list --folder type=string
-FLAG basecamp files document list --help type=bool
-FLAG basecamp files document list --hints type=bool
-FLAG basecamp files document list --ids-only type=bool
-FLAG basecamp files document list --in type=string
-FLAG basecamp files document list --jq type=string
-FLAG basecamp files document list --json type=bool
-FLAG basecamp files document list --limit type=int
-FLAG basecamp files document list --markdown type=bool
-FLAG basecamp files document list --md type=bool
-FLAG basecamp files document list --no-hints type=bool
-FLAG basecamp files document list --no-stats type=bool
-FLAG basecamp files document list --page type=int
-FLAG basecamp files document list --profile type=string
-FLAG basecamp files document list --project type=string
-FLAG basecamp files document list --quiet type=bool
-FLAG basecamp files document list --stats type=bool
-FLAG basecamp files document list --styled type=bool
-FLAG basecamp files document list --todolist type=string
-FLAG basecamp files document list --vault type=string
-FLAG basecamp files document list --verbose type=count
-FLAG basecamp files document list --version type=bool
 FLAG basecamp files documents --account type=string
 FLAG basecamp files documents --agent type=bool
 FLAG basecamp files documents --all type=bool
 FLAG basecamp files documents --cache-dir type=string
 FLAG basecamp files documents --count type=bool
 FLAG basecamp files documents --folder type=string
-FLAG basecamp files documents --help type=bool
 FLAG basecamp files documents --hints type=bool
 FLAG basecamp files documents --ids-only type=bool
 FLAG basecamp files documents --in type=string
@@ -7234,7 +3201,6 @@ FLAG basecamp files documents --styled type=bool
 FLAG basecamp files documents --todolist type=string
 FLAG basecamp files documents --vault type=string
 FLAG basecamp files documents --verbose type=count
-FLAG basecamp files documents --version type=bool
 FLAG basecamp files documents create --account type=string
 FLAG basecamp files documents create --agent type=bool
 FLAG basecamp files documents create --attach type=stringArray
@@ -7242,7 +3208,6 @@ FLAG basecamp files documents create --cache-dir type=string
 FLAG basecamp files documents create --count type=bool
 FLAG basecamp files documents create --draft type=bool
 FLAG basecamp files documents create --folder type=string
-FLAG basecamp files documents create --help type=bool
 FLAG basecamp files documents create --hints type=bool
 FLAG basecamp files documents create --ids-only type=bool
 FLAG basecamp files documents create --in type=string
@@ -7262,14 +3227,12 @@ FLAG basecamp files documents create --subscribe type=string
 FLAG basecamp files documents create --todolist type=string
 FLAG basecamp files documents create --vault type=string
 FLAG basecamp files documents create --verbose type=count
-FLAG basecamp files documents create --version type=bool
 FLAG basecamp files documents list --account type=string
 FLAG basecamp files documents list --agent type=bool
 FLAG basecamp files documents list --all type=bool
 FLAG basecamp files documents list --cache-dir type=string
 FLAG basecamp files documents list --count type=bool
 FLAG basecamp files documents list --folder type=string
-FLAG basecamp files documents list --help type=bool
 FLAG basecamp files documents list --hints type=bool
 FLAG basecamp files documents list --ids-only type=bool
 FLAG basecamp files documents list --in type=string
@@ -7289,13 +3252,11 @@ FLAG basecamp files documents list --styled type=bool
 FLAG basecamp files documents list --todolist type=string
 FLAG basecamp files documents list --vault type=string
 FLAG basecamp files documents list --verbose type=count
-FLAG basecamp files documents list --version type=bool
 FLAG basecamp files download --account type=string
 FLAG basecamp files download --agent type=bool
 FLAG basecamp files download --cache-dir type=string
 FLAG basecamp files download --count type=bool
 FLAG basecamp files download --folder type=string
-FLAG basecamp files download --help type=bool
 FLAG basecamp files download --hints type=bool
 FLAG basecamp files download --ids-only type=bool
 FLAG basecamp files download --in type=string
@@ -7314,92 +3275,12 @@ FLAG basecamp files download --styled type=bool
 FLAG basecamp files download --todolist type=string
 FLAG basecamp files download --vault type=string
 FLAG basecamp files download --verbose type=count
-FLAG basecamp files download --version type=bool
-FLAG basecamp files folder --account type=string
-FLAG basecamp files folder --agent type=bool
-FLAG basecamp files folder --all type=bool
-FLAG basecamp files folder --cache-dir type=string
-FLAG basecamp files folder --count type=bool
-FLAG basecamp files folder --folder type=string
-FLAG basecamp files folder --help type=bool
-FLAG basecamp files folder --hints type=bool
-FLAG basecamp files folder --ids-only type=bool
-FLAG basecamp files folder --in type=string
-FLAG basecamp files folder --jq type=string
-FLAG basecamp files folder --json type=bool
-FLAG basecamp files folder --limit type=int
-FLAG basecamp files folder --markdown type=bool
-FLAG basecamp files folder --md type=bool
-FLAG basecamp files folder --no-hints type=bool
-FLAG basecamp files folder --no-stats type=bool
-FLAG basecamp files folder --page type=int
-FLAG basecamp files folder --profile type=string
-FLAG basecamp files folder --project type=string
-FLAG basecamp files folder --quiet type=bool
-FLAG basecamp files folder --stats type=bool
-FLAG basecamp files folder --styled type=bool
-FLAG basecamp files folder --todolist type=string
-FLAG basecamp files folder --vault type=string
-FLAG basecamp files folder --verbose type=count
-FLAG basecamp files folder --version type=bool
-FLAG basecamp files folder create --account type=string
-FLAG basecamp files folder create --agent type=bool
-FLAG basecamp files folder create --cache-dir type=string
-FLAG basecamp files folder create --count type=bool
-FLAG basecamp files folder create --folder type=string
-FLAG basecamp files folder create --help type=bool
-FLAG basecamp files folder create --hints type=bool
-FLAG basecamp files folder create --ids-only type=bool
-FLAG basecamp files folder create --in type=string
-FLAG basecamp files folder create --jq type=string
-FLAG basecamp files folder create --json type=bool
-FLAG basecamp files folder create --markdown type=bool
-FLAG basecamp files folder create --md type=bool
-FLAG basecamp files folder create --no-hints type=bool
-FLAG basecamp files folder create --no-stats type=bool
-FLAG basecamp files folder create --profile type=string
-FLAG basecamp files folder create --project type=string
-FLAG basecamp files folder create --quiet type=bool
-FLAG basecamp files folder create --stats type=bool
-FLAG basecamp files folder create --styled type=bool
-FLAG basecamp files folder create --todolist type=string
-FLAG basecamp files folder create --vault type=string
-FLAG basecamp files folder create --verbose type=count
-FLAG basecamp files folder create --version type=bool
-FLAG basecamp files folder list --account type=string
-FLAG basecamp files folder list --agent type=bool
-FLAG basecamp files folder list --all type=bool
-FLAG basecamp files folder list --cache-dir type=string
-FLAG basecamp files folder list --count type=bool
-FLAG basecamp files folder list --folder type=string
-FLAG basecamp files folder list --help type=bool
-FLAG basecamp files folder list --hints type=bool
-FLAG basecamp files folder list --ids-only type=bool
-FLAG basecamp files folder list --in type=string
-FLAG basecamp files folder list --jq type=string
-FLAG basecamp files folder list --json type=bool
-FLAG basecamp files folder list --limit type=int
-FLAG basecamp files folder list --markdown type=bool
-FLAG basecamp files folder list --md type=bool
-FLAG basecamp files folder list --no-hints type=bool
-FLAG basecamp files folder list --no-stats type=bool
-FLAG basecamp files folder list --page type=int
-FLAG basecamp files folder list --profile type=string
-FLAG basecamp files folder list --project type=string
-FLAG basecamp files folder list --quiet type=bool
-FLAG basecamp files folder list --stats type=bool
-FLAG basecamp files folder list --styled type=bool
-FLAG basecamp files folder list --todolist type=string
-FLAG basecamp files folder list --vault type=string
-FLAG basecamp files folder list --verbose type=count
-FLAG basecamp files folder list --version type=bool
 FLAG basecamp files folders --account type=string
 FLAG basecamp files folders --agent type=bool
 FLAG basecamp files folders --all type=bool
 FLAG basecamp files folders --cache-dir type=string
 FLAG basecamp files folders --count type=bool
 FLAG basecamp files folders --folder type=string
-FLAG basecamp files folders --help type=bool
 FLAG basecamp files folders --hints type=bool
 FLAG basecamp files folders --ids-only type=bool
 FLAG basecamp files folders --in type=string
@@ -7419,13 +3300,11 @@ FLAG basecamp files folders --styled type=bool
 FLAG basecamp files folders --todolist type=string
 FLAG basecamp files folders --vault type=string
 FLAG basecamp files folders --verbose type=count
-FLAG basecamp files folders --version type=bool
 FLAG basecamp files folders create --account type=string
 FLAG basecamp files folders create --agent type=bool
 FLAG basecamp files folders create --cache-dir type=string
 FLAG basecamp files folders create --count type=bool
 FLAG basecamp files folders create --folder type=string
-FLAG basecamp files folders create --help type=bool
 FLAG basecamp files folders create --hints type=bool
 FLAG basecamp files folders create --ids-only type=bool
 FLAG basecamp files folders create --in type=string
@@ -7443,14 +3322,12 @@ FLAG basecamp files folders create --styled type=bool
 FLAG basecamp files folders create --todolist type=string
 FLAG basecamp files folders create --vault type=string
 FLAG basecamp files folders create --verbose type=count
-FLAG basecamp files folders create --version type=bool
 FLAG basecamp files folders list --account type=string
 FLAG basecamp files folders list --agent type=bool
 FLAG basecamp files folders list --all type=bool
 FLAG basecamp files folders list --cache-dir type=string
 FLAG basecamp files folders list --count type=bool
 FLAG basecamp files folders list --folder type=string
-FLAG basecamp files folders list --help type=bool
 FLAG basecamp files folders list --hints type=bool
 FLAG basecamp files folders list --ids-only type=bool
 FLAG basecamp files folders list --in type=string
@@ -7470,13 +3347,11 @@ FLAG basecamp files folders list --styled type=bool
 FLAG basecamp files folders list --todolist type=string
 FLAG basecamp files folders list --vault type=string
 FLAG basecamp files folders list --verbose type=count
-FLAG basecamp files folders list --version type=bool
 FLAG basecamp files list --account type=string
 FLAG basecamp files list --agent type=bool
 FLAG basecamp files list --cache-dir type=string
 FLAG basecamp files list --count type=bool
 FLAG basecamp files list --folder type=string
-FLAG basecamp files list --help type=bool
 FLAG basecamp files list --hints type=bool
 FLAG basecamp files list --ids-only type=bool
 FLAG basecamp files list --in type=string
@@ -7494,13 +3369,11 @@ FLAG basecamp files list --styled type=bool
 FLAG basecamp files list --todolist type=string
 FLAG basecamp files list --vault type=string
 FLAG basecamp files list --verbose type=count
-FLAG basecamp files list --version type=bool
 FLAG basecamp files restore --account type=string
 FLAG basecamp files restore --agent type=bool
 FLAG basecamp files restore --cache-dir type=string
 FLAG basecamp files restore --count type=bool
 FLAG basecamp files restore --folder type=string
-FLAG basecamp files restore --help type=bool
 FLAG basecamp files restore --hints type=bool
 FLAG basecamp files restore --ids-only type=bool
 FLAG basecamp files restore --in type=string
@@ -7518,13 +3391,11 @@ FLAG basecamp files restore --styled type=bool
 FLAG basecamp files restore --todolist type=string
 FLAG basecamp files restore --vault type=string
 FLAG basecamp files restore --verbose type=count
-FLAG basecamp files restore --version type=bool
 FLAG basecamp files show --account type=string
 FLAG basecamp files show --agent type=bool
 FLAG basecamp files show --cache-dir type=string
 FLAG basecamp files show --count type=bool
 FLAG basecamp files show --folder type=string
-FLAG basecamp files show --help type=bool
 FLAG basecamp files show --hints type=bool
 FLAG basecamp files show --ids-only type=bool
 FLAG basecamp files show --in type=string
@@ -7543,13 +3414,11 @@ FLAG basecamp files show --todolist type=string
 FLAG basecamp files show --type type=string
 FLAG basecamp files show --vault type=string
 FLAG basecamp files show --verbose type=count
-FLAG basecamp files show --version type=bool
 FLAG basecamp files trash --account type=string
 FLAG basecamp files trash --agent type=bool
 FLAG basecamp files trash --cache-dir type=string
 FLAG basecamp files trash --count type=bool
 FLAG basecamp files trash --folder type=string
-FLAG basecamp files trash --help type=bool
 FLAG basecamp files trash --hints type=bool
 FLAG basecamp files trash --ids-only type=bool
 FLAG basecamp files trash --in type=string
@@ -7567,14 +3436,12 @@ FLAG basecamp files trash --styled type=bool
 FLAG basecamp files trash --todolist type=string
 FLAG basecamp files trash --vault type=string
 FLAG basecamp files trash --verbose type=count
-FLAG basecamp files trash --version type=bool
 FLAG basecamp files update --account type=string
 FLAG basecamp files update --agent type=bool
 FLAG basecamp files update --cache-dir type=string
 FLAG basecamp files update --content type=string
 FLAG basecamp files update --count type=bool
 FLAG basecamp files update --folder type=string
-FLAG basecamp files update --help type=bool
 FLAG basecamp files update --hints type=bool
 FLAG basecamp files update --ids-only type=bool
 FLAG basecamp files update --in type=string
@@ -7594,93 +3461,12 @@ FLAG basecamp files update --todolist type=string
 FLAG basecamp files update --type type=string
 FLAG basecamp files update --vault type=string
 FLAG basecamp files update --verbose type=count
-FLAG basecamp files update --version type=bool
-FLAG basecamp files upload --account type=string
-FLAG basecamp files upload --agent type=bool
-FLAG basecamp files upload --all type=bool
-FLAG basecamp files upload --cache-dir type=string
-FLAG basecamp files upload --count type=bool
-FLAG basecamp files upload --folder type=string
-FLAG basecamp files upload --help type=bool
-FLAG basecamp files upload --hints type=bool
-FLAG basecamp files upload --ids-only type=bool
-FLAG basecamp files upload --in type=string
-FLAG basecamp files upload --jq type=string
-FLAG basecamp files upload --json type=bool
-FLAG basecamp files upload --limit type=int
-FLAG basecamp files upload --markdown type=bool
-FLAG basecamp files upload --md type=bool
-FLAG basecamp files upload --no-hints type=bool
-FLAG basecamp files upload --no-stats type=bool
-FLAG basecamp files upload --page type=int
-FLAG basecamp files upload --profile type=string
-FLAG basecamp files upload --project type=string
-FLAG basecamp files upload --quiet type=bool
-FLAG basecamp files upload --stats type=bool
-FLAG basecamp files upload --styled type=bool
-FLAG basecamp files upload --todolist type=string
-FLAG basecamp files upload --vault type=string
-FLAG basecamp files upload --verbose type=count
-FLAG basecamp files upload --version type=bool
-FLAG basecamp files upload create --account type=string
-FLAG basecamp files upload create --agent type=bool
-FLAG basecamp files upload create --cache-dir type=string
-FLAG basecamp files upload create --count type=bool
-FLAG basecamp files upload create --description type=string
-FLAG basecamp files upload create --folder type=string
-FLAG basecamp files upload create --help type=bool
-FLAG basecamp files upload create --hints type=bool
-FLAG basecamp files upload create --ids-only type=bool
-FLAG basecamp files upload create --in type=string
-FLAG basecamp files upload create --jq type=string
-FLAG basecamp files upload create --json type=bool
-FLAG basecamp files upload create --markdown type=bool
-FLAG basecamp files upload create --md type=bool
-FLAG basecamp files upload create --no-hints type=bool
-FLAG basecamp files upload create --no-stats type=bool
-FLAG basecamp files upload create --profile type=string
-FLAG basecamp files upload create --project type=string
-FLAG basecamp files upload create --quiet type=bool
-FLAG basecamp files upload create --stats type=bool
-FLAG basecamp files upload create --styled type=bool
-FLAG basecamp files upload create --todolist type=string
-FLAG basecamp files upload create --vault type=string
-FLAG basecamp files upload create --verbose type=count
-FLAG basecamp files upload create --version type=bool
-FLAG basecamp files upload list --account type=string
-FLAG basecamp files upload list --agent type=bool
-FLAG basecamp files upload list --all type=bool
-FLAG basecamp files upload list --cache-dir type=string
-FLAG basecamp files upload list --count type=bool
-FLAG basecamp files upload list --folder type=string
-FLAG basecamp files upload list --help type=bool
-FLAG basecamp files upload list --hints type=bool
-FLAG basecamp files upload list --ids-only type=bool
-FLAG basecamp files upload list --in type=string
-FLAG basecamp files upload list --jq type=string
-FLAG basecamp files upload list --json type=bool
-FLAG basecamp files upload list --limit type=int
-FLAG basecamp files upload list --markdown type=bool
-FLAG basecamp files upload list --md type=bool
-FLAG basecamp files upload list --no-hints type=bool
-FLAG basecamp files upload list --no-stats type=bool
-FLAG basecamp files upload list --page type=int
-FLAG basecamp files upload list --profile type=string
-FLAG basecamp files upload list --project type=string
-FLAG basecamp files upload list --quiet type=bool
-FLAG basecamp files upload list --stats type=bool
-FLAG basecamp files upload list --styled type=bool
-FLAG basecamp files upload list --todolist type=string
-FLAG basecamp files upload list --vault type=string
-FLAG basecamp files upload list --verbose type=count
-FLAG basecamp files upload list --version type=bool
 FLAG basecamp files uploads --account type=string
 FLAG basecamp files uploads --agent type=bool
 FLAG basecamp files uploads --all type=bool
 FLAG basecamp files uploads --cache-dir type=string
 FLAG basecamp files uploads --count type=bool
 FLAG basecamp files uploads --folder type=string
-FLAG basecamp files uploads --help type=bool
 FLAG basecamp files uploads --hints type=bool
 FLAG basecamp files uploads --ids-only type=bool
 FLAG basecamp files uploads --in type=string
@@ -7700,14 +3486,12 @@ FLAG basecamp files uploads --styled type=bool
 FLAG basecamp files uploads --todolist type=string
 FLAG basecamp files uploads --vault type=string
 FLAG basecamp files uploads --verbose type=count
-FLAG basecamp files uploads --version type=bool
 FLAG basecamp files uploads create --account type=string
 FLAG basecamp files uploads create --agent type=bool
 FLAG basecamp files uploads create --cache-dir type=string
 FLAG basecamp files uploads create --count type=bool
 FLAG basecamp files uploads create --description type=string
 FLAG basecamp files uploads create --folder type=string
-FLAG basecamp files uploads create --help type=bool
 FLAG basecamp files uploads create --hints type=bool
 FLAG basecamp files uploads create --ids-only type=bool
 FLAG basecamp files uploads create --in type=string
@@ -7725,14 +3509,12 @@ FLAG basecamp files uploads create --styled type=bool
 FLAG basecamp files uploads create --todolist type=string
 FLAG basecamp files uploads create --vault type=string
 FLAG basecamp files uploads create --verbose type=count
-FLAG basecamp files uploads create --version type=bool
 FLAG basecamp files uploads list --account type=string
 FLAG basecamp files uploads list --agent type=bool
 FLAG basecamp files uploads list --all type=bool
 FLAG basecamp files uploads list --cache-dir type=string
 FLAG basecamp files uploads list --count type=bool
 FLAG basecamp files uploads list --folder type=string
-FLAG basecamp files uploads list --help type=bool
 FLAG basecamp files uploads list --hints type=bool
 FLAG basecamp files uploads list --ids-only type=bool
 FLAG basecamp files uploads list --in type=string
@@ -7752,1081 +3534,10 @@ FLAG basecamp files uploads list --styled type=bool
 FLAG basecamp files uploads list --todolist type=string
 FLAG basecamp files uploads list --vault type=string
 FLAG basecamp files uploads list --verbose type=count
-FLAG basecamp files uploads list --version type=bool
-FLAG basecamp files vault --account type=string
-FLAG basecamp files vault --agent type=bool
-FLAG basecamp files vault --all type=bool
-FLAG basecamp files vault --cache-dir type=string
-FLAG basecamp files vault --count type=bool
-FLAG basecamp files vault --folder type=string
-FLAG basecamp files vault --help type=bool
-FLAG basecamp files vault --hints type=bool
-FLAG basecamp files vault --ids-only type=bool
-FLAG basecamp files vault --in type=string
-FLAG basecamp files vault --jq type=string
-FLAG basecamp files vault --json type=bool
-FLAG basecamp files vault --limit type=int
-FLAG basecamp files vault --markdown type=bool
-FLAG basecamp files vault --md type=bool
-FLAG basecamp files vault --no-hints type=bool
-FLAG basecamp files vault --no-stats type=bool
-FLAG basecamp files vault --page type=int
-FLAG basecamp files vault --profile type=string
-FLAG basecamp files vault --project type=string
-FLAG basecamp files vault --quiet type=bool
-FLAG basecamp files vault --stats type=bool
-FLAG basecamp files vault --styled type=bool
-FLAG basecamp files vault --todolist type=string
-FLAG basecamp files vault --vault type=string
-FLAG basecamp files vault --verbose type=count
-FLAG basecamp files vault --version type=bool
-FLAG basecamp files vault create --account type=string
-FLAG basecamp files vault create --agent type=bool
-FLAG basecamp files vault create --cache-dir type=string
-FLAG basecamp files vault create --count type=bool
-FLAG basecamp files vault create --folder type=string
-FLAG basecamp files vault create --help type=bool
-FLAG basecamp files vault create --hints type=bool
-FLAG basecamp files vault create --ids-only type=bool
-FLAG basecamp files vault create --in type=string
-FLAG basecamp files vault create --jq type=string
-FLAG basecamp files vault create --json type=bool
-FLAG basecamp files vault create --markdown type=bool
-FLAG basecamp files vault create --md type=bool
-FLAG basecamp files vault create --no-hints type=bool
-FLAG basecamp files vault create --no-stats type=bool
-FLAG basecamp files vault create --profile type=string
-FLAG basecamp files vault create --project type=string
-FLAG basecamp files vault create --quiet type=bool
-FLAG basecamp files vault create --stats type=bool
-FLAG basecamp files vault create --styled type=bool
-FLAG basecamp files vault create --todolist type=string
-FLAG basecamp files vault create --vault type=string
-FLAG basecamp files vault create --verbose type=count
-FLAG basecamp files vault create --version type=bool
-FLAG basecamp files vault list --account type=string
-FLAG basecamp files vault list --agent type=bool
-FLAG basecamp files vault list --all type=bool
-FLAG basecamp files vault list --cache-dir type=string
-FLAG basecamp files vault list --count type=bool
-FLAG basecamp files vault list --folder type=string
-FLAG basecamp files vault list --help type=bool
-FLAG basecamp files vault list --hints type=bool
-FLAG basecamp files vault list --ids-only type=bool
-FLAG basecamp files vault list --in type=string
-FLAG basecamp files vault list --jq type=string
-FLAG basecamp files vault list --json type=bool
-FLAG basecamp files vault list --limit type=int
-FLAG basecamp files vault list --markdown type=bool
-FLAG basecamp files vault list --md type=bool
-FLAG basecamp files vault list --no-hints type=bool
-FLAG basecamp files vault list --no-stats type=bool
-FLAG basecamp files vault list --page type=int
-FLAG basecamp files vault list --profile type=string
-FLAG basecamp files vault list --project type=string
-FLAG basecamp files vault list --quiet type=bool
-FLAG basecamp files vault list --stats type=bool
-FLAG basecamp files vault list --styled type=bool
-FLAG basecamp files vault list --todolist type=string
-FLAG basecamp files vault list --vault type=string
-FLAG basecamp files vault list --verbose type=count
-FLAG basecamp files vault list --version type=bool
-FLAG basecamp files vaults --account type=string
-FLAG basecamp files vaults --agent type=bool
-FLAG basecamp files vaults --all type=bool
-FLAG basecamp files vaults --cache-dir type=string
-FLAG basecamp files vaults --count type=bool
-FLAG basecamp files vaults --folder type=string
-FLAG basecamp files vaults --help type=bool
-FLAG basecamp files vaults --hints type=bool
-FLAG basecamp files vaults --ids-only type=bool
-FLAG basecamp files vaults --in type=string
-FLAG basecamp files vaults --jq type=string
-FLAG basecamp files vaults --json type=bool
-FLAG basecamp files vaults --limit type=int
-FLAG basecamp files vaults --markdown type=bool
-FLAG basecamp files vaults --md type=bool
-FLAG basecamp files vaults --no-hints type=bool
-FLAG basecamp files vaults --no-stats type=bool
-FLAG basecamp files vaults --page type=int
-FLAG basecamp files vaults --profile type=string
-FLAG basecamp files vaults --project type=string
-FLAG basecamp files vaults --quiet type=bool
-FLAG basecamp files vaults --stats type=bool
-FLAG basecamp files vaults --styled type=bool
-FLAG basecamp files vaults --todolist type=string
-FLAG basecamp files vaults --vault type=string
-FLAG basecamp files vaults --verbose type=count
-FLAG basecamp files vaults --version type=bool
-FLAG basecamp files vaults create --account type=string
-FLAG basecamp files vaults create --agent type=bool
-FLAG basecamp files vaults create --cache-dir type=string
-FLAG basecamp files vaults create --count type=bool
-FLAG basecamp files vaults create --folder type=string
-FLAG basecamp files vaults create --help type=bool
-FLAG basecamp files vaults create --hints type=bool
-FLAG basecamp files vaults create --ids-only type=bool
-FLAG basecamp files vaults create --in type=string
-FLAG basecamp files vaults create --jq type=string
-FLAG basecamp files vaults create --json type=bool
-FLAG basecamp files vaults create --markdown type=bool
-FLAG basecamp files vaults create --md type=bool
-FLAG basecamp files vaults create --no-hints type=bool
-FLAG basecamp files vaults create --no-stats type=bool
-FLAG basecamp files vaults create --profile type=string
-FLAG basecamp files vaults create --project type=string
-FLAG basecamp files vaults create --quiet type=bool
-FLAG basecamp files vaults create --stats type=bool
-FLAG basecamp files vaults create --styled type=bool
-FLAG basecamp files vaults create --todolist type=string
-FLAG basecamp files vaults create --vault type=string
-FLAG basecamp files vaults create --verbose type=count
-FLAG basecamp files vaults create --version type=bool
-FLAG basecamp files vaults list --account type=string
-FLAG basecamp files vaults list --agent type=bool
-FLAG basecamp files vaults list --all type=bool
-FLAG basecamp files vaults list --cache-dir type=string
-FLAG basecamp files vaults list --count type=bool
-FLAG basecamp files vaults list --folder type=string
-FLAG basecamp files vaults list --help type=bool
-FLAG basecamp files vaults list --hints type=bool
-FLAG basecamp files vaults list --ids-only type=bool
-FLAG basecamp files vaults list --in type=string
-FLAG basecamp files vaults list --jq type=string
-FLAG basecamp files vaults list --json type=bool
-FLAG basecamp files vaults list --limit type=int
-FLAG basecamp files vaults list --markdown type=bool
-FLAG basecamp files vaults list --md type=bool
-FLAG basecamp files vaults list --no-hints type=bool
-FLAG basecamp files vaults list --no-stats type=bool
-FLAG basecamp files vaults list --page type=int
-FLAG basecamp files vaults list --profile type=string
-FLAG basecamp files vaults list --project type=string
-FLAG basecamp files vaults list --quiet type=bool
-FLAG basecamp files vaults list --stats type=bool
-FLAG basecamp files vaults list --styled type=bool
-FLAG basecamp files vaults list --todolist type=string
-FLAG basecamp files vaults list --vault type=string
-FLAG basecamp files vaults list --verbose type=count
-FLAG basecamp files vaults list --version type=bool
-FLAG basecamp folders --account type=string
-FLAG basecamp folders --agent type=bool
-FLAG basecamp folders --cache-dir type=string
-FLAG basecamp folders --count type=bool
-FLAG basecamp folders --folder type=string
-FLAG basecamp folders --help type=bool
-FLAG basecamp folders --hints type=bool
-FLAG basecamp folders --ids-only type=bool
-FLAG basecamp folders --in type=string
-FLAG basecamp folders --jq type=string
-FLAG basecamp folders --json type=bool
-FLAG basecamp folders --markdown type=bool
-FLAG basecamp folders --md type=bool
-FLAG basecamp folders --no-hints type=bool
-FLAG basecamp folders --no-stats type=bool
-FLAG basecamp folders --profile type=string
-FLAG basecamp folders --project type=string
-FLAG basecamp folders --quiet type=bool
-FLAG basecamp folders --stats type=bool
-FLAG basecamp folders --styled type=bool
-FLAG basecamp folders --todolist type=string
-FLAG basecamp folders --vault type=string
-FLAG basecamp folders --verbose type=count
-FLAG basecamp folders --version type=bool
-FLAG basecamp folders archive --account type=string
-FLAG basecamp folders archive --agent type=bool
-FLAG basecamp folders archive --cache-dir type=string
-FLAG basecamp folders archive --count type=bool
-FLAG basecamp folders archive --folder type=string
-FLAG basecamp folders archive --help type=bool
-FLAG basecamp folders archive --hints type=bool
-FLAG basecamp folders archive --ids-only type=bool
-FLAG basecamp folders archive --in type=string
-FLAG basecamp folders archive --jq type=string
-FLAG basecamp folders archive --json type=bool
-FLAG basecamp folders archive --markdown type=bool
-FLAG basecamp folders archive --md type=bool
-FLAG basecamp folders archive --no-hints type=bool
-FLAG basecamp folders archive --no-stats type=bool
-FLAG basecamp folders archive --profile type=string
-FLAG basecamp folders archive --project type=string
-FLAG basecamp folders archive --quiet type=bool
-FLAG basecamp folders archive --stats type=bool
-FLAG basecamp folders archive --styled type=bool
-FLAG basecamp folders archive --todolist type=string
-FLAG basecamp folders archive --vault type=string
-FLAG basecamp folders archive --verbose type=count
-FLAG basecamp folders archive --version type=bool
-FLAG basecamp folders doc --account type=string
-FLAG basecamp folders doc --agent type=bool
-FLAG basecamp folders doc --all type=bool
-FLAG basecamp folders doc --cache-dir type=string
-FLAG basecamp folders doc --count type=bool
-FLAG basecamp folders doc --folder type=string
-FLAG basecamp folders doc --help type=bool
-FLAG basecamp folders doc --hints type=bool
-FLAG basecamp folders doc --ids-only type=bool
-FLAG basecamp folders doc --in type=string
-FLAG basecamp folders doc --jq type=string
-FLAG basecamp folders doc --json type=bool
-FLAG basecamp folders doc --limit type=int
-FLAG basecamp folders doc --markdown type=bool
-FLAG basecamp folders doc --md type=bool
-FLAG basecamp folders doc --no-hints type=bool
-FLAG basecamp folders doc --no-stats type=bool
-FLAG basecamp folders doc --page type=int
-FLAG basecamp folders doc --profile type=string
-FLAG basecamp folders doc --project type=string
-FLAG basecamp folders doc --quiet type=bool
-FLAG basecamp folders doc --stats type=bool
-FLAG basecamp folders doc --styled type=bool
-FLAG basecamp folders doc --todolist type=string
-FLAG basecamp folders doc --vault type=string
-FLAG basecamp folders doc --verbose type=count
-FLAG basecamp folders doc --version type=bool
-FLAG basecamp folders doc create --account type=string
-FLAG basecamp folders doc create --agent type=bool
-FLAG basecamp folders doc create --attach type=stringArray
-FLAG basecamp folders doc create --cache-dir type=string
-FLAG basecamp folders doc create --count type=bool
-FLAG basecamp folders doc create --draft type=bool
-FLAG basecamp folders doc create --folder type=string
-FLAG basecamp folders doc create --help type=bool
-FLAG basecamp folders doc create --hints type=bool
-FLAG basecamp folders doc create --ids-only type=bool
-FLAG basecamp folders doc create --in type=string
-FLAG basecamp folders doc create --jq type=string
-FLAG basecamp folders doc create --json type=bool
-FLAG basecamp folders doc create --markdown type=bool
-FLAG basecamp folders doc create --md type=bool
-FLAG basecamp folders doc create --no-hints type=bool
-FLAG basecamp folders doc create --no-stats type=bool
-FLAG basecamp folders doc create --no-subscribe type=bool
-FLAG basecamp folders doc create --profile type=string
-FLAG basecamp folders doc create --project type=string
-FLAG basecamp folders doc create --quiet type=bool
-FLAG basecamp folders doc create --stats type=bool
-FLAG basecamp folders doc create --styled type=bool
-FLAG basecamp folders doc create --subscribe type=string
-FLAG basecamp folders doc create --todolist type=string
-FLAG basecamp folders doc create --vault type=string
-FLAG basecamp folders doc create --verbose type=count
-FLAG basecamp folders doc create --version type=bool
-FLAG basecamp folders doc list --account type=string
-FLAG basecamp folders doc list --agent type=bool
-FLAG basecamp folders doc list --all type=bool
-FLAG basecamp folders doc list --cache-dir type=string
-FLAG basecamp folders doc list --count type=bool
-FLAG basecamp folders doc list --folder type=string
-FLAG basecamp folders doc list --help type=bool
-FLAG basecamp folders doc list --hints type=bool
-FLAG basecamp folders doc list --ids-only type=bool
-FLAG basecamp folders doc list --in type=string
-FLAG basecamp folders doc list --jq type=string
-FLAG basecamp folders doc list --json type=bool
-FLAG basecamp folders doc list --limit type=int
-FLAG basecamp folders doc list --markdown type=bool
-FLAG basecamp folders doc list --md type=bool
-FLAG basecamp folders doc list --no-hints type=bool
-FLAG basecamp folders doc list --no-stats type=bool
-FLAG basecamp folders doc list --page type=int
-FLAG basecamp folders doc list --profile type=string
-FLAG basecamp folders doc list --project type=string
-FLAG basecamp folders doc list --quiet type=bool
-FLAG basecamp folders doc list --stats type=bool
-FLAG basecamp folders doc list --styled type=bool
-FLAG basecamp folders doc list --todolist type=string
-FLAG basecamp folders doc list --vault type=string
-FLAG basecamp folders doc list --verbose type=count
-FLAG basecamp folders doc list --version type=bool
-FLAG basecamp folders document --account type=string
-FLAG basecamp folders document --agent type=bool
-FLAG basecamp folders document --all type=bool
-FLAG basecamp folders document --cache-dir type=string
-FLAG basecamp folders document --count type=bool
-FLAG basecamp folders document --folder type=string
-FLAG basecamp folders document --help type=bool
-FLAG basecamp folders document --hints type=bool
-FLAG basecamp folders document --ids-only type=bool
-FLAG basecamp folders document --in type=string
-FLAG basecamp folders document --jq type=string
-FLAG basecamp folders document --json type=bool
-FLAG basecamp folders document --limit type=int
-FLAG basecamp folders document --markdown type=bool
-FLAG basecamp folders document --md type=bool
-FLAG basecamp folders document --no-hints type=bool
-FLAG basecamp folders document --no-stats type=bool
-FLAG basecamp folders document --page type=int
-FLAG basecamp folders document --profile type=string
-FLAG basecamp folders document --project type=string
-FLAG basecamp folders document --quiet type=bool
-FLAG basecamp folders document --stats type=bool
-FLAG basecamp folders document --styled type=bool
-FLAG basecamp folders document --todolist type=string
-FLAG basecamp folders document --vault type=string
-FLAG basecamp folders document --verbose type=count
-FLAG basecamp folders document --version type=bool
-FLAG basecamp folders document create --account type=string
-FLAG basecamp folders document create --agent type=bool
-FLAG basecamp folders document create --attach type=stringArray
-FLAG basecamp folders document create --cache-dir type=string
-FLAG basecamp folders document create --count type=bool
-FLAG basecamp folders document create --draft type=bool
-FLAG basecamp folders document create --folder type=string
-FLAG basecamp folders document create --help type=bool
-FLAG basecamp folders document create --hints type=bool
-FLAG basecamp folders document create --ids-only type=bool
-FLAG basecamp folders document create --in type=string
-FLAG basecamp folders document create --jq type=string
-FLAG basecamp folders document create --json type=bool
-FLAG basecamp folders document create --markdown type=bool
-FLAG basecamp folders document create --md type=bool
-FLAG basecamp folders document create --no-hints type=bool
-FLAG basecamp folders document create --no-stats type=bool
-FLAG basecamp folders document create --no-subscribe type=bool
-FLAG basecamp folders document create --profile type=string
-FLAG basecamp folders document create --project type=string
-FLAG basecamp folders document create --quiet type=bool
-FLAG basecamp folders document create --stats type=bool
-FLAG basecamp folders document create --styled type=bool
-FLAG basecamp folders document create --subscribe type=string
-FLAG basecamp folders document create --todolist type=string
-FLAG basecamp folders document create --vault type=string
-FLAG basecamp folders document create --verbose type=count
-FLAG basecamp folders document create --version type=bool
-FLAG basecamp folders document list --account type=string
-FLAG basecamp folders document list --agent type=bool
-FLAG basecamp folders document list --all type=bool
-FLAG basecamp folders document list --cache-dir type=string
-FLAG basecamp folders document list --count type=bool
-FLAG basecamp folders document list --folder type=string
-FLAG basecamp folders document list --help type=bool
-FLAG basecamp folders document list --hints type=bool
-FLAG basecamp folders document list --ids-only type=bool
-FLAG basecamp folders document list --in type=string
-FLAG basecamp folders document list --jq type=string
-FLAG basecamp folders document list --json type=bool
-FLAG basecamp folders document list --limit type=int
-FLAG basecamp folders document list --markdown type=bool
-FLAG basecamp folders document list --md type=bool
-FLAG basecamp folders document list --no-hints type=bool
-FLAG basecamp folders document list --no-stats type=bool
-FLAG basecamp folders document list --page type=int
-FLAG basecamp folders document list --profile type=string
-FLAG basecamp folders document list --project type=string
-FLAG basecamp folders document list --quiet type=bool
-FLAG basecamp folders document list --stats type=bool
-FLAG basecamp folders document list --styled type=bool
-FLAG basecamp folders document list --todolist type=string
-FLAG basecamp folders document list --vault type=string
-FLAG basecamp folders document list --verbose type=count
-FLAG basecamp folders document list --version type=bool
-FLAG basecamp folders documents --account type=string
-FLAG basecamp folders documents --agent type=bool
-FLAG basecamp folders documents --all type=bool
-FLAG basecamp folders documents --cache-dir type=string
-FLAG basecamp folders documents --count type=bool
-FLAG basecamp folders documents --folder type=string
-FLAG basecamp folders documents --help type=bool
-FLAG basecamp folders documents --hints type=bool
-FLAG basecamp folders documents --ids-only type=bool
-FLAG basecamp folders documents --in type=string
-FLAG basecamp folders documents --jq type=string
-FLAG basecamp folders documents --json type=bool
-FLAG basecamp folders documents --limit type=int
-FLAG basecamp folders documents --markdown type=bool
-FLAG basecamp folders documents --md type=bool
-FLAG basecamp folders documents --no-hints type=bool
-FLAG basecamp folders documents --no-stats type=bool
-FLAG basecamp folders documents --page type=int
-FLAG basecamp folders documents --profile type=string
-FLAG basecamp folders documents --project type=string
-FLAG basecamp folders documents --quiet type=bool
-FLAG basecamp folders documents --stats type=bool
-FLAG basecamp folders documents --styled type=bool
-FLAG basecamp folders documents --todolist type=string
-FLAG basecamp folders documents --vault type=string
-FLAG basecamp folders documents --verbose type=count
-FLAG basecamp folders documents --version type=bool
-FLAG basecamp folders documents create --account type=string
-FLAG basecamp folders documents create --agent type=bool
-FLAG basecamp folders documents create --attach type=stringArray
-FLAG basecamp folders documents create --cache-dir type=string
-FLAG basecamp folders documents create --count type=bool
-FLAG basecamp folders documents create --draft type=bool
-FLAG basecamp folders documents create --folder type=string
-FLAG basecamp folders documents create --help type=bool
-FLAG basecamp folders documents create --hints type=bool
-FLAG basecamp folders documents create --ids-only type=bool
-FLAG basecamp folders documents create --in type=string
-FLAG basecamp folders documents create --jq type=string
-FLAG basecamp folders documents create --json type=bool
-FLAG basecamp folders documents create --markdown type=bool
-FLAG basecamp folders documents create --md type=bool
-FLAG basecamp folders documents create --no-hints type=bool
-FLAG basecamp folders documents create --no-stats type=bool
-FLAG basecamp folders documents create --no-subscribe type=bool
-FLAG basecamp folders documents create --profile type=string
-FLAG basecamp folders documents create --project type=string
-FLAG basecamp folders documents create --quiet type=bool
-FLAG basecamp folders documents create --stats type=bool
-FLAG basecamp folders documents create --styled type=bool
-FLAG basecamp folders documents create --subscribe type=string
-FLAG basecamp folders documents create --todolist type=string
-FLAG basecamp folders documents create --vault type=string
-FLAG basecamp folders documents create --verbose type=count
-FLAG basecamp folders documents create --version type=bool
-FLAG basecamp folders documents list --account type=string
-FLAG basecamp folders documents list --agent type=bool
-FLAG basecamp folders documents list --all type=bool
-FLAG basecamp folders documents list --cache-dir type=string
-FLAG basecamp folders documents list --count type=bool
-FLAG basecamp folders documents list --folder type=string
-FLAG basecamp folders documents list --help type=bool
-FLAG basecamp folders documents list --hints type=bool
-FLAG basecamp folders documents list --ids-only type=bool
-FLAG basecamp folders documents list --in type=string
-FLAG basecamp folders documents list --jq type=string
-FLAG basecamp folders documents list --json type=bool
-FLAG basecamp folders documents list --limit type=int
-FLAG basecamp folders documents list --markdown type=bool
-FLAG basecamp folders documents list --md type=bool
-FLAG basecamp folders documents list --no-hints type=bool
-FLAG basecamp folders documents list --no-stats type=bool
-FLAG basecamp folders documents list --page type=int
-FLAG basecamp folders documents list --profile type=string
-FLAG basecamp folders documents list --project type=string
-FLAG basecamp folders documents list --quiet type=bool
-FLAG basecamp folders documents list --stats type=bool
-FLAG basecamp folders documents list --styled type=bool
-FLAG basecamp folders documents list --todolist type=string
-FLAG basecamp folders documents list --vault type=string
-FLAG basecamp folders documents list --verbose type=count
-FLAG basecamp folders documents list --version type=bool
-FLAG basecamp folders download --account type=string
-FLAG basecamp folders download --agent type=bool
-FLAG basecamp folders download --cache-dir type=string
-FLAG basecamp folders download --count type=bool
-FLAG basecamp folders download --folder type=string
-FLAG basecamp folders download --help type=bool
-FLAG basecamp folders download --hints type=bool
-FLAG basecamp folders download --ids-only type=bool
-FLAG basecamp folders download --in type=string
-FLAG basecamp folders download --jq type=string
-FLAG basecamp folders download --json type=bool
-FLAG basecamp folders download --markdown type=bool
-FLAG basecamp folders download --md type=bool
-FLAG basecamp folders download --no-hints type=bool
-FLAG basecamp folders download --no-stats type=bool
-FLAG basecamp folders download --out type=string
-FLAG basecamp folders download --profile type=string
-FLAG basecamp folders download --project type=string
-FLAG basecamp folders download --quiet type=bool
-FLAG basecamp folders download --stats type=bool
-FLAG basecamp folders download --styled type=bool
-FLAG basecamp folders download --todolist type=string
-FLAG basecamp folders download --vault type=string
-FLAG basecamp folders download --verbose type=count
-FLAG basecamp folders download --version type=bool
-FLAG basecamp folders folder --account type=string
-FLAG basecamp folders folder --agent type=bool
-FLAG basecamp folders folder --all type=bool
-FLAG basecamp folders folder --cache-dir type=string
-FLAG basecamp folders folder --count type=bool
-FLAG basecamp folders folder --folder type=string
-FLAG basecamp folders folder --help type=bool
-FLAG basecamp folders folder --hints type=bool
-FLAG basecamp folders folder --ids-only type=bool
-FLAG basecamp folders folder --in type=string
-FLAG basecamp folders folder --jq type=string
-FLAG basecamp folders folder --json type=bool
-FLAG basecamp folders folder --limit type=int
-FLAG basecamp folders folder --markdown type=bool
-FLAG basecamp folders folder --md type=bool
-FLAG basecamp folders folder --no-hints type=bool
-FLAG basecamp folders folder --no-stats type=bool
-FLAG basecamp folders folder --page type=int
-FLAG basecamp folders folder --profile type=string
-FLAG basecamp folders folder --project type=string
-FLAG basecamp folders folder --quiet type=bool
-FLAG basecamp folders folder --stats type=bool
-FLAG basecamp folders folder --styled type=bool
-FLAG basecamp folders folder --todolist type=string
-FLAG basecamp folders folder --vault type=string
-FLAG basecamp folders folder --verbose type=count
-FLAG basecamp folders folder --version type=bool
-FLAG basecamp folders folder create --account type=string
-FLAG basecamp folders folder create --agent type=bool
-FLAG basecamp folders folder create --cache-dir type=string
-FLAG basecamp folders folder create --count type=bool
-FLAG basecamp folders folder create --folder type=string
-FLAG basecamp folders folder create --help type=bool
-FLAG basecamp folders folder create --hints type=bool
-FLAG basecamp folders folder create --ids-only type=bool
-FLAG basecamp folders folder create --in type=string
-FLAG basecamp folders folder create --jq type=string
-FLAG basecamp folders folder create --json type=bool
-FLAG basecamp folders folder create --markdown type=bool
-FLAG basecamp folders folder create --md type=bool
-FLAG basecamp folders folder create --no-hints type=bool
-FLAG basecamp folders folder create --no-stats type=bool
-FLAG basecamp folders folder create --profile type=string
-FLAG basecamp folders folder create --project type=string
-FLAG basecamp folders folder create --quiet type=bool
-FLAG basecamp folders folder create --stats type=bool
-FLAG basecamp folders folder create --styled type=bool
-FLAG basecamp folders folder create --todolist type=string
-FLAG basecamp folders folder create --vault type=string
-FLAG basecamp folders folder create --verbose type=count
-FLAG basecamp folders folder create --version type=bool
-FLAG basecamp folders folder list --account type=string
-FLAG basecamp folders folder list --agent type=bool
-FLAG basecamp folders folder list --all type=bool
-FLAG basecamp folders folder list --cache-dir type=string
-FLAG basecamp folders folder list --count type=bool
-FLAG basecamp folders folder list --folder type=string
-FLAG basecamp folders folder list --help type=bool
-FLAG basecamp folders folder list --hints type=bool
-FLAG basecamp folders folder list --ids-only type=bool
-FLAG basecamp folders folder list --in type=string
-FLAG basecamp folders folder list --jq type=string
-FLAG basecamp folders folder list --json type=bool
-FLAG basecamp folders folder list --limit type=int
-FLAG basecamp folders folder list --markdown type=bool
-FLAG basecamp folders folder list --md type=bool
-FLAG basecamp folders folder list --no-hints type=bool
-FLAG basecamp folders folder list --no-stats type=bool
-FLAG basecamp folders folder list --page type=int
-FLAG basecamp folders folder list --profile type=string
-FLAG basecamp folders folder list --project type=string
-FLAG basecamp folders folder list --quiet type=bool
-FLAG basecamp folders folder list --stats type=bool
-FLAG basecamp folders folder list --styled type=bool
-FLAG basecamp folders folder list --todolist type=string
-FLAG basecamp folders folder list --vault type=string
-FLAG basecamp folders folder list --verbose type=count
-FLAG basecamp folders folder list --version type=bool
-FLAG basecamp folders folders --account type=string
-FLAG basecamp folders folders --agent type=bool
-FLAG basecamp folders folders --all type=bool
-FLAG basecamp folders folders --cache-dir type=string
-FLAG basecamp folders folders --count type=bool
-FLAG basecamp folders folders --folder type=string
-FLAG basecamp folders folders --help type=bool
-FLAG basecamp folders folders --hints type=bool
-FLAG basecamp folders folders --ids-only type=bool
-FLAG basecamp folders folders --in type=string
-FLAG basecamp folders folders --jq type=string
-FLAG basecamp folders folders --json type=bool
-FLAG basecamp folders folders --limit type=int
-FLAG basecamp folders folders --markdown type=bool
-FLAG basecamp folders folders --md type=bool
-FLAG basecamp folders folders --no-hints type=bool
-FLAG basecamp folders folders --no-stats type=bool
-FLAG basecamp folders folders --page type=int
-FLAG basecamp folders folders --profile type=string
-FLAG basecamp folders folders --project type=string
-FLAG basecamp folders folders --quiet type=bool
-FLAG basecamp folders folders --stats type=bool
-FLAG basecamp folders folders --styled type=bool
-FLAG basecamp folders folders --todolist type=string
-FLAG basecamp folders folders --vault type=string
-FLAG basecamp folders folders --verbose type=count
-FLAG basecamp folders folders --version type=bool
-FLAG basecamp folders folders create --account type=string
-FLAG basecamp folders folders create --agent type=bool
-FLAG basecamp folders folders create --cache-dir type=string
-FLAG basecamp folders folders create --count type=bool
-FLAG basecamp folders folders create --folder type=string
-FLAG basecamp folders folders create --help type=bool
-FLAG basecamp folders folders create --hints type=bool
-FLAG basecamp folders folders create --ids-only type=bool
-FLAG basecamp folders folders create --in type=string
-FLAG basecamp folders folders create --jq type=string
-FLAG basecamp folders folders create --json type=bool
-FLAG basecamp folders folders create --markdown type=bool
-FLAG basecamp folders folders create --md type=bool
-FLAG basecamp folders folders create --no-hints type=bool
-FLAG basecamp folders folders create --no-stats type=bool
-FLAG basecamp folders folders create --profile type=string
-FLAG basecamp folders folders create --project type=string
-FLAG basecamp folders folders create --quiet type=bool
-FLAG basecamp folders folders create --stats type=bool
-FLAG basecamp folders folders create --styled type=bool
-FLAG basecamp folders folders create --todolist type=string
-FLAG basecamp folders folders create --vault type=string
-FLAG basecamp folders folders create --verbose type=count
-FLAG basecamp folders folders create --version type=bool
-FLAG basecamp folders folders list --account type=string
-FLAG basecamp folders folders list --agent type=bool
-FLAG basecamp folders folders list --all type=bool
-FLAG basecamp folders folders list --cache-dir type=string
-FLAG basecamp folders folders list --count type=bool
-FLAG basecamp folders folders list --folder type=string
-FLAG basecamp folders folders list --help type=bool
-FLAG basecamp folders folders list --hints type=bool
-FLAG basecamp folders folders list --ids-only type=bool
-FLAG basecamp folders folders list --in type=string
-FLAG basecamp folders folders list --jq type=string
-FLAG basecamp folders folders list --json type=bool
-FLAG basecamp folders folders list --limit type=int
-FLAG basecamp folders folders list --markdown type=bool
-FLAG basecamp folders folders list --md type=bool
-FLAG basecamp folders folders list --no-hints type=bool
-FLAG basecamp folders folders list --no-stats type=bool
-FLAG basecamp folders folders list --page type=int
-FLAG basecamp folders folders list --profile type=string
-FLAG basecamp folders folders list --project type=string
-FLAG basecamp folders folders list --quiet type=bool
-FLAG basecamp folders folders list --stats type=bool
-FLAG basecamp folders folders list --styled type=bool
-FLAG basecamp folders folders list --todolist type=string
-FLAG basecamp folders folders list --vault type=string
-FLAG basecamp folders folders list --verbose type=count
-FLAG basecamp folders folders list --version type=bool
-FLAG basecamp folders list --account type=string
-FLAG basecamp folders list --agent type=bool
-FLAG basecamp folders list --cache-dir type=string
-FLAG basecamp folders list --count type=bool
-FLAG basecamp folders list --folder type=string
-FLAG basecamp folders list --help type=bool
-FLAG basecamp folders list --hints type=bool
-FLAG basecamp folders list --ids-only type=bool
-FLAG basecamp folders list --in type=string
-FLAG basecamp folders list --jq type=string
-FLAG basecamp folders list --json type=bool
-FLAG basecamp folders list --markdown type=bool
-FLAG basecamp folders list --md type=bool
-FLAG basecamp folders list --no-hints type=bool
-FLAG basecamp folders list --no-stats type=bool
-FLAG basecamp folders list --profile type=string
-FLAG basecamp folders list --project type=string
-FLAG basecamp folders list --quiet type=bool
-FLAG basecamp folders list --stats type=bool
-FLAG basecamp folders list --styled type=bool
-FLAG basecamp folders list --todolist type=string
-FLAG basecamp folders list --vault type=string
-FLAG basecamp folders list --verbose type=count
-FLAG basecamp folders list --version type=bool
-FLAG basecamp folders restore --account type=string
-FLAG basecamp folders restore --agent type=bool
-FLAG basecamp folders restore --cache-dir type=string
-FLAG basecamp folders restore --count type=bool
-FLAG basecamp folders restore --folder type=string
-FLAG basecamp folders restore --help type=bool
-FLAG basecamp folders restore --hints type=bool
-FLAG basecamp folders restore --ids-only type=bool
-FLAG basecamp folders restore --in type=string
-FLAG basecamp folders restore --jq type=string
-FLAG basecamp folders restore --json type=bool
-FLAG basecamp folders restore --markdown type=bool
-FLAG basecamp folders restore --md type=bool
-FLAG basecamp folders restore --no-hints type=bool
-FLAG basecamp folders restore --no-stats type=bool
-FLAG basecamp folders restore --profile type=string
-FLAG basecamp folders restore --project type=string
-FLAG basecamp folders restore --quiet type=bool
-FLAG basecamp folders restore --stats type=bool
-FLAG basecamp folders restore --styled type=bool
-FLAG basecamp folders restore --todolist type=string
-FLAG basecamp folders restore --vault type=string
-FLAG basecamp folders restore --verbose type=count
-FLAG basecamp folders restore --version type=bool
-FLAG basecamp folders show --account type=string
-FLAG basecamp folders show --agent type=bool
-FLAG basecamp folders show --cache-dir type=string
-FLAG basecamp folders show --count type=bool
-FLAG basecamp folders show --folder type=string
-FLAG basecamp folders show --help type=bool
-FLAG basecamp folders show --hints type=bool
-FLAG basecamp folders show --ids-only type=bool
-FLAG basecamp folders show --in type=string
-FLAG basecamp folders show --jq type=string
-FLAG basecamp folders show --json type=bool
-FLAG basecamp folders show --markdown type=bool
-FLAG basecamp folders show --md type=bool
-FLAG basecamp folders show --no-hints type=bool
-FLAG basecamp folders show --no-stats type=bool
-FLAG basecamp folders show --profile type=string
-FLAG basecamp folders show --project type=string
-FLAG basecamp folders show --quiet type=bool
-FLAG basecamp folders show --stats type=bool
-FLAG basecamp folders show --styled type=bool
-FLAG basecamp folders show --todolist type=string
-FLAG basecamp folders show --type type=string
-FLAG basecamp folders show --vault type=string
-FLAG basecamp folders show --verbose type=count
-FLAG basecamp folders show --version type=bool
-FLAG basecamp folders trash --account type=string
-FLAG basecamp folders trash --agent type=bool
-FLAG basecamp folders trash --cache-dir type=string
-FLAG basecamp folders trash --count type=bool
-FLAG basecamp folders trash --folder type=string
-FLAG basecamp folders trash --help type=bool
-FLAG basecamp folders trash --hints type=bool
-FLAG basecamp folders trash --ids-only type=bool
-FLAG basecamp folders trash --in type=string
-FLAG basecamp folders trash --jq type=string
-FLAG basecamp folders trash --json type=bool
-FLAG basecamp folders trash --markdown type=bool
-FLAG basecamp folders trash --md type=bool
-FLAG basecamp folders trash --no-hints type=bool
-FLAG basecamp folders trash --no-stats type=bool
-FLAG basecamp folders trash --profile type=string
-FLAG basecamp folders trash --project type=string
-FLAG basecamp folders trash --quiet type=bool
-FLAG basecamp folders trash --stats type=bool
-FLAG basecamp folders trash --styled type=bool
-FLAG basecamp folders trash --todolist type=string
-FLAG basecamp folders trash --vault type=string
-FLAG basecamp folders trash --verbose type=count
-FLAG basecamp folders trash --version type=bool
-FLAG basecamp folders update --account type=string
-FLAG basecamp folders update --agent type=bool
-FLAG basecamp folders update --cache-dir type=string
-FLAG basecamp folders update --content type=string
-FLAG basecamp folders update --count type=bool
-FLAG basecamp folders update --folder type=string
-FLAG basecamp folders update --help type=bool
-FLAG basecamp folders update --hints type=bool
-FLAG basecamp folders update --ids-only type=bool
-FLAG basecamp folders update --in type=string
-FLAG basecamp folders update --jq type=string
-FLAG basecamp folders update --json type=bool
-FLAG basecamp folders update --markdown type=bool
-FLAG basecamp folders update --md type=bool
-FLAG basecamp folders update --no-hints type=bool
-FLAG basecamp folders update --no-stats type=bool
-FLAG basecamp folders update --profile type=string
-FLAG basecamp folders update --project type=string
-FLAG basecamp folders update --quiet type=bool
-FLAG basecamp folders update --stats type=bool
-FLAG basecamp folders update --styled type=bool
-FLAG basecamp folders update --title type=string
-FLAG basecamp folders update --todolist type=string
-FLAG basecamp folders update --type type=string
-FLAG basecamp folders update --vault type=string
-FLAG basecamp folders update --verbose type=count
-FLAG basecamp folders update --version type=bool
-FLAG basecamp folders upload --account type=string
-FLAG basecamp folders upload --agent type=bool
-FLAG basecamp folders upload --all type=bool
-FLAG basecamp folders upload --cache-dir type=string
-FLAG basecamp folders upload --count type=bool
-FLAG basecamp folders upload --folder type=string
-FLAG basecamp folders upload --help type=bool
-FLAG basecamp folders upload --hints type=bool
-FLAG basecamp folders upload --ids-only type=bool
-FLAG basecamp folders upload --in type=string
-FLAG basecamp folders upload --jq type=string
-FLAG basecamp folders upload --json type=bool
-FLAG basecamp folders upload --limit type=int
-FLAG basecamp folders upload --markdown type=bool
-FLAG basecamp folders upload --md type=bool
-FLAG basecamp folders upload --no-hints type=bool
-FLAG basecamp folders upload --no-stats type=bool
-FLAG basecamp folders upload --page type=int
-FLAG basecamp folders upload --profile type=string
-FLAG basecamp folders upload --project type=string
-FLAG basecamp folders upload --quiet type=bool
-FLAG basecamp folders upload --stats type=bool
-FLAG basecamp folders upload --styled type=bool
-FLAG basecamp folders upload --todolist type=string
-FLAG basecamp folders upload --vault type=string
-FLAG basecamp folders upload --verbose type=count
-FLAG basecamp folders upload --version type=bool
-FLAG basecamp folders upload create --account type=string
-FLAG basecamp folders upload create --agent type=bool
-FLAG basecamp folders upload create --cache-dir type=string
-FLAG basecamp folders upload create --count type=bool
-FLAG basecamp folders upload create --description type=string
-FLAG basecamp folders upload create --folder type=string
-FLAG basecamp folders upload create --help type=bool
-FLAG basecamp folders upload create --hints type=bool
-FLAG basecamp folders upload create --ids-only type=bool
-FLAG basecamp folders upload create --in type=string
-FLAG basecamp folders upload create --jq type=string
-FLAG basecamp folders upload create --json type=bool
-FLAG basecamp folders upload create --markdown type=bool
-FLAG basecamp folders upload create --md type=bool
-FLAG basecamp folders upload create --no-hints type=bool
-FLAG basecamp folders upload create --no-stats type=bool
-FLAG basecamp folders upload create --profile type=string
-FLAG basecamp folders upload create --project type=string
-FLAG basecamp folders upload create --quiet type=bool
-FLAG basecamp folders upload create --stats type=bool
-FLAG basecamp folders upload create --styled type=bool
-FLAG basecamp folders upload create --todolist type=string
-FLAG basecamp folders upload create --vault type=string
-FLAG basecamp folders upload create --verbose type=count
-FLAG basecamp folders upload create --version type=bool
-FLAG basecamp folders upload list --account type=string
-FLAG basecamp folders upload list --agent type=bool
-FLAG basecamp folders upload list --all type=bool
-FLAG basecamp folders upload list --cache-dir type=string
-FLAG basecamp folders upload list --count type=bool
-FLAG basecamp folders upload list --folder type=string
-FLAG basecamp folders upload list --help type=bool
-FLAG basecamp folders upload list --hints type=bool
-FLAG basecamp folders upload list --ids-only type=bool
-FLAG basecamp folders upload list --in type=string
-FLAG basecamp folders upload list --jq type=string
-FLAG basecamp folders upload list --json type=bool
-FLAG basecamp folders upload list --limit type=int
-FLAG basecamp folders upload list --markdown type=bool
-FLAG basecamp folders upload list --md type=bool
-FLAG basecamp folders upload list --no-hints type=bool
-FLAG basecamp folders upload list --no-stats type=bool
-FLAG basecamp folders upload list --page type=int
-FLAG basecamp folders upload list --profile type=string
-FLAG basecamp folders upload list --project type=string
-FLAG basecamp folders upload list --quiet type=bool
-FLAG basecamp folders upload list --stats type=bool
-FLAG basecamp folders upload list --styled type=bool
-FLAG basecamp folders upload list --todolist type=string
-FLAG basecamp folders upload list --vault type=string
-FLAG basecamp folders upload list --verbose type=count
-FLAG basecamp folders upload list --version type=bool
-FLAG basecamp folders uploads --account type=string
-FLAG basecamp folders uploads --agent type=bool
-FLAG basecamp folders uploads --all type=bool
-FLAG basecamp folders uploads --cache-dir type=string
-FLAG basecamp folders uploads --count type=bool
-FLAG basecamp folders uploads --folder type=string
-FLAG basecamp folders uploads --help type=bool
-FLAG basecamp folders uploads --hints type=bool
-FLAG basecamp folders uploads --ids-only type=bool
-FLAG basecamp folders uploads --in type=string
-FLAG basecamp folders uploads --jq type=string
-FLAG basecamp folders uploads --json type=bool
-FLAG basecamp folders uploads --limit type=int
-FLAG basecamp folders uploads --markdown type=bool
-FLAG basecamp folders uploads --md type=bool
-FLAG basecamp folders uploads --no-hints type=bool
-FLAG basecamp folders uploads --no-stats type=bool
-FLAG basecamp folders uploads --page type=int
-FLAG basecamp folders uploads --profile type=string
-FLAG basecamp folders uploads --project type=string
-FLAG basecamp folders uploads --quiet type=bool
-FLAG basecamp folders uploads --stats type=bool
-FLAG basecamp folders uploads --styled type=bool
-FLAG basecamp folders uploads --todolist type=string
-FLAG basecamp folders uploads --vault type=string
-FLAG basecamp folders uploads --verbose type=count
-FLAG basecamp folders uploads --version type=bool
-FLAG basecamp folders uploads create --account type=string
-FLAG basecamp folders uploads create --agent type=bool
-FLAG basecamp folders uploads create --cache-dir type=string
-FLAG basecamp folders uploads create --count type=bool
-FLAG basecamp folders uploads create --description type=string
-FLAG basecamp folders uploads create --folder type=string
-FLAG basecamp folders uploads create --help type=bool
-FLAG basecamp folders uploads create --hints type=bool
-FLAG basecamp folders uploads create --ids-only type=bool
-FLAG basecamp folders uploads create --in type=string
-FLAG basecamp folders uploads create --jq type=string
-FLAG basecamp folders uploads create --json type=bool
-FLAG basecamp folders uploads create --markdown type=bool
-FLAG basecamp folders uploads create --md type=bool
-FLAG basecamp folders uploads create --no-hints type=bool
-FLAG basecamp folders uploads create --no-stats type=bool
-FLAG basecamp folders uploads create --profile type=string
-FLAG basecamp folders uploads create --project type=string
-FLAG basecamp folders uploads create --quiet type=bool
-FLAG basecamp folders uploads create --stats type=bool
-FLAG basecamp folders uploads create --styled type=bool
-FLAG basecamp folders uploads create --todolist type=string
-FLAG basecamp folders uploads create --vault type=string
-FLAG basecamp folders uploads create --verbose type=count
-FLAG basecamp folders uploads create --version type=bool
-FLAG basecamp folders uploads list --account type=string
-FLAG basecamp folders uploads list --agent type=bool
-FLAG basecamp folders uploads list --all type=bool
-FLAG basecamp folders uploads list --cache-dir type=string
-FLAG basecamp folders uploads list --count type=bool
-FLAG basecamp folders uploads list --folder type=string
-FLAG basecamp folders uploads list --help type=bool
-FLAG basecamp folders uploads list --hints type=bool
-FLAG basecamp folders uploads list --ids-only type=bool
-FLAG basecamp folders uploads list --in type=string
-FLAG basecamp folders uploads list --jq type=string
-FLAG basecamp folders uploads list --json type=bool
-FLAG basecamp folders uploads list --limit type=int
-FLAG basecamp folders uploads list --markdown type=bool
-FLAG basecamp folders uploads list --md type=bool
-FLAG basecamp folders uploads list --no-hints type=bool
-FLAG basecamp folders uploads list --no-stats type=bool
-FLAG basecamp folders uploads list --page type=int
-FLAG basecamp folders uploads list --profile type=string
-FLAG basecamp folders uploads list --project type=string
-FLAG basecamp folders uploads list --quiet type=bool
-FLAG basecamp folders uploads list --stats type=bool
-FLAG basecamp folders uploads list --styled type=bool
-FLAG basecamp folders uploads list --todolist type=string
-FLAG basecamp folders uploads list --vault type=string
-FLAG basecamp folders uploads list --verbose type=count
-FLAG basecamp folders uploads list --version type=bool
-FLAG basecamp folders vault --account type=string
-FLAG basecamp folders vault --agent type=bool
-FLAG basecamp folders vault --all type=bool
-FLAG basecamp folders vault --cache-dir type=string
-FLAG basecamp folders vault --count type=bool
-FLAG basecamp folders vault --folder type=string
-FLAG basecamp folders vault --help type=bool
-FLAG basecamp folders vault --hints type=bool
-FLAG basecamp folders vault --ids-only type=bool
-FLAG basecamp folders vault --in type=string
-FLAG basecamp folders vault --jq type=string
-FLAG basecamp folders vault --json type=bool
-FLAG basecamp folders vault --limit type=int
-FLAG basecamp folders vault --markdown type=bool
-FLAG basecamp folders vault --md type=bool
-FLAG basecamp folders vault --no-hints type=bool
-FLAG basecamp folders vault --no-stats type=bool
-FLAG basecamp folders vault --page type=int
-FLAG basecamp folders vault --profile type=string
-FLAG basecamp folders vault --project type=string
-FLAG basecamp folders vault --quiet type=bool
-FLAG basecamp folders vault --stats type=bool
-FLAG basecamp folders vault --styled type=bool
-FLAG basecamp folders vault --todolist type=string
-FLAG basecamp folders vault --vault type=string
-FLAG basecamp folders vault --verbose type=count
-FLAG basecamp folders vault --version type=bool
-FLAG basecamp folders vault create --account type=string
-FLAG basecamp folders vault create --agent type=bool
-FLAG basecamp folders vault create --cache-dir type=string
-FLAG basecamp folders vault create --count type=bool
-FLAG basecamp folders vault create --folder type=string
-FLAG basecamp folders vault create --help type=bool
-FLAG basecamp folders vault create --hints type=bool
-FLAG basecamp folders vault create --ids-only type=bool
-FLAG basecamp folders vault create --in type=string
-FLAG basecamp folders vault create --jq type=string
-FLAG basecamp folders vault create --json type=bool
-FLAG basecamp folders vault create --markdown type=bool
-FLAG basecamp folders vault create --md type=bool
-FLAG basecamp folders vault create --no-hints type=bool
-FLAG basecamp folders vault create --no-stats type=bool
-FLAG basecamp folders vault create --profile type=string
-FLAG basecamp folders vault create --project type=string
-FLAG basecamp folders vault create --quiet type=bool
-FLAG basecamp folders vault create --stats type=bool
-FLAG basecamp folders vault create --styled type=bool
-FLAG basecamp folders vault create --todolist type=string
-FLAG basecamp folders vault create --vault type=string
-FLAG basecamp folders vault create --verbose type=count
-FLAG basecamp folders vault create --version type=bool
-FLAG basecamp folders vault list --account type=string
-FLAG basecamp folders vault list --agent type=bool
-FLAG basecamp folders vault list --all type=bool
-FLAG basecamp folders vault list --cache-dir type=string
-FLAG basecamp folders vault list --count type=bool
-FLAG basecamp folders vault list --folder type=string
-FLAG basecamp folders vault list --help type=bool
-FLAG basecamp folders vault list --hints type=bool
-FLAG basecamp folders vault list --ids-only type=bool
-FLAG basecamp folders vault list --in type=string
-FLAG basecamp folders vault list --jq type=string
-FLAG basecamp folders vault list --json type=bool
-FLAG basecamp folders vault list --limit type=int
-FLAG basecamp folders vault list --markdown type=bool
-FLAG basecamp folders vault list --md type=bool
-FLAG basecamp folders vault list --no-hints type=bool
-FLAG basecamp folders vault list --no-stats type=bool
-FLAG basecamp folders vault list --page type=int
-FLAG basecamp folders vault list --profile type=string
-FLAG basecamp folders vault list --project type=string
-FLAG basecamp folders vault list --quiet type=bool
-FLAG basecamp folders vault list --stats type=bool
-FLAG basecamp folders vault list --styled type=bool
-FLAG basecamp folders vault list --todolist type=string
-FLAG basecamp folders vault list --vault type=string
-FLAG basecamp folders vault list --verbose type=count
-FLAG basecamp folders vault list --version type=bool
-FLAG basecamp folders vaults --account type=string
-FLAG basecamp folders vaults --agent type=bool
-FLAG basecamp folders vaults --all type=bool
-FLAG basecamp folders vaults --cache-dir type=string
-FLAG basecamp folders vaults --count type=bool
-FLAG basecamp folders vaults --folder type=string
-FLAG basecamp folders vaults --help type=bool
-FLAG basecamp folders vaults --hints type=bool
-FLAG basecamp folders vaults --ids-only type=bool
-FLAG basecamp folders vaults --in type=string
-FLAG basecamp folders vaults --jq type=string
-FLAG basecamp folders vaults --json type=bool
-FLAG basecamp folders vaults --limit type=int
-FLAG basecamp folders vaults --markdown type=bool
-FLAG basecamp folders vaults --md type=bool
-FLAG basecamp folders vaults --no-hints type=bool
-FLAG basecamp folders vaults --no-stats type=bool
-FLAG basecamp folders vaults --page type=int
-FLAG basecamp folders vaults --profile type=string
-FLAG basecamp folders vaults --project type=string
-FLAG basecamp folders vaults --quiet type=bool
-FLAG basecamp folders vaults --stats type=bool
-FLAG basecamp folders vaults --styled type=bool
-FLAG basecamp folders vaults --todolist type=string
-FLAG basecamp folders vaults --vault type=string
-FLAG basecamp folders vaults --verbose type=count
-FLAG basecamp folders vaults --version type=bool
-FLAG basecamp folders vaults create --account type=string
-FLAG basecamp folders vaults create --agent type=bool
-FLAG basecamp folders vaults create --cache-dir type=string
-FLAG basecamp folders vaults create --count type=bool
-FLAG basecamp folders vaults create --folder type=string
-FLAG basecamp folders vaults create --help type=bool
-FLAG basecamp folders vaults create --hints type=bool
-FLAG basecamp folders vaults create --ids-only type=bool
-FLAG basecamp folders vaults create --in type=string
-FLAG basecamp folders vaults create --jq type=string
-FLAG basecamp folders vaults create --json type=bool
-FLAG basecamp folders vaults create --markdown type=bool
-FLAG basecamp folders vaults create --md type=bool
-FLAG basecamp folders vaults create --no-hints type=bool
-FLAG basecamp folders vaults create --no-stats type=bool
-FLAG basecamp folders vaults create --profile type=string
-FLAG basecamp folders vaults create --project type=string
-FLAG basecamp folders vaults create --quiet type=bool
-FLAG basecamp folders vaults create --stats type=bool
-FLAG basecamp folders vaults create --styled type=bool
-FLAG basecamp folders vaults create --todolist type=string
-FLAG basecamp folders vaults create --vault type=string
-FLAG basecamp folders vaults create --verbose type=count
-FLAG basecamp folders vaults create --version type=bool
-FLAG basecamp folders vaults list --account type=string
-FLAG basecamp folders vaults list --agent type=bool
-FLAG basecamp folders vaults list --all type=bool
-FLAG basecamp folders vaults list --cache-dir type=string
-FLAG basecamp folders vaults list --count type=bool
-FLAG basecamp folders vaults list --folder type=string
-FLAG basecamp folders vaults list --help type=bool
-FLAG basecamp folders vaults list --hints type=bool
-FLAG basecamp folders vaults list --ids-only type=bool
-FLAG basecamp folders vaults list --in type=string
-FLAG basecamp folders vaults list --jq type=string
-FLAG basecamp folders vaults list --json type=bool
-FLAG basecamp folders vaults list --limit type=int
-FLAG basecamp folders vaults list --markdown type=bool
-FLAG basecamp folders vaults list --md type=bool
-FLAG basecamp folders vaults list --no-hints type=bool
-FLAG basecamp folders vaults list --no-stats type=bool
-FLAG basecamp folders vaults list --page type=int
-FLAG basecamp folders vaults list --profile type=string
-FLAG basecamp folders vaults list --project type=string
-FLAG basecamp folders vaults list --quiet type=bool
-FLAG basecamp folders vaults list --stats type=bool
-FLAG basecamp folders vaults list --styled type=bool
-FLAG basecamp folders vaults list --todolist type=string
-FLAG basecamp folders vaults list --vault type=string
-FLAG basecamp folders vaults list --verbose type=count
-FLAG basecamp folders vaults list --version type=bool
 FLAG basecamp forwards --account type=string
 FLAG basecamp forwards --agent type=bool
 FLAG basecamp forwards --cache-dir type=string
 FLAG basecamp forwards --count type=bool
-FLAG basecamp forwards --help type=bool
 FLAG basecamp forwards --hints type=bool
 FLAG basecamp forwards --ids-only type=bool
 FLAG basecamp forwards --in type=string
@@ -8844,12 +3555,10 @@ FLAG basecamp forwards --stats type=bool
 FLAG basecamp forwards --styled type=bool
 FLAG basecamp forwards --todolist type=string
 FLAG basecamp forwards --verbose type=count
-FLAG basecamp forwards --version type=bool
 FLAG basecamp forwards inbox --account type=string
 FLAG basecamp forwards inbox --agent type=bool
 FLAG basecamp forwards inbox --cache-dir type=string
 FLAG basecamp forwards inbox --count type=bool
-FLAG basecamp forwards inbox --help type=bool
 FLAG basecamp forwards inbox --hints type=bool
 FLAG basecamp forwards inbox --ids-only type=bool
 FLAG basecamp forwards inbox --in type=string
@@ -8867,13 +3576,11 @@ FLAG basecamp forwards inbox --stats type=bool
 FLAG basecamp forwards inbox --styled type=bool
 FLAG basecamp forwards inbox --todolist type=string
 FLAG basecamp forwards inbox --verbose type=count
-FLAG basecamp forwards inbox --version type=bool
 FLAG basecamp forwards list --account type=string
 FLAG basecamp forwards list --agent type=bool
 FLAG basecamp forwards list --all type=bool
 FLAG basecamp forwards list --cache-dir type=string
 FLAG basecamp forwards list --count type=bool
-FLAG basecamp forwards list --help type=bool
 FLAG basecamp forwards list --hints type=bool
 FLAG basecamp forwards list --ids-only type=bool
 FLAG basecamp forwards list --in type=string
@@ -8889,17 +3596,17 @@ FLAG basecamp forwards list --page type=int
 FLAG basecamp forwards list --profile type=string
 FLAG basecamp forwards list --project type=string
 FLAG basecamp forwards list --quiet type=bool
+FLAG basecamp forwards list --reverse type=bool
+FLAG basecamp forwards list --sort type=string
 FLAG basecamp forwards list --stats type=bool
 FLAG basecamp forwards list --styled type=bool
 FLAG basecamp forwards list --todolist type=string
 FLAG basecamp forwards list --verbose type=count
-FLAG basecamp forwards list --version type=bool
 FLAG basecamp forwards replies --account type=string
 FLAG basecamp forwards replies --agent type=bool
 FLAG basecamp forwards replies --all type=bool
 FLAG basecamp forwards replies --cache-dir type=string
 FLAG basecamp forwards replies --count type=bool
-FLAG basecamp forwards replies --help type=bool
 FLAG basecamp forwards replies --hints type=bool
 FLAG basecamp forwards replies --ids-only type=bool
 FLAG basecamp forwards replies --in type=string
@@ -8919,12 +3626,10 @@ FLAG basecamp forwards replies --stats type=bool
 FLAG basecamp forwards replies --styled type=bool
 FLAG basecamp forwards replies --todolist type=string
 FLAG basecamp forwards replies --verbose type=count
-FLAG basecamp forwards replies --version type=bool
 FLAG basecamp forwards reply --account type=string
 FLAG basecamp forwards reply --agent type=bool
 FLAG basecamp forwards reply --cache-dir type=string
 FLAG basecamp forwards reply --count type=bool
-FLAG basecamp forwards reply --help type=bool
 FLAG basecamp forwards reply --hints type=bool
 FLAG basecamp forwards reply --ids-only type=bool
 FLAG basecamp forwards reply --in type=string
@@ -8942,12 +3647,10 @@ FLAG basecamp forwards reply --stats type=bool
 FLAG basecamp forwards reply --styled type=bool
 FLAG basecamp forwards reply --todolist type=string
 FLAG basecamp forwards reply --verbose type=count
-FLAG basecamp forwards reply --version type=bool
 FLAG basecamp forwards show --account type=string
 FLAG basecamp forwards show --agent type=bool
 FLAG basecamp forwards show --cache-dir type=string
 FLAG basecamp forwards show --count type=bool
-FLAG basecamp forwards show --help type=bool
 FLAG basecamp forwards show --hints type=bool
 FLAG basecamp forwards show --ids-only type=bool
 FLAG basecamp forwards show --in type=string
@@ -8965,12 +3668,196 @@ FLAG basecamp forwards show --stats type=bool
 FLAG basecamp forwards show --styled type=bool
 FLAG basecamp forwards show --todolist type=string
 FLAG basecamp forwards show --verbose type=count
-FLAG basecamp forwards show --version type=bool
+FLAG basecamp gauges --account type=string
+FLAG basecamp gauges --agent type=bool
+FLAG basecamp gauges --cache-dir type=string
+FLAG basecamp gauges --count type=bool
+FLAG basecamp gauges --hints type=bool
+FLAG basecamp gauges --ids-only type=bool
+FLAG basecamp gauges --in type=string
+FLAG basecamp gauges --jq type=string
+FLAG basecamp gauges --json type=bool
+FLAG basecamp gauges --markdown type=bool
+FLAG basecamp gauges --md type=bool
+FLAG basecamp gauges --no-hints type=bool
+FLAG basecamp gauges --no-stats type=bool
+FLAG basecamp gauges --profile type=string
+FLAG basecamp gauges --project type=string
+FLAG basecamp gauges --quiet type=bool
+FLAG basecamp gauges --stats type=bool
+FLAG basecamp gauges --styled type=bool
+FLAG basecamp gauges --todolist type=string
+FLAG basecamp gauges --verbose type=count
+FLAG basecamp gauges create --account type=string
+FLAG basecamp gauges create --agent type=bool
+FLAG basecamp gauges create --cache-dir type=string
+FLAG basecamp gauges create --color type=string
+FLAG basecamp gauges create --count type=bool
+FLAG basecamp gauges create --description type=string
+FLAG basecamp gauges create --hints type=bool
+FLAG basecamp gauges create --ids-only type=bool
+FLAG basecamp gauges create --in type=string
+FLAG basecamp gauges create --jq type=string
+FLAG basecamp gauges create --json type=bool
+FLAG basecamp gauges create --markdown type=bool
+FLAG basecamp gauges create --md type=bool
+FLAG basecamp gauges create --no-hints type=bool
+FLAG basecamp gauges create --no-stats type=bool
+FLAG basecamp gauges create --notify type=string
+FLAG basecamp gauges create --position type=int
+FLAG basecamp gauges create --profile type=string
+FLAG basecamp gauges create --project type=string
+FLAG basecamp gauges create --quiet type=bool
+FLAG basecamp gauges create --stats type=bool
+FLAG basecamp gauges create --styled type=bool
+FLAG basecamp gauges create --subscribe type=stringSlice
+FLAG basecamp gauges create --todolist type=string
+FLAG basecamp gauges create --verbose type=count
+FLAG basecamp gauges delete --account type=string
+FLAG basecamp gauges delete --agent type=bool
+FLAG basecamp gauges delete --cache-dir type=string
+FLAG basecamp gauges delete --count type=bool
+FLAG basecamp gauges delete --hints type=bool
+FLAG basecamp gauges delete --ids-only type=bool
+FLAG basecamp gauges delete --in type=string
+FLAG basecamp gauges delete --jq type=string
+FLAG basecamp gauges delete --json type=bool
+FLAG basecamp gauges delete --markdown type=bool
+FLAG basecamp gauges delete --md type=bool
+FLAG basecamp gauges delete --no-hints type=bool
+FLAG basecamp gauges delete --no-stats type=bool
+FLAG basecamp gauges delete --profile type=string
+FLAG basecamp gauges delete --project type=string
+FLAG basecamp gauges delete --quiet type=bool
+FLAG basecamp gauges delete --stats type=bool
+FLAG basecamp gauges delete --styled type=bool
+FLAG basecamp gauges delete --todolist type=string
+FLAG basecamp gauges delete --verbose type=count
+FLAG basecamp gauges disable --account type=string
+FLAG basecamp gauges disable --agent type=bool
+FLAG basecamp gauges disable --cache-dir type=string
+FLAG basecamp gauges disable --count type=bool
+FLAG basecamp gauges disable --hints type=bool
+FLAG basecamp gauges disable --ids-only type=bool
+FLAG basecamp gauges disable --in type=string
+FLAG basecamp gauges disable --jq type=string
+FLAG basecamp gauges disable --json type=bool
+FLAG basecamp gauges disable --markdown type=bool
+FLAG basecamp gauges disable --md type=bool
+FLAG basecamp gauges disable --no-hints type=bool
+FLAG basecamp gauges disable --no-stats type=bool
+FLAG basecamp gauges disable --profile type=string
+FLAG basecamp gauges disable --project type=string
+FLAG basecamp gauges disable --quiet type=bool
+FLAG basecamp gauges disable --stats type=bool
+FLAG basecamp gauges disable --styled type=bool
+FLAG basecamp gauges disable --todolist type=string
+FLAG basecamp gauges disable --verbose type=count
+FLAG basecamp gauges enable --account type=string
+FLAG basecamp gauges enable --agent type=bool
+FLAG basecamp gauges enable --cache-dir type=string
+FLAG basecamp gauges enable --count type=bool
+FLAG basecamp gauges enable --hints type=bool
+FLAG basecamp gauges enable --ids-only type=bool
+FLAG basecamp gauges enable --in type=string
+FLAG basecamp gauges enable --jq type=string
+FLAG basecamp gauges enable --json type=bool
+FLAG basecamp gauges enable --markdown type=bool
+FLAG basecamp gauges enable --md type=bool
+FLAG basecamp gauges enable --no-hints type=bool
+FLAG basecamp gauges enable --no-stats type=bool
+FLAG basecamp gauges enable --profile type=string
+FLAG basecamp gauges enable --project type=string
+FLAG basecamp gauges enable --quiet type=bool
+FLAG basecamp gauges enable --stats type=bool
+FLAG basecamp gauges enable --styled type=bool
+FLAG basecamp gauges enable --todolist type=string
+FLAG basecamp gauges enable --verbose type=count
+FLAG basecamp gauges list --account type=string
+FLAG basecamp gauges list --agent type=bool
+FLAG basecamp gauges list --cache-dir type=string
+FLAG basecamp gauges list --count type=bool
+FLAG basecamp gauges list --hints type=bool
+FLAG basecamp gauges list --ids-only type=bool
+FLAG basecamp gauges list --in type=string
+FLAG basecamp gauges list --jq type=string
+FLAG basecamp gauges list --json type=bool
+FLAG basecamp gauges list --markdown type=bool
+FLAG basecamp gauges list --md type=bool
+FLAG basecamp gauges list --no-hints type=bool
+FLAG basecamp gauges list --no-stats type=bool
+FLAG basecamp gauges list --profile type=string
+FLAG basecamp gauges list --project type=string
+FLAG basecamp gauges list --quiet type=bool
+FLAG basecamp gauges list --stats type=bool
+FLAG basecamp gauges list --styled type=bool
+FLAG basecamp gauges list --todolist type=string
+FLAG basecamp gauges list --verbose type=count
+FLAG basecamp gauges needles --account type=string
+FLAG basecamp gauges needles --agent type=bool
+FLAG basecamp gauges needles --cache-dir type=string
+FLAG basecamp gauges needles --count type=bool
+FLAG basecamp gauges needles --hints type=bool
+FLAG basecamp gauges needles --ids-only type=bool
+FLAG basecamp gauges needles --in type=string
+FLAG basecamp gauges needles --jq type=string
+FLAG basecamp gauges needles --json type=bool
+FLAG basecamp gauges needles --markdown type=bool
+FLAG basecamp gauges needles --md type=bool
+FLAG basecamp gauges needles --no-hints type=bool
+FLAG basecamp gauges needles --no-stats type=bool
+FLAG basecamp gauges needles --profile type=string
+FLAG basecamp gauges needles --project type=string
+FLAG basecamp gauges needles --quiet type=bool
+FLAG basecamp gauges needles --stats type=bool
+FLAG basecamp gauges needles --styled type=bool
+FLAG basecamp gauges needles --todolist type=string
+FLAG basecamp gauges needles --verbose type=count
+FLAG basecamp gauges show --account type=string
+FLAG basecamp gauges show --agent type=bool
+FLAG basecamp gauges show --cache-dir type=string
+FLAG basecamp gauges show --count type=bool
+FLAG basecamp gauges show --hints type=bool
+FLAG basecamp gauges show --ids-only type=bool
+FLAG basecamp gauges show --in type=string
+FLAG basecamp gauges show --jq type=string
+FLAG basecamp gauges show --json type=bool
+FLAG basecamp gauges show --markdown type=bool
+FLAG basecamp gauges show --md type=bool
+FLAG basecamp gauges show --no-hints type=bool
+FLAG basecamp gauges show --no-stats type=bool
+FLAG basecamp gauges show --profile type=string
+FLAG basecamp gauges show --project type=string
+FLAG basecamp gauges show --quiet type=bool
+FLAG basecamp gauges show --stats type=bool
+FLAG basecamp gauges show --styled type=bool
+FLAG basecamp gauges show --todolist type=string
+FLAG basecamp gauges show --verbose type=count
+FLAG basecamp gauges update --account type=string
+FLAG basecamp gauges update --agent type=bool
+FLAG basecamp gauges update --cache-dir type=string
+FLAG basecamp gauges update --count type=bool
+FLAG basecamp gauges update --description type=string
+FLAG basecamp gauges update --hints type=bool
+FLAG basecamp gauges update --ids-only type=bool
+FLAG basecamp gauges update --in type=string
+FLAG basecamp gauges update --jq type=string
+FLAG basecamp gauges update --json type=bool
+FLAG basecamp gauges update --markdown type=bool
+FLAG basecamp gauges update --md type=bool
+FLAG basecamp gauges update --no-hints type=bool
+FLAG basecamp gauges update --no-stats type=bool
+FLAG basecamp gauges update --profile type=string
+FLAG basecamp gauges update --project type=string
+FLAG basecamp gauges update --quiet type=bool
+FLAG basecamp gauges update --stats type=bool
+FLAG basecamp gauges update --styled type=bool
+FLAG basecamp gauges update --todolist type=string
+FLAG basecamp gauges update --verbose type=count
 FLAG basecamp help --account type=string
 FLAG basecamp help --agent type=bool
 FLAG basecamp help --cache-dir type=string
 FLAG basecamp help --count type=bool
-FLAG basecamp help --help type=bool
 FLAG basecamp help --hints type=bool
 FLAG basecamp help --ids-only type=bool
 FLAG basecamp help --in type=string
@@ -8987,12 +3874,10 @@ FLAG basecamp help --stats type=bool
 FLAG basecamp help --styled type=bool
 FLAG basecamp help --todolist type=string
 FLAG basecamp help --verbose type=count
-FLAG basecamp help --version type=bool
 FLAG basecamp hillcharts --account type=string
 FLAG basecamp hillcharts --agent type=bool
 FLAG basecamp hillcharts --cache-dir type=string
 FLAG basecamp hillcharts --count type=bool
-FLAG basecamp hillcharts --help type=bool
 FLAG basecamp hillcharts --hints type=bool
 FLAG basecamp hillcharts --ids-only type=bool
 FLAG basecamp hillcharts --in type=string
@@ -9009,12 +3894,10 @@ FLAG basecamp hillcharts --stats type=bool
 FLAG basecamp hillcharts --styled type=bool
 FLAG basecamp hillcharts --todolist type=string
 FLAG basecamp hillcharts --verbose type=count
-FLAG basecamp hillcharts --version type=bool
 FLAG basecamp hillcharts show --account type=string
 FLAG basecamp hillcharts show --agent type=bool
 FLAG basecamp hillcharts show --cache-dir type=string
 FLAG basecamp hillcharts show --count type=bool
-FLAG basecamp hillcharts show --help type=bool
 FLAG basecamp hillcharts show --hints type=bool
 FLAG basecamp hillcharts show --ids-only type=bool
 FLAG basecamp hillcharts show --in type=string
@@ -9032,12 +3915,10 @@ FLAG basecamp hillcharts show --styled type=bool
 FLAG basecamp hillcharts show --todolist type=string
 FLAG basecamp hillcharts show --todoset type=string
 FLAG basecamp hillcharts show --verbose type=count
-FLAG basecamp hillcharts show --version type=bool
 FLAG basecamp hillcharts track --account type=string
 FLAG basecamp hillcharts track --agent type=bool
 FLAG basecamp hillcharts track --cache-dir type=string
 FLAG basecamp hillcharts track --count type=bool
-FLAG basecamp hillcharts track --help type=bool
 FLAG basecamp hillcharts track --hints type=bool
 FLAG basecamp hillcharts track --ids-only type=bool
 FLAG basecamp hillcharts track --in type=string
@@ -9055,12 +3936,10 @@ FLAG basecamp hillcharts track --styled type=bool
 FLAG basecamp hillcharts track --todolist type=string
 FLAG basecamp hillcharts track --todoset type=string
 FLAG basecamp hillcharts track --verbose type=count
-FLAG basecamp hillcharts track --version type=bool
 FLAG basecamp hillcharts untrack --account type=string
 FLAG basecamp hillcharts untrack --agent type=bool
 FLAG basecamp hillcharts untrack --cache-dir type=string
 FLAG basecamp hillcharts untrack --count type=bool
-FLAG basecamp hillcharts untrack --help type=bool
 FLAG basecamp hillcharts untrack --hints type=bool
 FLAG basecamp hillcharts untrack --ids-only type=bool
 FLAG basecamp hillcharts untrack --in type=string
@@ -9078,12 +3957,10 @@ FLAG basecamp hillcharts untrack --styled type=bool
 FLAG basecamp hillcharts untrack --todolist type=string
 FLAG basecamp hillcharts untrack --todoset type=string
 FLAG basecamp hillcharts untrack --verbose type=count
-FLAG basecamp hillcharts untrack --version type=bool
 FLAG basecamp lineup --account type=string
 FLAG basecamp lineup --agent type=bool
 FLAG basecamp lineup --cache-dir type=string
 FLAG basecamp lineup --count type=bool
-FLAG basecamp lineup --help type=bool
 FLAG basecamp lineup --hints type=bool
 FLAG basecamp lineup --ids-only type=bool
 FLAG basecamp lineup --in type=string
@@ -9100,12 +3977,10 @@ FLAG basecamp lineup --stats type=bool
 FLAG basecamp lineup --styled type=bool
 FLAG basecamp lineup --todolist type=string
 FLAG basecamp lineup --verbose type=count
-FLAG basecamp lineup --version type=bool
 FLAG basecamp lineup create --account type=string
 FLAG basecamp lineup create --agent type=bool
 FLAG basecamp lineup create --cache-dir type=string
 FLAG basecamp lineup create --count type=bool
-FLAG basecamp lineup create --help type=bool
 FLAG basecamp lineup create --hints type=bool
 FLAG basecamp lineup create --ids-only type=bool
 FLAG basecamp lineup create --in type=string
@@ -9122,12 +3997,10 @@ FLAG basecamp lineup create --stats type=bool
 FLAG basecamp lineup create --styled type=bool
 FLAG basecamp lineup create --todolist type=string
 FLAG basecamp lineup create --verbose type=count
-FLAG basecamp lineup create --version type=bool
 FLAG basecamp lineup delete --account type=string
 FLAG basecamp lineup delete --agent type=bool
 FLAG basecamp lineup delete --cache-dir type=string
 FLAG basecamp lineup delete --count type=bool
-FLAG basecamp lineup delete --help type=bool
 FLAG basecamp lineup delete --hints type=bool
 FLAG basecamp lineup delete --ids-only type=bool
 FLAG basecamp lineup delete --in type=string
@@ -9144,12 +4017,10 @@ FLAG basecamp lineup delete --stats type=bool
 FLAG basecamp lineup delete --styled type=bool
 FLAG basecamp lineup delete --todolist type=string
 FLAG basecamp lineup delete --verbose type=count
-FLAG basecamp lineup delete --version type=bool
 FLAG basecamp lineup list --account type=string
 FLAG basecamp lineup list --agent type=bool
 FLAG basecamp lineup list --cache-dir type=string
 FLAG basecamp lineup list --count type=bool
-FLAG basecamp lineup list --help type=bool
 FLAG basecamp lineup list --hints type=bool
 FLAG basecamp lineup list --ids-only type=bool
 FLAG basecamp lineup list --in type=string
@@ -9166,12 +4037,10 @@ FLAG basecamp lineup list --stats type=bool
 FLAG basecamp lineup list --styled type=bool
 FLAG basecamp lineup list --todolist type=string
 FLAG basecamp lineup list --verbose type=count
-FLAG basecamp lineup list --version type=bool
 FLAG basecamp lineup update --account type=string
 FLAG basecamp lineup update --agent type=bool
 FLAG basecamp lineup update --cache-dir type=string
 FLAG basecamp lineup update --count type=bool
-FLAG basecamp lineup update --help type=bool
 FLAG basecamp lineup update --hints type=bool
 FLAG basecamp lineup update --ids-only type=bool
 FLAG basecamp lineup update --in type=string
@@ -9188,13 +4057,11 @@ FLAG basecamp lineup update --stats type=bool
 FLAG basecamp lineup update --styled type=bool
 FLAG basecamp lineup update --todolist type=string
 FLAG basecamp lineup update --verbose type=count
-FLAG basecamp lineup update --version type=bool
 FLAG basecamp login --account type=string
 FLAG basecamp login --agent type=bool
 FLAG basecamp login --cache-dir type=string
 FLAG basecamp login --count type=bool
 FLAG basecamp login --device-code type=bool
-FLAG basecamp login --help type=bool
 FLAG basecamp login --hints type=bool
 FLAG basecamp login --ids-only type=bool
 FLAG basecamp login --in type=string
@@ -9215,12 +4082,10 @@ FLAG basecamp login --stats type=bool
 FLAG basecamp login --styled type=bool
 FLAG basecamp login --todolist type=string
 FLAG basecamp login --verbose type=count
-FLAG basecamp login --version type=bool
 FLAG basecamp logout --account type=string
 FLAG basecamp logout --agent type=bool
 FLAG basecamp logout --cache-dir type=string
 FLAG basecamp logout --count type=bool
-FLAG basecamp logout --help type=bool
 FLAG basecamp logout --hints type=bool
 FLAG basecamp logout --ids-only type=bool
 FLAG basecamp logout --in type=string
@@ -9237,12 +4102,30 @@ FLAG basecamp logout --stats type=bool
 FLAG basecamp logout --styled type=bool
 FLAG basecamp logout --todolist type=string
 FLAG basecamp logout --verbose type=count
-FLAG basecamp logout --version type=bool
+FLAG basecamp mcp --account type=string
+FLAG basecamp mcp --agent type=bool
+FLAG basecamp mcp --cache-dir type=string
+FLAG basecamp mcp --count type=bool
+FLAG basecamp mcp --hints type=bool
+FLAG basecamp mcp --ids-only type=bool
+FLAG basecamp mcp --in type=string
+FLAG basecamp mcp --jq type=string
+FLAG basecamp mcp --json type=bool
+FLAG basecamp mcp --markdown type=bool
+FLAG basecamp mcp --md type=bool
+FLAG basecamp mcp --no-hints type=bool
+FLAG basecamp mcp --no-stats type=bool
+FLAG basecamp mcp --profile type=string
+FLAG basecamp mcp --project type=string
+FLAG basecamp mcp --quiet type=bool
+FLAG basecamp mcp --stats type=bool
+FLAG basecamp mcp --styled type=bool
+FLAG basecamp mcp --todolist type=string
+FLAG basecamp mcp --verbose type=count
 FLAG basecamp me --account type=string
 FLAG basecamp me --agent type=bool
 FLAG basecamp me --cache-dir type=string
 FLAG basecamp me --count type=bool
-FLAG basecamp me --help type=bool
 FLAG basecamp me --hints type=bool
 FLAG basecamp me --ids-only type=bool
 FLAG basecamp me --in type=string
@@ -9259,7 +4142,6 @@ FLAG basecamp me --stats type=bool
 FLAG basecamp me --styled type=bool
 FLAG basecamp me --todolist type=string
 FLAG basecamp me --verbose type=count
-FLAG basecamp me --version type=bool
 FLAG basecamp message --account type=string
 FLAG basecamp message --agent type=bool
 FLAG basecamp message --attach type=stringArray
@@ -9267,7 +4149,6 @@ FLAG basecamp message --cache-dir type=string
 FLAG basecamp message --count type=bool
 FLAG basecamp message --draft type=bool
 FLAG basecamp message --edit type=bool
-FLAG basecamp message --help type=bool
 FLAG basecamp message --hints type=bool
 FLAG basecamp message --ids-only type=bool
 FLAG basecamp message --in type=string
@@ -9287,13 +4168,11 @@ FLAG basecamp message --styled type=bool
 FLAG basecamp message --subscribe type=string
 FLAG basecamp message --todolist type=string
 FLAG basecamp message --verbose type=count
-FLAG basecamp message --version type=bool
 FLAG basecamp messageboards --account type=string
 FLAG basecamp messageboards --agent type=bool
 FLAG basecamp messageboards --board type=string
 FLAG basecamp messageboards --cache-dir type=string
 FLAG basecamp messageboards --count type=bool
-FLAG basecamp messageboards --help type=bool
 FLAG basecamp messageboards --hints type=bool
 FLAG basecamp messageboards --ids-only type=bool
 FLAG basecamp messageboards --in type=string
@@ -9310,13 +4189,11 @@ FLAG basecamp messageboards --stats type=bool
 FLAG basecamp messageboards --styled type=bool
 FLAG basecamp messageboards --todolist type=string
 FLAG basecamp messageboards --verbose type=count
-FLAG basecamp messageboards --version type=bool
 FLAG basecamp messageboards show --account type=string
 FLAG basecamp messageboards show --agent type=bool
 FLAG basecamp messageboards show --board type=string
 FLAG basecamp messageboards show --cache-dir type=string
 FLAG basecamp messageboards show --count type=bool
-FLAG basecamp messageboards show --help type=bool
 FLAG basecamp messageboards show --hints type=bool
 FLAG basecamp messageboards show --ids-only type=bool
 FLAG basecamp messageboards show --in type=string
@@ -9333,12 +4210,10 @@ FLAG basecamp messageboards show --stats type=bool
 FLAG basecamp messageboards show --styled type=bool
 FLAG basecamp messageboards show --todolist type=string
 FLAG basecamp messageboards show --verbose type=count
-FLAG basecamp messageboards show --version type=bool
 FLAG basecamp messages --account type=string
 FLAG basecamp messages --agent type=bool
 FLAG basecamp messages --cache-dir type=string
 FLAG basecamp messages --count type=bool
-FLAG basecamp messages --help type=bool
 FLAG basecamp messages --hints type=bool
 FLAG basecamp messages --ids-only type=bool
 FLAG basecamp messages --in type=string
@@ -9356,12 +4231,10 @@ FLAG basecamp messages --stats type=bool
 FLAG basecamp messages --styled type=bool
 FLAG basecamp messages --todolist type=string
 FLAG basecamp messages --verbose type=count
-FLAG basecamp messages --version type=bool
 FLAG basecamp messages archive --account type=string
 FLAG basecamp messages archive --agent type=bool
 FLAG basecamp messages archive --cache-dir type=string
 FLAG basecamp messages archive --count type=bool
-FLAG basecamp messages archive --help type=bool
 FLAG basecamp messages archive --hints type=bool
 FLAG basecamp messages archive --ids-only type=bool
 FLAG basecamp messages archive --in type=string
@@ -9379,7 +4252,6 @@ FLAG basecamp messages archive --stats type=bool
 FLAG basecamp messages archive --styled type=bool
 FLAG basecamp messages archive --todolist type=string
 FLAG basecamp messages archive --verbose type=count
-FLAG basecamp messages archive --version type=bool
 FLAG basecamp messages create --account type=string
 FLAG basecamp messages create --agent type=bool
 FLAG basecamp messages create --attach type=stringArray
@@ -9387,7 +4259,6 @@ FLAG basecamp messages create --cache-dir type=string
 FLAG basecamp messages create --count type=bool
 FLAG basecamp messages create --draft type=bool
 FLAG basecamp messages create --edit type=bool
-FLAG basecamp messages create --help type=bool
 FLAG basecamp messages create --hints type=bool
 FLAG basecamp messages create --ids-only type=bool
 FLAG basecamp messages create --in type=string
@@ -9407,13 +4278,11 @@ FLAG basecamp messages create --styled type=bool
 FLAG basecamp messages create --subscribe type=string
 FLAG basecamp messages create --todolist type=string
 FLAG basecamp messages create --verbose type=count
-FLAG basecamp messages create --version type=bool
 FLAG basecamp messages list --account type=string
 FLAG basecamp messages list --agent type=bool
 FLAG basecamp messages list --all type=bool
 FLAG basecamp messages list --cache-dir type=string
 FLAG basecamp messages list --count type=bool
-FLAG basecamp messages list --help type=bool
 FLAG basecamp messages list --hints type=bool
 FLAG basecamp messages list --ids-only type=bool
 FLAG basecamp messages list --in type=string
@@ -9435,12 +4304,10 @@ FLAG basecamp messages list --stats type=bool
 FLAG basecamp messages list --styled type=bool
 FLAG basecamp messages list --todolist type=string
 FLAG basecamp messages list --verbose type=count
-FLAG basecamp messages list --version type=bool
 FLAG basecamp messages pin --account type=string
 FLAG basecamp messages pin --agent type=bool
 FLAG basecamp messages pin --cache-dir type=string
 FLAG basecamp messages pin --count type=bool
-FLAG basecamp messages pin --help type=bool
 FLAG basecamp messages pin --hints type=bool
 FLAG basecamp messages pin --ids-only type=bool
 FLAG basecamp messages pin --in type=string
@@ -9458,12 +4325,10 @@ FLAG basecamp messages pin --stats type=bool
 FLAG basecamp messages pin --styled type=bool
 FLAG basecamp messages pin --todolist type=string
 FLAG basecamp messages pin --verbose type=count
-FLAG basecamp messages pin --version type=bool
 FLAG basecamp messages publish --account type=string
 FLAG basecamp messages publish --agent type=bool
 FLAG basecamp messages publish --cache-dir type=string
 FLAG basecamp messages publish --count type=bool
-FLAG basecamp messages publish --help type=bool
 FLAG basecamp messages publish --hints type=bool
 FLAG basecamp messages publish --ids-only type=bool
 FLAG basecamp messages publish --in type=string
@@ -9481,12 +4346,10 @@ FLAG basecamp messages publish --stats type=bool
 FLAG basecamp messages publish --styled type=bool
 FLAG basecamp messages publish --todolist type=string
 FLAG basecamp messages publish --verbose type=count
-FLAG basecamp messages publish --version type=bool
 FLAG basecamp messages restore --account type=string
 FLAG basecamp messages restore --agent type=bool
 FLAG basecamp messages restore --cache-dir type=string
 FLAG basecamp messages restore --count type=bool
-FLAG basecamp messages restore --help type=bool
 FLAG basecamp messages restore --hints type=bool
 FLAG basecamp messages restore --ids-only type=bool
 FLAG basecamp messages restore --in type=string
@@ -9504,12 +4367,10 @@ FLAG basecamp messages restore --stats type=bool
 FLAG basecamp messages restore --styled type=bool
 FLAG basecamp messages restore --todolist type=string
 FLAG basecamp messages restore --verbose type=count
-FLAG basecamp messages restore --version type=bool
 FLAG basecamp messages show --account type=string
 FLAG basecamp messages show --agent type=bool
 FLAG basecamp messages show --cache-dir type=string
 FLAG basecamp messages show --count type=bool
-FLAG basecamp messages show --help type=bool
 FLAG basecamp messages show --hints type=bool
 FLAG basecamp messages show --ids-only type=bool
 FLAG basecamp messages show --in type=string
@@ -9527,12 +4388,10 @@ FLAG basecamp messages show --stats type=bool
 FLAG basecamp messages show --styled type=bool
 FLAG basecamp messages show --todolist type=string
 FLAG basecamp messages show --verbose type=count
-FLAG basecamp messages show --version type=bool
 FLAG basecamp messages trash --account type=string
 FLAG basecamp messages trash --agent type=bool
 FLAG basecamp messages trash --cache-dir type=string
 FLAG basecamp messages trash --count type=bool
-FLAG basecamp messages trash --help type=bool
 FLAG basecamp messages trash --hints type=bool
 FLAG basecamp messages trash --ids-only type=bool
 FLAG basecamp messages trash --in type=string
@@ -9550,12 +4409,10 @@ FLAG basecamp messages trash --stats type=bool
 FLAG basecamp messages trash --styled type=bool
 FLAG basecamp messages trash --todolist type=string
 FLAG basecamp messages trash --verbose type=count
-FLAG basecamp messages trash --version type=bool
 FLAG basecamp messages unpin --account type=string
 FLAG basecamp messages unpin --agent type=bool
 FLAG basecamp messages unpin --cache-dir type=string
 FLAG basecamp messages unpin --count type=bool
-FLAG basecamp messages unpin --help type=bool
 FLAG basecamp messages unpin --hints type=bool
 FLAG basecamp messages unpin --ids-only type=bool
 FLAG basecamp messages unpin --in type=string
@@ -9573,13 +4430,11 @@ FLAG basecamp messages unpin --stats type=bool
 FLAG basecamp messages unpin --styled type=bool
 FLAG basecamp messages unpin --todolist type=string
 FLAG basecamp messages unpin --verbose type=count
-FLAG basecamp messages unpin --version type=bool
 FLAG basecamp messages update --account type=string
 FLAG basecamp messages update --agent type=bool
 FLAG basecamp messages update --body type=string
 FLAG basecamp messages update --cache-dir type=string
 FLAG basecamp messages update --count type=bool
-FLAG basecamp messages update --help type=bool
 FLAG basecamp messages update --hints type=bool
 FLAG basecamp messages update --ids-only type=bool
 FLAG basecamp messages update --in type=string
@@ -9598,12 +4453,10 @@ FLAG basecamp messages update --styled type=bool
 FLAG basecamp messages update --title type=string
 FLAG basecamp messages update --todolist type=string
 FLAG basecamp messages update --verbose type=count
-FLAG basecamp messages update --version type=bool
 FLAG basecamp messagetypes --account type=string
 FLAG basecamp messagetypes --agent type=bool
 FLAG basecamp messagetypes --cache-dir type=string
 FLAG basecamp messagetypes --count type=bool
-FLAG basecamp messagetypes --help type=bool
 FLAG basecamp messagetypes --hints type=bool
 FLAG basecamp messagetypes --ids-only type=bool
 FLAG basecamp messagetypes --in type=string
@@ -9620,12 +4473,10 @@ FLAG basecamp messagetypes --stats type=bool
 FLAG basecamp messagetypes --styled type=bool
 FLAG basecamp messagetypes --todolist type=string
 FLAG basecamp messagetypes --verbose type=count
-FLAG basecamp messagetypes --version type=bool
 FLAG basecamp messagetypes create --account type=string
 FLAG basecamp messagetypes create --agent type=bool
 FLAG basecamp messagetypes create --cache-dir type=string
 FLAG basecamp messagetypes create --count type=bool
-FLAG basecamp messagetypes create --help type=bool
 FLAG basecamp messagetypes create --hints type=bool
 FLAG basecamp messagetypes create --icon type=string
 FLAG basecamp messagetypes create --ids-only type=bool
@@ -9644,12 +4495,10 @@ FLAG basecamp messagetypes create --stats type=bool
 FLAG basecamp messagetypes create --styled type=bool
 FLAG basecamp messagetypes create --todolist type=string
 FLAG basecamp messagetypes create --verbose type=count
-FLAG basecamp messagetypes create --version type=bool
 FLAG basecamp messagetypes delete --account type=string
 FLAG basecamp messagetypes delete --agent type=bool
 FLAG basecamp messagetypes delete --cache-dir type=string
 FLAG basecamp messagetypes delete --count type=bool
-FLAG basecamp messagetypes delete --help type=bool
 FLAG basecamp messagetypes delete --hints type=bool
 FLAG basecamp messagetypes delete --ids-only type=bool
 FLAG basecamp messagetypes delete --in type=string
@@ -9666,12 +4515,10 @@ FLAG basecamp messagetypes delete --stats type=bool
 FLAG basecamp messagetypes delete --styled type=bool
 FLAG basecamp messagetypes delete --todolist type=string
 FLAG basecamp messagetypes delete --verbose type=count
-FLAG basecamp messagetypes delete --version type=bool
 FLAG basecamp messagetypes list --account type=string
 FLAG basecamp messagetypes list --agent type=bool
 FLAG basecamp messagetypes list --cache-dir type=string
 FLAG basecamp messagetypes list --count type=bool
-FLAG basecamp messagetypes list --help type=bool
 FLAG basecamp messagetypes list --hints type=bool
 FLAG basecamp messagetypes list --ids-only type=bool
 FLAG basecamp messagetypes list --in type=string
@@ -9688,12 +4535,10 @@ FLAG basecamp messagetypes list --stats type=bool
 FLAG basecamp messagetypes list --styled type=bool
 FLAG basecamp messagetypes list --todolist type=string
 FLAG basecamp messagetypes list --verbose type=count
-FLAG basecamp messagetypes list --version type=bool
 FLAG basecamp messagetypes show --account type=string
 FLAG basecamp messagetypes show --agent type=bool
 FLAG basecamp messagetypes show --cache-dir type=string
 FLAG basecamp messagetypes show --count type=bool
-FLAG basecamp messagetypes show --help type=bool
 FLAG basecamp messagetypes show --hints type=bool
 FLAG basecamp messagetypes show --ids-only type=bool
 FLAG basecamp messagetypes show --in type=string
@@ -9710,12 +4555,10 @@ FLAG basecamp messagetypes show --stats type=bool
 FLAG basecamp messagetypes show --styled type=bool
 FLAG basecamp messagetypes show --todolist type=string
 FLAG basecamp messagetypes show --verbose type=count
-FLAG basecamp messagetypes show --version type=bool
 FLAG basecamp messagetypes update --account type=string
 FLAG basecamp messagetypes update --agent type=bool
 FLAG basecamp messagetypes update --cache-dir type=string
 FLAG basecamp messagetypes update --count type=bool
-FLAG basecamp messagetypes update --help type=bool
 FLAG basecamp messagetypes update --hints type=bool
 FLAG basecamp messagetypes update --icon type=string
 FLAG basecamp messagetypes update --ids-only type=bool
@@ -9734,13 +4577,11 @@ FLAG basecamp messagetypes update --stats type=bool
 FLAG basecamp messagetypes update --styled type=bool
 FLAG basecamp messagetypes update --todolist type=string
 FLAG basecamp messagetypes update --verbose type=count
-FLAG basecamp messagetypes update --version type=bool
 FLAG basecamp migrate --account type=string
 FLAG basecamp migrate --agent type=bool
 FLAG basecamp migrate --cache-dir type=string
 FLAG basecamp migrate --count type=bool
 FLAG basecamp migrate --force type=bool
-FLAG basecamp migrate --help type=bool
 FLAG basecamp migrate --hints type=bool
 FLAG basecamp migrate --ids-only type=bool
 FLAG basecamp migrate --in type=string
@@ -9757,277 +4598,71 @@ FLAG basecamp migrate --stats type=bool
 FLAG basecamp migrate --styled type=bool
 FLAG basecamp migrate --todolist type=string
 FLAG basecamp migrate --verbose type=count
-FLAG basecamp migrate --version type=bool
-FLAG basecamp msgs --account type=string
-FLAG basecamp msgs --agent type=bool
-FLAG basecamp msgs --cache-dir type=string
-FLAG basecamp msgs --count type=bool
-FLAG basecamp msgs --help type=bool
-FLAG basecamp msgs --hints type=bool
-FLAG basecamp msgs --ids-only type=bool
-FLAG basecamp msgs --in type=string
-FLAG basecamp msgs --jq type=string
-FLAG basecamp msgs --json type=bool
-FLAG basecamp msgs --markdown type=bool
-FLAG basecamp msgs --md type=bool
-FLAG basecamp msgs --message-board type=string
-FLAG basecamp msgs --no-hints type=bool
-FLAG basecamp msgs --no-stats type=bool
-FLAG basecamp msgs --profile type=string
-FLAG basecamp msgs --project type=string
-FLAG basecamp msgs --quiet type=bool
-FLAG basecamp msgs --stats type=bool
-FLAG basecamp msgs --styled type=bool
-FLAG basecamp msgs --todolist type=string
-FLAG basecamp msgs --verbose type=count
-FLAG basecamp msgs --version type=bool
-FLAG basecamp msgs archive --account type=string
-FLAG basecamp msgs archive --agent type=bool
-FLAG basecamp msgs archive --cache-dir type=string
-FLAG basecamp msgs archive --count type=bool
-FLAG basecamp msgs archive --help type=bool
-FLAG basecamp msgs archive --hints type=bool
-FLAG basecamp msgs archive --ids-only type=bool
-FLAG basecamp msgs archive --in type=string
-FLAG basecamp msgs archive --jq type=string
-FLAG basecamp msgs archive --json type=bool
-FLAG basecamp msgs archive --markdown type=bool
-FLAG basecamp msgs archive --md type=bool
-FLAG basecamp msgs archive --message-board type=string
-FLAG basecamp msgs archive --no-hints type=bool
-FLAG basecamp msgs archive --no-stats type=bool
-FLAG basecamp msgs archive --profile type=string
-FLAG basecamp msgs archive --project type=string
-FLAG basecamp msgs archive --quiet type=bool
-FLAG basecamp msgs archive --stats type=bool
-FLAG basecamp msgs archive --styled type=bool
-FLAG basecamp msgs archive --todolist type=string
-FLAG basecamp msgs archive --verbose type=count
-FLAG basecamp msgs archive --version type=bool
-FLAG basecamp msgs create --account type=string
-FLAG basecamp msgs create --agent type=bool
-FLAG basecamp msgs create --attach type=stringArray
-FLAG basecamp msgs create --cache-dir type=string
-FLAG basecamp msgs create --count type=bool
-FLAG basecamp msgs create --draft type=bool
-FLAG basecamp msgs create --edit type=bool
-FLAG basecamp msgs create --help type=bool
-FLAG basecamp msgs create --hints type=bool
-FLAG basecamp msgs create --ids-only type=bool
-FLAG basecamp msgs create --in type=string
-FLAG basecamp msgs create --jq type=string
-FLAG basecamp msgs create --json type=bool
-FLAG basecamp msgs create --markdown type=bool
-FLAG basecamp msgs create --md type=bool
-FLAG basecamp msgs create --message-board type=string
-FLAG basecamp msgs create --no-hints type=bool
-FLAG basecamp msgs create --no-stats type=bool
-FLAG basecamp msgs create --no-subscribe type=bool
-FLAG basecamp msgs create --profile type=string
-FLAG basecamp msgs create --project type=string
-FLAG basecamp msgs create --quiet type=bool
-FLAG basecamp msgs create --stats type=bool
-FLAG basecamp msgs create --styled type=bool
-FLAG basecamp msgs create --subscribe type=string
-FLAG basecamp msgs create --todolist type=string
-FLAG basecamp msgs create --verbose type=count
-FLAG basecamp msgs create --version type=bool
-FLAG basecamp msgs list --account type=string
-FLAG basecamp msgs list --agent type=bool
-FLAG basecamp msgs list --all type=bool
-FLAG basecamp msgs list --cache-dir type=string
-FLAG basecamp msgs list --count type=bool
-FLAG basecamp msgs list --help type=bool
-FLAG basecamp msgs list --hints type=bool
-FLAG basecamp msgs list --ids-only type=bool
-FLAG basecamp msgs list --in type=string
-FLAG basecamp msgs list --jq type=string
-FLAG basecamp msgs list --json type=bool
-FLAG basecamp msgs list --limit type=int
-FLAG basecamp msgs list --markdown type=bool
-FLAG basecamp msgs list --md type=bool
-FLAG basecamp msgs list --message-board type=string
-FLAG basecamp msgs list --no-hints type=bool
-FLAG basecamp msgs list --no-stats type=bool
-FLAG basecamp msgs list --page type=int
-FLAG basecamp msgs list --profile type=string
-FLAG basecamp msgs list --project type=string
-FLAG basecamp msgs list --quiet type=bool
-FLAG basecamp msgs list --reverse type=bool
-FLAG basecamp msgs list --sort type=string
-FLAG basecamp msgs list --stats type=bool
-FLAG basecamp msgs list --styled type=bool
-FLAG basecamp msgs list --todolist type=string
-FLAG basecamp msgs list --verbose type=count
-FLAG basecamp msgs list --version type=bool
-FLAG basecamp msgs pin --account type=string
-FLAG basecamp msgs pin --agent type=bool
-FLAG basecamp msgs pin --cache-dir type=string
-FLAG basecamp msgs pin --count type=bool
-FLAG basecamp msgs pin --help type=bool
-FLAG basecamp msgs pin --hints type=bool
-FLAG basecamp msgs pin --ids-only type=bool
-FLAG basecamp msgs pin --in type=string
-FLAG basecamp msgs pin --jq type=string
-FLAG basecamp msgs pin --json type=bool
-FLAG basecamp msgs pin --markdown type=bool
-FLAG basecamp msgs pin --md type=bool
-FLAG basecamp msgs pin --message-board type=string
-FLAG basecamp msgs pin --no-hints type=bool
-FLAG basecamp msgs pin --no-stats type=bool
-FLAG basecamp msgs pin --profile type=string
-FLAG basecamp msgs pin --project type=string
-FLAG basecamp msgs pin --quiet type=bool
-FLAG basecamp msgs pin --stats type=bool
-FLAG basecamp msgs pin --styled type=bool
-FLAG basecamp msgs pin --todolist type=string
-FLAG basecamp msgs pin --verbose type=count
-FLAG basecamp msgs pin --version type=bool
-FLAG basecamp msgs publish --account type=string
-FLAG basecamp msgs publish --agent type=bool
-FLAG basecamp msgs publish --cache-dir type=string
-FLAG basecamp msgs publish --count type=bool
-FLAG basecamp msgs publish --help type=bool
-FLAG basecamp msgs publish --hints type=bool
-FLAG basecamp msgs publish --ids-only type=bool
-FLAG basecamp msgs publish --in type=string
-FLAG basecamp msgs publish --jq type=string
-FLAG basecamp msgs publish --json type=bool
-FLAG basecamp msgs publish --markdown type=bool
-FLAG basecamp msgs publish --md type=bool
-FLAG basecamp msgs publish --message-board type=string
-FLAG basecamp msgs publish --no-hints type=bool
-FLAG basecamp msgs publish --no-stats type=bool
-FLAG basecamp msgs publish --profile type=string
-FLAG basecamp msgs publish --project type=string
-FLAG basecamp msgs publish --quiet type=bool
-FLAG basecamp msgs publish --stats type=bool
-FLAG basecamp msgs publish --styled type=bool
-FLAG basecamp msgs publish --todolist type=string
-FLAG basecamp msgs publish --verbose type=count
-FLAG basecamp msgs publish --version type=bool
-FLAG basecamp msgs restore --account type=string
-FLAG basecamp msgs restore --agent type=bool
-FLAG basecamp msgs restore --cache-dir type=string
-FLAG basecamp msgs restore --count type=bool
-FLAG basecamp msgs restore --help type=bool
-FLAG basecamp msgs restore --hints type=bool
-FLAG basecamp msgs restore --ids-only type=bool
-FLAG basecamp msgs restore --in type=string
-FLAG basecamp msgs restore --jq type=string
-FLAG basecamp msgs restore --json type=bool
-FLAG basecamp msgs restore --markdown type=bool
-FLAG basecamp msgs restore --md type=bool
-FLAG basecamp msgs restore --message-board type=string
-FLAG basecamp msgs restore --no-hints type=bool
-FLAG basecamp msgs restore --no-stats type=bool
-FLAG basecamp msgs restore --profile type=string
-FLAG basecamp msgs restore --project type=string
-FLAG basecamp msgs restore --quiet type=bool
-FLAG basecamp msgs restore --stats type=bool
-FLAG basecamp msgs restore --styled type=bool
-FLAG basecamp msgs restore --todolist type=string
-FLAG basecamp msgs restore --verbose type=count
-FLAG basecamp msgs restore --version type=bool
-FLAG basecamp msgs show --account type=string
-FLAG basecamp msgs show --agent type=bool
-FLAG basecamp msgs show --cache-dir type=string
-FLAG basecamp msgs show --count type=bool
-FLAG basecamp msgs show --help type=bool
-FLAG basecamp msgs show --hints type=bool
-FLAG basecamp msgs show --ids-only type=bool
-FLAG basecamp msgs show --in type=string
-FLAG basecamp msgs show --jq type=string
-FLAG basecamp msgs show --json type=bool
-FLAG basecamp msgs show --markdown type=bool
-FLAG basecamp msgs show --md type=bool
-FLAG basecamp msgs show --message-board type=string
-FLAG basecamp msgs show --no-hints type=bool
-FLAG basecamp msgs show --no-stats type=bool
-FLAG basecamp msgs show --profile type=string
-FLAG basecamp msgs show --project type=string
-FLAG basecamp msgs show --quiet type=bool
-FLAG basecamp msgs show --stats type=bool
-FLAG basecamp msgs show --styled type=bool
-FLAG basecamp msgs show --todolist type=string
-FLAG basecamp msgs show --verbose type=count
-FLAG basecamp msgs show --version type=bool
-FLAG basecamp msgs trash --account type=string
-FLAG basecamp msgs trash --agent type=bool
-FLAG basecamp msgs trash --cache-dir type=string
-FLAG basecamp msgs trash --count type=bool
-FLAG basecamp msgs trash --help type=bool
-FLAG basecamp msgs trash --hints type=bool
-FLAG basecamp msgs trash --ids-only type=bool
-FLAG basecamp msgs trash --in type=string
-FLAG basecamp msgs trash --jq type=string
-FLAG basecamp msgs trash --json type=bool
-FLAG basecamp msgs trash --markdown type=bool
-FLAG basecamp msgs trash --md type=bool
-FLAG basecamp msgs trash --message-board type=string
-FLAG basecamp msgs trash --no-hints type=bool
-FLAG basecamp msgs trash --no-stats type=bool
-FLAG basecamp msgs trash --profile type=string
-FLAG basecamp msgs trash --project type=string
-FLAG basecamp msgs trash --quiet type=bool
-FLAG basecamp msgs trash --stats type=bool
-FLAG basecamp msgs trash --styled type=bool
-FLAG basecamp msgs trash --todolist type=string
-FLAG basecamp msgs trash --verbose type=count
-FLAG basecamp msgs trash --version type=bool
-FLAG basecamp msgs unpin --account type=string
-FLAG basecamp msgs unpin --agent type=bool
-FLAG basecamp msgs unpin --cache-dir type=string
-FLAG basecamp msgs unpin --count type=bool
-FLAG basecamp msgs unpin --help type=bool
-FLAG basecamp msgs unpin --hints type=bool
-FLAG basecamp msgs unpin --ids-only type=bool
-FLAG basecamp msgs unpin --in type=string
-FLAG basecamp msgs unpin --jq type=string
-FLAG basecamp msgs unpin --json type=bool
-FLAG basecamp msgs unpin --markdown type=bool
-FLAG basecamp msgs unpin --md type=bool
-FLAG basecamp msgs unpin --message-board type=string
-FLAG basecamp msgs unpin --no-hints type=bool
-FLAG basecamp msgs unpin --no-stats type=bool
-FLAG basecamp msgs unpin --profile type=string
-FLAG basecamp msgs unpin --project type=string
-FLAG basecamp msgs unpin --quiet type=bool
-FLAG basecamp msgs unpin --stats type=bool
-FLAG basecamp msgs unpin --styled type=bool
-FLAG basecamp msgs unpin --todolist type=string
-FLAG basecamp msgs unpin --verbose type=count
-FLAG basecamp msgs unpin --version type=bool
-FLAG basecamp msgs update --account type=string
-FLAG basecamp msgs update --agent type=bool
-FLAG basecamp msgs update --body type=string
-FLAG basecamp msgs update --cache-dir type=string
-FLAG basecamp msgs update --count type=bool
-FLAG basecamp msgs update --help type=bool
-FLAG basecamp msgs update --hints type=bool
-FLAG basecamp msgs update --ids-only type=bool
-FLAG basecamp msgs update --in type=string
-FLAG basecamp msgs update --jq type=string
-FLAG basecamp msgs update --json type=bool
-FLAG basecamp msgs update --markdown type=bool
-FLAG basecamp msgs update --md type=bool
-FLAG basecamp msgs update --message-board type=string
-FLAG basecamp msgs update --no-hints type=bool
-FLAG basecamp msgs update --no-stats type=bool
-FLAG basecamp msgs update --profile type=string
-FLAG basecamp msgs update --project type=string
-FLAG basecamp msgs update --quiet type=bool
-FLAG basecamp msgs update --stats type=bool
-FLAG basecamp msgs update --styled type=bool
-FLAG basecamp msgs update --title type=string
-FLAG basecamp msgs update --todolist type=string
-FLAG basecamp msgs update --verbose type=count
-FLAG basecamp msgs update --version type=bool
+FLAG basecamp notifications --account type=string
+FLAG basecamp notifications --agent type=bool
+FLAG basecamp notifications --cache-dir type=string
+FLAG basecamp notifications --count type=bool
+FLAG basecamp notifications --hints type=bool
+FLAG basecamp notifications --ids-only type=bool
+FLAG basecamp notifications --in type=string
+FLAG basecamp notifications --jq type=string
+FLAG basecamp notifications --json type=bool
+FLAG basecamp notifications --markdown type=bool
+FLAG basecamp notifications --md type=bool
+FLAG basecamp notifications --no-hints type=bool
+FLAG basecamp notifications --no-stats type=bool
+FLAG basecamp notifications --profile type=string
+FLAG basecamp notifications --project type=string
+FLAG basecamp notifications --quiet type=bool
+FLAG basecamp notifications --stats type=bool
+FLAG basecamp notifications --styled type=bool
+FLAG basecamp notifications --todolist type=string
+FLAG basecamp notifications --verbose type=count
+FLAG basecamp notifications list --account type=string
+FLAG basecamp notifications list --agent type=bool
+FLAG basecamp notifications list --cache-dir type=string
+FLAG basecamp notifications list --count type=bool
+FLAG basecamp notifications list --hints type=bool
+FLAG basecamp notifications list --ids-only type=bool
+FLAG basecamp notifications list --in type=string
+FLAG basecamp notifications list --jq type=string
+FLAG basecamp notifications list --json type=bool
+FLAG basecamp notifications list --markdown type=bool
+FLAG basecamp notifications list --md type=bool
+FLAG basecamp notifications list --no-hints type=bool
+FLAG basecamp notifications list --no-stats type=bool
+FLAG basecamp notifications list --page type=int32
+FLAG basecamp notifications list --profile type=string
+FLAG basecamp notifications list --project type=string
+FLAG basecamp notifications list --quiet type=bool
+FLAG basecamp notifications list --stats type=bool
+FLAG basecamp notifications list --styled type=bool
+FLAG basecamp notifications list --todolist type=string
+FLAG basecamp notifications list --verbose type=count
+FLAG basecamp notifications read --account type=string
+FLAG basecamp notifications read --agent type=bool
+FLAG basecamp notifications read --cache-dir type=string
+FLAG basecamp notifications read --count type=bool
+FLAG basecamp notifications read --hints type=bool
+FLAG basecamp notifications read --ids-only type=bool
+FLAG basecamp notifications read --in type=string
+FLAG basecamp notifications read --jq type=string
+FLAG basecamp notifications read --json type=bool
+FLAG basecamp notifications read --markdown type=bool
+FLAG basecamp notifications read --md type=bool
+FLAG basecamp notifications read --no-hints type=bool
+FLAG basecamp notifications read --no-stats type=bool
+FLAG basecamp notifications read --profile type=string
+FLAG basecamp notifications read --project type=string
+FLAG basecamp notifications read --quiet type=bool
+FLAG basecamp notifications read --stats type=bool
+FLAG basecamp notifications read --styled type=bool
+FLAG basecamp notifications read --todolist type=string
+FLAG basecamp notifications read --verbose type=count
 FLAG basecamp people --account type=string
 FLAG basecamp people --agent type=bool
 FLAG basecamp people --cache-dir type=string
 FLAG basecamp people --count type=bool
-FLAG basecamp people --help type=bool
 FLAG basecamp people --hints type=bool
 FLAG basecamp people --ids-only type=bool
 FLAG basecamp people --in type=string
@@ -10044,12 +4679,10 @@ FLAG basecamp people --stats type=bool
 FLAG basecamp people --styled type=bool
 FLAG basecamp people --todolist type=string
 FLAG basecamp people --verbose type=count
-FLAG basecamp people --version type=bool
 FLAG basecamp people add --account type=string
 FLAG basecamp people add --agent type=bool
 FLAG basecamp people add --cache-dir type=string
 FLAG basecamp people add --count type=bool
-FLAG basecamp people add --help type=bool
 FLAG basecamp people add --hints type=bool
 FLAG basecamp people add --ids-only type=bool
 FLAG basecamp people add --in type=string
@@ -10066,13 +4699,11 @@ FLAG basecamp people add --stats type=bool
 FLAG basecamp people add --styled type=bool
 FLAG basecamp people add --todolist type=string
 FLAG basecamp people add --verbose type=count
-FLAG basecamp people add --version type=bool
 FLAG basecamp people list --account type=string
 FLAG basecamp people list --agent type=bool
 FLAG basecamp people list --all type=bool
 FLAG basecamp people list --cache-dir type=string
 FLAG basecamp people list --count type=bool
-FLAG basecamp people list --help type=bool
 FLAG basecamp people list --hints type=bool
 FLAG basecamp people list --ids-only type=bool
 FLAG basecamp people list --in type=string
@@ -10093,12 +4724,92 @@ FLAG basecamp people list --stats type=bool
 FLAG basecamp people list --styled type=bool
 FLAG basecamp people list --todolist type=string
 FLAG basecamp people list --verbose type=count
-FLAG basecamp people list --version type=bool
+FLAG basecamp people out-of-office --account type=string
+FLAG basecamp people out-of-office --agent type=bool
+FLAG basecamp people out-of-office --cache-dir type=string
+FLAG basecamp people out-of-office --count type=bool
+FLAG basecamp people out-of-office --hints type=bool
+FLAG basecamp people out-of-office --ids-only type=bool
+FLAG basecamp people out-of-office --in type=string
+FLAG basecamp people out-of-office --jq type=string
+FLAG basecamp people out-of-office --json type=bool
+FLAG basecamp people out-of-office --markdown type=bool
+FLAG basecamp people out-of-office --md type=bool
+FLAG basecamp people out-of-office --no-hints type=bool
+FLAG basecamp people out-of-office --no-stats type=bool
+FLAG basecamp people out-of-office --profile type=string
+FLAG basecamp people out-of-office --project type=string
+FLAG basecamp people out-of-office --quiet type=bool
+FLAG basecamp people out-of-office --stats type=bool
+FLAG basecamp people out-of-office --styled type=bool
+FLAG basecamp people out-of-office --todolist type=string
+FLAG basecamp people out-of-office --verbose type=count
+FLAG basecamp people out-of-office disable --account type=string
+FLAG basecamp people out-of-office disable --agent type=bool
+FLAG basecamp people out-of-office disable --cache-dir type=string
+FLAG basecamp people out-of-office disable --count type=bool
+FLAG basecamp people out-of-office disable --hints type=bool
+FLAG basecamp people out-of-office disable --ids-only type=bool
+FLAG basecamp people out-of-office disable --in type=string
+FLAG basecamp people out-of-office disable --jq type=string
+FLAG basecamp people out-of-office disable --json type=bool
+FLAG basecamp people out-of-office disable --markdown type=bool
+FLAG basecamp people out-of-office disable --md type=bool
+FLAG basecamp people out-of-office disable --no-hints type=bool
+FLAG basecamp people out-of-office disable --no-stats type=bool
+FLAG basecamp people out-of-office disable --profile type=string
+FLAG basecamp people out-of-office disable --project type=string
+FLAG basecamp people out-of-office disable --quiet type=bool
+FLAG basecamp people out-of-office disable --stats type=bool
+FLAG basecamp people out-of-office disable --styled type=bool
+FLAG basecamp people out-of-office disable --todolist type=string
+FLAG basecamp people out-of-office disable --verbose type=count
+FLAG basecamp people out-of-office enable --account type=string
+FLAG basecamp people out-of-office enable --agent type=bool
+FLAG basecamp people out-of-office enable --cache-dir type=string
+FLAG basecamp people out-of-office enable --count type=bool
+FLAG basecamp people out-of-office enable --from type=string
+FLAG basecamp people out-of-office enable --hints type=bool
+FLAG basecamp people out-of-office enable --ids-only type=bool
+FLAG basecamp people out-of-office enable --in type=string
+FLAG basecamp people out-of-office enable --jq type=string
+FLAG basecamp people out-of-office enable --json type=bool
+FLAG basecamp people out-of-office enable --markdown type=bool
+FLAG basecamp people out-of-office enable --md type=bool
+FLAG basecamp people out-of-office enable --no-hints type=bool
+FLAG basecamp people out-of-office enable --no-stats type=bool
+FLAG basecamp people out-of-office enable --profile type=string
+FLAG basecamp people out-of-office enable --project type=string
+FLAG basecamp people out-of-office enable --quiet type=bool
+FLAG basecamp people out-of-office enable --stats type=bool
+FLAG basecamp people out-of-office enable --styled type=bool
+FLAG basecamp people out-of-office enable --to type=string
+FLAG basecamp people out-of-office enable --todolist type=string
+FLAG basecamp people out-of-office enable --verbose type=count
+FLAG basecamp people out-of-office show --account type=string
+FLAG basecamp people out-of-office show --agent type=bool
+FLAG basecamp people out-of-office show --cache-dir type=string
+FLAG basecamp people out-of-office show --count type=bool
+FLAG basecamp people out-of-office show --hints type=bool
+FLAG basecamp people out-of-office show --ids-only type=bool
+FLAG basecamp people out-of-office show --in type=string
+FLAG basecamp people out-of-office show --jq type=string
+FLAG basecamp people out-of-office show --json type=bool
+FLAG basecamp people out-of-office show --markdown type=bool
+FLAG basecamp people out-of-office show --md type=bool
+FLAG basecamp people out-of-office show --no-hints type=bool
+FLAG basecamp people out-of-office show --no-stats type=bool
+FLAG basecamp people out-of-office show --profile type=string
+FLAG basecamp people out-of-office show --project type=string
+FLAG basecamp people out-of-office show --quiet type=bool
+FLAG basecamp people out-of-office show --stats type=bool
+FLAG basecamp people out-of-office show --styled type=bool
+FLAG basecamp people out-of-office show --todolist type=string
+FLAG basecamp people out-of-office show --verbose type=count
 FLAG basecamp people pingable --account type=string
 FLAG basecamp people pingable --agent type=bool
 FLAG basecamp people pingable --cache-dir type=string
 FLAG basecamp people pingable --count type=bool
-FLAG basecamp people pingable --help type=bool
 FLAG basecamp people pingable --hints type=bool
 FLAG basecamp people pingable --ids-only type=bool
 FLAG basecamp people pingable --in type=string
@@ -10115,12 +4826,141 @@ FLAG basecamp people pingable --stats type=bool
 FLAG basecamp people pingable --styled type=bool
 FLAG basecamp people pingable --todolist type=string
 FLAG basecamp people pingable --verbose type=count
-FLAG basecamp people pingable --version type=bool
+FLAG basecamp people preferences --account type=string
+FLAG basecamp people preferences --agent type=bool
+FLAG basecamp people preferences --cache-dir type=string
+FLAG basecamp people preferences --count type=bool
+FLAG basecamp people preferences --hints type=bool
+FLAG basecamp people preferences --ids-only type=bool
+FLAG basecamp people preferences --in type=string
+FLAG basecamp people preferences --jq type=string
+FLAG basecamp people preferences --json type=bool
+FLAG basecamp people preferences --markdown type=bool
+FLAG basecamp people preferences --md type=bool
+FLAG basecamp people preferences --no-hints type=bool
+FLAG basecamp people preferences --no-stats type=bool
+FLAG basecamp people preferences --profile type=string
+FLAG basecamp people preferences --project type=string
+FLAG basecamp people preferences --quiet type=bool
+FLAG basecamp people preferences --stats type=bool
+FLAG basecamp people preferences --styled type=bool
+FLAG basecamp people preferences --todolist type=string
+FLAG basecamp people preferences --verbose type=count
+FLAG basecamp people preferences show --account type=string
+FLAG basecamp people preferences show --agent type=bool
+FLAG basecamp people preferences show --cache-dir type=string
+FLAG basecamp people preferences show --count type=bool
+FLAG basecamp people preferences show --hints type=bool
+FLAG basecamp people preferences show --ids-only type=bool
+FLAG basecamp people preferences show --in type=string
+FLAG basecamp people preferences show --jq type=string
+FLAG basecamp people preferences show --json type=bool
+FLAG basecamp people preferences show --markdown type=bool
+FLAG basecamp people preferences show --md type=bool
+FLAG basecamp people preferences show --no-hints type=bool
+FLAG basecamp people preferences show --no-stats type=bool
+FLAG basecamp people preferences show --profile type=string
+FLAG basecamp people preferences show --project type=string
+FLAG basecamp people preferences show --quiet type=bool
+FLAG basecamp people preferences show --stats type=bool
+FLAG basecamp people preferences show --styled type=bool
+FLAG basecamp people preferences show --todolist type=string
+FLAG basecamp people preferences show --verbose type=count
+FLAG basecamp people preferences update --account type=string
+FLAG basecamp people preferences update --agent type=bool
+FLAG basecamp people preferences update --cache-dir type=string
+FLAG basecamp people preferences update --count type=bool
+FLAG basecamp people preferences update --first-week-day type=string
+FLAG basecamp people preferences update --hints type=bool
+FLAG basecamp people preferences update --ids-only type=bool
+FLAG basecamp people preferences update --in type=string
+FLAG basecamp people preferences update --jq type=string
+FLAG basecamp people preferences update --json type=bool
+FLAG basecamp people preferences update --markdown type=bool
+FLAG basecamp people preferences update --md type=bool
+FLAG basecamp people preferences update --no-hints type=bool
+FLAG basecamp people preferences update --no-stats type=bool
+FLAG basecamp people preferences update --profile type=string
+FLAG basecamp people preferences update --project type=string
+FLAG basecamp people preferences update --quiet type=bool
+FLAG basecamp people preferences update --stats type=bool
+FLAG basecamp people preferences update --styled type=bool
+FLAG basecamp people preferences update --time-format type=string
+FLAG basecamp people preferences update --time-zone type=string
+FLAG basecamp people preferences update --todolist type=string
+FLAG basecamp people preferences update --verbose type=count
+FLAG basecamp people profile --account type=string
+FLAG basecamp people profile --agent type=bool
+FLAG basecamp people profile --cache-dir type=string
+FLAG basecamp people profile --count type=bool
+FLAG basecamp people profile --hints type=bool
+FLAG basecamp people profile --ids-only type=bool
+FLAG basecamp people profile --in type=string
+FLAG basecamp people profile --jq type=string
+FLAG basecamp people profile --json type=bool
+FLAG basecamp people profile --markdown type=bool
+FLAG basecamp people profile --md type=bool
+FLAG basecamp people profile --no-hints type=bool
+FLAG basecamp people profile --no-stats type=bool
+FLAG basecamp people profile --profile type=string
+FLAG basecamp people profile --project type=string
+FLAG basecamp people profile --quiet type=bool
+FLAG basecamp people profile --stats type=bool
+FLAG basecamp people profile --styled type=bool
+FLAG basecamp people profile --todolist type=string
+FLAG basecamp people profile --verbose type=count
+FLAG basecamp people profile show --account type=string
+FLAG basecamp people profile show --agent type=bool
+FLAG basecamp people profile show --cache-dir type=string
+FLAG basecamp people profile show --count type=bool
+FLAG basecamp people profile show --hints type=bool
+FLAG basecamp people profile show --ids-only type=bool
+FLAG basecamp people profile show --in type=string
+FLAG basecamp people profile show --jq type=string
+FLAG basecamp people profile show --json type=bool
+FLAG basecamp people profile show --markdown type=bool
+FLAG basecamp people profile show --md type=bool
+FLAG basecamp people profile show --no-hints type=bool
+FLAG basecamp people profile show --no-stats type=bool
+FLAG basecamp people profile show --profile type=string
+FLAG basecamp people profile show --project type=string
+FLAG basecamp people profile show --quiet type=bool
+FLAG basecamp people profile show --stats type=bool
+FLAG basecamp people profile show --styled type=bool
+FLAG basecamp people profile show --todolist type=string
+FLAG basecamp people profile show --verbose type=count
+FLAG basecamp people profile update --account type=string
+FLAG basecamp people profile update --agent type=bool
+FLAG basecamp people profile update --bio type=string
+FLAG basecamp people profile update --cache-dir type=string
+FLAG basecamp people profile update --count type=bool
+FLAG basecamp people profile update --email type=string
+FLAG basecamp people profile update --first-week-day type=string
+FLAG basecamp people profile update --hints type=bool
+FLAG basecamp people profile update --ids-only type=bool
+FLAG basecamp people profile update --in type=string
+FLAG basecamp people profile update --jq type=string
+FLAG basecamp people profile update --json type=bool
+FLAG basecamp people profile update --location type=string
+FLAG basecamp people profile update --markdown type=bool
+FLAG basecamp people profile update --md type=bool
+FLAG basecamp people profile update --name type=string
+FLAG basecamp people profile update --no-hints type=bool
+FLAG basecamp people profile update --no-stats type=bool
+FLAG basecamp people profile update --profile type=string
+FLAG basecamp people profile update --project type=string
+FLAG basecamp people profile update --quiet type=bool
+FLAG basecamp people profile update --stats type=bool
+FLAG basecamp people profile update --styled type=bool
+FLAG basecamp people profile update --time-format type=string
+FLAG basecamp people profile update --time-zone type=string
+FLAG basecamp people profile update --title type=string
+FLAG basecamp people profile update --todolist type=string
+FLAG basecamp people profile update --verbose type=count
 FLAG basecamp people remove --account type=string
 FLAG basecamp people remove --agent type=bool
 FLAG basecamp people remove --cache-dir type=string
 FLAG basecamp people remove --count type=bool
-FLAG basecamp people remove --help type=bool
 FLAG basecamp people remove --hints type=bool
 FLAG basecamp people remove --ids-only type=bool
 FLAG basecamp people remove --in type=string
@@ -10137,12 +4977,10 @@ FLAG basecamp people remove --stats type=bool
 FLAG basecamp people remove --styled type=bool
 FLAG basecamp people remove --todolist type=string
 FLAG basecamp people remove --verbose type=count
-FLAG basecamp people remove --version type=bool
 FLAG basecamp people show --account type=string
 FLAG basecamp people show --agent type=bool
 FLAG basecamp people show --cache-dir type=string
 FLAG basecamp people show --count type=bool
-FLAG basecamp people show --help type=bool
 FLAG basecamp people show --hints type=bool
 FLAG basecamp people show --ids-only type=bool
 FLAG basecamp people show --in type=string
@@ -10159,12 +4997,10 @@ FLAG basecamp people show --stats type=bool
 FLAG basecamp people show --styled type=bool
 FLAG basecamp people show --todolist type=string
 FLAG basecamp people show --verbose type=count
-FLAG basecamp people show --version type=bool
 FLAG basecamp profile --account type=string
 FLAG basecamp profile --agent type=bool
 FLAG basecamp profile --cache-dir type=string
 FLAG basecamp profile --count type=bool
-FLAG basecamp profile --help type=bool
 FLAG basecamp profile --hints type=bool
 FLAG basecamp profile --ids-only type=bool
 FLAG basecamp profile --in type=string
@@ -10181,14 +5017,12 @@ FLAG basecamp profile --stats type=bool
 FLAG basecamp profile --styled type=bool
 FLAG basecamp profile --todolist type=string
 FLAG basecamp profile --verbose type=count
-FLAG basecamp profile --version type=bool
 FLAG basecamp profile create --account type=string
 FLAG basecamp profile create --agent type=bool
 FLAG basecamp profile create --base-url type=string
 FLAG basecamp profile create --cache-dir type=string
 FLAG basecamp profile create --count type=bool
 FLAG basecamp profile create --device-code type=bool
-FLAG basecamp profile create --help type=bool
 FLAG basecamp profile create --hints type=bool
 FLAG basecamp profile create --ids-only type=bool
 FLAG basecamp profile create --in type=string
@@ -10209,12 +5043,10 @@ FLAG basecamp profile create --stats type=bool
 FLAG basecamp profile create --styled type=bool
 FLAG basecamp profile create --todolist type=string
 FLAG basecamp profile create --verbose type=count
-FLAG basecamp profile create --version type=bool
 FLAG basecamp profile delete --account type=string
 FLAG basecamp profile delete --agent type=bool
 FLAG basecamp profile delete --cache-dir type=string
 FLAG basecamp profile delete --count type=bool
-FLAG basecamp profile delete --help type=bool
 FLAG basecamp profile delete --hints type=bool
 FLAG basecamp profile delete --ids-only type=bool
 FLAG basecamp profile delete --in type=string
@@ -10231,12 +5063,10 @@ FLAG basecamp profile delete --stats type=bool
 FLAG basecamp profile delete --styled type=bool
 FLAG basecamp profile delete --todolist type=string
 FLAG basecamp profile delete --verbose type=count
-FLAG basecamp profile delete --version type=bool
 FLAG basecamp profile list --account type=string
 FLAG basecamp profile list --agent type=bool
 FLAG basecamp profile list --cache-dir type=string
 FLAG basecamp profile list --count type=bool
-FLAG basecamp profile list --help type=bool
 FLAG basecamp profile list --hints type=bool
 FLAG basecamp profile list --ids-only type=bool
 FLAG basecamp profile list --in type=string
@@ -10253,12 +5083,10 @@ FLAG basecamp profile list --stats type=bool
 FLAG basecamp profile list --styled type=bool
 FLAG basecamp profile list --todolist type=string
 FLAG basecamp profile list --verbose type=count
-FLAG basecamp profile list --version type=bool
 FLAG basecamp profile set-default --account type=string
 FLAG basecamp profile set-default --agent type=bool
 FLAG basecamp profile set-default --cache-dir type=string
 FLAG basecamp profile set-default --count type=bool
-FLAG basecamp profile set-default --help type=bool
 FLAG basecamp profile set-default --hints type=bool
 FLAG basecamp profile set-default --ids-only type=bool
 FLAG basecamp profile set-default --in type=string
@@ -10275,12 +5103,10 @@ FLAG basecamp profile set-default --stats type=bool
 FLAG basecamp profile set-default --styled type=bool
 FLAG basecamp profile set-default --todolist type=string
 FLAG basecamp profile set-default --verbose type=count
-FLAG basecamp profile set-default --version type=bool
 FLAG basecamp profile show --account type=string
 FLAG basecamp profile show --agent type=bool
 FLAG basecamp profile show --cache-dir type=string
 FLAG basecamp profile show --count type=bool
-FLAG basecamp profile show --help type=bool
 FLAG basecamp profile show --hints type=bool
 FLAG basecamp profile show --ids-only type=bool
 FLAG basecamp profile show --in type=string
@@ -10297,176 +5123,10 @@ FLAG basecamp profile show --stats type=bool
 FLAG basecamp profile show --styled type=bool
 FLAG basecamp profile show --todolist type=string
 FLAG basecamp profile show --verbose type=count
-FLAG basecamp profile show --version type=bool
-FLAG basecamp project --account type=string
-FLAG basecamp project --agent type=bool
-FLAG basecamp project --cache-dir type=string
-FLAG basecamp project --count type=bool
-FLAG basecamp project --help type=bool
-FLAG basecamp project --hints type=bool
-FLAG basecamp project --ids-only type=bool
-FLAG basecamp project --in type=string
-FLAG basecamp project --jq type=string
-FLAG basecamp project --json type=bool
-FLAG basecamp project --markdown type=bool
-FLAG basecamp project --md type=bool
-FLAG basecamp project --no-hints type=bool
-FLAG basecamp project --no-stats type=bool
-FLAG basecamp project --profile type=string
-FLAG basecamp project --project type=string
-FLAG basecamp project --quiet type=bool
-FLAG basecamp project --stats type=bool
-FLAG basecamp project --styled type=bool
-FLAG basecamp project --todolist type=string
-FLAG basecamp project --verbose type=count
-FLAG basecamp project --version type=bool
-FLAG basecamp project create --account type=string
-FLAG basecamp project create --agent type=bool
-FLAG basecamp project create --cache-dir type=string
-FLAG basecamp project create --count type=bool
-FLAG basecamp project create --description type=string
-FLAG basecamp project create --help type=bool
-FLAG basecamp project create --hints type=bool
-FLAG basecamp project create --ids-only type=bool
-FLAG basecamp project create --in type=string
-FLAG basecamp project create --jq type=string
-FLAG basecamp project create --json type=bool
-FLAG basecamp project create --markdown type=bool
-FLAG basecamp project create --md type=bool
-FLAG basecamp project create --no-hints type=bool
-FLAG basecamp project create --no-stats type=bool
-FLAG basecamp project create --profile type=string
-FLAG basecamp project create --project type=string
-FLAG basecamp project create --quiet type=bool
-FLAG basecamp project create --stats type=bool
-FLAG basecamp project create --styled type=bool
-FLAG basecamp project create --todolist type=string
-FLAG basecamp project create --verbose type=count
-FLAG basecamp project create --version type=bool
-FLAG basecamp project delete --account type=string
-FLAG basecamp project delete --agent type=bool
-FLAG basecamp project delete --cache-dir type=string
-FLAG basecamp project delete --count type=bool
-FLAG basecamp project delete --help type=bool
-FLAG basecamp project delete --hints type=bool
-FLAG basecamp project delete --ids-only type=bool
-FLAG basecamp project delete --in type=string
-FLAG basecamp project delete --jq type=string
-FLAG basecamp project delete --json type=bool
-FLAG basecamp project delete --markdown type=bool
-FLAG basecamp project delete --md type=bool
-FLAG basecamp project delete --no-hints type=bool
-FLAG basecamp project delete --no-stats type=bool
-FLAG basecamp project delete --profile type=string
-FLAG basecamp project delete --project type=string
-FLAG basecamp project delete --quiet type=bool
-FLAG basecamp project delete --stats type=bool
-FLAG basecamp project delete --styled type=bool
-FLAG basecamp project delete --todolist type=string
-FLAG basecamp project delete --verbose type=count
-FLAG basecamp project delete --version type=bool
-FLAG basecamp project list --account type=string
-FLAG basecamp project list --agent type=bool
-FLAG basecamp project list --all type=bool
-FLAG basecamp project list --cache-dir type=string
-FLAG basecamp project list --count type=bool
-FLAG basecamp project list --help type=bool
-FLAG basecamp project list --hints type=bool
-FLAG basecamp project list --ids-only type=bool
-FLAG basecamp project list --in type=string
-FLAG basecamp project list --jq type=string
-FLAG basecamp project list --json type=bool
-FLAG basecamp project list --limit type=int
-FLAG basecamp project list --markdown type=bool
-FLAG basecamp project list --md type=bool
-FLAG basecamp project list --no-hints type=bool
-FLAG basecamp project list --no-stats type=bool
-FLAG basecamp project list --page type=int
-FLAG basecamp project list --profile type=string
-FLAG basecamp project list --project type=string
-FLAG basecamp project list --quiet type=bool
-FLAG basecamp project list --reverse type=bool
-FLAG basecamp project list --sort type=string
-FLAG basecamp project list --stats type=bool
-FLAG basecamp project list --status type=string
-FLAG basecamp project list --styled type=bool
-FLAG basecamp project list --todolist type=string
-FLAG basecamp project list --verbose type=count
-FLAG basecamp project list --version type=bool
-FLAG basecamp project show --account type=string
-FLAG basecamp project show --agent type=bool
-FLAG basecamp project show --all type=bool
-FLAG basecamp project show --cache-dir type=string
-FLAG basecamp project show --count type=bool
-FLAG basecamp project show --help type=bool
-FLAG basecamp project show --hints type=bool
-FLAG basecamp project show --ids-only type=bool
-FLAG basecamp project show --in type=string
-FLAG basecamp project show --jq type=string
-FLAG basecamp project show --json type=bool
-FLAG basecamp project show --markdown type=bool
-FLAG basecamp project show --md type=bool
-FLAG basecamp project show --no-hints type=bool
-FLAG basecamp project show --no-stats type=bool
-FLAG basecamp project show --profile type=string
-FLAG basecamp project show --project type=string
-FLAG basecamp project show --quiet type=bool
-FLAG basecamp project show --stats type=bool
-FLAG basecamp project show --styled type=bool
-FLAG basecamp project show --todolist type=string
-FLAG basecamp project show --verbose type=count
-FLAG basecamp project show --version type=bool
-FLAG basecamp project trash --account type=string
-FLAG basecamp project trash --agent type=bool
-FLAG basecamp project trash --cache-dir type=string
-FLAG basecamp project trash --count type=bool
-FLAG basecamp project trash --help type=bool
-FLAG basecamp project trash --hints type=bool
-FLAG basecamp project trash --ids-only type=bool
-FLAG basecamp project trash --in type=string
-FLAG basecamp project trash --jq type=string
-FLAG basecamp project trash --json type=bool
-FLAG basecamp project trash --markdown type=bool
-FLAG basecamp project trash --md type=bool
-FLAG basecamp project trash --no-hints type=bool
-FLAG basecamp project trash --no-stats type=bool
-FLAG basecamp project trash --profile type=string
-FLAG basecamp project trash --project type=string
-FLAG basecamp project trash --quiet type=bool
-FLAG basecamp project trash --stats type=bool
-FLAG basecamp project trash --styled type=bool
-FLAG basecamp project trash --todolist type=string
-FLAG basecamp project trash --verbose type=count
-FLAG basecamp project trash --version type=bool
-FLAG basecamp project update --account type=string
-FLAG basecamp project update --agent type=bool
-FLAG basecamp project update --cache-dir type=string
-FLAG basecamp project update --count type=bool
-FLAG basecamp project update --description type=string
-FLAG basecamp project update --help type=bool
-FLAG basecamp project update --hints type=bool
-FLAG basecamp project update --ids-only type=bool
-FLAG basecamp project update --in type=string
-FLAG basecamp project update --jq type=string
-FLAG basecamp project update --json type=bool
-FLAG basecamp project update --markdown type=bool
-FLAG basecamp project update --md type=bool
-FLAG basecamp project update --name type=string
-FLAG basecamp project update --no-hints type=bool
-FLAG basecamp project update --no-stats type=bool
-FLAG basecamp project update --profile type=string
-FLAG basecamp project update --project type=string
-FLAG basecamp project update --quiet type=bool
-FLAG basecamp project update --stats type=bool
-FLAG basecamp project update --styled type=bool
-FLAG basecamp project update --todolist type=string
-FLAG basecamp project update --verbose type=count
-FLAG basecamp project update --version type=bool
 FLAG basecamp projects --account type=string
 FLAG basecamp projects --agent type=bool
 FLAG basecamp projects --cache-dir type=string
 FLAG basecamp projects --count type=bool
-FLAG basecamp projects --help type=bool
 FLAG basecamp projects --hints type=bool
 FLAG basecamp projects --ids-only type=bool
 FLAG basecamp projects --in type=string
@@ -10483,13 +5143,11 @@ FLAG basecamp projects --stats type=bool
 FLAG basecamp projects --styled type=bool
 FLAG basecamp projects --todolist type=string
 FLAG basecamp projects --verbose type=count
-FLAG basecamp projects --version type=bool
 FLAG basecamp projects create --account type=string
 FLAG basecamp projects create --agent type=bool
 FLAG basecamp projects create --cache-dir type=string
 FLAG basecamp projects create --count type=bool
 FLAG basecamp projects create --description type=string
-FLAG basecamp projects create --help type=bool
 FLAG basecamp projects create --hints type=bool
 FLAG basecamp projects create --ids-only type=bool
 FLAG basecamp projects create --in type=string
@@ -10506,12 +5164,10 @@ FLAG basecamp projects create --stats type=bool
 FLAG basecamp projects create --styled type=bool
 FLAG basecamp projects create --todolist type=string
 FLAG basecamp projects create --verbose type=count
-FLAG basecamp projects create --version type=bool
 FLAG basecamp projects delete --account type=string
 FLAG basecamp projects delete --agent type=bool
 FLAG basecamp projects delete --cache-dir type=string
 FLAG basecamp projects delete --count type=bool
-FLAG basecamp projects delete --help type=bool
 FLAG basecamp projects delete --hints type=bool
 FLAG basecamp projects delete --ids-only type=bool
 FLAG basecamp projects delete --in type=string
@@ -10528,13 +5184,11 @@ FLAG basecamp projects delete --stats type=bool
 FLAG basecamp projects delete --styled type=bool
 FLAG basecamp projects delete --todolist type=string
 FLAG basecamp projects delete --verbose type=count
-FLAG basecamp projects delete --version type=bool
 FLAG basecamp projects list --account type=string
 FLAG basecamp projects list --agent type=bool
 FLAG basecamp projects list --all type=bool
 FLAG basecamp projects list --cache-dir type=string
 FLAG basecamp projects list --count type=bool
-FLAG basecamp projects list --help type=bool
 FLAG basecamp projects list --hints type=bool
 FLAG basecamp projects list --ids-only type=bool
 FLAG basecamp projects list --in type=string
@@ -10556,13 +5210,11 @@ FLAG basecamp projects list --status type=string
 FLAG basecamp projects list --styled type=bool
 FLAG basecamp projects list --todolist type=string
 FLAG basecamp projects list --verbose type=count
-FLAG basecamp projects list --version type=bool
 FLAG basecamp projects show --account type=string
 FLAG basecamp projects show --agent type=bool
 FLAG basecamp projects show --all type=bool
 FLAG basecamp projects show --cache-dir type=string
 FLAG basecamp projects show --count type=bool
-FLAG basecamp projects show --help type=bool
 FLAG basecamp projects show --hints type=bool
 FLAG basecamp projects show --ids-only type=bool
 FLAG basecamp projects show --in type=string
@@ -10579,35 +5231,11 @@ FLAG basecamp projects show --stats type=bool
 FLAG basecamp projects show --styled type=bool
 FLAG basecamp projects show --todolist type=string
 FLAG basecamp projects show --verbose type=count
-FLAG basecamp projects show --version type=bool
-FLAG basecamp projects trash --account type=string
-FLAG basecamp projects trash --agent type=bool
-FLAG basecamp projects trash --cache-dir type=string
-FLAG basecamp projects trash --count type=bool
-FLAG basecamp projects trash --help type=bool
-FLAG basecamp projects trash --hints type=bool
-FLAG basecamp projects trash --ids-only type=bool
-FLAG basecamp projects trash --in type=string
-FLAG basecamp projects trash --jq type=string
-FLAG basecamp projects trash --json type=bool
-FLAG basecamp projects trash --markdown type=bool
-FLAG basecamp projects trash --md type=bool
-FLAG basecamp projects trash --no-hints type=bool
-FLAG basecamp projects trash --no-stats type=bool
-FLAG basecamp projects trash --profile type=string
-FLAG basecamp projects trash --project type=string
-FLAG basecamp projects trash --quiet type=bool
-FLAG basecamp projects trash --stats type=bool
-FLAG basecamp projects trash --styled type=bool
-FLAG basecamp projects trash --todolist type=string
-FLAG basecamp projects trash --verbose type=count
-FLAG basecamp projects trash --version type=bool
 FLAG basecamp projects update --account type=string
 FLAG basecamp projects update --agent type=bool
 FLAG basecamp projects update --cache-dir type=string
 FLAG basecamp projects update --count type=bool
 FLAG basecamp projects update --description type=string
-FLAG basecamp projects update --help type=bool
 FLAG basecamp projects update --hints type=bool
 FLAG basecamp projects update --ids-only type=bool
 FLAG basecamp projects update --in type=string
@@ -10625,13 +5253,11 @@ FLAG basecamp projects update --stats type=bool
 FLAG basecamp projects update --styled type=bool
 FLAG basecamp projects update --todolist type=string
 FLAG basecamp projects update --verbose type=count
-FLAG basecamp projects update --version type=bool
 FLAG basecamp react --account type=string
 FLAG basecamp react --agent type=bool
 FLAG basecamp react --cache-dir type=string
 FLAG basecamp react --count type=bool
 FLAG basecamp react --event type=string
-FLAG basecamp react --help type=bool
 FLAG basecamp react --hints type=bool
 FLAG basecamp react --ids-only type=bool
 FLAG basecamp react --in type=string
@@ -10650,15 +5276,12 @@ FLAG basecamp react --stats type=bool
 FLAG basecamp react --styled type=bool
 FLAG basecamp react --todolist type=string
 FLAG basecamp react --verbose type=count
-FLAG basecamp react --version type=bool
 FLAG basecamp recordings --account type=string
 FLAG basecamp recordings --agent type=bool
 FLAG basecamp recordings --all type=bool
-FLAG basecamp recordings --assignee type=string
 FLAG basecamp recordings --cache-dir type=string
 FLAG basecamp recordings --count type=bool
 FLAG basecamp recordings --direction type=string
-FLAG basecamp recordings --help type=bool
 FLAG basecamp recordings --hints type=bool
 FLAG basecamp recordings --ids-only type=bool
 FLAG basecamp recordings --in type=string
@@ -10680,34 +5303,10 @@ FLAG basecamp recordings --styled type=bool
 FLAG basecamp recordings --todolist type=string
 FLAG basecamp recordings --type type=string
 FLAG basecamp recordings --verbose type=count
-FLAG basecamp recordings --version type=bool
-FLAG basecamp recordings active --account type=string
-FLAG basecamp recordings active --agent type=bool
-FLAG basecamp recordings active --cache-dir type=string
-FLAG basecamp recordings active --count type=bool
-FLAG basecamp recordings active --help type=bool
-FLAG basecamp recordings active --hints type=bool
-FLAG basecamp recordings active --ids-only type=bool
-FLAG basecamp recordings active --in type=string
-FLAG basecamp recordings active --jq type=string
-FLAG basecamp recordings active --json type=bool
-FLAG basecamp recordings active --markdown type=bool
-FLAG basecamp recordings active --md type=bool
-FLAG basecamp recordings active --no-hints type=bool
-FLAG basecamp recordings active --no-stats type=bool
-FLAG basecamp recordings active --profile type=string
-FLAG basecamp recordings active --project type=string
-FLAG basecamp recordings active --quiet type=bool
-FLAG basecamp recordings active --stats type=bool
-FLAG basecamp recordings active --styled type=bool
-FLAG basecamp recordings active --todolist type=string
-FLAG basecamp recordings active --verbose type=count
-FLAG basecamp recordings active --version type=bool
 FLAG basecamp recordings archive --account type=string
 FLAG basecamp recordings archive --agent type=bool
 FLAG basecamp recordings archive --cache-dir type=string
 FLAG basecamp recordings archive --count type=bool
-FLAG basecamp recordings archive --help type=bool
 FLAG basecamp recordings archive --hints type=bool
 FLAG basecamp recordings archive --ids-only type=bool
 FLAG basecamp recordings archive --in type=string
@@ -10724,63 +5323,12 @@ FLAG basecamp recordings archive --stats type=bool
 FLAG basecamp recordings archive --styled type=bool
 FLAG basecamp recordings archive --todolist type=string
 FLAG basecamp recordings archive --verbose type=count
-FLAG basecamp recordings archive --version type=bool
-FLAG basecamp recordings archived --account type=string
-FLAG basecamp recordings archived --agent type=bool
-FLAG basecamp recordings archived --cache-dir type=string
-FLAG basecamp recordings archived --count type=bool
-FLAG basecamp recordings archived --help type=bool
-FLAG basecamp recordings archived --hints type=bool
-FLAG basecamp recordings archived --ids-only type=bool
-FLAG basecamp recordings archived --in type=string
-FLAG basecamp recordings archived --jq type=string
-FLAG basecamp recordings archived --json type=bool
-FLAG basecamp recordings archived --markdown type=bool
-FLAG basecamp recordings archived --md type=bool
-FLAG basecamp recordings archived --no-hints type=bool
-FLAG basecamp recordings archived --no-stats type=bool
-FLAG basecamp recordings archived --profile type=string
-FLAG basecamp recordings archived --project type=string
-FLAG basecamp recordings archived --quiet type=bool
-FLAG basecamp recordings archived --stats type=bool
-FLAG basecamp recordings archived --styled type=bool
-FLAG basecamp recordings archived --todolist type=string
-FLAG basecamp recordings archived --verbose type=count
-FLAG basecamp recordings archived --version type=bool
-FLAG basecamp recordings client-visibility --account type=string
-FLAG basecamp recordings client-visibility --agent type=bool
-FLAG basecamp recordings client-visibility --cache-dir type=string
-FLAG basecamp recordings client-visibility --count type=bool
-FLAG basecamp recordings client-visibility --help type=bool
-FLAG basecamp recordings client-visibility --hidden type=bool
-FLAG basecamp recordings client-visibility --hide type=bool
-FLAG basecamp recordings client-visibility --hints type=bool
-FLAG basecamp recordings client-visibility --ids-only type=bool
-FLAG basecamp recordings client-visibility --in type=string
-FLAG basecamp recordings client-visibility --jq type=string
-FLAG basecamp recordings client-visibility --json type=bool
-FLAG basecamp recordings client-visibility --markdown type=bool
-FLAG basecamp recordings client-visibility --md type=bool
-FLAG basecamp recordings client-visibility --no-hints type=bool
-FLAG basecamp recordings client-visibility --no-stats type=bool
-FLAG basecamp recordings client-visibility --profile type=string
-FLAG basecamp recordings client-visibility --project type=string
-FLAG basecamp recordings client-visibility --quiet type=bool
-FLAG basecamp recordings client-visibility --show type=bool
-FLAG basecamp recordings client-visibility --stats type=bool
-FLAG basecamp recordings client-visibility --styled type=bool
-FLAG basecamp recordings client-visibility --todolist type=string
-FLAG basecamp recordings client-visibility --verbose type=count
-FLAG basecamp recordings client-visibility --version type=bool
-FLAG basecamp recordings client-visibility --visible type=bool
 FLAG basecamp recordings list --account type=string
 FLAG basecamp recordings list --agent type=bool
 FLAG basecamp recordings list --all type=bool
-FLAG basecamp recordings list --assignee type=string
 FLAG basecamp recordings list --cache-dir type=string
 FLAG basecamp recordings list --count type=bool
 FLAG basecamp recordings list --direction type=string
-FLAG basecamp recordings list --help type=bool
 FLAG basecamp recordings list --hints type=bool
 FLAG basecamp recordings list --ids-only type=bool
 FLAG basecamp recordings list --in type=string
@@ -10802,12 +5350,10 @@ FLAG basecamp recordings list --styled type=bool
 FLAG basecamp recordings list --todolist type=string
 FLAG basecamp recordings list --type type=string
 FLAG basecamp recordings list --verbose type=count
-FLAG basecamp recordings list --version type=bool
 FLAG basecamp recordings restore --account type=string
 FLAG basecamp recordings restore --agent type=bool
 FLAG basecamp recordings restore --cache-dir type=string
 FLAG basecamp recordings restore --count type=bool
-FLAG basecamp recordings restore --help type=bool
 FLAG basecamp recordings restore --hints type=bool
 FLAG basecamp recordings restore --ids-only type=bool
 FLAG basecamp recordings restore --in type=string
@@ -10824,12 +5370,10 @@ FLAG basecamp recordings restore --stats type=bool
 FLAG basecamp recordings restore --styled type=bool
 FLAG basecamp recordings restore --todolist type=string
 FLAG basecamp recordings restore --verbose type=count
-FLAG basecamp recordings restore --version type=bool
 FLAG basecamp recordings trash --account type=string
 FLAG basecamp recordings trash --agent type=bool
 FLAG basecamp recordings trash --cache-dir type=string
 FLAG basecamp recordings trash --count type=bool
-FLAG basecamp recordings trash --help type=bool
 FLAG basecamp recordings trash --hints type=bool
 FLAG basecamp recordings trash --ids-only type=bool
 FLAG basecamp recordings trash --in type=string
@@ -10846,34 +5390,10 @@ FLAG basecamp recordings trash --stats type=bool
 FLAG basecamp recordings trash --styled type=bool
 FLAG basecamp recordings trash --todolist type=string
 FLAG basecamp recordings trash --verbose type=count
-FLAG basecamp recordings trash --version type=bool
-FLAG basecamp recordings trashed --account type=string
-FLAG basecamp recordings trashed --agent type=bool
-FLAG basecamp recordings trashed --cache-dir type=string
-FLAG basecamp recordings trashed --count type=bool
-FLAG basecamp recordings trashed --help type=bool
-FLAG basecamp recordings trashed --hints type=bool
-FLAG basecamp recordings trashed --ids-only type=bool
-FLAG basecamp recordings trashed --in type=string
-FLAG basecamp recordings trashed --jq type=string
-FLAG basecamp recordings trashed --json type=bool
-FLAG basecamp recordings trashed --markdown type=bool
-FLAG basecamp recordings trashed --md type=bool
-FLAG basecamp recordings trashed --no-hints type=bool
-FLAG basecamp recordings trashed --no-stats type=bool
-FLAG basecamp recordings trashed --profile type=string
-FLAG basecamp recordings trashed --project type=string
-FLAG basecamp recordings trashed --quiet type=bool
-FLAG basecamp recordings trashed --stats type=bool
-FLAG basecamp recordings trashed --styled type=bool
-FLAG basecamp recordings trashed --todolist type=string
-FLAG basecamp recordings trashed --verbose type=count
-FLAG basecamp recordings trashed --version type=bool
 FLAG basecamp recordings visibility --account type=string
 FLAG basecamp recordings visibility --agent type=bool
 FLAG basecamp recordings visibility --cache-dir type=string
 FLAG basecamp recordings visibility --count type=bool
-FLAG basecamp recordings visibility --help type=bool
 FLAG basecamp recordings visibility --hidden type=bool
 FLAG basecamp recordings visibility --hide type=bool
 FLAG basecamp recordings visibility --hints type=bool
@@ -10893,13 +5413,11 @@ FLAG basecamp recordings visibility --stats type=bool
 FLAG basecamp recordings visibility --styled type=bool
 FLAG basecamp recordings visibility --todolist type=string
 FLAG basecamp recordings visibility --verbose type=count
-FLAG basecamp recordings visibility --version type=bool
 FLAG basecamp recordings visibility --visible type=bool
 FLAG basecamp reopen --account type=string
 FLAG basecamp reopen --agent type=bool
 FLAG basecamp reopen --cache-dir type=string
 FLAG basecamp reopen --count type=bool
-FLAG basecamp reopen --help type=bool
 FLAG basecamp reopen --hints type=bool
 FLAG basecamp reopen --ids-only type=bool
 FLAG basecamp reopen --in type=string
@@ -10916,12 +5434,10 @@ FLAG basecamp reopen --stats type=bool
 FLAG basecamp reopen --styled type=bool
 FLAG basecamp reopen --todolist type=string
 FLAG basecamp reopen --verbose type=count
-FLAG basecamp reopen --version type=bool
 FLAG basecamp reports --account type=string
 FLAG basecamp reports --agent type=bool
 FLAG basecamp reports --cache-dir type=string
 FLAG basecamp reports --count type=bool
-FLAG basecamp reports --help type=bool
 FLAG basecamp reports --hints type=bool
 FLAG basecamp reports --ids-only type=bool
 FLAG basecamp reports --in type=string
@@ -10938,12 +5454,10 @@ FLAG basecamp reports --stats type=bool
 FLAG basecamp reports --styled type=bool
 FLAG basecamp reports --todolist type=string
 FLAG basecamp reports --verbose type=count
-FLAG basecamp reports --version type=bool
 FLAG basecamp reports assignable --account type=string
 FLAG basecamp reports assignable --agent type=bool
 FLAG basecamp reports assignable --cache-dir type=string
 FLAG basecamp reports assignable --count type=bool
-FLAG basecamp reports assignable --help type=bool
 FLAG basecamp reports assignable --hints type=bool
 FLAG basecamp reports assignable --ids-only type=bool
 FLAG basecamp reports assignable --in type=string
@@ -10960,13 +5474,11 @@ FLAG basecamp reports assignable --stats type=bool
 FLAG basecamp reports assignable --styled type=bool
 FLAG basecamp reports assignable --todolist type=string
 FLAG basecamp reports assignable --verbose type=count
-FLAG basecamp reports assignable --version type=bool
 FLAG basecamp reports assigned --account type=string
 FLAG basecamp reports assigned --agent type=bool
 FLAG basecamp reports assigned --cache-dir type=string
 FLAG basecamp reports assigned --count type=bool
 FLAG basecamp reports assigned --group-by type=string
-FLAG basecamp reports assigned --help type=bool
 FLAG basecamp reports assigned --hints type=bool
 FLAG basecamp reports assigned --ids-only type=bool
 FLAG basecamp reports assigned --in type=string
@@ -10983,12 +5495,71 @@ FLAG basecamp reports assigned --stats type=bool
 FLAG basecamp reports assigned --styled type=bool
 FLAG basecamp reports assigned --todolist type=string
 FLAG basecamp reports assigned --verbose type=count
-FLAG basecamp reports assigned --version type=bool
+FLAG basecamp reports completed --account type=string
+FLAG basecamp reports completed --agent type=bool
+FLAG basecamp reports completed --cache-dir type=string
+FLAG basecamp reports completed --count type=bool
+FLAG basecamp reports completed --hints type=bool
+FLAG basecamp reports completed --ids-only type=bool
+FLAG basecamp reports completed --in type=string
+FLAG basecamp reports completed --jq type=string
+FLAG basecamp reports completed --json type=bool
+FLAG basecamp reports completed --markdown type=bool
+FLAG basecamp reports completed --md type=bool
+FLAG basecamp reports completed --no-hints type=bool
+FLAG basecamp reports completed --no-stats type=bool
+FLAG basecamp reports completed --profile type=string
+FLAG basecamp reports completed --project type=string
+FLAG basecamp reports completed --quiet type=bool
+FLAG basecamp reports completed --stats type=bool
+FLAG basecamp reports completed --styled type=bool
+FLAG basecamp reports completed --todolist type=string
+FLAG basecamp reports completed --verbose type=count
+FLAG basecamp reports due --account type=string
+FLAG basecamp reports due --agent type=bool
+FLAG basecamp reports due --cache-dir type=string
+FLAG basecamp reports due --count type=bool
+FLAG basecamp reports due --hints type=bool
+FLAG basecamp reports due --ids-only type=bool
+FLAG basecamp reports due --in type=string
+FLAG basecamp reports due --jq type=string
+FLAG basecamp reports due --json type=bool
+FLAG basecamp reports due --markdown type=bool
+FLAG basecamp reports due --md type=bool
+FLAG basecamp reports due --no-hints type=bool
+FLAG basecamp reports due --no-stats type=bool
+FLAG basecamp reports due --profile type=string
+FLAG basecamp reports due --project type=string
+FLAG basecamp reports due --quiet type=bool
+FLAG basecamp reports due --scope type=string
+FLAG basecamp reports due --stats type=bool
+FLAG basecamp reports due --styled type=bool
+FLAG basecamp reports due --todolist type=string
+FLAG basecamp reports due --verbose type=count
+FLAG basecamp reports mine --account type=string
+FLAG basecamp reports mine --agent type=bool
+FLAG basecamp reports mine --cache-dir type=string
+FLAG basecamp reports mine --count type=bool
+FLAG basecamp reports mine --hints type=bool
+FLAG basecamp reports mine --ids-only type=bool
+FLAG basecamp reports mine --in type=string
+FLAG basecamp reports mine --jq type=string
+FLAG basecamp reports mine --json type=bool
+FLAG basecamp reports mine --markdown type=bool
+FLAG basecamp reports mine --md type=bool
+FLAG basecamp reports mine --no-hints type=bool
+FLAG basecamp reports mine --no-stats type=bool
+FLAG basecamp reports mine --profile type=string
+FLAG basecamp reports mine --project type=string
+FLAG basecamp reports mine --quiet type=bool
+FLAG basecamp reports mine --stats type=bool
+FLAG basecamp reports mine --styled type=bool
+FLAG basecamp reports mine --todolist type=string
+FLAG basecamp reports mine --verbose type=count
 FLAG basecamp reports overdue --account type=string
 FLAG basecamp reports overdue --agent type=bool
 FLAG basecamp reports overdue --cache-dir type=string
 FLAG basecamp reports overdue --count type=bool
-FLAG basecamp reports overdue --help type=bool
 FLAG basecamp reports overdue --hints type=bool
 FLAG basecamp reports overdue --ids-only type=bool
 FLAG basecamp reports overdue --in type=string
@@ -11005,13 +5576,11 @@ FLAG basecamp reports overdue --stats type=bool
 FLAG basecamp reports overdue --styled type=bool
 FLAG basecamp reports overdue --todolist type=string
 FLAG basecamp reports overdue --verbose type=count
-FLAG basecamp reports overdue --version type=bool
 FLAG basecamp reports schedule --account type=string
 FLAG basecamp reports schedule --agent type=bool
 FLAG basecamp reports schedule --cache-dir type=string
 FLAG basecamp reports schedule --count type=bool
 FLAG basecamp reports schedule --end type=string
-FLAG basecamp reports schedule --help type=bool
 FLAG basecamp reports schedule --hints type=bool
 FLAG basecamp reports schedule --ids-only type=bool
 FLAG basecamp reports schedule --in type=string
@@ -11029,12 +5598,10 @@ FLAG basecamp reports schedule --stats type=bool
 FLAG basecamp reports schedule --styled type=bool
 FLAG basecamp reports schedule --todolist type=string
 FLAG basecamp reports schedule --verbose type=count
-FLAG basecamp reports schedule --version type=bool
 FLAG basecamp schedule --account type=string
 FLAG basecamp schedule --agent type=bool
 FLAG basecamp schedule --cache-dir type=string
 FLAG basecamp schedule --count type=bool
-FLAG basecamp schedule --help type=bool
 FLAG basecamp schedule --hints type=bool
 FLAG basecamp schedule --ids-only type=bool
 FLAG basecamp schedule --in type=string
@@ -11052,7 +5619,6 @@ FLAG basecamp schedule --stats type=bool
 FLAG basecamp schedule --styled type=bool
 FLAG basecamp schedule --todolist type=string
 FLAG basecamp schedule --verbose type=count
-FLAG basecamp schedule --version type=bool
 FLAG basecamp schedule create --account type=string
 FLAG basecamp schedule create --agent type=bool
 FLAG basecamp schedule create --all-day type=bool
@@ -11063,7 +5629,6 @@ FLAG basecamp schedule create --desc type=string
 FLAG basecamp schedule create --description type=string
 FLAG basecamp schedule create --end type=string
 FLAG basecamp schedule create --ends-at type=string
-FLAG basecamp schedule create --help type=bool
 FLAG basecamp schedule create --hints type=bool
 FLAG basecamp schedule create --ids-only type=bool
 FLAG basecamp schedule create --in type=string
@@ -11090,13 +5655,11 @@ FLAG basecamp schedule create --summary type=string
 FLAG basecamp schedule create --title type=string
 FLAG basecamp schedule create --todolist type=string
 FLAG basecamp schedule create --verbose type=count
-FLAG basecamp schedule create --version type=bool
 FLAG basecamp schedule entries --account type=string
 FLAG basecamp schedule entries --agent type=bool
 FLAG basecamp schedule entries --all type=bool
 FLAG basecamp schedule entries --cache-dir type=string
 FLAG basecamp schedule entries --count type=bool
-FLAG basecamp schedule entries --help type=bool
 FLAG basecamp schedule entries --hints type=bool
 FLAG basecamp schedule entries --ids-only type=bool
 FLAG basecamp schedule entries --in type=string
@@ -11119,12 +5682,10 @@ FLAG basecamp schedule entries --status type=string
 FLAG basecamp schedule entries --styled type=bool
 FLAG basecamp schedule entries --todolist type=string
 FLAG basecamp schedule entries --verbose type=count
-FLAG basecamp schedule entries --version type=bool
 FLAG basecamp schedule info --account type=string
 FLAG basecamp schedule info --agent type=bool
 FLAG basecamp schedule info --cache-dir type=string
 FLAG basecamp schedule info --count type=bool
-FLAG basecamp schedule info --help type=bool
 FLAG basecamp schedule info --hints type=bool
 FLAG basecamp schedule info --ids-only type=bool
 FLAG basecamp schedule info --in type=string
@@ -11142,12 +5703,10 @@ FLAG basecamp schedule info --stats type=bool
 FLAG basecamp schedule info --styled type=bool
 FLAG basecamp schedule info --todolist type=string
 FLAG basecamp schedule info --verbose type=count
-FLAG basecamp schedule info --version type=bool
 FLAG basecamp schedule settings --account type=string
 FLAG basecamp schedule settings --agent type=bool
 FLAG basecamp schedule settings --cache-dir type=string
 FLAG basecamp schedule settings --count type=bool
-FLAG basecamp schedule settings --help type=bool
 FLAG basecamp schedule settings --hints type=bool
 FLAG basecamp schedule settings --ids-only type=bool
 FLAG basecamp schedule settings --in type=string
@@ -11167,13 +5726,11 @@ FLAG basecamp schedule settings --stats type=bool
 FLAG basecamp schedule settings --styled type=bool
 FLAG basecamp schedule settings --todolist type=string
 FLAG basecamp schedule settings --verbose type=count
-FLAG basecamp schedule settings --version type=bool
 FLAG basecamp schedule show --account type=string
 FLAG basecamp schedule show --agent type=bool
 FLAG basecamp schedule show --cache-dir type=string
 FLAG basecamp schedule show --count type=bool
 FLAG basecamp schedule show --date type=string
-FLAG basecamp schedule show --help type=bool
 FLAG basecamp schedule show --hints type=bool
 FLAG basecamp schedule show --ids-only type=bool
 FLAG basecamp schedule show --in type=string
@@ -11192,7 +5749,6 @@ FLAG basecamp schedule show --stats type=bool
 FLAG basecamp schedule show --styled type=bool
 FLAG basecamp schedule show --todolist type=string
 FLAG basecamp schedule show --verbose type=count
-FLAG basecamp schedule show --version type=bool
 FLAG basecamp schedule update --account type=string
 FLAG basecamp schedule update --agent type=bool
 FLAG basecamp schedule update --all-day type=bool
@@ -11203,7 +5759,6 @@ FLAG basecamp schedule update --desc type=string
 FLAG basecamp schedule update --description type=string
 FLAG basecamp schedule update --end type=string
 FLAG basecamp schedule update --ends-at type=string
-FLAG basecamp schedule update --help type=bool
 FLAG basecamp schedule update --hints type=bool
 FLAG basecamp schedule update --ids-only type=bool
 FLAG basecamp schedule update --in type=string
@@ -11228,13 +5783,11 @@ FLAG basecamp schedule update --summary type=string
 FLAG basecamp schedule update --title type=string
 FLAG basecamp schedule update --todolist type=string
 FLAG basecamp schedule update --verbose type=count
-FLAG basecamp schedule update --version type=bool
 FLAG basecamp search --account type=string
 FLAG basecamp search --agent type=bool
 FLAG basecamp search --all type=bool
 FLAG basecamp search --cache-dir type=string
 FLAG basecamp search --count type=bool
-FLAG basecamp search --help type=bool
 FLAG basecamp search --hints type=bool
 FLAG basecamp search --ids-only type=bool
 FLAG basecamp search --in type=string
@@ -11253,12 +5806,10 @@ FLAG basecamp search --stats type=bool
 FLAG basecamp search --styled type=bool
 FLAG basecamp search --todolist type=string
 FLAG basecamp search --verbose type=count
-FLAG basecamp search --version type=bool
 FLAG basecamp search metadata --account type=string
 FLAG basecamp search metadata --agent type=bool
 FLAG basecamp search metadata --cache-dir type=string
 FLAG basecamp search metadata --count type=bool
-FLAG basecamp search metadata --help type=bool
 FLAG basecamp search metadata --hints type=bool
 FLAG basecamp search metadata --ids-only type=bool
 FLAG basecamp search metadata --in type=string
@@ -11275,34 +5826,10 @@ FLAG basecamp search metadata --stats type=bool
 FLAG basecamp search metadata --styled type=bool
 FLAG basecamp search metadata --todolist type=string
 FLAG basecamp search metadata --verbose type=count
-FLAG basecamp search metadata --version type=bool
-FLAG basecamp search types --account type=string
-FLAG basecamp search types --agent type=bool
-FLAG basecamp search types --cache-dir type=string
-FLAG basecamp search types --count type=bool
-FLAG basecamp search types --help type=bool
-FLAG basecamp search types --hints type=bool
-FLAG basecamp search types --ids-only type=bool
-FLAG basecamp search types --in type=string
-FLAG basecamp search types --jq type=string
-FLAG basecamp search types --json type=bool
-FLAG basecamp search types --markdown type=bool
-FLAG basecamp search types --md type=bool
-FLAG basecamp search types --no-hints type=bool
-FLAG basecamp search types --no-stats type=bool
-FLAG basecamp search types --profile type=string
-FLAG basecamp search types --project type=string
-FLAG basecamp search types --quiet type=bool
-FLAG basecamp search types --stats type=bool
-FLAG basecamp search types --styled type=bool
-FLAG basecamp search types --todolist type=string
-FLAG basecamp search types --verbose type=count
-FLAG basecamp search types --version type=bool
 FLAG basecamp setup --account type=string
 FLAG basecamp setup --agent type=bool
 FLAG basecamp setup --cache-dir type=string
 FLAG basecamp setup --count type=bool
-FLAG basecamp setup --help type=bool
 FLAG basecamp setup --hints type=bool
 FLAG basecamp setup --ids-only type=bool
 FLAG basecamp setup --in type=string
@@ -11319,12 +5846,10 @@ FLAG basecamp setup --stats type=bool
 FLAG basecamp setup --styled type=bool
 FLAG basecamp setup --todolist type=string
 FLAG basecamp setup --verbose type=count
-FLAG basecamp setup --version type=bool
 FLAG basecamp setup claude --account type=string
 FLAG basecamp setup claude --agent type=bool
 FLAG basecamp setup claude --cache-dir type=string
 FLAG basecamp setup claude --count type=bool
-FLAG basecamp setup claude --help type=bool
 FLAG basecamp setup claude --hints type=bool
 FLAG basecamp setup claude --ids-only type=bool
 FLAG basecamp setup claude --in type=string
@@ -11341,12 +5866,10 @@ FLAG basecamp setup claude --stats type=bool
 FLAG basecamp setup claude --styled type=bool
 FLAG basecamp setup claude --todolist type=string
 FLAG basecamp setup claude --verbose type=count
-FLAG basecamp setup claude --version type=bool
 FLAG basecamp show --account type=string
 FLAG basecamp show --agent type=bool
 FLAG basecamp show --cache-dir type=string
 FLAG basecamp show --count type=bool
-FLAG basecamp show --help type=bool
 FLAG basecamp show --hints type=bool
 FLAG basecamp show --ids-only type=bool
 FLAG basecamp show --in type=string
@@ -11364,12 +5887,10 @@ FLAG basecamp show --styled type=bool
 FLAG basecamp show --todolist type=string
 FLAG basecamp show --type type=string
 FLAG basecamp show --verbose type=count
-FLAG basecamp show --version type=bool
 FLAG basecamp skill --account type=string
 FLAG basecamp skill --agent type=bool
 FLAG basecamp skill --cache-dir type=string
 FLAG basecamp skill --count type=bool
-FLAG basecamp skill --help type=bool
 FLAG basecamp skill --hints type=bool
 FLAG basecamp skill --ids-only type=bool
 FLAG basecamp skill --in type=string
@@ -11386,12 +5907,10 @@ FLAG basecamp skill --stats type=bool
 FLAG basecamp skill --styled type=bool
 FLAG basecamp skill --todolist type=string
 FLAG basecamp skill --verbose type=count
-FLAG basecamp skill --version type=bool
 FLAG basecamp skill install --account type=string
 FLAG basecamp skill install --agent type=bool
 FLAG basecamp skill install --cache-dir type=string
 FLAG basecamp skill install --count type=bool
-FLAG basecamp skill install --help type=bool
 FLAG basecamp skill install --hints type=bool
 FLAG basecamp skill install --ids-only type=bool
 FLAG basecamp skill install --in type=string
@@ -11408,12 +5927,10 @@ FLAG basecamp skill install --stats type=bool
 FLAG basecamp skill install --styled type=bool
 FLAG basecamp skill install --todolist type=string
 FLAG basecamp skill install --verbose type=count
-FLAG basecamp skill install --version type=bool
 FLAG basecamp subscriptions --account type=string
 FLAG basecamp subscriptions --agent type=bool
 FLAG basecamp subscriptions --cache-dir type=string
 FLAG basecamp subscriptions --count type=bool
-FLAG basecamp subscriptions --help type=bool
 FLAG basecamp subscriptions --hints type=bool
 FLAG basecamp subscriptions --ids-only type=bool
 FLAG basecamp subscriptions --in type=string
@@ -11430,12 +5947,10 @@ FLAG basecamp subscriptions --stats type=bool
 FLAG basecamp subscriptions --styled type=bool
 FLAG basecamp subscriptions --todolist type=string
 FLAG basecamp subscriptions --verbose type=count
-FLAG basecamp subscriptions --version type=bool
 FLAG basecamp subscriptions add --account type=string
 FLAG basecamp subscriptions add --agent type=bool
 FLAG basecamp subscriptions add --cache-dir type=string
 FLAG basecamp subscriptions add --count type=bool
-FLAG basecamp subscriptions add --help type=bool
 FLAG basecamp subscriptions add --hints type=bool
 FLAG basecamp subscriptions add --ids-only type=bool
 FLAG basecamp subscriptions add --in type=string
@@ -11453,12 +5968,10 @@ FLAG basecamp subscriptions add --stats type=bool
 FLAG basecamp subscriptions add --styled type=bool
 FLAG basecamp subscriptions add --todolist type=string
 FLAG basecamp subscriptions add --verbose type=count
-FLAG basecamp subscriptions add --version type=bool
 FLAG basecamp subscriptions remove --account type=string
 FLAG basecamp subscriptions remove --agent type=bool
 FLAG basecamp subscriptions remove --cache-dir type=string
 FLAG basecamp subscriptions remove --count type=bool
-FLAG basecamp subscriptions remove --help type=bool
 FLAG basecamp subscriptions remove --hints type=bool
 FLAG basecamp subscriptions remove --ids-only type=bool
 FLAG basecamp subscriptions remove --in type=string
@@ -11476,12 +5989,10 @@ FLAG basecamp subscriptions remove --stats type=bool
 FLAG basecamp subscriptions remove --styled type=bool
 FLAG basecamp subscriptions remove --todolist type=string
 FLAG basecamp subscriptions remove --verbose type=count
-FLAG basecamp subscriptions remove --version type=bool
 FLAG basecamp subscriptions show --account type=string
 FLAG basecamp subscriptions show --agent type=bool
 FLAG basecamp subscriptions show --cache-dir type=string
 FLAG basecamp subscriptions show --count type=bool
-FLAG basecamp subscriptions show --help type=bool
 FLAG basecamp subscriptions show --hints type=bool
 FLAG basecamp subscriptions show --ids-only type=bool
 FLAG basecamp subscriptions show --in type=string
@@ -11498,12 +6009,10 @@ FLAG basecamp subscriptions show --stats type=bool
 FLAG basecamp subscriptions show --styled type=bool
 FLAG basecamp subscriptions show --todolist type=string
 FLAG basecamp subscriptions show --verbose type=count
-FLAG basecamp subscriptions show --version type=bool
 FLAG basecamp subscriptions subscribe --account type=string
 FLAG basecamp subscriptions subscribe --agent type=bool
 FLAG basecamp subscriptions subscribe --cache-dir type=string
 FLAG basecamp subscriptions subscribe --count type=bool
-FLAG basecamp subscriptions subscribe --help type=bool
 FLAG basecamp subscriptions subscribe --hints type=bool
 FLAG basecamp subscriptions subscribe --ids-only type=bool
 FLAG basecamp subscriptions subscribe --in type=string
@@ -11520,12 +6029,10 @@ FLAG basecamp subscriptions subscribe --stats type=bool
 FLAG basecamp subscriptions subscribe --styled type=bool
 FLAG basecamp subscriptions subscribe --todolist type=string
 FLAG basecamp subscriptions subscribe --verbose type=count
-FLAG basecamp subscriptions subscribe --version type=bool
 FLAG basecamp subscriptions unsubscribe --account type=string
 FLAG basecamp subscriptions unsubscribe --agent type=bool
 FLAG basecamp subscriptions unsubscribe --cache-dir type=string
 FLAG basecamp subscriptions unsubscribe --count type=bool
-FLAG basecamp subscriptions unsubscribe --help type=bool
 FLAG basecamp subscriptions unsubscribe --hints type=bool
 FLAG basecamp subscriptions unsubscribe --ids-only type=bool
 FLAG basecamp subscriptions unsubscribe --in type=string
@@ -11542,12 +6049,10 @@ FLAG basecamp subscriptions unsubscribe --stats type=bool
 FLAG basecamp subscriptions unsubscribe --styled type=bool
 FLAG basecamp subscriptions unsubscribe --todolist type=string
 FLAG basecamp subscriptions unsubscribe --verbose type=count
-FLAG basecamp subscriptions unsubscribe --version type=bool
 FLAG basecamp templates --account type=string
 FLAG basecamp templates --agent type=bool
 FLAG basecamp templates --cache-dir type=string
 FLAG basecamp templates --count type=bool
-FLAG basecamp templates --help type=bool
 FLAG basecamp templates --hints type=bool
 FLAG basecamp templates --ids-only type=bool
 FLAG basecamp templates --in type=string
@@ -11565,14 +6070,12 @@ FLAG basecamp templates --status type=string
 FLAG basecamp templates --styled type=bool
 FLAG basecamp templates --todolist type=string
 FLAG basecamp templates --verbose type=count
-FLAG basecamp templates --version type=bool
 FLAG basecamp templates construct --account type=string
 FLAG basecamp templates construct --agent type=bool
 FLAG basecamp templates construct --cache-dir type=string
 FLAG basecamp templates construct --count type=bool
 FLAG basecamp templates construct --desc type=string
 FLAG basecamp templates construct --description type=string
-FLAG basecamp templates construct --help type=bool
 FLAG basecamp templates construct --hints type=bool
 FLAG basecamp templates construct --ids-only type=bool
 FLAG basecamp templates construct --in type=string
@@ -11591,12 +6094,10 @@ FLAG basecamp templates construct --status type=string
 FLAG basecamp templates construct --styled type=bool
 FLAG basecamp templates construct --todolist type=string
 FLAG basecamp templates construct --verbose type=count
-FLAG basecamp templates construct --version type=bool
 FLAG basecamp templates construction --account type=string
 FLAG basecamp templates construction --agent type=bool
 FLAG basecamp templates construction --cache-dir type=string
 FLAG basecamp templates construction --count type=bool
-FLAG basecamp templates construction --help type=bool
 FLAG basecamp templates construction --hints type=bool
 FLAG basecamp templates construction --ids-only type=bool
 FLAG basecamp templates construction --in type=string
@@ -11614,14 +6115,12 @@ FLAG basecamp templates construction --status type=string
 FLAG basecamp templates construction --styled type=bool
 FLAG basecamp templates construction --todolist type=string
 FLAG basecamp templates construction --verbose type=count
-FLAG basecamp templates construction --version type=bool
 FLAG basecamp templates create --account type=string
 FLAG basecamp templates create --agent type=bool
 FLAG basecamp templates create --cache-dir type=string
 FLAG basecamp templates create --count type=bool
 FLAG basecamp templates create --desc type=string
 FLAG basecamp templates create --description type=string
-FLAG basecamp templates create --help type=bool
 FLAG basecamp templates create --hints type=bool
 FLAG basecamp templates create --ids-only type=bool
 FLAG basecamp templates create --in type=string
@@ -11640,12 +6139,10 @@ FLAG basecamp templates create --status type=string
 FLAG basecamp templates create --styled type=bool
 FLAG basecamp templates create --todolist type=string
 FLAG basecamp templates create --verbose type=count
-FLAG basecamp templates create --version type=bool
 FLAG basecamp templates delete --account type=string
 FLAG basecamp templates delete --agent type=bool
 FLAG basecamp templates delete --cache-dir type=string
 FLAG basecamp templates delete --count type=bool
-FLAG basecamp templates delete --help type=bool
 FLAG basecamp templates delete --hints type=bool
 FLAG basecamp templates delete --ids-only type=bool
 FLAG basecamp templates delete --in type=string
@@ -11663,12 +6160,10 @@ FLAG basecamp templates delete --status type=string
 FLAG basecamp templates delete --styled type=bool
 FLAG basecamp templates delete --todolist type=string
 FLAG basecamp templates delete --verbose type=count
-FLAG basecamp templates delete --version type=bool
 FLAG basecamp templates list --account type=string
 FLAG basecamp templates list --agent type=bool
 FLAG basecamp templates list --cache-dir type=string
 FLAG basecamp templates list --count type=bool
-FLAG basecamp templates list --help type=bool
 FLAG basecamp templates list --hints type=bool
 FLAG basecamp templates list --ids-only type=bool
 FLAG basecamp templates list --in type=string
@@ -11686,12 +6181,10 @@ FLAG basecamp templates list --status type=string
 FLAG basecamp templates list --styled type=bool
 FLAG basecamp templates list --todolist type=string
 FLAG basecamp templates list --verbose type=count
-FLAG basecamp templates list --version type=bool
 FLAG basecamp templates show --account type=string
 FLAG basecamp templates show --agent type=bool
 FLAG basecamp templates show --cache-dir type=string
 FLAG basecamp templates show --count type=bool
-FLAG basecamp templates show --help type=bool
 FLAG basecamp templates show --hints type=bool
 FLAG basecamp templates show --ids-only type=bool
 FLAG basecamp templates show --in type=string
@@ -11709,14 +6202,12 @@ FLAG basecamp templates show --status type=string
 FLAG basecamp templates show --styled type=bool
 FLAG basecamp templates show --todolist type=string
 FLAG basecamp templates show --verbose type=count
-FLAG basecamp templates show --version type=bool
 FLAG basecamp templates update --account type=string
 FLAG basecamp templates update --agent type=bool
 FLAG basecamp templates update --cache-dir type=string
 FLAG basecamp templates update --count type=bool
 FLAG basecamp templates update --desc type=string
 FLAG basecamp templates update --description type=string
-FLAG basecamp templates update --help type=bool
 FLAG basecamp templates update --hints type=bool
 FLAG basecamp templates update --ids-only type=bool
 FLAG basecamp templates update --in type=string
@@ -11735,13 +6226,11 @@ FLAG basecamp templates update --status type=string
 FLAG basecamp templates update --styled type=bool
 FLAG basecamp templates update --todolist type=string
 FLAG basecamp templates update --verbose type=count
-FLAG basecamp templates update --version type=bool
 FLAG basecamp timeline --account type=string
 FLAG basecamp timeline --agent type=bool
 FLAG basecamp timeline --all type=bool
 FLAG basecamp timeline --cache-dir type=string
 FLAG basecamp timeline --count type=bool
-FLAG basecamp timeline --help type=bool
 FLAG basecamp timeline --hints type=bool
 FLAG basecamp timeline --ids-only type=bool
 FLAG basecamp timeline --in type=string
@@ -11762,7 +6251,6 @@ FLAG basecamp timeline --stats type=bool
 FLAG basecamp timeline --styled type=bool
 FLAG basecamp timeline --todolist type=string
 FLAG basecamp timeline --verbose type=count
-FLAG basecamp timeline --version type=bool
 FLAG basecamp timeline --watch type=bool
 FLAG basecamp timesheet --account type=string
 FLAG basecamp timesheet --agent type=bool
@@ -11770,7 +6258,6 @@ FLAG basecamp timesheet --cache-dir type=string
 FLAG basecamp timesheet --count type=bool
 FLAG basecamp timesheet --end type=string
 FLAG basecamp timesheet --from type=string
-FLAG basecamp timesheet --help type=bool
 FLAG basecamp timesheet --hints type=bool
 FLAG basecamp timesheet --ids-only type=bool
 FLAG basecamp timesheet --in type=string
@@ -11790,14 +6277,12 @@ FLAG basecamp timesheet --styled type=bool
 FLAG basecamp timesheet --to type=string
 FLAG basecamp timesheet --todolist type=string
 FLAG basecamp timesheet --verbose type=count
-FLAG basecamp timesheet --version type=bool
 FLAG basecamp timesheet item --account type=string
 FLAG basecamp timesheet item --agent type=bool
 FLAG basecamp timesheet item --cache-dir type=string
 FLAG basecamp timesheet item --count type=bool
 FLAG basecamp timesheet item --end type=string
 FLAG basecamp timesheet item --from type=string
-FLAG basecamp timesheet item --help type=bool
 FLAG basecamp timesheet item --hints type=bool
 FLAG basecamp timesheet item --ids-only type=bool
 FLAG basecamp timesheet item --in type=string
@@ -11817,14 +6302,12 @@ FLAG basecamp timesheet item --styled type=bool
 FLAG basecamp timesheet item --to type=string
 FLAG basecamp timesheet item --todolist type=string
 FLAG basecamp timesheet item --verbose type=count
-FLAG basecamp timesheet item --version type=bool
 FLAG basecamp timesheet project --account type=string
 FLAG basecamp timesheet project --agent type=bool
 FLAG basecamp timesheet project --cache-dir type=string
 FLAG basecamp timesheet project --count type=bool
 FLAG basecamp timesheet project --end type=string
 FLAG basecamp timesheet project --from type=string
-FLAG basecamp timesheet project --help type=bool
 FLAG basecamp timesheet project --hints type=bool
 FLAG basecamp timesheet project --ids-only type=bool
 FLAG basecamp timesheet project --in type=string
@@ -11844,41 +6327,12 @@ FLAG basecamp timesheet project --styled type=bool
 FLAG basecamp timesheet project --to type=string
 FLAG basecamp timesheet project --todolist type=string
 FLAG basecamp timesheet project --verbose type=count
-FLAG basecamp timesheet project --version type=bool
-FLAG basecamp timesheet recording --account type=string
-FLAG basecamp timesheet recording --agent type=bool
-FLAG basecamp timesheet recording --cache-dir type=string
-FLAG basecamp timesheet recording --count type=bool
-FLAG basecamp timesheet recording --end type=string
-FLAG basecamp timesheet recording --from type=string
-FLAG basecamp timesheet recording --help type=bool
-FLAG basecamp timesheet recording --hints type=bool
-FLAG basecamp timesheet recording --ids-only type=bool
-FLAG basecamp timesheet recording --in type=string
-FLAG basecamp timesheet recording --jq type=string
-FLAG basecamp timesheet recording --json type=bool
-FLAG basecamp timesheet recording --markdown type=bool
-FLAG basecamp timesheet recording --md type=bool
-FLAG basecamp timesheet recording --no-hints type=bool
-FLAG basecamp timesheet recording --no-stats type=bool
-FLAG basecamp timesheet recording --person type=string
-FLAG basecamp timesheet recording --profile type=string
-FLAG basecamp timesheet recording --project type=string
-FLAG basecamp timesheet recording --quiet type=bool
-FLAG basecamp timesheet recording --start type=string
-FLAG basecamp timesheet recording --stats type=bool
-FLAG basecamp timesheet recording --styled type=bool
-FLAG basecamp timesheet recording --to type=string
-FLAG basecamp timesheet recording --todolist type=string
-FLAG basecamp timesheet recording --verbose type=count
-FLAG basecamp timesheet recording --version type=bool
 FLAG basecamp timesheet report --account type=string
 FLAG basecamp timesheet report --agent type=bool
 FLAG basecamp timesheet report --cache-dir type=string
 FLAG basecamp timesheet report --count type=bool
 FLAG basecamp timesheet report --end type=string
 FLAG basecamp timesheet report --from type=string
-FLAG basecamp timesheet report --help type=bool
 FLAG basecamp timesheet report --hints type=bool
 FLAG basecamp timesheet report --ids-only type=bool
 FLAG basecamp timesheet report --in type=string
@@ -11898,383 +6352,6 @@ FLAG basecamp timesheet report --styled type=bool
 FLAG basecamp timesheet report --to type=string
 FLAG basecamp timesheet report --todolist type=string
 FLAG basecamp timesheet report --verbose type=count
-FLAG basecamp timesheet report --version type=bool
-FLAG basecamp tlgroup --account type=string
-FLAG basecamp tlgroup --agent type=bool
-FLAG basecamp tlgroup --cache-dir type=string
-FLAG basecamp tlgroup --count type=bool
-FLAG basecamp tlgroup --help type=bool
-FLAG basecamp tlgroup --hints type=bool
-FLAG basecamp tlgroup --ids-only type=bool
-FLAG basecamp tlgroup --in type=string
-FLAG basecamp tlgroup --jq type=string
-FLAG basecamp tlgroup --json type=bool
-FLAG basecamp tlgroup --list type=string
-FLAG basecamp tlgroup --markdown type=bool
-FLAG basecamp tlgroup --md type=bool
-FLAG basecamp tlgroup --no-hints type=bool
-FLAG basecamp tlgroup --no-stats type=bool
-FLAG basecamp tlgroup --profile type=string
-FLAG basecamp tlgroup --project type=string
-FLAG basecamp tlgroup --quiet type=bool
-FLAG basecamp tlgroup --stats type=bool
-FLAG basecamp tlgroup --styled type=bool
-FLAG basecamp tlgroup --todolist type=string
-FLAG basecamp tlgroup --verbose type=count
-FLAG basecamp tlgroup --version type=bool
-FLAG basecamp tlgroup create --account type=string
-FLAG basecamp tlgroup create --agent type=bool
-FLAG basecamp tlgroup create --cache-dir type=string
-FLAG basecamp tlgroup create --count type=bool
-FLAG basecamp tlgroup create --help type=bool
-FLAG basecamp tlgroup create --hints type=bool
-FLAG basecamp tlgroup create --ids-only type=bool
-FLAG basecamp tlgroup create --in type=string
-FLAG basecamp tlgroup create --jq type=string
-FLAG basecamp tlgroup create --json type=bool
-FLAG basecamp tlgroup create --list type=string
-FLAG basecamp tlgroup create --markdown type=bool
-FLAG basecamp tlgroup create --md type=bool
-FLAG basecamp tlgroup create --no-hints type=bool
-FLAG basecamp tlgroup create --no-stats type=bool
-FLAG basecamp tlgroup create --profile type=string
-FLAG basecamp tlgroup create --project type=string
-FLAG basecamp tlgroup create --quiet type=bool
-FLAG basecamp tlgroup create --stats type=bool
-FLAG basecamp tlgroup create --styled type=bool
-FLAG basecamp tlgroup create --todolist type=string
-FLAG basecamp tlgroup create --verbose type=count
-FLAG basecamp tlgroup create --version type=bool
-FLAG basecamp tlgroup list --account type=string
-FLAG basecamp tlgroup list --agent type=bool
-FLAG basecamp tlgroup list --cache-dir type=string
-FLAG basecamp tlgroup list --count type=bool
-FLAG basecamp tlgroup list --help type=bool
-FLAG basecamp tlgroup list --hints type=bool
-FLAG basecamp tlgroup list --ids-only type=bool
-FLAG basecamp tlgroup list --in type=string
-FLAG basecamp tlgroup list --jq type=string
-FLAG basecamp tlgroup list --json type=bool
-FLAG basecamp tlgroup list --list type=string
-FLAG basecamp tlgroup list --markdown type=bool
-FLAG basecamp tlgroup list --md type=bool
-FLAG basecamp tlgroup list --no-hints type=bool
-FLAG basecamp tlgroup list --no-stats type=bool
-FLAG basecamp tlgroup list --profile type=string
-FLAG basecamp tlgroup list --project type=string
-FLAG basecamp tlgroup list --quiet type=bool
-FLAG basecamp tlgroup list --stats type=bool
-FLAG basecamp tlgroup list --styled type=bool
-FLAG basecamp tlgroup list --todolist type=string
-FLAG basecamp tlgroup list --verbose type=count
-FLAG basecamp tlgroup list --version type=bool
-FLAG basecamp tlgroup move --account type=string
-FLAG basecamp tlgroup move --agent type=bool
-FLAG basecamp tlgroup move --cache-dir type=string
-FLAG basecamp tlgroup move --count type=bool
-FLAG basecamp tlgroup move --help type=bool
-FLAG basecamp tlgroup move --hints type=bool
-FLAG basecamp tlgroup move --ids-only type=bool
-FLAG basecamp tlgroup move --in type=string
-FLAG basecamp tlgroup move --jq type=string
-FLAG basecamp tlgroup move --json type=bool
-FLAG basecamp tlgroup move --list type=string
-FLAG basecamp tlgroup move --markdown type=bool
-FLAG basecamp tlgroup move --md type=bool
-FLAG basecamp tlgroup move --no-hints type=bool
-FLAG basecamp tlgroup move --no-stats type=bool
-FLAG basecamp tlgroup move --pos type=int
-FLAG basecamp tlgroup move --position type=int
-FLAG basecamp tlgroup move --profile type=string
-FLAG basecamp tlgroup move --project type=string
-FLAG basecamp tlgroup move --quiet type=bool
-FLAG basecamp tlgroup move --stats type=bool
-FLAG basecamp tlgroup move --styled type=bool
-FLAG basecamp tlgroup move --todolist type=string
-FLAG basecamp tlgroup move --verbose type=count
-FLAG basecamp tlgroup move --version type=bool
-FLAG basecamp tlgroup position --account type=string
-FLAG basecamp tlgroup position --agent type=bool
-FLAG basecamp tlgroup position --cache-dir type=string
-FLAG basecamp tlgroup position --count type=bool
-FLAG basecamp tlgroup position --help type=bool
-FLAG basecamp tlgroup position --hints type=bool
-FLAG basecamp tlgroup position --ids-only type=bool
-FLAG basecamp tlgroup position --in type=string
-FLAG basecamp tlgroup position --jq type=string
-FLAG basecamp tlgroup position --json type=bool
-FLAG basecamp tlgroup position --list type=string
-FLAG basecamp tlgroup position --markdown type=bool
-FLAG basecamp tlgroup position --md type=bool
-FLAG basecamp tlgroup position --no-hints type=bool
-FLAG basecamp tlgroup position --no-stats type=bool
-FLAG basecamp tlgroup position --pos type=int
-FLAG basecamp tlgroup position --position type=int
-FLAG basecamp tlgroup position --profile type=string
-FLAG basecamp tlgroup position --project type=string
-FLAG basecamp tlgroup position --quiet type=bool
-FLAG basecamp tlgroup position --stats type=bool
-FLAG basecamp tlgroup position --styled type=bool
-FLAG basecamp tlgroup position --todolist type=string
-FLAG basecamp tlgroup position --verbose type=count
-FLAG basecamp tlgroup position --version type=bool
-FLAG basecamp tlgroup rename --account type=string
-FLAG basecamp tlgroup rename --agent type=bool
-FLAG basecamp tlgroup rename --cache-dir type=string
-FLAG basecamp tlgroup rename --count type=bool
-FLAG basecamp tlgroup rename --help type=bool
-FLAG basecamp tlgroup rename --hints type=bool
-FLAG basecamp tlgroup rename --ids-only type=bool
-FLAG basecamp tlgroup rename --in type=string
-FLAG basecamp tlgroup rename --jq type=string
-FLAG basecamp tlgroup rename --json type=bool
-FLAG basecamp tlgroup rename --list type=string
-FLAG basecamp tlgroup rename --markdown type=bool
-FLAG basecamp tlgroup rename --md type=bool
-FLAG basecamp tlgroup rename --no-hints type=bool
-FLAG basecamp tlgroup rename --no-stats type=bool
-FLAG basecamp tlgroup rename --profile type=string
-FLAG basecamp tlgroup rename --project type=string
-FLAG basecamp tlgroup rename --quiet type=bool
-FLAG basecamp tlgroup rename --stats type=bool
-FLAG basecamp tlgroup rename --styled type=bool
-FLAG basecamp tlgroup rename --todolist type=string
-FLAG basecamp tlgroup rename --verbose type=count
-FLAG basecamp tlgroup rename --version type=bool
-FLAG basecamp tlgroup show --account type=string
-FLAG basecamp tlgroup show --agent type=bool
-FLAG basecamp tlgroup show --cache-dir type=string
-FLAG basecamp tlgroup show --count type=bool
-FLAG basecamp tlgroup show --help type=bool
-FLAG basecamp tlgroup show --hints type=bool
-FLAG basecamp tlgroup show --ids-only type=bool
-FLAG basecamp tlgroup show --in type=string
-FLAG basecamp tlgroup show --jq type=string
-FLAG basecamp tlgroup show --json type=bool
-FLAG basecamp tlgroup show --list type=string
-FLAG basecamp tlgroup show --markdown type=bool
-FLAG basecamp tlgroup show --md type=bool
-FLAG basecamp tlgroup show --no-hints type=bool
-FLAG basecamp tlgroup show --no-stats type=bool
-FLAG basecamp tlgroup show --profile type=string
-FLAG basecamp tlgroup show --project type=string
-FLAG basecamp tlgroup show --quiet type=bool
-FLAG basecamp tlgroup show --stats type=bool
-FLAG basecamp tlgroup show --styled type=bool
-FLAG basecamp tlgroup show --todolist type=string
-FLAG basecamp tlgroup show --verbose type=count
-FLAG basecamp tlgroup show --version type=bool
-FLAG basecamp tlgroup update --account type=string
-FLAG basecamp tlgroup update --agent type=bool
-FLAG basecamp tlgroup update --cache-dir type=string
-FLAG basecamp tlgroup update --count type=bool
-FLAG basecamp tlgroup update --help type=bool
-FLAG basecamp tlgroup update --hints type=bool
-FLAG basecamp tlgroup update --ids-only type=bool
-FLAG basecamp tlgroup update --in type=string
-FLAG basecamp tlgroup update --jq type=string
-FLAG basecamp tlgroup update --json type=bool
-FLAG basecamp tlgroup update --list type=string
-FLAG basecamp tlgroup update --markdown type=bool
-FLAG basecamp tlgroup update --md type=bool
-FLAG basecamp tlgroup update --no-hints type=bool
-FLAG basecamp tlgroup update --no-stats type=bool
-FLAG basecamp tlgroup update --profile type=string
-FLAG basecamp tlgroup update --project type=string
-FLAG basecamp tlgroup update --quiet type=bool
-FLAG basecamp tlgroup update --stats type=bool
-FLAG basecamp tlgroup update --styled type=bool
-FLAG basecamp tlgroup update --todolist type=string
-FLAG basecamp tlgroup update --verbose type=count
-FLAG basecamp tlgroup update --version type=bool
-FLAG basecamp tlgroups --account type=string
-FLAG basecamp tlgroups --agent type=bool
-FLAG basecamp tlgroups --cache-dir type=string
-FLAG basecamp tlgroups --count type=bool
-FLAG basecamp tlgroups --help type=bool
-FLAG basecamp tlgroups --hints type=bool
-FLAG basecamp tlgroups --ids-only type=bool
-FLAG basecamp tlgroups --in type=string
-FLAG basecamp tlgroups --jq type=string
-FLAG basecamp tlgroups --json type=bool
-FLAG basecamp tlgroups --list type=string
-FLAG basecamp tlgroups --markdown type=bool
-FLAG basecamp tlgroups --md type=bool
-FLAG basecamp tlgroups --no-hints type=bool
-FLAG basecamp tlgroups --no-stats type=bool
-FLAG basecamp tlgroups --profile type=string
-FLAG basecamp tlgroups --project type=string
-FLAG basecamp tlgroups --quiet type=bool
-FLAG basecamp tlgroups --stats type=bool
-FLAG basecamp tlgroups --styled type=bool
-FLAG basecamp tlgroups --todolist type=string
-FLAG basecamp tlgroups --verbose type=count
-FLAG basecamp tlgroups --version type=bool
-FLAG basecamp tlgroups create --account type=string
-FLAG basecamp tlgroups create --agent type=bool
-FLAG basecamp tlgroups create --cache-dir type=string
-FLAG basecamp tlgroups create --count type=bool
-FLAG basecamp tlgroups create --help type=bool
-FLAG basecamp tlgroups create --hints type=bool
-FLAG basecamp tlgroups create --ids-only type=bool
-FLAG basecamp tlgroups create --in type=string
-FLAG basecamp tlgroups create --jq type=string
-FLAG basecamp tlgroups create --json type=bool
-FLAG basecamp tlgroups create --list type=string
-FLAG basecamp tlgroups create --markdown type=bool
-FLAG basecamp tlgroups create --md type=bool
-FLAG basecamp tlgroups create --no-hints type=bool
-FLAG basecamp tlgroups create --no-stats type=bool
-FLAG basecamp tlgroups create --profile type=string
-FLAG basecamp tlgroups create --project type=string
-FLAG basecamp tlgroups create --quiet type=bool
-FLAG basecamp tlgroups create --stats type=bool
-FLAG basecamp tlgroups create --styled type=bool
-FLAG basecamp tlgroups create --todolist type=string
-FLAG basecamp tlgroups create --verbose type=count
-FLAG basecamp tlgroups create --version type=bool
-FLAG basecamp tlgroups list --account type=string
-FLAG basecamp tlgroups list --agent type=bool
-FLAG basecamp tlgroups list --cache-dir type=string
-FLAG basecamp tlgroups list --count type=bool
-FLAG basecamp tlgroups list --help type=bool
-FLAG basecamp tlgroups list --hints type=bool
-FLAG basecamp tlgroups list --ids-only type=bool
-FLAG basecamp tlgroups list --in type=string
-FLAG basecamp tlgroups list --jq type=string
-FLAG basecamp tlgroups list --json type=bool
-FLAG basecamp tlgroups list --list type=string
-FLAG basecamp tlgroups list --markdown type=bool
-FLAG basecamp tlgroups list --md type=bool
-FLAG basecamp tlgroups list --no-hints type=bool
-FLAG basecamp tlgroups list --no-stats type=bool
-FLAG basecamp tlgroups list --profile type=string
-FLAG basecamp tlgroups list --project type=string
-FLAG basecamp tlgroups list --quiet type=bool
-FLAG basecamp tlgroups list --stats type=bool
-FLAG basecamp tlgroups list --styled type=bool
-FLAG basecamp tlgroups list --todolist type=string
-FLAG basecamp tlgroups list --verbose type=count
-FLAG basecamp tlgroups list --version type=bool
-FLAG basecamp tlgroups move --account type=string
-FLAG basecamp tlgroups move --agent type=bool
-FLAG basecamp tlgroups move --cache-dir type=string
-FLAG basecamp tlgroups move --count type=bool
-FLAG basecamp tlgroups move --help type=bool
-FLAG basecamp tlgroups move --hints type=bool
-FLAG basecamp tlgroups move --ids-only type=bool
-FLAG basecamp tlgroups move --in type=string
-FLAG basecamp tlgroups move --jq type=string
-FLAG basecamp tlgroups move --json type=bool
-FLAG basecamp tlgroups move --list type=string
-FLAG basecamp tlgroups move --markdown type=bool
-FLAG basecamp tlgroups move --md type=bool
-FLAG basecamp tlgroups move --no-hints type=bool
-FLAG basecamp tlgroups move --no-stats type=bool
-FLAG basecamp tlgroups move --pos type=int
-FLAG basecamp tlgroups move --position type=int
-FLAG basecamp tlgroups move --profile type=string
-FLAG basecamp tlgroups move --project type=string
-FLAG basecamp tlgroups move --quiet type=bool
-FLAG basecamp tlgroups move --stats type=bool
-FLAG basecamp tlgroups move --styled type=bool
-FLAG basecamp tlgroups move --todolist type=string
-FLAG basecamp tlgroups move --verbose type=count
-FLAG basecamp tlgroups move --version type=bool
-FLAG basecamp tlgroups position --account type=string
-FLAG basecamp tlgroups position --agent type=bool
-FLAG basecamp tlgroups position --cache-dir type=string
-FLAG basecamp tlgroups position --count type=bool
-FLAG basecamp tlgroups position --help type=bool
-FLAG basecamp tlgroups position --hints type=bool
-FLAG basecamp tlgroups position --ids-only type=bool
-FLAG basecamp tlgroups position --in type=string
-FLAG basecamp tlgroups position --jq type=string
-FLAG basecamp tlgroups position --json type=bool
-FLAG basecamp tlgroups position --list type=string
-FLAG basecamp tlgroups position --markdown type=bool
-FLAG basecamp tlgroups position --md type=bool
-FLAG basecamp tlgroups position --no-hints type=bool
-FLAG basecamp tlgroups position --no-stats type=bool
-FLAG basecamp tlgroups position --pos type=int
-FLAG basecamp tlgroups position --position type=int
-FLAG basecamp tlgroups position --profile type=string
-FLAG basecamp tlgroups position --project type=string
-FLAG basecamp tlgroups position --quiet type=bool
-FLAG basecamp tlgroups position --stats type=bool
-FLAG basecamp tlgroups position --styled type=bool
-FLAG basecamp tlgroups position --todolist type=string
-FLAG basecamp tlgroups position --verbose type=count
-FLAG basecamp tlgroups position --version type=bool
-FLAG basecamp tlgroups rename --account type=string
-FLAG basecamp tlgroups rename --agent type=bool
-FLAG basecamp tlgroups rename --cache-dir type=string
-FLAG basecamp tlgroups rename --count type=bool
-FLAG basecamp tlgroups rename --help type=bool
-FLAG basecamp tlgroups rename --hints type=bool
-FLAG basecamp tlgroups rename --ids-only type=bool
-FLAG basecamp tlgroups rename --in type=string
-FLAG basecamp tlgroups rename --jq type=string
-FLAG basecamp tlgroups rename --json type=bool
-FLAG basecamp tlgroups rename --list type=string
-FLAG basecamp tlgroups rename --markdown type=bool
-FLAG basecamp tlgroups rename --md type=bool
-FLAG basecamp tlgroups rename --no-hints type=bool
-FLAG basecamp tlgroups rename --no-stats type=bool
-FLAG basecamp tlgroups rename --profile type=string
-FLAG basecamp tlgroups rename --project type=string
-FLAG basecamp tlgroups rename --quiet type=bool
-FLAG basecamp tlgroups rename --stats type=bool
-FLAG basecamp tlgroups rename --styled type=bool
-FLAG basecamp tlgroups rename --todolist type=string
-FLAG basecamp tlgroups rename --verbose type=count
-FLAG basecamp tlgroups rename --version type=bool
-FLAG basecamp tlgroups show --account type=string
-FLAG basecamp tlgroups show --agent type=bool
-FLAG basecamp tlgroups show --cache-dir type=string
-FLAG basecamp tlgroups show --count type=bool
-FLAG basecamp tlgroups show --help type=bool
-FLAG basecamp tlgroups show --hints type=bool
-FLAG basecamp tlgroups show --ids-only type=bool
-FLAG basecamp tlgroups show --in type=string
-FLAG basecamp tlgroups show --jq type=string
-FLAG basecamp tlgroups show --json type=bool
-FLAG basecamp tlgroups show --list type=string
-FLAG basecamp tlgroups show --markdown type=bool
-FLAG basecamp tlgroups show --md type=bool
-FLAG basecamp tlgroups show --no-hints type=bool
-FLAG basecamp tlgroups show --no-stats type=bool
-FLAG basecamp tlgroups show --profile type=string
-FLAG basecamp tlgroups show --project type=string
-FLAG basecamp tlgroups show --quiet type=bool
-FLAG basecamp tlgroups show --stats type=bool
-FLAG basecamp tlgroups show --styled type=bool
-FLAG basecamp tlgroups show --todolist type=string
-FLAG basecamp tlgroups show --verbose type=count
-FLAG basecamp tlgroups show --version type=bool
-FLAG basecamp tlgroups update --account type=string
-FLAG basecamp tlgroups update --agent type=bool
-FLAG basecamp tlgroups update --cache-dir type=string
-FLAG basecamp tlgroups update --count type=bool
-FLAG basecamp tlgroups update --help type=bool
-FLAG basecamp tlgroups update --hints type=bool
-FLAG basecamp tlgroups update --ids-only type=bool
-FLAG basecamp tlgroups update --in type=string
-FLAG basecamp tlgroups update --jq type=string
-FLAG basecamp tlgroups update --json type=bool
-FLAG basecamp tlgroups update --list type=string
-FLAG basecamp tlgroups update --markdown type=bool
-FLAG basecamp tlgroups update --md type=bool
-FLAG basecamp tlgroups update --no-hints type=bool
-FLAG basecamp tlgroups update --no-stats type=bool
-FLAG basecamp tlgroups update --profile type=string
-FLAG basecamp tlgroups update --project type=string
-FLAG basecamp tlgroups update --quiet type=bool
-FLAG basecamp tlgroups update --stats type=bool
-FLAG basecamp tlgroups update --styled type=bool
-FLAG basecamp tlgroups update --todolist type=string
-FLAG basecamp tlgroups update --verbose type=count
-FLAG basecamp tlgroups update --version type=bool
 FLAG basecamp todo --account type=string
 FLAG basecamp todo --agent type=bool
 FLAG basecamp todo --assignee type=string
@@ -12283,7 +6360,6 @@ FLAG basecamp todo --cache-dir type=string
 FLAG basecamp todo --count type=bool
 FLAG basecamp todo --description type=string
 FLAG basecamp todo --due type=string
-FLAG basecamp todo --help type=bool
 FLAG basecamp todo --hints type=bool
 FLAG basecamp todo --ids-only type=bool
 FLAG basecamp todo --in type=string
@@ -12303,387 +6379,10 @@ FLAG basecamp todo --to type=string
 FLAG basecamp todo --todolist type=string
 FLAG basecamp todo --todoset type=string
 FLAG basecamp todo --verbose type=count
-FLAG basecamp todo --version type=bool
-FLAG basecamp todolist --account type=string
-FLAG basecamp todolist --agent type=bool
-FLAG basecamp todolist --cache-dir type=string
-FLAG basecamp todolist --count type=bool
-FLAG basecamp todolist --help type=bool
-FLAG basecamp todolist --hints type=bool
-FLAG basecamp todolist --ids-only type=bool
-FLAG basecamp todolist --in type=string
-FLAG basecamp todolist --jq type=string
-FLAG basecamp todolist --json type=bool
-FLAG basecamp todolist --markdown type=bool
-FLAG basecamp todolist --md type=bool
-FLAG basecamp todolist --no-hints type=bool
-FLAG basecamp todolist --no-stats type=bool
-FLAG basecamp todolist --profile type=string
-FLAG basecamp todolist --project type=string
-FLAG basecamp todolist --quiet type=bool
-FLAG basecamp todolist --stats type=bool
-FLAG basecamp todolist --styled type=bool
-FLAG basecamp todolist --todolist type=string
-FLAG basecamp todolist --verbose type=count
-FLAG basecamp todolist --version type=bool
-FLAG basecamp todolist archive --account type=string
-FLAG basecamp todolist archive --agent type=bool
-FLAG basecamp todolist archive --cache-dir type=string
-FLAG basecamp todolist archive --count type=bool
-FLAG basecamp todolist archive --help type=bool
-FLAG basecamp todolist archive --hints type=bool
-FLAG basecamp todolist archive --ids-only type=bool
-FLAG basecamp todolist archive --in type=string
-FLAG basecamp todolist archive --jq type=string
-FLAG basecamp todolist archive --json type=bool
-FLAG basecamp todolist archive --markdown type=bool
-FLAG basecamp todolist archive --md type=bool
-FLAG basecamp todolist archive --no-hints type=bool
-FLAG basecamp todolist archive --no-stats type=bool
-FLAG basecamp todolist archive --profile type=string
-FLAG basecamp todolist archive --project type=string
-FLAG basecamp todolist archive --quiet type=bool
-FLAG basecamp todolist archive --stats type=bool
-FLAG basecamp todolist archive --styled type=bool
-FLAG basecamp todolist archive --todolist type=string
-FLAG basecamp todolist archive --verbose type=count
-FLAG basecamp todolist archive --version type=bool
-FLAG basecamp todolist create --account type=string
-FLAG basecamp todolist create --agent type=bool
-FLAG basecamp todolist create --cache-dir type=string
-FLAG basecamp todolist create --count type=bool
-FLAG basecamp todolist create --description type=string
-FLAG basecamp todolist create --help type=bool
-FLAG basecamp todolist create --hints type=bool
-FLAG basecamp todolist create --ids-only type=bool
-FLAG basecamp todolist create --in type=string
-FLAG basecamp todolist create --jq type=string
-FLAG basecamp todolist create --json type=bool
-FLAG basecamp todolist create --markdown type=bool
-FLAG basecamp todolist create --md type=bool
-FLAG basecamp todolist create --no-hints type=bool
-FLAG basecamp todolist create --no-stats type=bool
-FLAG basecamp todolist create --profile type=string
-FLAG basecamp todolist create --project type=string
-FLAG basecamp todolist create --quiet type=bool
-FLAG basecamp todolist create --stats type=bool
-FLAG basecamp todolist create --styled type=bool
-FLAG basecamp todolist create --todolist type=string
-FLAG basecamp todolist create --todoset type=string
-FLAG basecamp todolist create --verbose type=count
-FLAG basecamp todolist create --version type=bool
-FLAG basecamp todolist list --account type=string
-FLAG basecamp todolist list --agent type=bool
-FLAG basecamp todolist list --all type=bool
-FLAG basecamp todolist list --archived type=bool
-FLAG basecamp todolist list --cache-dir type=string
-FLAG basecamp todolist list --count type=bool
-FLAG basecamp todolist list --help type=bool
-FLAG basecamp todolist list --hints type=bool
-FLAG basecamp todolist list --ids-only type=bool
-FLAG basecamp todolist list --in type=string
-FLAG basecamp todolist list --jq type=string
-FLAG basecamp todolist list --json type=bool
-FLAG basecamp todolist list --limit type=int
-FLAG basecamp todolist list --markdown type=bool
-FLAG basecamp todolist list --md type=bool
-FLAG basecamp todolist list --no-hints type=bool
-FLAG basecamp todolist list --no-stats type=bool
-FLAG basecamp todolist list --page type=int
-FLAG basecamp todolist list --profile type=string
-FLAG basecamp todolist list --project type=string
-FLAG basecamp todolist list --quiet type=bool
-FLAG basecamp todolist list --reverse type=bool
-FLAG basecamp todolist list --sort type=string
-FLAG basecamp todolist list --stats type=bool
-FLAG basecamp todolist list --styled type=bool
-FLAG basecamp todolist list --todolist type=string
-FLAG basecamp todolist list --todoset type=string
-FLAG basecamp todolist list --verbose type=count
-FLAG basecamp todolist list --version type=bool
-FLAG basecamp todolist restore --account type=string
-FLAG basecamp todolist restore --agent type=bool
-FLAG basecamp todolist restore --cache-dir type=string
-FLAG basecamp todolist restore --count type=bool
-FLAG basecamp todolist restore --help type=bool
-FLAG basecamp todolist restore --hints type=bool
-FLAG basecamp todolist restore --ids-only type=bool
-FLAG basecamp todolist restore --in type=string
-FLAG basecamp todolist restore --jq type=string
-FLAG basecamp todolist restore --json type=bool
-FLAG basecamp todolist restore --markdown type=bool
-FLAG basecamp todolist restore --md type=bool
-FLAG basecamp todolist restore --no-hints type=bool
-FLAG basecamp todolist restore --no-stats type=bool
-FLAG basecamp todolist restore --profile type=string
-FLAG basecamp todolist restore --project type=string
-FLAG basecamp todolist restore --quiet type=bool
-FLAG basecamp todolist restore --stats type=bool
-FLAG basecamp todolist restore --styled type=bool
-FLAG basecamp todolist restore --todolist type=string
-FLAG basecamp todolist restore --verbose type=count
-FLAG basecamp todolist restore --version type=bool
-FLAG basecamp todolist show --account type=string
-FLAG basecamp todolist show --agent type=bool
-FLAG basecamp todolist show --cache-dir type=string
-FLAG basecamp todolist show --count type=bool
-FLAG basecamp todolist show --help type=bool
-FLAG basecamp todolist show --hints type=bool
-FLAG basecamp todolist show --ids-only type=bool
-FLAG basecamp todolist show --in type=string
-FLAG basecamp todolist show --jq type=string
-FLAG basecamp todolist show --json type=bool
-FLAG basecamp todolist show --markdown type=bool
-FLAG basecamp todolist show --md type=bool
-FLAG basecamp todolist show --no-hints type=bool
-FLAG basecamp todolist show --no-stats type=bool
-FLAG basecamp todolist show --profile type=string
-FLAG basecamp todolist show --project type=string
-FLAG basecamp todolist show --quiet type=bool
-FLAG basecamp todolist show --stats type=bool
-FLAG basecamp todolist show --styled type=bool
-FLAG basecamp todolist show --todolist type=string
-FLAG basecamp todolist show --verbose type=count
-FLAG basecamp todolist show --version type=bool
-FLAG basecamp todolist trash --account type=string
-FLAG basecamp todolist trash --agent type=bool
-FLAG basecamp todolist trash --cache-dir type=string
-FLAG basecamp todolist trash --count type=bool
-FLAG basecamp todolist trash --help type=bool
-FLAG basecamp todolist trash --hints type=bool
-FLAG basecamp todolist trash --ids-only type=bool
-FLAG basecamp todolist trash --in type=string
-FLAG basecamp todolist trash --jq type=string
-FLAG basecamp todolist trash --json type=bool
-FLAG basecamp todolist trash --markdown type=bool
-FLAG basecamp todolist trash --md type=bool
-FLAG basecamp todolist trash --no-hints type=bool
-FLAG basecamp todolist trash --no-stats type=bool
-FLAG basecamp todolist trash --profile type=string
-FLAG basecamp todolist trash --project type=string
-FLAG basecamp todolist trash --quiet type=bool
-FLAG basecamp todolist trash --stats type=bool
-FLAG basecamp todolist trash --styled type=bool
-FLAG basecamp todolist trash --todolist type=string
-FLAG basecamp todolist trash --verbose type=count
-FLAG basecamp todolist trash --version type=bool
-FLAG basecamp todolist update --account type=string
-FLAG basecamp todolist update --agent type=bool
-FLAG basecamp todolist update --cache-dir type=string
-FLAG basecamp todolist update --count type=bool
-FLAG basecamp todolist update --description type=string
-FLAG basecamp todolist update --help type=bool
-FLAG basecamp todolist update --hints type=bool
-FLAG basecamp todolist update --ids-only type=bool
-FLAG basecamp todolist update --in type=string
-FLAG basecamp todolist update --jq type=string
-FLAG basecamp todolist update --json type=bool
-FLAG basecamp todolist update --markdown type=bool
-FLAG basecamp todolist update --md type=bool
-FLAG basecamp todolist update --name type=string
-FLAG basecamp todolist update --no-hints type=bool
-FLAG basecamp todolist update --no-stats type=bool
-FLAG basecamp todolist update --profile type=string
-FLAG basecamp todolist update --project type=string
-FLAG basecamp todolist update --quiet type=bool
-FLAG basecamp todolist update --stats type=bool
-FLAG basecamp todolist update --styled type=bool
-FLAG basecamp todolist update --todolist type=string
-FLAG basecamp todolist update --verbose type=count
-FLAG basecamp todolist update --version type=bool
-FLAG basecamp todolistgroup --account type=string
-FLAG basecamp todolistgroup --agent type=bool
-FLAG basecamp todolistgroup --cache-dir type=string
-FLAG basecamp todolistgroup --count type=bool
-FLAG basecamp todolistgroup --help type=bool
-FLAG basecamp todolistgroup --hints type=bool
-FLAG basecamp todolistgroup --ids-only type=bool
-FLAG basecamp todolistgroup --in type=string
-FLAG basecamp todolistgroup --jq type=string
-FLAG basecamp todolistgroup --json type=bool
-FLAG basecamp todolistgroup --list type=string
-FLAG basecamp todolistgroup --markdown type=bool
-FLAG basecamp todolistgroup --md type=bool
-FLAG basecamp todolistgroup --no-hints type=bool
-FLAG basecamp todolistgroup --no-stats type=bool
-FLAG basecamp todolistgroup --profile type=string
-FLAG basecamp todolistgroup --project type=string
-FLAG basecamp todolistgroup --quiet type=bool
-FLAG basecamp todolistgroup --stats type=bool
-FLAG basecamp todolistgroup --styled type=bool
-FLAG basecamp todolistgroup --todolist type=string
-FLAG basecamp todolistgroup --verbose type=count
-FLAG basecamp todolistgroup --version type=bool
-FLAG basecamp todolistgroup create --account type=string
-FLAG basecamp todolistgroup create --agent type=bool
-FLAG basecamp todolistgroup create --cache-dir type=string
-FLAG basecamp todolistgroup create --count type=bool
-FLAG basecamp todolistgroup create --help type=bool
-FLAG basecamp todolistgroup create --hints type=bool
-FLAG basecamp todolistgroup create --ids-only type=bool
-FLAG basecamp todolistgroup create --in type=string
-FLAG basecamp todolistgroup create --jq type=string
-FLAG basecamp todolistgroup create --json type=bool
-FLAG basecamp todolistgroup create --list type=string
-FLAG basecamp todolistgroup create --markdown type=bool
-FLAG basecamp todolistgroup create --md type=bool
-FLAG basecamp todolistgroup create --no-hints type=bool
-FLAG basecamp todolistgroup create --no-stats type=bool
-FLAG basecamp todolistgroup create --profile type=string
-FLAG basecamp todolistgroup create --project type=string
-FLAG basecamp todolistgroup create --quiet type=bool
-FLAG basecamp todolistgroup create --stats type=bool
-FLAG basecamp todolistgroup create --styled type=bool
-FLAG basecamp todolistgroup create --todolist type=string
-FLAG basecamp todolistgroup create --verbose type=count
-FLAG basecamp todolistgroup create --version type=bool
-FLAG basecamp todolistgroup list --account type=string
-FLAG basecamp todolistgroup list --agent type=bool
-FLAG basecamp todolistgroup list --cache-dir type=string
-FLAG basecamp todolistgroup list --count type=bool
-FLAG basecamp todolistgroup list --help type=bool
-FLAG basecamp todolistgroup list --hints type=bool
-FLAG basecamp todolistgroup list --ids-only type=bool
-FLAG basecamp todolistgroup list --in type=string
-FLAG basecamp todolistgroup list --jq type=string
-FLAG basecamp todolistgroup list --json type=bool
-FLAG basecamp todolistgroup list --list type=string
-FLAG basecamp todolistgroup list --markdown type=bool
-FLAG basecamp todolistgroup list --md type=bool
-FLAG basecamp todolistgroup list --no-hints type=bool
-FLAG basecamp todolistgroup list --no-stats type=bool
-FLAG basecamp todolistgroup list --profile type=string
-FLAG basecamp todolistgroup list --project type=string
-FLAG basecamp todolistgroup list --quiet type=bool
-FLAG basecamp todolistgroup list --stats type=bool
-FLAG basecamp todolistgroup list --styled type=bool
-FLAG basecamp todolistgroup list --todolist type=string
-FLAG basecamp todolistgroup list --verbose type=count
-FLAG basecamp todolistgroup list --version type=bool
-FLAG basecamp todolistgroup move --account type=string
-FLAG basecamp todolistgroup move --agent type=bool
-FLAG basecamp todolistgroup move --cache-dir type=string
-FLAG basecamp todolistgroup move --count type=bool
-FLAG basecamp todolistgroup move --help type=bool
-FLAG basecamp todolistgroup move --hints type=bool
-FLAG basecamp todolistgroup move --ids-only type=bool
-FLAG basecamp todolistgroup move --in type=string
-FLAG basecamp todolistgroup move --jq type=string
-FLAG basecamp todolistgroup move --json type=bool
-FLAG basecamp todolistgroup move --list type=string
-FLAG basecamp todolistgroup move --markdown type=bool
-FLAG basecamp todolistgroup move --md type=bool
-FLAG basecamp todolistgroup move --no-hints type=bool
-FLAG basecamp todolistgroup move --no-stats type=bool
-FLAG basecamp todolistgroup move --pos type=int
-FLAG basecamp todolistgroup move --position type=int
-FLAG basecamp todolistgroup move --profile type=string
-FLAG basecamp todolistgroup move --project type=string
-FLAG basecamp todolistgroup move --quiet type=bool
-FLAG basecamp todolistgroup move --stats type=bool
-FLAG basecamp todolistgroup move --styled type=bool
-FLAG basecamp todolistgroup move --todolist type=string
-FLAG basecamp todolistgroup move --verbose type=count
-FLAG basecamp todolistgroup move --version type=bool
-FLAG basecamp todolistgroup position --account type=string
-FLAG basecamp todolistgroup position --agent type=bool
-FLAG basecamp todolistgroup position --cache-dir type=string
-FLAG basecamp todolistgroup position --count type=bool
-FLAG basecamp todolistgroup position --help type=bool
-FLAG basecamp todolistgroup position --hints type=bool
-FLAG basecamp todolistgroup position --ids-only type=bool
-FLAG basecamp todolistgroup position --in type=string
-FLAG basecamp todolistgroup position --jq type=string
-FLAG basecamp todolistgroup position --json type=bool
-FLAG basecamp todolistgroup position --list type=string
-FLAG basecamp todolistgroup position --markdown type=bool
-FLAG basecamp todolistgroup position --md type=bool
-FLAG basecamp todolistgroup position --no-hints type=bool
-FLAG basecamp todolistgroup position --no-stats type=bool
-FLAG basecamp todolistgroup position --pos type=int
-FLAG basecamp todolistgroup position --position type=int
-FLAG basecamp todolistgroup position --profile type=string
-FLAG basecamp todolistgroup position --project type=string
-FLAG basecamp todolistgroup position --quiet type=bool
-FLAG basecamp todolistgroup position --stats type=bool
-FLAG basecamp todolistgroup position --styled type=bool
-FLAG basecamp todolistgroup position --todolist type=string
-FLAG basecamp todolistgroup position --verbose type=count
-FLAG basecamp todolistgroup position --version type=bool
-FLAG basecamp todolistgroup rename --account type=string
-FLAG basecamp todolistgroup rename --agent type=bool
-FLAG basecamp todolistgroup rename --cache-dir type=string
-FLAG basecamp todolistgroup rename --count type=bool
-FLAG basecamp todolistgroup rename --help type=bool
-FLAG basecamp todolistgroup rename --hints type=bool
-FLAG basecamp todolistgroup rename --ids-only type=bool
-FLAG basecamp todolistgroup rename --in type=string
-FLAG basecamp todolistgroup rename --jq type=string
-FLAG basecamp todolistgroup rename --json type=bool
-FLAG basecamp todolistgroup rename --list type=string
-FLAG basecamp todolistgroup rename --markdown type=bool
-FLAG basecamp todolistgroup rename --md type=bool
-FLAG basecamp todolistgroup rename --no-hints type=bool
-FLAG basecamp todolistgroup rename --no-stats type=bool
-FLAG basecamp todolistgroup rename --profile type=string
-FLAG basecamp todolistgroup rename --project type=string
-FLAG basecamp todolistgroup rename --quiet type=bool
-FLAG basecamp todolistgroup rename --stats type=bool
-FLAG basecamp todolistgroup rename --styled type=bool
-FLAG basecamp todolistgroup rename --todolist type=string
-FLAG basecamp todolistgroup rename --verbose type=count
-FLAG basecamp todolistgroup rename --version type=bool
-FLAG basecamp todolistgroup show --account type=string
-FLAG basecamp todolistgroup show --agent type=bool
-FLAG basecamp todolistgroup show --cache-dir type=string
-FLAG basecamp todolistgroup show --count type=bool
-FLAG basecamp todolistgroup show --help type=bool
-FLAG basecamp todolistgroup show --hints type=bool
-FLAG basecamp todolistgroup show --ids-only type=bool
-FLAG basecamp todolistgroup show --in type=string
-FLAG basecamp todolistgroup show --jq type=string
-FLAG basecamp todolistgroup show --json type=bool
-FLAG basecamp todolistgroup show --list type=string
-FLAG basecamp todolistgroup show --markdown type=bool
-FLAG basecamp todolistgroup show --md type=bool
-FLAG basecamp todolistgroup show --no-hints type=bool
-FLAG basecamp todolistgroup show --no-stats type=bool
-FLAG basecamp todolistgroup show --profile type=string
-FLAG basecamp todolistgroup show --project type=string
-FLAG basecamp todolistgroup show --quiet type=bool
-FLAG basecamp todolistgroup show --stats type=bool
-FLAG basecamp todolistgroup show --styled type=bool
-FLAG basecamp todolistgroup show --todolist type=string
-FLAG basecamp todolistgroup show --verbose type=count
-FLAG basecamp todolistgroup show --version type=bool
-FLAG basecamp todolistgroup update --account type=string
-FLAG basecamp todolistgroup update --agent type=bool
-FLAG basecamp todolistgroup update --cache-dir type=string
-FLAG basecamp todolistgroup update --count type=bool
-FLAG basecamp todolistgroup update --help type=bool
-FLAG basecamp todolistgroup update --hints type=bool
-FLAG basecamp todolistgroup update --ids-only type=bool
-FLAG basecamp todolistgroup update --in type=string
-FLAG basecamp todolistgroup update --jq type=string
-FLAG basecamp todolistgroup update --json type=bool
-FLAG basecamp todolistgroup update --list type=string
-FLAG basecamp todolistgroup update --markdown type=bool
-FLAG basecamp todolistgroup update --md type=bool
-FLAG basecamp todolistgroup update --no-hints type=bool
-FLAG basecamp todolistgroup update --no-stats type=bool
-FLAG basecamp todolistgroup update --profile type=string
-FLAG basecamp todolistgroup update --project type=string
-FLAG basecamp todolistgroup update --quiet type=bool
-FLAG basecamp todolistgroup update --stats type=bool
-FLAG basecamp todolistgroup update --styled type=bool
-FLAG basecamp todolistgroup update --todolist type=string
-FLAG basecamp todolistgroup update --verbose type=count
-FLAG basecamp todolistgroup update --version type=bool
 FLAG basecamp todolistgroups --account type=string
 FLAG basecamp todolistgroups --agent type=bool
 FLAG basecamp todolistgroups --cache-dir type=string
 FLAG basecamp todolistgroups --count type=bool
-FLAG basecamp todolistgroups --help type=bool
 FLAG basecamp todolistgroups --hints type=bool
 FLAG basecamp todolistgroups --ids-only type=bool
 FLAG basecamp todolistgroups --in type=string
@@ -12701,12 +6400,10 @@ FLAG basecamp todolistgroups --stats type=bool
 FLAG basecamp todolistgroups --styled type=bool
 FLAG basecamp todolistgroups --todolist type=string
 FLAG basecamp todolistgroups --verbose type=count
-FLAG basecamp todolistgroups --version type=bool
 FLAG basecamp todolistgroups create --account type=string
 FLAG basecamp todolistgroups create --agent type=bool
 FLAG basecamp todolistgroups create --cache-dir type=string
 FLAG basecamp todolistgroups create --count type=bool
-FLAG basecamp todolistgroups create --help type=bool
 FLAG basecamp todolistgroups create --hints type=bool
 FLAG basecamp todolistgroups create --ids-only type=bool
 FLAG basecamp todolistgroups create --in type=string
@@ -12724,12 +6421,10 @@ FLAG basecamp todolistgroups create --stats type=bool
 FLAG basecamp todolistgroups create --styled type=bool
 FLAG basecamp todolistgroups create --todolist type=string
 FLAG basecamp todolistgroups create --verbose type=count
-FLAG basecamp todolistgroups create --version type=bool
 FLAG basecamp todolistgroups list --account type=string
 FLAG basecamp todolistgroups list --agent type=bool
 FLAG basecamp todolistgroups list --cache-dir type=string
 FLAG basecamp todolistgroups list --count type=bool
-FLAG basecamp todolistgroups list --help type=bool
 FLAG basecamp todolistgroups list --hints type=bool
 FLAG basecamp todolistgroups list --ids-only type=bool
 FLAG basecamp todolistgroups list --in type=string
@@ -12747,37 +6442,10 @@ FLAG basecamp todolistgroups list --stats type=bool
 FLAG basecamp todolistgroups list --styled type=bool
 FLAG basecamp todolistgroups list --todolist type=string
 FLAG basecamp todolistgroups list --verbose type=count
-FLAG basecamp todolistgroups list --version type=bool
-FLAG basecamp todolistgroups move --account type=string
-FLAG basecamp todolistgroups move --agent type=bool
-FLAG basecamp todolistgroups move --cache-dir type=string
-FLAG basecamp todolistgroups move --count type=bool
-FLAG basecamp todolistgroups move --help type=bool
-FLAG basecamp todolistgroups move --hints type=bool
-FLAG basecamp todolistgroups move --ids-only type=bool
-FLAG basecamp todolistgroups move --in type=string
-FLAG basecamp todolistgroups move --jq type=string
-FLAG basecamp todolistgroups move --json type=bool
-FLAG basecamp todolistgroups move --list type=string
-FLAG basecamp todolistgroups move --markdown type=bool
-FLAG basecamp todolistgroups move --md type=bool
-FLAG basecamp todolistgroups move --no-hints type=bool
-FLAG basecamp todolistgroups move --no-stats type=bool
-FLAG basecamp todolistgroups move --pos type=int
-FLAG basecamp todolistgroups move --position type=int
-FLAG basecamp todolistgroups move --profile type=string
-FLAG basecamp todolistgroups move --project type=string
-FLAG basecamp todolistgroups move --quiet type=bool
-FLAG basecamp todolistgroups move --stats type=bool
-FLAG basecamp todolistgroups move --styled type=bool
-FLAG basecamp todolistgroups move --todolist type=string
-FLAG basecamp todolistgroups move --verbose type=count
-FLAG basecamp todolistgroups move --version type=bool
 FLAG basecamp todolistgroups position --account type=string
 FLAG basecamp todolistgroups position --agent type=bool
 FLAG basecamp todolistgroups position --cache-dir type=string
 FLAG basecamp todolistgroups position --count type=bool
-FLAG basecamp todolistgroups position --help type=bool
 FLAG basecamp todolistgroups position --hints type=bool
 FLAG basecamp todolistgroups position --ids-only type=bool
 FLAG basecamp todolistgroups position --in type=string
@@ -12797,35 +6465,10 @@ FLAG basecamp todolistgroups position --stats type=bool
 FLAG basecamp todolistgroups position --styled type=bool
 FLAG basecamp todolistgroups position --todolist type=string
 FLAG basecamp todolistgroups position --verbose type=count
-FLAG basecamp todolistgroups position --version type=bool
-FLAG basecamp todolistgroups rename --account type=string
-FLAG basecamp todolistgroups rename --agent type=bool
-FLAG basecamp todolistgroups rename --cache-dir type=string
-FLAG basecamp todolistgroups rename --count type=bool
-FLAG basecamp todolistgroups rename --help type=bool
-FLAG basecamp todolistgroups rename --hints type=bool
-FLAG basecamp todolistgroups rename --ids-only type=bool
-FLAG basecamp todolistgroups rename --in type=string
-FLAG basecamp todolistgroups rename --jq type=string
-FLAG basecamp todolistgroups rename --json type=bool
-FLAG basecamp todolistgroups rename --list type=string
-FLAG basecamp todolistgroups rename --markdown type=bool
-FLAG basecamp todolistgroups rename --md type=bool
-FLAG basecamp todolistgroups rename --no-hints type=bool
-FLAG basecamp todolistgroups rename --no-stats type=bool
-FLAG basecamp todolistgroups rename --profile type=string
-FLAG basecamp todolistgroups rename --project type=string
-FLAG basecamp todolistgroups rename --quiet type=bool
-FLAG basecamp todolistgroups rename --stats type=bool
-FLAG basecamp todolistgroups rename --styled type=bool
-FLAG basecamp todolistgroups rename --todolist type=string
-FLAG basecamp todolistgroups rename --verbose type=count
-FLAG basecamp todolistgroups rename --version type=bool
 FLAG basecamp todolistgroups show --account type=string
 FLAG basecamp todolistgroups show --agent type=bool
 FLAG basecamp todolistgroups show --cache-dir type=string
 FLAG basecamp todolistgroups show --count type=bool
-FLAG basecamp todolistgroups show --help type=bool
 FLAG basecamp todolistgroups show --hints type=bool
 FLAG basecamp todolistgroups show --ids-only type=bool
 FLAG basecamp todolistgroups show --in type=string
@@ -12843,12 +6486,10 @@ FLAG basecamp todolistgroups show --stats type=bool
 FLAG basecamp todolistgroups show --styled type=bool
 FLAG basecamp todolistgroups show --todolist type=string
 FLAG basecamp todolistgroups show --verbose type=count
-FLAG basecamp todolistgroups show --version type=bool
 FLAG basecamp todolistgroups update --account type=string
 FLAG basecamp todolistgroups update --agent type=bool
 FLAG basecamp todolistgroups update --cache-dir type=string
 FLAG basecamp todolistgroups update --count type=bool
-FLAG basecamp todolistgroups update --help type=bool
 FLAG basecamp todolistgroups update --hints type=bool
 FLAG basecamp todolistgroups update --ids-only type=bool
 FLAG basecamp todolistgroups update --in type=string
@@ -12866,12 +6507,10 @@ FLAG basecamp todolistgroups update --stats type=bool
 FLAG basecamp todolistgroups update --styled type=bool
 FLAG basecamp todolistgroups update --todolist type=string
 FLAG basecamp todolistgroups update --verbose type=count
-FLAG basecamp todolistgroups update --version type=bool
 FLAG basecamp todolists --account type=string
 FLAG basecamp todolists --agent type=bool
 FLAG basecamp todolists --cache-dir type=string
 FLAG basecamp todolists --count type=bool
-FLAG basecamp todolists --help type=bool
 FLAG basecamp todolists --hints type=bool
 FLAG basecamp todolists --ids-only type=bool
 FLAG basecamp todolists --in type=string
@@ -12888,12 +6527,10 @@ FLAG basecamp todolists --stats type=bool
 FLAG basecamp todolists --styled type=bool
 FLAG basecamp todolists --todolist type=string
 FLAG basecamp todolists --verbose type=count
-FLAG basecamp todolists --version type=bool
 FLAG basecamp todolists archive --account type=string
 FLAG basecamp todolists archive --agent type=bool
 FLAG basecamp todolists archive --cache-dir type=string
 FLAG basecamp todolists archive --count type=bool
-FLAG basecamp todolists archive --help type=bool
 FLAG basecamp todolists archive --hints type=bool
 FLAG basecamp todolists archive --ids-only type=bool
 FLAG basecamp todolists archive --in type=string
@@ -12910,13 +6547,11 @@ FLAG basecamp todolists archive --stats type=bool
 FLAG basecamp todolists archive --styled type=bool
 FLAG basecamp todolists archive --todolist type=string
 FLAG basecamp todolists archive --verbose type=count
-FLAG basecamp todolists archive --version type=bool
 FLAG basecamp todolists create --account type=string
 FLAG basecamp todolists create --agent type=bool
 FLAG basecamp todolists create --cache-dir type=string
 FLAG basecamp todolists create --count type=bool
 FLAG basecamp todolists create --description type=string
-FLAG basecamp todolists create --help type=bool
 FLAG basecamp todolists create --hints type=bool
 FLAG basecamp todolists create --ids-only type=bool
 FLAG basecamp todolists create --in type=string
@@ -12934,14 +6569,12 @@ FLAG basecamp todolists create --styled type=bool
 FLAG basecamp todolists create --todolist type=string
 FLAG basecamp todolists create --todoset type=string
 FLAG basecamp todolists create --verbose type=count
-FLAG basecamp todolists create --version type=bool
 FLAG basecamp todolists list --account type=string
 FLAG basecamp todolists list --agent type=bool
 FLAG basecamp todolists list --all type=bool
 FLAG basecamp todolists list --archived type=bool
 FLAG basecamp todolists list --cache-dir type=string
 FLAG basecamp todolists list --count type=bool
-FLAG basecamp todolists list --help type=bool
 FLAG basecamp todolists list --hints type=bool
 FLAG basecamp todolists list --ids-only type=bool
 FLAG basecamp todolists list --in type=string
@@ -12963,12 +6596,10 @@ FLAG basecamp todolists list --styled type=bool
 FLAG basecamp todolists list --todolist type=string
 FLAG basecamp todolists list --todoset type=string
 FLAG basecamp todolists list --verbose type=count
-FLAG basecamp todolists list --version type=bool
 FLAG basecamp todolists restore --account type=string
 FLAG basecamp todolists restore --agent type=bool
 FLAG basecamp todolists restore --cache-dir type=string
 FLAG basecamp todolists restore --count type=bool
-FLAG basecamp todolists restore --help type=bool
 FLAG basecamp todolists restore --hints type=bool
 FLAG basecamp todolists restore --ids-only type=bool
 FLAG basecamp todolists restore --in type=string
@@ -12985,12 +6616,10 @@ FLAG basecamp todolists restore --stats type=bool
 FLAG basecamp todolists restore --styled type=bool
 FLAG basecamp todolists restore --todolist type=string
 FLAG basecamp todolists restore --verbose type=count
-FLAG basecamp todolists restore --version type=bool
 FLAG basecamp todolists show --account type=string
 FLAG basecamp todolists show --agent type=bool
 FLAG basecamp todolists show --cache-dir type=string
 FLAG basecamp todolists show --count type=bool
-FLAG basecamp todolists show --help type=bool
 FLAG basecamp todolists show --hints type=bool
 FLAG basecamp todolists show --ids-only type=bool
 FLAG basecamp todolists show --in type=string
@@ -13007,12 +6636,10 @@ FLAG basecamp todolists show --stats type=bool
 FLAG basecamp todolists show --styled type=bool
 FLAG basecamp todolists show --todolist type=string
 FLAG basecamp todolists show --verbose type=count
-FLAG basecamp todolists show --version type=bool
 FLAG basecamp todolists trash --account type=string
 FLAG basecamp todolists trash --agent type=bool
 FLAG basecamp todolists trash --cache-dir type=string
 FLAG basecamp todolists trash --count type=bool
-FLAG basecamp todolists trash --help type=bool
 FLAG basecamp todolists trash --hints type=bool
 FLAG basecamp todolists trash --ids-only type=bool
 FLAG basecamp todolists trash --in type=string
@@ -13029,13 +6656,11 @@ FLAG basecamp todolists trash --stats type=bool
 FLAG basecamp todolists trash --styled type=bool
 FLAG basecamp todolists trash --todolist type=string
 FLAG basecamp todolists trash --verbose type=count
-FLAG basecamp todolists trash --version type=bool
 FLAG basecamp todolists update --account type=string
 FLAG basecamp todolists update --agent type=bool
 FLAG basecamp todolists update --cache-dir type=string
 FLAG basecamp todolists update --count type=bool
 FLAG basecamp todolists update --description type=string
-FLAG basecamp todolists update --help type=bool
 FLAG basecamp todolists update --hints type=bool
 FLAG basecamp todolists update --ids-only type=bool
 FLAG basecamp todolists update --in type=string
@@ -13053,12 +6678,10 @@ FLAG basecamp todolists update --stats type=bool
 FLAG basecamp todolists update --styled type=bool
 FLAG basecamp todolists update --todolist type=string
 FLAG basecamp todolists update --verbose type=count
-FLAG basecamp todolists update --version type=bool
 FLAG basecamp todos --account type=string
 FLAG basecamp todos --agent type=bool
 FLAG basecamp todos --cache-dir type=string
 FLAG basecamp todos --count type=bool
-FLAG basecamp todos --help type=bool
 FLAG basecamp todos --hints type=bool
 FLAG basecamp todos --ids-only type=bool
 FLAG basecamp todos --in type=string
@@ -13075,12 +6698,10 @@ FLAG basecamp todos --stats type=bool
 FLAG basecamp todos --styled type=bool
 FLAG basecamp todos --todolist type=string
 FLAG basecamp todos --verbose type=count
-FLAG basecamp todos --version type=bool
 FLAG basecamp todos archive --account type=string
 FLAG basecamp todos archive --agent type=bool
 FLAG basecamp todos archive --cache-dir type=string
 FLAG basecamp todos archive --count type=bool
-FLAG basecamp todos archive --help type=bool
 FLAG basecamp todos archive --hints type=bool
 FLAG basecamp todos archive --ids-only type=bool
 FLAG basecamp todos archive --in type=string
@@ -13097,12 +6718,10 @@ FLAG basecamp todos archive --stats type=bool
 FLAG basecamp todos archive --styled type=bool
 FLAG basecamp todos archive --todolist type=string
 FLAG basecamp todos archive --verbose type=count
-FLAG basecamp todos archive --version type=bool
 FLAG basecamp todos complete --account type=string
 FLAG basecamp todos complete --agent type=bool
 FLAG basecamp todos complete --cache-dir type=string
 FLAG basecamp todos complete --count type=bool
-FLAG basecamp todos complete --help type=bool
 FLAG basecamp todos complete --hints type=bool
 FLAG basecamp todos complete --ids-only type=bool
 FLAG basecamp todos complete --in type=string
@@ -13119,7 +6738,6 @@ FLAG basecamp todos complete --stats type=bool
 FLAG basecamp todos complete --styled type=bool
 FLAG basecamp todos complete --todolist type=string
 FLAG basecamp todos complete --verbose type=count
-FLAG basecamp todos complete --version type=bool
 FLAG basecamp todos create --account type=string
 FLAG basecamp todos create --agent type=bool
 FLAG basecamp todos create --assignee type=string
@@ -13128,7 +6746,6 @@ FLAG basecamp todos create --cache-dir type=string
 FLAG basecamp todos create --count type=bool
 FLAG basecamp todos create --description type=string
 FLAG basecamp todos create --due type=string
-FLAG basecamp todos create --help type=bool
 FLAG basecamp todos create --hints type=bool
 FLAG basecamp todos create --ids-only type=bool
 FLAG basecamp todos create --in type=string
@@ -13148,7 +6765,6 @@ FLAG basecamp todos create --to type=string
 FLAG basecamp todos create --todolist type=string
 FLAG basecamp todos create --todoset type=string
 FLAG basecamp todos create --verbose type=count
-FLAG basecamp todos create --version type=bool
 FLAG basecamp todos list --account type=string
 FLAG basecamp todos list --agent type=bool
 FLAG basecamp todos list --all type=bool
@@ -13156,7 +6772,6 @@ FLAG basecamp todos list --assignee type=string
 FLAG basecamp todos list --cache-dir type=string
 FLAG basecamp todos list --completed type=bool
 FLAG basecamp todos list --count type=bool
-FLAG basecamp todos list --help type=bool
 FLAG basecamp todos list --hints type=bool
 FLAG basecamp todos list --ids-only type=bool
 FLAG basecamp todos list --in type=string
@@ -13181,36 +6796,10 @@ FLAG basecamp todos list --styled type=bool
 FLAG basecamp todos list --todolist type=string
 FLAG basecamp todos list --todoset type=string
 FLAG basecamp todos list --verbose type=count
-FLAG basecamp todos list --version type=bool
-FLAG basecamp todos move --account type=string
-FLAG basecamp todos move --agent type=bool
-FLAG basecamp todos move --cache-dir type=string
-FLAG basecamp todos move --count type=bool
-FLAG basecamp todos move --help type=bool
-FLAG basecamp todos move --hints type=bool
-FLAG basecamp todos move --ids-only type=bool
-FLAG basecamp todos move --in type=string
-FLAG basecamp todos move --jq type=string
-FLAG basecamp todos move --json type=bool
-FLAG basecamp todos move --markdown type=bool
-FLAG basecamp todos move --md type=bool
-FLAG basecamp todos move --no-hints type=bool
-FLAG basecamp todos move --no-stats type=bool
-FLAG basecamp todos move --position type=int
-FLAG basecamp todos move --profile type=string
-FLAG basecamp todos move --project type=string
-FLAG basecamp todos move --quiet type=bool
-FLAG basecamp todos move --stats type=bool
-FLAG basecamp todos move --styled type=bool
-FLAG basecamp todos move --to type=int
-FLAG basecamp todos move --todolist type=string
-FLAG basecamp todos move --verbose type=count
-FLAG basecamp todos move --version type=bool
 FLAG basecamp todos position --account type=string
 FLAG basecamp todos position --agent type=bool
 FLAG basecamp todos position --cache-dir type=string
 FLAG basecamp todos position --count type=bool
-FLAG basecamp todos position --help type=bool
 FLAG basecamp todos position --hints type=bool
 FLAG basecamp todos position --ids-only type=bool
 FLAG basecamp todos position --in type=string
@@ -13229,58 +6818,10 @@ FLAG basecamp todos position --styled type=bool
 FLAG basecamp todos position --to type=int
 FLAG basecamp todos position --todolist type=string
 FLAG basecamp todos position --verbose type=count
-FLAG basecamp todos position --version type=bool
-FLAG basecamp todos reopen --account type=string
-FLAG basecamp todos reopen --agent type=bool
-FLAG basecamp todos reopen --cache-dir type=string
-FLAG basecamp todos reopen --count type=bool
-FLAG basecamp todos reopen --help type=bool
-FLAG basecamp todos reopen --hints type=bool
-FLAG basecamp todos reopen --ids-only type=bool
-FLAG basecamp todos reopen --in type=string
-FLAG basecamp todos reopen --jq type=string
-FLAG basecamp todos reopen --json type=bool
-FLAG basecamp todos reopen --markdown type=bool
-FLAG basecamp todos reopen --md type=bool
-FLAG basecamp todos reopen --no-hints type=bool
-FLAG basecamp todos reopen --no-stats type=bool
-FLAG basecamp todos reopen --profile type=string
-FLAG basecamp todos reopen --project type=string
-FLAG basecamp todos reopen --quiet type=bool
-FLAG basecamp todos reopen --stats type=bool
-FLAG basecamp todos reopen --styled type=bool
-FLAG basecamp todos reopen --todolist type=string
-FLAG basecamp todos reopen --verbose type=count
-FLAG basecamp todos reopen --version type=bool
-FLAG basecamp todos reorder --account type=string
-FLAG basecamp todos reorder --agent type=bool
-FLAG basecamp todos reorder --cache-dir type=string
-FLAG basecamp todos reorder --count type=bool
-FLAG basecamp todos reorder --help type=bool
-FLAG basecamp todos reorder --hints type=bool
-FLAG basecamp todos reorder --ids-only type=bool
-FLAG basecamp todos reorder --in type=string
-FLAG basecamp todos reorder --jq type=string
-FLAG basecamp todos reorder --json type=bool
-FLAG basecamp todos reorder --markdown type=bool
-FLAG basecamp todos reorder --md type=bool
-FLAG basecamp todos reorder --no-hints type=bool
-FLAG basecamp todos reorder --no-stats type=bool
-FLAG basecamp todos reorder --position type=int
-FLAG basecamp todos reorder --profile type=string
-FLAG basecamp todos reorder --project type=string
-FLAG basecamp todos reorder --quiet type=bool
-FLAG basecamp todos reorder --stats type=bool
-FLAG basecamp todos reorder --styled type=bool
-FLAG basecamp todos reorder --to type=int
-FLAG basecamp todos reorder --todolist type=string
-FLAG basecamp todos reorder --verbose type=count
-FLAG basecamp todos reorder --version type=bool
 FLAG basecamp todos restore --account type=string
 FLAG basecamp todos restore --agent type=bool
 FLAG basecamp todos restore --cache-dir type=string
 FLAG basecamp todos restore --count type=bool
-FLAG basecamp todos restore --help type=bool
 FLAG basecamp todos restore --hints type=bool
 FLAG basecamp todos restore --ids-only type=bool
 FLAG basecamp todos restore --in type=string
@@ -13297,12 +6838,10 @@ FLAG basecamp todos restore --stats type=bool
 FLAG basecamp todos restore --styled type=bool
 FLAG basecamp todos restore --todolist type=string
 FLAG basecamp todos restore --verbose type=count
-FLAG basecamp todos restore --version type=bool
 FLAG basecamp todos show --account type=string
 FLAG basecamp todos show --agent type=bool
 FLAG basecamp todos show --cache-dir type=string
 FLAG basecamp todos show --count type=bool
-FLAG basecamp todos show --help type=bool
 FLAG basecamp todos show --hints type=bool
 FLAG basecamp todos show --ids-only type=bool
 FLAG basecamp todos show --in type=string
@@ -13319,7 +6858,6 @@ FLAG basecamp todos show --stats type=bool
 FLAG basecamp todos show --styled type=bool
 FLAG basecamp todos show --todolist type=string
 FLAG basecamp todos show --verbose type=count
-FLAG basecamp todos show --version type=bool
 FLAG basecamp todos sweep --account type=string
 FLAG basecamp todos sweep --agent type=bool
 FLAG basecamp todos sweep --assignee type=string
@@ -13329,7 +6867,6 @@ FLAG basecamp todos sweep --complete type=bool
 FLAG basecamp todos sweep --count type=bool
 FLAG basecamp todos sweep --done type=bool
 FLAG basecamp todos sweep --dry-run type=bool
-FLAG basecamp todos sweep --help type=bool
 FLAG basecamp todos sweep --hints type=bool
 FLAG basecamp todos sweep --ids-only type=bool
 FLAG basecamp todos sweep --in type=string
@@ -13348,12 +6885,10 @@ FLAG basecamp todos sweep --styled type=bool
 FLAG basecamp todos sweep --todolist type=string
 FLAG basecamp todos sweep --todoset type=string
 FLAG basecamp todos sweep --verbose type=count
-FLAG basecamp todos sweep --version type=bool
 FLAG basecamp todos trash --account type=string
 FLAG basecamp todos trash --agent type=bool
 FLAG basecamp todos trash --cache-dir type=string
 FLAG basecamp todos trash --count type=bool
-FLAG basecamp todos trash --help type=bool
 FLAG basecamp todos trash --hints type=bool
 FLAG basecamp todos trash --ids-only type=bool
 FLAG basecamp todos trash --in type=string
@@ -13370,12 +6905,10 @@ FLAG basecamp todos trash --stats type=bool
 FLAG basecamp todos trash --styled type=bool
 FLAG basecamp todos trash --todolist type=string
 FLAG basecamp todos trash --verbose type=count
-FLAG basecamp todos trash --version type=bool
 FLAG basecamp todos uncomplete --account type=string
 FLAG basecamp todos uncomplete --agent type=bool
 FLAG basecamp todos uncomplete --cache-dir type=string
 FLAG basecamp todos uncomplete --count type=bool
-FLAG basecamp todos uncomplete --help type=bool
 FLAG basecamp todos uncomplete --hints type=bool
 FLAG basecamp todos uncomplete --ids-only type=bool
 FLAG basecamp todos uncomplete --in type=string
@@ -13392,7 +6925,6 @@ FLAG basecamp todos uncomplete --stats type=bool
 FLAG basecamp todos uncomplete --styled type=bool
 FLAG basecamp todos uncomplete --todolist type=string
 FLAG basecamp todos uncomplete --verbose type=count
-FLAG basecamp todos uncomplete --version type=bool
 FLAG basecamp todos update --account type=string
 FLAG basecamp todos update --agent type=bool
 FLAG basecamp todos update --assignee type=string
@@ -13400,7 +6932,6 @@ FLAG basecamp todos update --cache-dir type=string
 FLAG basecamp todos update --count type=bool
 FLAG basecamp todos update --description type=string
 FLAG basecamp todos update --due type=string
-FLAG basecamp todos update --help type=bool
 FLAG basecamp todos update --hints type=bool
 FLAG basecamp todos update --ids-only type=bool
 FLAG basecamp todos update --in type=string
@@ -13421,12 +6952,10 @@ FLAG basecamp todos update --title type=string
 FLAG basecamp todos update --to type=string
 FLAG basecamp todos update --todolist type=string
 FLAG basecamp todos update --verbose type=count
-FLAG basecamp todos update --version type=bool
 FLAG basecamp todosets --account type=string
 FLAG basecamp todosets --agent type=bool
 FLAG basecamp todosets --cache-dir type=string
 FLAG basecamp todosets --count type=bool
-FLAG basecamp todosets --help type=bool
 FLAG basecamp todosets --hints type=bool
 FLAG basecamp todosets --ids-only type=bool
 FLAG basecamp todosets --in type=string
@@ -13443,12 +6972,10 @@ FLAG basecamp todosets --stats type=bool
 FLAG basecamp todosets --styled type=bool
 FLAG basecamp todosets --todolist type=string
 FLAG basecamp todosets --verbose type=count
-FLAG basecamp todosets --version type=bool
 FLAG basecamp todosets list --account type=string
 FLAG basecamp todosets list --agent type=bool
 FLAG basecamp todosets list --cache-dir type=string
 FLAG basecamp todosets list --count type=bool
-FLAG basecamp todosets list --help type=bool
 FLAG basecamp todosets list --hints type=bool
 FLAG basecamp todosets list --ids-only type=bool
 FLAG basecamp todosets list --in type=string
@@ -13465,12 +6992,10 @@ FLAG basecamp todosets list --stats type=bool
 FLAG basecamp todosets list --styled type=bool
 FLAG basecamp todosets list --todolist type=string
 FLAG basecamp todosets list --verbose type=count
-FLAG basecamp todosets list --version type=bool
 FLAG basecamp todosets show --account type=string
 FLAG basecamp todosets show --agent type=bool
 FLAG basecamp todosets show --cache-dir type=string
 FLAG basecamp todosets show --count type=bool
-FLAG basecamp todosets show --help type=bool
 FLAG basecamp todosets show --hints type=bool
 FLAG basecamp todosets show --ids-only type=bool
 FLAG basecamp todosets show --in type=string
@@ -13488,12 +7013,10 @@ FLAG basecamp todosets show --styled type=bool
 FLAG basecamp todosets show --todolist type=string
 FLAG basecamp todosets show --todoset type=string
 FLAG basecamp todosets show --verbose type=count
-FLAG basecamp todosets show --version type=bool
 FLAG basecamp tools --account type=string
 FLAG basecamp tools --agent type=bool
 FLAG basecamp tools --cache-dir type=string
 FLAG basecamp tools --count type=bool
-FLAG basecamp tools --help type=bool
 FLAG basecamp tools --hints type=bool
 FLAG basecamp tools --ids-only type=bool
 FLAG basecamp tools --in type=string
@@ -13510,13 +7033,11 @@ FLAG basecamp tools --stats type=bool
 FLAG basecamp tools --styled type=bool
 FLAG basecamp tools --todolist type=string
 FLAG basecamp tools --verbose type=count
-FLAG basecamp tools --version type=bool
 FLAG basecamp tools create --account type=string
 FLAG basecamp tools create --agent type=bool
 FLAG basecamp tools create --cache-dir type=string
 FLAG basecamp tools create --clone type=string
 FLAG basecamp tools create --count type=bool
-FLAG basecamp tools create --help type=bool
 FLAG basecamp tools create --hints type=bool
 FLAG basecamp tools create --ids-only type=bool
 FLAG basecamp tools create --in type=string
@@ -13534,34 +7055,10 @@ FLAG basecamp tools create --stats type=bool
 FLAG basecamp tools create --styled type=bool
 FLAG basecamp tools create --todolist type=string
 FLAG basecamp tools create --verbose type=count
-FLAG basecamp tools create --version type=bool
-FLAG basecamp tools delete --account type=string
-FLAG basecamp tools delete --agent type=bool
-FLAG basecamp tools delete --cache-dir type=string
-FLAG basecamp tools delete --count type=bool
-FLAG basecamp tools delete --help type=bool
-FLAG basecamp tools delete --hints type=bool
-FLAG basecamp tools delete --ids-only type=bool
-FLAG basecamp tools delete --in type=string
-FLAG basecamp tools delete --jq type=string
-FLAG basecamp tools delete --json type=bool
-FLAG basecamp tools delete --markdown type=bool
-FLAG basecamp tools delete --md type=bool
-FLAG basecamp tools delete --no-hints type=bool
-FLAG basecamp tools delete --no-stats type=bool
-FLAG basecamp tools delete --profile type=string
-FLAG basecamp tools delete --project type=string
-FLAG basecamp tools delete --quiet type=bool
-FLAG basecamp tools delete --stats type=bool
-FLAG basecamp tools delete --styled type=bool
-FLAG basecamp tools delete --todolist type=string
-FLAG basecamp tools delete --verbose type=count
-FLAG basecamp tools delete --version type=bool
 FLAG basecamp tools disable --account type=string
 FLAG basecamp tools disable --agent type=bool
 FLAG basecamp tools disable --cache-dir type=string
 FLAG basecamp tools disable --count type=bool
-FLAG basecamp tools disable --help type=bool
 FLAG basecamp tools disable --hints type=bool
 FLAG basecamp tools disable --ids-only type=bool
 FLAG basecamp tools disable --in type=string
@@ -13578,12 +7075,10 @@ FLAG basecamp tools disable --stats type=bool
 FLAG basecamp tools disable --styled type=bool
 FLAG basecamp tools disable --todolist type=string
 FLAG basecamp tools disable --verbose type=count
-FLAG basecamp tools disable --version type=bool
 FLAG basecamp tools enable --account type=string
 FLAG basecamp tools enable --agent type=bool
 FLAG basecamp tools enable --cache-dir type=string
 FLAG basecamp tools enable --count type=bool
-FLAG basecamp tools enable --help type=bool
 FLAG basecamp tools enable --hints type=bool
 FLAG basecamp tools enable --ids-only type=bool
 FLAG basecamp tools enable --in type=string
@@ -13600,58 +7095,10 @@ FLAG basecamp tools enable --stats type=bool
 FLAG basecamp tools enable --styled type=bool
 FLAG basecamp tools enable --todolist type=string
 FLAG basecamp tools enable --verbose type=count
-FLAG basecamp tools enable --version type=bool
-FLAG basecamp tools move --account type=string
-FLAG basecamp tools move --agent type=bool
-FLAG basecamp tools move --cache-dir type=string
-FLAG basecamp tools move --count type=bool
-FLAG basecamp tools move --help type=bool
-FLAG basecamp tools move --hints type=bool
-FLAG basecamp tools move --ids-only type=bool
-FLAG basecamp tools move --in type=string
-FLAG basecamp tools move --jq type=string
-FLAG basecamp tools move --json type=bool
-FLAG basecamp tools move --markdown type=bool
-FLAG basecamp tools move --md type=bool
-FLAG basecamp tools move --no-hints type=bool
-FLAG basecamp tools move --no-stats type=bool
-FLAG basecamp tools move --pos type=int
-FLAG basecamp tools move --position type=int
-FLAG basecamp tools move --profile type=string
-FLAG basecamp tools move --project type=string
-FLAG basecamp tools move --quiet type=bool
-FLAG basecamp tools move --stats type=bool
-FLAG basecamp tools move --styled type=bool
-FLAG basecamp tools move --todolist type=string
-FLAG basecamp tools move --verbose type=count
-FLAG basecamp tools move --version type=bool
-FLAG basecamp tools rename --account type=string
-FLAG basecamp tools rename --agent type=bool
-FLAG basecamp tools rename --cache-dir type=string
-FLAG basecamp tools rename --count type=bool
-FLAG basecamp tools rename --help type=bool
-FLAG basecamp tools rename --hints type=bool
-FLAG basecamp tools rename --ids-only type=bool
-FLAG basecamp tools rename --in type=string
-FLAG basecamp tools rename --jq type=string
-FLAG basecamp tools rename --json type=bool
-FLAG basecamp tools rename --markdown type=bool
-FLAG basecamp tools rename --md type=bool
-FLAG basecamp tools rename --no-hints type=bool
-FLAG basecamp tools rename --no-stats type=bool
-FLAG basecamp tools rename --profile type=string
-FLAG basecamp tools rename --project type=string
-FLAG basecamp tools rename --quiet type=bool
-FLAG basecamp tools rename --stats type=bool
-FLAG basecamp tools rename --styled type=bool
-FLAG basecamp tools rename --todolist type=string
-FLAG basecamp tools rename --verbose type=count
-FLAG basecamp tools rename --version type=bool
 FLAG basecamp tools reposition --account type=string
 FLAG basecamp tools reposition --agent type=bool
 FLAG basecamp tools reposition --cache-dir type=string
 FLAG basecamp tools reposition --count type=bool
-FLAG basecamp tools reposition --help type=bool
 FLAG basecamp tools reposition --hints type=bool
 FLAG basecamp tools reposition --ids-only type=bool
 FLAG basecamp tools reposition --in type=string
@@ -13670,12 +7117,10 @@ FLAG basecamp tools reposition --stats type=bool
 FLAG basecamp tools reposition --styled type=bool
 FLAG basecamp tools reposition --todolist type=string
 FLAG basecamp tools reposition --verbose type=count
-FLAG basecamp tools reposition --version type=bool
 FLAG basecamp tools show --account type=string
 FLAG basecamp tools show --agent type=bool
 FLAG basecamp tools show --cache-dir type=string
 FLAG basecamp tools show --count type=bool
-FLAG basecamp tools show --help type=bool
 FLAG basecamp tools show --hints type=bool
 FLAG basecamp tools show --ids-only type=bool
 FLAG basecamp tools show --in type=string
@@ -13692,12 +7137,10 @@ FLAG basecamp tools show --stats type=bool
 FLAG basecamp tools show --styled type=bool
 FLAG basecamp tools show --todolist type=string
 FLAG basecamp tools show --verbose type=count
-FLAG basecamp tools show --version type=bool
 FLAG basecamp tools trash --account type=string
 FLAG basecamp tools trash --agent type=bool
 FLAG basecamp tools trash --cache-dir type=string
 FLAG basecamp tools trash --count type=bool
-FLAG basecamp tools trash --help type=bool
 FLAG basecamp tools trash --hints type=bool
 FLAG basecamp tools trash --ids-only type=bool
 FLAG basecamp tools trash --in type=string
@@ -13714,12 +7157,10 @@ FLAG basecamp tools trash --stats type=bool
 FLAG basecamp tools trash --styled type=bool
 FLAG basecamp tools trash --todolist type=string
 FLAG basecamp tools trash --verbose type=count
-FLAG basecamp tools trash --version type=bool
 FLAG basecamp tools update --account type=string
 FLAG basecamp tools update --agent type=bool
 FLAG basecamp tools update --cache-dir type=string
 FLAG basecamp tools update --count type=bool
-FLAG basecamp tools update --help type=bool
 FLAG basecamp tools update --hints type=bool
 FLAG basecamp tools update --ids-only type=bool
 FLAG basecamp tools update --in type=string
@@ -13736,12 +7177,10 @@ FLAG basecamp tools update --stats type=bool
 FLAG basecamp tools update --styled type=bool
 FLAG basecamp tools update --todolist type=string
 FLAG basecamp tools update --verbose type=count
-FLAG basecamp tools update --version type=bool
 FLAG basecamp tui --account type=string
 FLAG basecamp tui --agent type=bool
 FLAG basecamp tui --cache-dir type=string
 FLAG basecamp tui --count type=bool
-FLAG basecamp tui --help type=bool
 FLAG basecamp tui --hints type=bool
 FLAG basecamp tui --ids-only type=bool
 FLAG basecamp tui --in type=string
@@ -13759,14 +7198,12 @@ FLAG basecamp tui --styled type=bool
 FLAG basecamp tui --todolist type=string
 FLAG basecamp tui --trace type=bool
 FLAG basecamp tui --verbose type=count
-FLAG basecamp tui --version type=bool
 FLAG basecamp unassign --account type=string
 FLAG basecamp unassign --agent type=bool
 FLAG basecamp unassign --cache-dir type=string
 FLAG basecamp unassign --card type=bool
 FLAG basecamp unassign --count type=bool
 FLAG basecamp unassign --from type=string
-FLAG basecamp unassign --help type=bool
 FLAG basecamp unassign --hints type=bool
 FLAG basecamp unassign --ids-only type=bool
 FLAG basecamp unassign --in type=string
@@ -13784,12 +7221,10 @@ FLAG basecamp unassign --step type=bool
 FLAG basecamp unassign --styled type=bool
 FLAG basecamp unassign --todolist type=string
 FLAG basecamp unassign --verbose type=count
-FLAG basecamp unassign --version type=bool
 FLAG basecamp upgrade --account type=string
 FLAG basecamp upgrade --agent type=bool
 FLAG basecamp upgrade --cache-dir type=string
 FLAG basecamp upgrade --count type=bool
-FLAG basecamp upgrade --help type=bool
 FLAG basecamp upgrade --hints type=bool
 FLAG basecamp upgrade --ids-only type=bool
 FLAG basecamp upgrade --in type=string
@@ -13806,14 +7241,12 @@ FLAG basecamp upgrade --stats type=bool
 FLAG basecamp upgrade --styled type=bool
 FLAG basecamp upgrade --todolist type=string
 FLAG basecamp upgrade --verbose type=count
-FLAG basecamp upgrade --version type=bool
 FLAG basecamp upload --account type=string
 FLAG basecamp upload --agent type=bool
 FLAG basecamp upload --cache-dir type=string
 FLAG basecamp upload --count type=bool
 FLAG basecamp upload --description type=string
 FLAG basecamp upload --folder type=string
-FLAG basecamp upload --help type=bool
 FLAG basecamp upload --hints type=bool
 FLAG basecamp upload --ids-only type=bool
 FLAG basecamp upload --in type=string
@@ -13831,13 +7264,11 @@ FLAG basecamp upload --styled type=bool
 FLAG basecamp upload --todolist type=string
 FLAG basecamp upload --vault type=string
 FLAG basecamp upload --verbose type=count
-FLAG basecamp upload --version type=bool
 FLAG basecamp uploads --account type=string
 FLAG basecamp uploads --agent type=bool
 FLAG basecamp uploads --cache-dir type=string
 FLAG basecamp uploads --count type=bool
 FLAG basecamp uploads --folder type=string
-FLAG basecamp uploads --help type=bool
 FLAG basecamp uploads --hints type=bool
 FLAG basecamp uploads --ids-only type=bool
 FLAG basecamp uploads --in type=string
@@ -13855,14 +7286,12 @@ FLAG basecamp uploads --styled type=bool
 FLAG basecamp uploads --todolist type=string
 FLAG basecamp uploads --vault type=string
 FLAG basecamp uploads --verbose type=count
-FLAG basecamp uploads --version type=bool
 FLAG basecamp uploads create --account type=string
 FLAG basecamp uploads create --agent type=bool
 FLAG basecamp uploads create --cache-dir type=string
 FLAG basecamp uploads create --count type=bool
 FLAG basecamp uploads create --description type=string
 FLAG basecamp uploads create --folder type=string
-FLAG basecamp uploads create --help type=bool
 FLAG basecamp uploads create --hints type=bool
 FLAG basecamp uploads create --ids-only type=bool
 FLAG basecamp uploads create --in type=string
@@ -13880,14 +7309,12 @@ FLAG basecamp uploads create --styled type=bool
 FLAG basecamp uploads create --todolist type=string
 FLAG basecamp uploads create --vault type=string
 FLAG basecamp uploads create --verbose type=count
-FLAG basecamp uploads create --version type=bool
 FLAG basecamp uploads list --account type=string
 FLAG basecamp uploads list --agent type=bool
 FLAG basecamp uploads list --all type=bool
 FLAG basecamp uploads list --cache-dir type=string
 FLAG basecamp uploads list --count type=bool
 FLAG basecamp uploads list --folder type=string
-FLAG basecamp uploads list --help type=bool
 FLAG basecamp uploads list --hints type=bool
 FLAG basecamp uploads list --ids-only type=bool
 FLAG basecamp uploads list --in type=string
@@ -13907,13 +7334,11 @@ FLAG basecamp uploads list --styled type=bool
 FLAG basecamp uploads list --todolist type=string
 FLAG basecamp uploads list --vault type=string
 FLAG basecamp uploads list --verbose type=count
-FLAG basecamp uploads list --version type=bool
 FLAG basecamp uploads show --account type=string
 FLAG basecamp uploads show --agent type=bool
 FLAG basecamp uploads show --cache-dir type=string
 FLAG basecamp uploads show --count type=bool
 FLAG basecamp uploads show --folder type=string
-FLAG basecamp uploads show --help type=bool
 FLAG basecamp uploads show --hints type=bool
 FLAG basecamp uploads show --ids-only type=bool
 FLAG basecamp uploads show --in type=string
@@ -13932,12 +7357,10 @@ FLAG basecamp uploads show --todolist type=string
 FLAG basecamp uploads show --type type=string
 FLAG basecamp uploads show --vault type=string
 FLAG basecamp uploads show --verbose type=count
-FLAG basecamp uploads show --version type=bool
 FLAG basecamp url --account type=string
 FLAG basecamp url --agent type=bool
 FLAG basecamp url --cache-dir type=string
 FLAG basecamp url --count type=bool
-FLAG basecamp url --help type=bool
 FLAG basecamp url --hints type=bool
 FLAG basecamp url --ids-only type=bool
 FLAG basecamp url --in type=string
@@ -13954,12 +7377,10 @@ FLAG basecamp url --stats type=bool
 FLAG basecamp url --styled type=bool
 FLAG basecamp url --todolist type=string
 FLAG basecamp url --verbose type=count
-FLAG basecamp url --version type=bool
 FLAG basecamp url parse --account type=string
 FLAG basecamp url parse --agent type=bool
 FLAG basecamp url parse --cache-dir type=string
 FLAG basecamp url parse --count type=bool
-FLAG basecamp url parse --help type=bool
 FLAG basecamp url parse --hints type=bool
 FLAG basecamp url parse --ids-only type=bool
 FLAG basecamp url parse --in type=string
@@ -13976,926 +7397,11 @@ FLAG basecamp url parse --stats type=bool
 FLAG basecamp url parse --styled type=bool
 FLAG basecamp url parse --todolist type=string
 FLAG basecamp url parse --verbose type=count
-FLAG basecamp url parse --version type=bool
-FLAG basecamp vault --account type=string
-FLAG basecamp vault --agent type=bool
-FLAG basecamp vault --cache-dir type=string
-FLAG basecamp vault --count type=bool
-FLAG basecamp vault --folder type=string
-FLAG basecamp vault --help type=bool
-FLAG basecamp vault --hints type=bool
-FLAG basecamp vault --ids-only type=bool
-FLAG basecamp vault --in type=string
-FLAG basecamp vault --jq type=string
-FLAG basecamp vault --json type=bool
-FLAG basecamp vault --markdown type=bool
-FLAG basecamp vault --md type=bool
-FLAG basecamp vault --no-hints type=bool
-FLAG basecamp vault --no-stats type=bool
-FLAG basecamp vault --profile type=string
-FLAG basecamp vault --project type=string
-FLAG basecamp vault --quiet type=bool
-FLAG basecamp vault --stats type=bool
-FLAG basecamp vault --styled type=bool
-FLAG basecamp vault --todolist type=string
-FLAG basecamp vault --vault type=string
-FLAG basecamp vault --verbose type=count
-FLAG basecamp vault --version type=bool
-FLAG basecamp vault archive --account type=string
-FLAG basecamp vault archive --agent type=bool
-FLAG basecamp vault archive --cache-dir type=string
-FLAG basecamp vault archive --count type=bool
-FLAG basecamp vault archive --folder type=string
-FLAG basecamp vault archive --help type=bool
-FLAG basecamp vault archive --hints type=bool
-FLAG basecamp vault archive --ids-only type=bool
-FLAG basecamp vault archive --in type=string
-FLAG basecamp vault archive --jq type=string
-FLAG basecamp vault archive --json type=bool
-FLAG basecamp vault archive --markdown type=bool
-FLAG basecamp vault archive --md type=bool
-FLAG basecamp vault archive --no-hints type=bool
-FLAG basecamp vault archive --no-stats type=bool
-FLAG basecamp vault archive --profile type=string
-FLAG basecamp vault archive --project type=string
-FLAG basecamp vault archive --quiet type=bool
-FLAG basecamp vault archive --stats type=bool
-FLAG basecamp vault archive --styled type=bool
-FLAG basecamp vault archive --todolist type=string
-FLAG basecamp vault archive --vault type=string
-FLAG basecamp vault archive --verbose type=count
-FLAG basecamp vault archive --version type=bool
-FLAG basecamp vault doc --account type=string
-FLAG basecamp vault doc --agent type=bool
-FLAG basecamp vault doc --all type=bool
-FLAG basecamp vault doc --cache-dir type=string
-FLAG basecamp vault doc --count type=bool
-FLAG basecamp vault doc --folder type=string
-FLAG basecamp vault doc --help type=bool
-FLAG basecamp vault doc --hints type=bool
-FLAG basecamp vault doc --ids-only type=bool
-FLAG basecamp vault doc --in type=string
-FLAG basecamp vault doc --jq type=string
-FLAG basecamp vault doc --json type=bool
-FLAG basecamp vault doc --limit type=int
-FLAG basecamp vault doc --markdown type=bool
-FLAG basecamp vault doc --md type=bool
-FLAG basecamp vault doc --no-hints type=bool
-FLAG basecamp vault doc --no-stats type=bool
-FLAG basecamp vault doc --page type=int
-FLAG basecamp vault doc --profile type=string
-FLAG basecamp vault doc --project type=string
-FLAG basecamp vault doc --quiet type=bool
-FLAG basecamp vault doc --stats type=bool
-FLAG basecamp vault doc --styled type=bool
-FLAG basecamp vault doc --todolist type=string
-FLAG basecamp vault doc --vault type=string
-FLAG basecamp vault doc --verbose type=count
-FLAG basecamp vault doc --version type=bool
-FLAG basecamp vault doc create --account type=string
-FLAG basecamp vault doc create --agent type=bool
-FLAG basecamp vault doc create --attach type=stringArray
-FLAG basecamp vault doc create --cache-dir type=string
-FLAG basecamp vault doc create --count type=bool
-FLAG basecamp vault doc create --draft type=bool
-FLAG basecamp vault doc create --folder type=string
-FLAG basecamp vault doc create --help type=bool
-FLAG basecamp vault doc create --hints type=bool
-FLAG basecamp vault doc create --ids-only type=bool
-FLAG basecamp vault doc create --in type=string
-FLAG basecamp vault doc create --jq type=string
-FLAG basecamp vault doc create --json type=bool
-FLAG basecamp vault doc create --markdown type=bool
-FLAG basecamp vault doc create --md type=bool
-FLAG basecamp vault doc create --no-hints type=bool
-FLAG basecamp vault doc create --no-stats type=bool
-FLAG basecamp vault doc create --no-subscribe type=bool
-FLAG basecamp vault doc create --profile type=string
-FLAG basecamp vault doc create --project type=string
-FLAG basecamp vault doc create --quiet type=bool
-FLAG basecamp vault doc create --stats type=bool
-FLAG basecamp vault doc create --styled type=bool
-FLAG basecamp vault doc create --subscribe type=string
-FLAG basecamp vault doc create --todolist type=string
-FLAG basecamp vault doc create --vault type=string
-FLAG basecamp vault doc create --verbose type=count
-FLAG basecamp vault doc create --version type=bool
-FLAG basecamp vault doc list --account type=string
-FLAG basecamp vault doc list --agent type=bool
-FLAG basecamp vault doc list --all type=bool
-FLAG basecamp vault doc list --cache-dir type=string
-FLAG basecamp vault doc list --count type=bool
-FLAG basecamp vault doc list --folder type=string
-FLAG basecamp vault doc list --help type=bool
-FLAG basecamp vault doc list --hints type=bool
-FLAG basecamp vault doc list --ids-only type=bool
-FLAG basecamp vault doc list --in type=string
-FLAG basecamp vault doc list --jq type=string
-FLAG basecamp vault doc list --json type=bool
-FLAG basecamp vault doc list --limit type=int
-FLAG basecamp vault doc list --markdown type=bool
-FLAG basecamp vault doc list --md type=bool
-FLAG basecamp vault doc list --no-hints type=bool
-FLAG basecamp vault doc list --no-stats type=bool
-FLAG basecamp vault doc list --page type=int
-FLAG basecamp vault doc list --profile type=string
-FLAG basecamp vault doc list --project type=string
-FLAG basecamp vault doc list --quiet type=bool
-FLAG basecamp vault doc list --stats type=bool
-FLAG basecamp vault doc list --styled type=bool
-FLAG basecamp vault doc list --todolist type=string
-FLAG basecamp vault doc list --vault type=string
-FLAG basecamp vault doc list --verbose type=count
-FLAG basecamp vault doc list --version type=bool
-FLAG basecamp vault document --account type=string
-FLAG basecamp vault document --agent type=bool
-FLAG basecamp vault document --all type=bool
-FLAG basecamp vault document --cache-dir type=string
-FLAG basecamp vault document --count type=bool
-FLAG basecamp vault document --folder type=string
-FLAG basecamp vault document --help type=bool
-FLAG basecamp vault document --hints type=bool
-FLAG basecamp vault document --ids-only type=bool
-FLAG basecamp vault document --in type=string
-FLAG basecamp vault document --jq type=string
-FLAG basecamp vault document --json type=bool
-FLAG basecamp vault document --limit type=int
-FLAG basecamp vault document --markdown type=bool
-FLAG basecamp vault document --md type=bool
-FLAG basecamp vault document --no-hints type=bool
-FLAG basecamp vault document --no-stats type=bool
-FLAG basecamp vault document --page type=int
-FLAG basecamp vault document --profile type=string
-FLAG basecamp vault document --project type=string
-FLAG basecamp vault document --quiet type=bool
-FLAG basecamp vault document --stats type=bool
-FLAG basecamp vault document --styled type=bool
-FLAG basecamp vault document --todolist type=string
-FLAG basecamp vault document --vault type=string
-FLAG basecamp vault document --verbose type=count
-FLAG basecamp vault document --version type=bool
-FLAG basecamp vault document create --account type=string
-FLAG basecamp vault document create --agent type=bool
-FLAG basecamp vault document create --attach type=stringArray
-FLAG basecamp vault document create --cache-dir type=string
-FLAG basecamp vault document create --count type=bool
-FLAG basecamp vault document create --draft type=bool
-FLAG basecamp vault document create --folder type=string
-FLAG basecamp vault document create --help type=bool
-FLAG basecamp vault document create --hints type=bool
-FLAG basecamp vault document create --ids-only type=bool
-FLAG basecamp vault document create --in type=string
-FLAG basecamp vault document create --jq type=string
-FLAG basecamp vault document create --json type=bool
-FLAG basecamp vault document create --markdown type=bool
-FLAG basecamp vault document create --md type=bool
-FLAG basecamp vault document create --no-hints type=bool
-FLAG basecamp vault document create --no-stats type=bool
-FLAG basecamp vault document create --no-subscribe type=bool
-FLAG basecamp vault document create --profile type=string
-FLAG basecamp vault document create --project type=string
-FLAG basecamp vault document create --quiet type=bool
-FLAG basecamp vault document create --stats type=bool
-FLAG basecamp vault document create --styled type=bool
-FLAG basecamp vault document create --subscribe type=string
-FLAG basecamp vault document create --todolist type=string
-FLAG basecamp vault document create --vault type=string
-FLAG basecamp vault document create --verbose type=count
-FLAG basecamp vault document create --version type=bool
-FLAG basecamp vault document list --account type=string
-FLAG basecamp vault document list --agent type=bool
-FLAG basecamp vault document list --all type=bool
-FLAG basecamp vault document list --cache-dir type=string
-FLAG basecamp vault document list --count type=bool
-FLAG basecamp vault document list --folder type=string
-FLAG basecamp vault document list --help type=bool
-FLAG basecamp vault document list --hints type=bool
-FLAG basecamp vault document list --ids-only type=bool
-FLAG basecamp vault document list --in type=string
-FLAG basecamp vault document list --jq type=string
-FLAG basecamp vault document list --json type=bool
-FLAG basecamp vault document list --limit type=int
-FLAG basecamp vault document list --markdown type=bool
-FLAG basecamp vault document list --md type=bool
-FLAG basecamp vault document list --no-hints type=bool
-FLAG basecamp vault document list --no-stats type=bool
-FLAG basecamp vault document list --page type=int
-FLAG basecamp vault document list --profile type=string
-FLAG basecamp vault document list --project type=string
-FLAG basecamp vault document list --quiet type=bool
-FLAG basecamp vault document list --stats type=bool
-FLAG basecamp vault document list --styled type=bool
-FLAG basecamp vault document list --todolist type=string
-FLAG basecamp vault document list --vault type=string
-FLAG basecamp vault document list --verbose type=count
-FLAG basecamp vault document list --version type=bool
-FLAG basecamp vault documents --account type=string
-FLAG basecamp vault documents --agent type=bool
-FLAG basecamp vault documents --all type=bool
-FLAG basecamp vault documents --cache-dir type=string
-FLAG basecamp vault documents --count type=bool
-FLAG basecamp vault documents --folder type=string
-FLAG basecamp vault documents --help type=bool
-FLAG basecamp vault documents --hints type=bool
-FLAG basecamp vault documents --ids-only type=bool
-FLAG basecamp vault documents --in type=string
-FLAG basecamp vault documents --jq type=string
-FLAG basecamp vault documents --json type=bool
-FLAG basecamp vault documents --limit type=int
-FLAG basecamp vault documents --markdown type=bool
-FLAG basecamp vault documents --md type=bool
-FLAG basecamp vault documents --no-hints type=bool
-FLAG basecamp vault documents --no-stats type=bool
-FLAG basecamp vault documents --page type=int
-FLAG basecamp vault documents --profile type=string
-FLAG basecamp vault documents --project type=string
-FLAG basecamp vault documents --quiet type=bool
-FLAG basecamp vault documents --stats type=bool
-FLAG basecamp vault documents --styled type=bool
-FLAG basecamp vault documents --todolist type=string
-FLAG basecamp vault documents --vault type=string
-FLAG basecamp vault documents --verbose type=count
-FLAG basecamp vault documents --version type=bool
-FLAG basecamp vault documents create --account type=string
-FLAG basecamp vault documents create --agent type=bool
-FLAG basecamp vault documents create --attach type=stringArray
-FLAG basecamp vault documents create --cache-dir type=string
-FLAG basecamp vault documents create --count type=bool
-FLAG basecamp vault documents create --draft type=bool
-FLAG basecamp vault documents create --folder type=string
-FLAG basecamp vault documents create --help type=bool
-FLAG basecamp vault documents create --hints type=bool
-FLAG basecamp vault documents create --ids-only type=bool
-FLAG basecamp vault documents create --in type=string
-FLAG basecamp vault documents create --jq type=string
-FLAG basecamp vault documents create --json type=bool
-FLAG basecamp vault documents create --markdown type=bool
-FLAG basecamp vault documents create --md type=bool
-FLAG basecamp vault documents create --no-hints type=bool
-FLAG basecamp vault documents create --no-stats type=bool
-FLAG basecamp vault documents create --no-subscribe type=bool
-FLAG basecamp vault documents create --profile type=string
-FLAG basecamp vault documents create --project type=string
-FLAG basecamp vault documents create --quiet type=bool
-FLAG basecamp vault documents create --stats type=bool
-FLAG basecamp vault documents create --styled type=bool
-FLAG basecamp vault documents create --subscribe type=string
-FLAG basecamp vault documents create --todolist type=string
-FLAG basecamp vault documents create --vault type=string
-FLAG basecamp vault documents create --verbose type=count
-FLAG basecamp vault documents create --version type=bool
-FLAG basecamp vault documents list --account type=string
-FLAG basecamp vault documents list --agent type=bool
-FLAG basecamp vault documents list --all type=bool
-FLAG basecamp vault documents list --cache-dir type=string
-FLAG basecamp vault documents list --count type=bool
-FLAG basecamp vault documents list --folder type=string
-FLAG basecamp vault documents list --help type=bool
-FLAG basecamp vault documents list --hints type=bool
-FLAG basecamp vault documents list --ids-only type=bool
-FLAG basecamp vault documents list --in type=string
-FLAG basecamp vault documents list --jq type=string
-FLAG basecamp vault documents list --json type=bool
-FLAG basecamp vault documents list --limit type=int
-FLAG basecamp vault documents list --markdown type=bool
-FLAG basecamp vault documents list --md type=bool
-FLAG basecamp vault documents list --no-hints type=bool
-FLAG basecamp vault documents list --no-stats type=bool
-FLAG basecamp vault documents list --page type=int
-FLAG basecamp vault documents list --profile type=string
-FLAG basecamp vault documents list --project type=string
-FLAG basecamp vault documents list --quiet type=bool
-FLAG basecamp vault documents list --stats type=bool
-FLAG basecamp vault documents list --styled type=bool
-FLAG basecamp vault documents list --todolist type=string
-FLAG basecamp vault documents list --vault type=string
-FLAG basecamp vault documents list --verbose type=count
-FLAG basecamp vault documents list --version type=bool
-FLAG basecamp vault download --account type=string
-FLAG basecamp vault download --agent type=bool
-FLAG basecamp vault download --cache-dir type=string
-FLAG basecamp vault download --count type=bool
-FLAG basecamp vault download --folder type=string
-FLAG basecamp vault download --help type=bool
-FLAG basecamp vault download --hints type=bool
-FLAG basecamp vault download --ids-only type=bool
-FLAG basecamp vault download --in type=string
-FLAG basecamp vault download --jq type=string
-FLAG basecamp vault download --json type=bool
-FLAG basecamp vault download --markdown type=bool
-FLAG basecamp vault download --md type=bool
-FLAG basecamp vault download --no-hints type=bool
-FLAG basecamp vault download --no-stats type=bool
-FLAG basecamp vault download --out type=string
-FLAG basecamp vault download --profile type=string
-FLAG basecamp vault download --project type=string
-FLAG basecamp vault download --quiet type=bool
-FLAG basecamp vault download --stats type=bool
-FLAG basecamp vault download --styled type=bool
-FLAG basecamp vault download --todolist type=string
-FLAG basecamp vault download --vault type=string
-FLAG basecamp vault download --verbose type=count
-FLAG basecamp vault download --version type=bool
-FLAG basecamp vault folder --account type=string
-FLAG basecamp vault folder --agent type=bool
-FLAG basecamp vault folder --all type=bool
-FLAG basecamp vault folder --cache-dir type=string
-FLAG basecamp vault folder --count type=bool
-FLAG basecamp vault folder --folder type=string
-FLAG basecamp vault folder --help type=bool
-FLAG basecamp vault folder --hints type=bool
-FLAG basecamp vault folder --ids-only type=bool
-FLAG basecamp vault folder --in type=string
-FLAG basecamp vault folder --jq type=string
-FLAG basecamp vault folder --json type=bool
-FLAG basecamp vault folder --limit type=int
-FLAG basecamp vault folder --markdown type=bool
-FLAG basecamp vault folder --md type=bool
-FLAG basecamp vault folder --no-hints type=bool
-FLAG basecamp vault folder --no-stats type=bool
-FLAG basecamp vault folder --page type=int
-FLAG basecamp vault folder --profile type=string
-FLAG basecamp vault folder --project type=string
-FLAG basecamp vault folder --quiet type=bool
-FLAG basecamp vault folder --stats type=bool
-FLAG basecamp vault folder --styled type=bool
-FLAG basecamp vault folder --todolist type=string
-FLAG basecamp vault folder --vault type=string
-FLAG basecamp vault folder --verbose type=count
-FLAG basecamp vault folder --version type=bool
-FLAG basecamp vault folder create --account type=string
-FLAG basecamp vault folder create --agent type=bool
-FLAG basecamp vault folder create --cache-dir type=string
-FLAG basecamp vault folder create --count type=bool
-FLAG basecamp vault folder create --folder type=string
-FLAG basecamp vault folder create --help type=bool
-FLAG basecamp vault folder create --hints type=bool
-FLAG basecamp vault folder create --ids-only type=bool
-FLAG basecamp vault folder create --in type=string
-FLAG basecamp vault folder create --jq type=string
-FLAG basecamp vault folder create --json type=bool
-FLAG basecamp vault folder create --markdown type=bool
-FLAG basecamp vault folder create --md type=bool
-FLAG basecamp vault folder create --no-hints type=bool
-FLAG basecamp vault folder create --no-stats type=bool
-FLAG basecamp vault folder create --profile type=string
-FLAG basecamp vault folder create --project type=string
-FLAG basecamp vault folder create --quiet type=bool
-FLAG basecamp vault folder create --stats type=bool
-FLAG basecamp vault folder create --styled type=bool
-FLAG basecamp vault folder create --todolist type=string
-FLAG basecamp vault folder create --vault type=string
-FLAG basecamp vault folder create --verbose type=count
-FLAG basecamp vault folder create --version type=bool
-FLAG basecamp vault folder list --account type=string
-FLAG basecamp vault folder list --agent type=bool
-FLAG basecamp vault folder list --all type=bool
-FLAG basecamp vault folder list --cache-dir type=string
-FLAG basecamp vault folder list --count type=bool
-FLAG basecamp vault folder list --folder type=string
-FLAG basecamp vault folder list --help type=bool
-FLAG basecamp vault folder list --hints type=bool
-FLAG basecamp vault folder list --ids-only type=bool
-FLAG basecamp vault folder list --in type=string
-FLAG basecamp vault folder list --jq type=string
-FLAG basecamp vault folder list --json type=bool
-FLAG basecamp vault folder list --limit type=int
-FLAG basecamp vault folder list --markdown type=bool
-FLAG basecamp vault folder list --md type=bool
-FLAG basecamp vault folder list --no-hints type=bool
-FLAG basecamp vault folder list --no-stats type=bool
-FLAG basecamp vault folder list --page type=int
-FLAG basecamp vault folder list --profile type=string
-FLAG basecamp vault folder list --project type=string
-FLAG basecamp vault folder list --quiet type=bool
-FLAG basecamp vault folder list --stats type=bool
-FLAG basecamp vault folder list --styled type=bool
-FLAG basecamp vault folder list --todolist type=string
-FLAG basecamp vault folder list --vault type=string
-FLAG basecamp vault folder list --verbose type=count
-FLAG basecamp vault folder list --version type=bool
-FLAG basecamp vault folders --account type=string
-FLAG basecamp vault folders --agent type=bool
-FLAG basecamp vault folders --all type=bool
-FLAG basecamp vault folders --cache-dir type=string
-FLAG basecamp vault folders --count type=bool
-FLAG basecamp vault folders --folder type=string
-FLAG basecamp vault folders --help type=bool
-FLAG basecamp vault folders --hints type=bool
-FLAG basecamp vault folders --ids-only type=bool
-FLAG basecamp vault folders --in type=string
-FLAG basecamp vault folders --jq type=string
-FLAG basecamp vault folders --json type=bool
-FLAG basecamp vault folders --limit type=int
-FLAG basecamp vault folders --markdown type=bool
-FLAG basecamp vault folders --md type=bool
-FLAG basecamp vault folders --no-hints type=bool
-FLAG basecamp vault folders --no-stats type=bool
-FLAG basecamp vault folders --page type=int
-FLAG basecamp vault folders --profile type=string
-FLAG basecamp vault folders --project type=string
-FLAG basecamp vault folders --quiet type=bool
-FLAG basecamp vault folders --stats type=bool
-FLAG basecamp vault folders --styled type=bool
-FLAG basecamp vault folders --todolist type=string
-FLAG basecamp vault folders --vault type=string
-FLAG basecamp vault folders --verbose type=count
-FLAG basecamp vault folders --version type=bool
-FLAG basecamp vault folders create --account type=string
-FLAG basecamp vault folders create --agent type=bool
-FLAG basecamp vault folders create --cache-dir type=string
-FLAG basecamp vault folders create --count type=bool
-FLAG basecamp vault folders create --folder type=string
-FLAG basecamp vault folders create --help type=bool
-FLAG basecamp vault folders create --hints type=bool
-FLAG basecamp vault folders create --ids-only type=bool
-FLAG basecamp vault folders create --in type=string
-FLAG basecamp vault folders create --jq type=string
-FLAG basecamp vault folders create --json type=bool
-FLAG basecamp vault folders create --markdown type=bool
-FLAG basecamp vault folders create --md type=bool
-FLAG basecamp vault folders create --no-hints type=bool
-FLAG basecamp vault folders create --no-stats type=bool
-FLAG basecamp vault folders create --profile type=string
-FLAG basecamp vault folders create --project type=string
-FLAG basecamp vault folders create --quiet type=bool
-FLAG basecamp vault folders create --stats type=bool
-FLAG basecamp vault folders create --styled type=bool
-FLAG basecamp vault folders create --todolist type=string
-FLAG basecamp vault folders create --vault type=string
-FLAG basecamp vault folders create --verbose type=count
-FLAG basecamp vault folders create --version type=bool
-FLAG basecamp vault folders list --account type=string
-FLAG basecamp vault folders list --agent type=bool
-FLAG basecamp vault folders list --all type=bool
-FLAG basecamp vault folders list --cache-dir type=string
-FLAG basecamp vault folders list --count type=bool
-FLAG basecamp vault folders list --folder type=string
-FLAG basecamp vault folders list --help type=bool
-FLAG basecamp vault folders list --hints type=bool
-FLAG basecamp vault folders list --ids-only type=bool
-FLAG basecamp vault folders list --in type=string
-FLAG basecamp vault folders list --jq type=string
-FLAG basecamp vault folders list --json type=bool
-FLAG basecamp vault folders list --limit type=int
-FLAG basecamp vault folders list --markdown type=bool
-FLAG basecamp vault folders list --md type=bool
-FLAG basecamp vault folders list --no-hints type=bool
-FLAG basecamp vault folders list --no-stats type=bool
-FLAG basecamp vault folders list --page type=int
-FLAG basecamp vault folders list --profile type=string
-FLAG basecamp vault folders list --project type=string
-FLAG basecamp vault folders list --quiet type=bool
-FLAG basecamp vault folders list --stats type=bool
-FLAG basecamp vault folders list --styled type=bool
-FLAG basecamp vault folders list --todolist type=string
-FLAG basecamp vault folders list --vault type=string
-FLAG basecamp vault folders list --verbose type=count
-FLAG basecamp vault folders list --version type=bool
-FLAG basecamp vault list --account type=string
-FLAG basecamp vault list --agent type=bool
-FLAG basecamp vault list --cache-dir type=string
-FLAG basecamp vault list --count type=bool
-FLAG basecamp vault list --folder type=string
-FLAG basecamp vault list --help type=bool
-FLAG basecamp vault list --hints type=bool
-FLAG basecamp vault list --ids-only type=bool
-FLAG basecamp vault list --in type=string
-FLAG basecamp vault list --jq type=string
-FLAG basecamp vault list --json type=bool
-FLAG basecamp vault list --markdown type=bool
-FLAG basecamp vault list --md type=bool
-FLAG basecamp vault list --no-hints type=bool
-FLAG basecamp vault list --no-stats type=bool
-FLAG basecamp vault list --profile type=string
-FLAG basecamp vault list --project type=string
-FLAG basecamp vault list --quiet type=bool
-FLAG basecamp vault list --stats type=bool
-FLAG basecamp vault list --styled type=bool
-FLAG basecamp vault list --todolist type=string
-FLAG basecamp vault list --vault type=string
-FLAG basecamp vault list --verbose type=count
-FLAG basecamp vault list --version type=bool
-FLAG basecamp vault restore --account type=string
-FLAG basecamp vault restore --agent type=bool
-FLAG basecamp vault restore --cache-dir type=string
-FLAG basecamp vault restore --count type=bool
-FLAG basecamp vault restore --folder type=string
-FLAG basecamp vault restore --help type=bool
-FLAG basecamp vault restore --hints type=bool
-FLAG basecamp vault restore --ids-only type=bool
-FLAG basecamp vault restore --in type=string
-FLAG basecamp vault restore --jq type=string
-FLAG basecamp vault restore --json type=bool
-FLAG basecamp vault restore --markdown type=bool
-FLAG basecamp vault restore --md type=bool
-FLAG basecamp vault restore --no-hints type=bool
-FLAG basecamp vault restore --no-stats type=bool
-FLAG basecamp vault restore --profile type=string
-FLAG basecamp vault restore --project type=string
-FLAG basecamp vault restore --quiet type=bool
-FLAG basecamp vault restore --stats type=bool
-FLAG basecamp vault restore --styled type=bool
-FLAG basecamp vault restore --todolist type=string
-FLAG basecamp vault restore --vault type=string
-FLAG basecamp vault restore --verbose type=count
-FLAG basecamp vault restore --version type=bool
-FLAG basecamp vault show --account type=string
-FLAG basecamp vault show --agent type=bool
-FLAG basecamp vault show --cache-dir type=string
-FLAG basecamp vault show --count type=bool
-FLAG basecamp vault show --folder type=string
-FLAG basecamp vault show --help type=bool
-FLAG basecamp vault show --hints type=bool
-FLAG basecamp vault show --ids-only type=bool
-FLAG basecamp vault show --in type=string
-FLAG basecamp vault show --jq type=string
-FLAG basecamp vault show --json type=bool
-FLAG basecamp vault show --markdown type=bool
-FLAG basecamp vault show --md type=bool
-FLAG basecamp vault show --no-hints type=bool
-FLAG basecamp vault show --no-stats type=bool
-FLAG basecamp vault show --profile type=string
-FLAG basecamp vault show --project type=string
-FLAG basecamp vault show --quiet type=bool
-FLAG basecamp vault show --stats type=bool
-FLAG basecamp vault show --styled type=bool
-FLAG basecamp vault show --todolist type=string
-FLAG basecamp vault show --type type=string
-FLAG basecamp vault show --vault type=string
-FLAG basecamp vault show --verbose type=count
-FLAG basecamp vault show --version type=bool
-FLAG basecamp vault trash --account type=string
-FLAG basecamp vault trash --agent type=bool
-FLAG basecamp vault trash --cache-dir type=string
-FLAG basecamp vault trash --count type=bool
-FLAG basecamp vault trash --folder type=string
-FLAG basecamp vault trash --help type=bool
-FLAG basecamp vault trash --hints type=bool
-FLAG basecamp vault trash --ids-only type=bool
-FLAG basecamp vault trash --in type=string
-FLAG basecamp vault trash --jq type=string
-FLAG basecamp vault trash --json type=bool
-FLAG basecamp vault trash --markdown type=bool
-FLAG basecamp vault trash --md type=bool
-FLAG basecamp vault trash --no-hints type=bool
-FLAG basecamp vault trash --no-stats type=bool
-FLAG basecamp vault trash --profile type=string
-FLAG basecamp vault trash --project type=string
-FLAG basecamp vault trash --quiet type=bool
-FLAG basecamp vault trash --stats type=bool
-FLAG basecamp vault trash --styled type=bool
-FLAG basecamp vault trash --todolist type=string
-FLAG basecamp vault trash --vault type=string
-FLAG basecamp vault trash --verbose type=count
-FLAG basecamp vault trash --version type=bool
-FLAG basecamp vault update --account type=string
-FLAG basecamp vault update --agent type=bool
-FLAG basecamp vault update --cache-dir type=string
-FLAG basecamp vault update --content type=string
-FLAG basecamp vault update --count type=bool
-FLAG basecamp vault update --folder type=string
-FLAG basecamp vault update --help type=bool
-FLAG basecamp vault update --hints type=bool
-FLAG basecamp vault update --ids-only type=bool
-FLAG basecamp vault update --in type=string
-FLAG basecamp vault update --jq type=string
-FLAG basecamp vault update --json type=bool
-FLAG basecamp vault update --markdown type=bool
-FLAG basecamp vault update --md type=bool
-FLAG basecamp vault update --no-hints type=bool
-FLAG basecamp vault update --no-stats type=bool
-FLAG basecamp vault update --profile type=string
-FLAG basecamp vault update --project type=string
-FLAG basecamp vault update --quiet type=bool
-FLAG basecamp vault update --stats type=bool
-FLAG basecamp vault update --styled type=bool
-FLAG basecamp vault update --title type=string
-FLAG basecamp vault update --todolist type=string
-FLAG basecamp vault update --type type=string
-FLAG basecamp vault update --vault type=string
-FLAG basecamp vault update --verbose type=count
-FLAG basecamp vault update --version type=bool
-FLAG basecamp vault upload --account type=string
-FLAG basecamp vault upload --agent type=bool
-FLAG basecamp vault upload --all type=bool
-FLAG basecamp vault upload --cache-dir type=string
-FLAG basecamp vault upload --count type=bool
-FLAG basecamp vault upload --folder type=string
-FLAG basecamp vault upload --help type=bool
-FLAG basecamp vault upload --hints type=bool
-FLAG basecamp vault upload --ids-only type=bool
-FLAG basecamp vault upload --in type=string
-FLAG basecamp vault upload --jq type=string
-FLAG basecamp vault upload --json type=bool
-FLAG basecamp vault upload --limit type=int
-FLAG basecamp vault upload --markdown type=bool
-FLAG basecamp vault upload --md type=bool
-FLAG basecamp vault upload --no-hints type=bool
-FLAG basecamp vault upload --no-stats type=bool
-FLAG basecamp vault upload --page type=int
-FLAG basecamp vault upload --profile type=string
-FLAG basecamp vault upload --project type=string
-FLAG basecamp vault upload --quiet type=bool
-FLAG basecamp vault upload --stats type=bool
-FLAG basecamp vault upload --styled type=bool
-FLAG basecamp vault upload --todolist type=string
-FLAG basecamp vault upload --vault type=string
-FLAG basecamp vault upload --verbose type=count
-FLAG basecamp vault upload --version type=bool
-FLAG basecamp vault upload create --account type=string
-FLAG basecamp vault upload create --agent type=bool
-FLAG basecamp vault upload create --cache-dir type=string
-FLAG basecamp vault upload create --count type=bool
-FLAG basecamp vault upload create --description type=string
-FLAG basecamp vault upload create --folder type=string
-FLAG basecamp vault upload create --help type=bool
-FLAG basecamp vault upload create --hints type=bool
-FLAG basecamp vault upload create --ids-only type=bool
-FLAG basecamp vault upload create --in type=string
-FLAG basecamp vault upload create --jq type=string
-FLAG basecamp vault upload create --json type=bool
-FLAG basecamp vault upload create --markdown type=bool
-FLAG basecamp vault upload create --md type=bool
-FLAG basecamp vault upload create --no-hints type=bool
-FLAG basecamp vault upload create --no-stats type=bool
-FLAG basecamp vault upload create --profile type=string
-FLAG basecamp vault upload create --project type=string
-FLAG basecamp vault upload create --quiet type=bool
-FLAG basecamp vault upload create --stats type=bool
-FLAG basecamp vault upload create --styled type=bool
-FLAG basecamp vault upload create --todolist type=string
-FLAG basecamp vault upload create --vault type=string
-FLAG basecamp vault upload create --verbose type=count
-FLAG basecamp vault upload create --version type=bool
-FLAG basecamp vault upload list --account type=string
-FLAG basecamp vault upload list --agent type=bool
-FLAG basecamp vault upload list --all type=bool
-FLAG basecamp vault upload list --cache-dir type=string
-FLAG basecamp vault upload list --count type=bool
-FLAG basecamp vault upload list --folder type=string
-FLAG basecamp vault upload list --help type=bool
-FLAG basecamp vault upload list --hints type=bool
-FLAG basecamp vault upload list --ids-only type=bool
-FLAG basecamp vault upload list --in type=string
-FLAG basecamp vault upload list --jq type=string
-FLAG basecamp vault upload list --json type=bool
-FLAG basecamp vault upload list --limit type=int
-FLAG basecamp vault upload list --markdown type=bool
-FLAG basecamp vault upload list --md type=bool
-FLAG basecamp vault upload list --no-hints type=bool
-FLAG basecamp vault upload list --no-stats type=bool
-FLAG basecamp vault upload list --page type=int
-FLAG basecamp vault upload list --profile type=string
-FLAG basecamp vault upload list --project type=string
-FLAG basecamp vault upload list --quiet type=bool
-FLAG basecamp vault upload list --stats type=bool
-FLAG basecamp vault upload list --styled type=bool
-FLAG basecamp vault upload list --todolist type=string
-FLAG basecamp vault upload list --vault type=string
-FLAG basecamp vault upload list --verbose type=count
-FLAG basecamp vault upload list --version type=bool
-FLAG basecamp vault uploads --account type=string
-FLAG basecamp vault uploads --agent type=bool
-FLAG basecamp vault uploads --all type=bool
-FLAG basecamp vault uploads --cache-dir type=string
-FLAG basecamp vault uploads --count type=bool
-FLAG basecamp vault uploads --folder type=string
-FLAG basecamp vault uploads --help type=bool
-FLAG basecamp vault uploads --hints type=bool
-FLAG basecamp vault uploads --ids-only type=bool
-FLAG basecamp vault uploads --in type=string
-FLAG basecamp vault uploads --jq type=string
-FLAG basecamp vault uploads --json type=bool
-FLAG basecamp vault uploads --limit type=int
-FLAG basecamp vault uploads --markdown type=bool
-FLAG basecamp vault uploads --md type=bool
-FLAG basecamp vault uploads --no-hints type=bool
-FLAG basecamp vault uploads --no-stats type=bool
-FLAG basecamp vault uploads --page type=int
-FLAG basecamp vault uploads --profile type=string
-FLAG basecamp vault uploads --project type=string
-FLAG basecamp vault uploads --quiet type=bool
-FLAG basecamp vault uploads --stats type=bool
-FLAG basecamp vault uploads --styled type=bool
-FLAG basecamp vault uploads --todolist type=string
-FLAG basecamp vault uploads --vault type=string
-FLAG basecamp vault uploads --verbose type=count
-FLAG basecamp vault uploads --version type=bool
-FLAG basecamp vault uploads create --account type=string
-FLAG basecamp vault uploads create --agent type=bool
-FLAG basecamp vault uploads create --cache-dir type=string
-FLAG basecamp vault uploads create --count type=bool
-FLAG basecamp vault uploads create --description type=string
-FLAG basecamp vault uploads create --folder type=string
-FLAG basecamp vault uploads create --help type=bool
-FLAG basecamp vault uploads create --hints type=bool
-FLAG basecamp vault uploads create --ids-only type=bool
-FLAG basecamp vault uploads create --in type=string
-FLAG basecamp vault uploads create --jq type=string
-FLAG basecamp vault uploads create --json type=bool
-FLAG basecamp vault uploads create --markdown type=bool
-FLAG basecamp vault uploads create --md type=bool
-FLAG basecamp vault uploads create --no-hints type=bool
-FLAG basecamp vault uploads create --no-stats type=bool
-FLAG basecamp vault uploads create --profile type=string
-FLAG basecamp vault uploads create --project type=string
-FLAG basecamp vault uploads create --quiet type=bool
-FLAG basecamp vault uploads create --stats type=bool
-FLAG basecamp vault uploads create --styled type=bool
-FLAG basecamp vault uploads create --todolist type=string
-FLAG basecamp vault uploads create --vault type=string
-FLAG basecamp vault uploads create --verbose type=count
-FLAG basecamp vault uploads create --version type=bool
-FLAG basecamp vault uploads list --account type=string
-FLAG basecamp vault uploads list --agent type=bool
-FLAG basecamp vault uploads list --all type=bool
-FLAG basecamp vault uploads list --cache-dir type=string
-FLAG basecamp vault uploads list --count type=bool
-FLAG basecamp vault uploads list --folder type=string
-FLAG basecamp vault uploads list --help type=bool
-FLAG basecamp vault uploads list --hints type=bool
-FLAG basecamp vault uploads list --ids-only type=bool
-FLAG basecamp vault uploads list --in type=string
-FLAG basecamp vault uploads list --jq type=string
-FLAG basecamp vault uploads list --json type=bool
-FLAG basecamp vault uploads list --limit type=int
-FLAG basecamp vault uploads list --markdown type=bool
-FLAG basecamp vault uploads list --md type=bool
-FLAG basecamp vault uploads list --no-hints type=bool
-FLAG basecamp vault uploads list --no-stats type=bool
-FLAG basecamp vault uploads list --page type=int
-FLAG basecamp vault uploads list --profile type=string
-FLAG basecamp vault uploads list --project type=string
-FLAG basecamp vault uploads list --quiet type=bool
-FLAG basecamp vault uploads list --stats type=bool
-FLAG basecamp vault uploads list --styled type=bool
-FLAG basecamp vault uploads list --todolist type=string
-FLAG basecamp vault uploads list --vault type=string
-FLAG basecamp vault uploads list --verbose type=count
-FLAG basecamp vault uploads list --version type=bool
-FLAG basecamp vault vault --account type=string
-FLAG basecamp vault vault --agent type=bool
-FLAG basecamp vault vault --all type=bool
-FLAG basecamp vault vault --cache-dir type=string
-FLAG basecamp vault vault --count type=bool
-FLAG basecamp vault vault --folder type=string
-FLAG basecamp vault vault --help type=bool
-FLAG basecamp vault vault --hints type=bool
-FLAG basecamp vault vault --ids-only type=bool
-FLAG basecamp vault vault --in type=string
-FLAG basecamp vault vault --jq type=string
-FLAG basecamp vault vault --json type=bool
-FLAG basecamp vault vault --limit type=int
-FLAG basecamp vault vault --markdown type=bool
-FLAG basecamp vault vault --md type=bool
-FLAG basecamp vault vault --no-hints type=bool
-FLAG basecamp vault vault --no-stats type=bool
-FLAG basecamp vault vault --page type=int
-FLAG basecamp vault vault --profile type=string
-FLAG basecamp vault vault --project type=string
-FLAG basecamp vault vault --quiet type=bool
-FLAG basecamp vault vault --stats type=bool
-FLAG basecamp vault vault --styled type=bool
-FLAG basecamp vault vault --todolist type=string
-FLAG basecamp vault vault --vault type=string
-FLAG basecamp vault vault --verbose type=count
-FLAG basecamp vault vault --version type=bool
-FLAG basecamp vault vault create --account type=string
-FLAG basecamp vault vault create --agent type=bool
-FLAG basecamp vault vault create --cache-dir type=string
-FLAG basecamp vault vault create --count type=bool
-FLAG basecamp vault vault create --folder type=string
-FLAG basecamp vault vault create --help type=bool
-FLAG basecamp vault vault create --hints type=bool
-FLAG basecamp vault vault create --ids-only type=bool
-FLAG basecamp vault vault create --in type=string
-FLAG basecamp vault vault create --jq type=string
-FLAG basecamp vault vault create --json type=bool
-FLAG basecamp vault vault create --markdown type=bool
-FLAG basecamp vault vault create --md type=bool
-FLAG basecamp vault vault create --no-hints type=bool
-FLAG basecamp vault vault create --no-stats type=bool
-FLAG basecamp vault vault create --profile type=string
-FLAG basecamp vault vault create --project type=string
-FLAG basecamp vault vault create --quiet type=bool
-FLAG basecamp vault vault create --stats type=bool
-FLAG basecamp vault vault create --styled type=bool
-FLAG basecamp vault vault create --todolist type=string
-FLAG basecamp vault vault create --vault type=string
-FLAG basecamp vault vault create --verbose type=count
-FLAG basecamp vault vault create --version type=bool
-FLAG basecamp vault vault list --account type=string
-FLAG basecamp vault vault list --agent type=bool
-FLAG basecamp vault vault list --all type=bool
-FLAG basecamp vault vault list --cache-dir type=string
-FLAG basecamp vault vault list --count type=bool
-FLAG basecamp vault vault list --folder type=string
-FLAG basecamp vault vault list --help type=bool
-FLAG basecamp vault vault list --hints type=bool
-FLAG basecamp vault vault list --ids-only type=bool
-FLAG basecamp vault vault list --in type=string
-FLAG basecamp vault vault list --jq type=string
-FLAG basecamp vault vault list --json type=bool
-FLAG basecamp vault vault list --limit type=int
-FLAG basecamp vault vault list --markdown type=bool
-FLAG basecamp vault vault list --md type=bool
-FLAG basecamp vault vault list --no-hints type=bool
-FLAG basecamp vault vault list --no-stats type=bool
-FLAG basecamp vault vault list --page type=int
-FLAG basecamp vault vault list --profile type=string
-FLAG basecamp vault vault list --project type=string
-FLAG basecamp vault vault list --quiet type=bool
-FLAG basecamp vault vault list --stats type=bool
-FLAG basecamp vault vault list --styled type=bool
-FLAG basecamp vault vault list --todolist type=string
-FLAG basecamp vault vault list --vault type=string
-FLAG basecamp vault vault list --verbose type=count
-FLAG basecamp vault vault list --version type=bool
-FLAG basecamp vault vaults --account type=string
-FLAG basecamp vault vaults --agent type=bool
-FLAG basecamp vault vaults --all type=bool
-FLAG basecamp vault vaults --cache-dir type=string
-FLAG basecamp vault vaults --count type=bool
-FLAG basecamp vault vaults --folder type=string
-FLAG basecamp vault vaults --help type=bool
-FLAG basecamp vault vaults --hints type=bool
-FLAG basecamp vault vaults --ids-only type=bool
-FLAG basecamp vault vaults --in type=string
-FLAG basecamp vault vaults --jq type=string
-FLAG basecamp vault vaults --json type=bool
-FLAG basecamp vault vaults --limit type=int
-FLAG basecamp vault vaults --markdown type=bool
-FLAG basecamp vault vaults --md type=bool
-FLAG basecamp vault vaults --no-hints type=bool
-FLAG basecamp vault vaults --no-stats type=bool
-FLAG basecamp vault vaults --page type=int
-FLAG basecamp vault vaults --profile type=string
-FLAG basecamp vault vaults --project type=string
-FLAG basecamp vault vaults --quiet type=bool
-FLAG basecamp vault vaults --stats type=bool
-FLAG basecamp vault vaults --styled type=bool
-FLAG basecamp vault vaults --todolist type=string
-FLAG basecamp vault vaults --vault type=string
-FLAG basecamp vault vaults --verbose type=count
-FLAG basecamp vault vaults --version type=bool
-FLAG basecamp vault vaults create --account type=string
-FLAG basecamp vault vaults create --agent type=bool
-FLAG basecamp vault vaults create --cache-dir type=string
-FLAG basecamp vault vaults create --count type=bool
-FLAG basecamp vault vaults create --folder type=string
-FLAG basecamp vault vaults create --help type=bool
-FLAG basecamp vault vaults create --hints type=bool
-FLAG basecamp vault vaults create --ids-only type=bool
-FLAG basecamp vault vaults create --in type=string
-FLAG basecamp vault vaults create --jq type=string
-FLAG basecamp vault vaults create --json type=bool
-FLAG basecamp vault vaults create --markdown type=bool
-FLAG basecamp vault vaults create --md type=bool
-FLAG basecamp vault vaults create --no-hints type=bool
-FLAG basecamp vault vaults create --no-stats type=bool
-FLAG basecamp vault vaults create --profile type=string
-FLAG basecamp vault vaults create --project type=string
-FLAG basecamp vault vaults create --quiet type=bool
-FLAG basecamp vault vaults create --stats type=bool
-FLAG basecamp vault vaults create --styled type=bool
-FLAG basecamp vault vaults create --todolist type=string
-FLAG basecamp vault vaults create --vault type=string
-FLAG basecamp vault vaults create --verbose type=count
-FLAG basecamp vault vaults create --version type=bool
-FLAG basecamp vault vaults list --account type=string
-FLAG basecamp vault vaults list --agent type=bool
-FLAG basecamp vault vaults list --all type=bool
-FLAG basecamp vault vaults list --cache-dir type=string
-FLAG basecamp vault vaults list --count type=bool
-FLAG basecamp vault vaults list --folder type=string
-FLAG basecamp vault vaults list --help type=bool
-FLAG basecamp vault vaults list --hints type=bool
-FLAG basecamp vault vaults list --ids-only type=bool
-FLAG basecamp vault vaults list --in type=string
-FLAG basecamp vault vaults list --jq type=string
-FLAG basecamp vault vaults list --json type=bool
-FLAG basecamp vault vaults list --limit type=int
-FLAG basecamp vault vaults list --markdown type=bool
-FLAG basecamp vault vaults list --md type=bool
-FLAG basecamp vault vaults list --no-hints type=bool
-FLAG basecamp vault vaults list --no-stats type=bool
-FLAG basecamp vault vaults list --page type=int
-FLAG basecamp vault vaults list --profile type=string
-FLAG basecamp vault vaults list --project type=string
-FLAG basecamp vault vaults list --quiet type=bool
-FLAG basecamp vault vaults list --stats type=bool
-FLAG basecamp vault vaults list --styled type=bool
-FLAG basecamp vault vaults list --todolist type=string
-FLAG basecamp vault vaults list --vault type=string
-FLAG basecamp vault vaults list --verbose type=count
-FLAG basecamp vault vaults list --version type=bool
 FLAG basecamp vaults --account type=string
 FLAG basecamp vaults --agent type=bool
 FLAG basecamp vaults --cache-dir type=string
 FLAG basecamp vaults --count type=bool
 FLAG basecamp vaults --folder type=string
-FLAG basecamp vaults --help type=bool
 FLAG basecamp vaults --hints type=bool
 FLAG basecamp vaults --ids-only type=bool
 FLAG basecamp vaults --in type=string
@@ -14913,13 +7419,11 @@ FLAG basecamp vaults --styled type=bool
 FLAG basecamp vaults --todolist type=string
 FLAG basecamp vaults --vault type=string
 FLAG basecamp vaults --verbose type=count
-FLAG basecamp vaults --version type=bool
 FLAG basecamp vaults archive --account type=string
 FLAG basecamp vaults archive --agent type=bool
 FLAG basecamp vaults archive --cache-dir type=string
 FLAG basecamp vaults archive --count type=bool
 FLAG basecamp vaults archive --folder type=string
-FLAG basecamp vaults archive --help type=bool
 FLAG basecamp vaults archive --hints type=bool
 FLAG basecamp vaults archive --ids-only type=bool
 FLAG basecamp vaults archive --in type=string
@@ -14937,178 +7441,12 @@ FLAG basecamp vaults archive --styled type=bool
 FLAG basecamp vaults archive --todolist type=string
 FLAG basecamp vaults archive --vault type=string
 FLAG basecamp vaults archive --verbose type=count
-FLAG basecamp vaults archive --version type=bool
-FLAG basecamp vaults doc --account type=string
-FLAG basecamp vaults doc --agent type=bool
-FLAG basecamp vaults doc --all type=bool
-FLAG basecamp vaults doc --cache-dir type=string
-FLAG basecamp vaults doc --count type=bool
-FLAG basecamp vaults doc --folder type=string
-FLAG basecamp vaults doc --help type=bool
-FLAG basecamp vaults doc --hints type=bool
-FLAG basecamp vaults doc --ids-only type=bool
-FLAG basecamp vaults doc --in type=string
-FLAG basecamp vaults doc --jq type=string
-FLAG basecamp vaults doc --json type=bool
-FLAG basecamp vaults doc --limit type=int
-FLAG basecamp vaults doc --markdown type=bool
-FLAG basecamp vaults doc --md type=bool
-FLAG basecamp vaults doc --no-hints type=bool
-FLAG basecamp vaults doc --no-stats type=bool
-FLAG basecamp vaults doc --page type=int
-FLAG basecamp vaults doc --profile type=string
-FLAG basecamp vaults doc --project type=string
-FLAG basecamp vaults doc --quiet type=bool
-FLAG basecamp vaults doc --stats type=bool
-FLAG basecamp vaults doc --styled type=bool
-FLAG basecamp vaults doc --todolist type=string
-FLAG basecamp vaults doc --vault type=string
-FLAG basecamp vaults doc --verbose type=count
-FLAG basecamp vaults doc --version type=bool
-FLAG basecamp vaults doc create --account type=string
-FLAG basecamp vaults doc create --agent type=bool
-FLAG basecamp vaults doc create --attach type=stringArray
-FLAG basecamp vaults doc create --cache-dir type=string
-FLAG basecamp vaults doc create --count type=bool
-FLAG basecamp vaults doc create --draft type=bool
-FLAG basecamp vaults doc create --folder type=string
-FLAG basecamp vaults doc create --help type=bool
-FLAG basecamp vaults doc create --hints type=bool
-FLAG basecamp vaults doc create --ids-only type=bool
-FLAG basecamp vaults doc create --in type=string
-FLAG basecamp vaults doc create --jq type=string
-FLAG basecamp vaults doc create --json type=bool
-FLAG basecamp vaults doc create --markdown type=bool
-FLAG basecamp vaults doc create --md type=bool
-FLAG basecamp vaults doc create --no-hints type=bool
-FLAG basecamp vaults doc create --no-stats type=bool
-FLAG basecamp vaults doc create --no-subscribe type=bool
-FLAG basecamp vaults doc create --profile type=string
-FLAG basecamp vaults doc create --project type=string
-FLAG basecamp vaults doc create --quiet type=bool
-FLAG basecamp vaults doc create --stats type=bool
-FLAG basecamp vaults doc create --styled type=bool
-FLAG basecamp vaults doc create --subscribe type=string
-FLAG basecamp vaults doc create --todolist type=string
-FLAG basecamp vaults doc create --vault type=string
-FLAG basecamp vaults doc create --verbose type=count
-FLAG basecamp vaults doc create --version type=bool
-FLAG basecamp vaults doc list --account type=string
-FLAG basecamp vaults doc list --agent type=bool
-FLAG basecamp vaults doc list --all type=bool
-FLAG basecamp vaults doc list --cache-dir type=string
-FLAG basecamp vaults doc list --count type=bool
-FLAG basecamp vaults doc list --folder type=string
-FLAG basecamp vaults doc list --help type=bool
-FLAG basecamp vaults doc list --hints type=bool
-FLAG basecamp vaults doc list --ids-only type=bool
-FLAG basecamp vaults doc list --in type=string
-FLAG basecamp vaults doc list --jq type=string
-FLAG basecamp vaults doc list --json type=bool
-FLAG basecamp vaults doc list --limit type=int
-FLAG basecamp vaults doc list --markdown type=bool
-FLAG basecamp vaults doc list --md type=bool
-FLAG basecamp vaults doc list --no-hints type=bool
-FLAG basecamp vaults doc list --no-stats type=bool
-FLAG basecamp vaults doc list --page type=int
-FLAG basecamp vaults doc list --profile type=string
-FLAG basecamp vaults doc list --project type=string
-FLAG basecamp vaults doc list --quiet type=bool
-FLAG basecamp vaults doc list --stats type=bool
-FLAG basecamp vaults doc list --styled type=bool
-FLAG basecamp vaults doc list --todolist type=string
-FLAG basecamp vaults doc list --vault type=string
-FLAG basecamp vaults doc list --verbose type=count
-FLAG basecamp vaults doc list --version type=bool
-FLAG basecamp vaults document --account type=string
-FLAG basecamp vaults document --agent type=bool
-FLAG basecamp vaults document --all type=bool
-FLAG basecamp vaults document --cache-dir type=string
-FLAG basecamp vaults document --count type=bool
-FLAG basecamp vaults document --folder type=string
-FLAG basecamp vaults document --help type=bool
-FLAG basecamp vaults document --hints type=bool
-FLAG basecamp vaults document --ids-only type=bool
-FLAG basecamp vaults document --in type=string
-FLAG basecamp vaults document --jq type=string
-FLAG basecamp vaults document --json type=bool
-FLAG basecamp vaults document --limit type=int
-FLAG basecamp vaults document --markdown type=bool
-FLAG basecamp vaults document --md type=bool
-FLAG basecamp vaults document --no-hints type=bool
-FLAG basecamp vaults document --no-stats type=bool
-FLAG basecamp vaults document --page type=int
-FLAG basecamp vaults document --profile type=string
-FLAG basecamp vaults document --project type=string
-FLAG basecamp vaults document --quiet type=bool
-FLAG basecamp vaults document --stats type=bool
-FLAG basecamp vaults document --styled type=bool
-FLAG basecamp vaults document --todolist type=string
-FLAG basecamp vaults document --vault type=string
-FLAG basecamp vaults document --verbose type=count
-FLAG basecamp vaults document --version type=bool
-FLAG basecamp vaults document create --account type=string
-FLAG basecamp vaults document create --agent type=bool
-FLAG basecamp vaults document create --attach type=stringArray
-FLAG basecamp vaults document create --cache-dir type=string
-FLAG basecamp vaults document create --count type=bool
-FLAG basecamp vaults document create --draft type=bool
-FLAG basecamp vaults document create --folder type=string
-FLAG basecamp vaults document create --help type=bool
-FLAG basecamp vaults document create --hints type=bool
-FLAG basecamp vaults document create --ids-only type=bool
-FLAG basecamp vaults document create --in type=string
-FLAG basecamp vaults document create --jq type=string
-FLAG basecamp vaults document create --json type=bool
-FLAG basecamp vaults document create --markdown type=bool
-FLAG basecamp vaults document create --md type=bool
-FLAG basecamp vaults document create --no-hints type=bool
-FLAG basecamp vaults document create --no-stats type=bool
-FLAG basecamp vaults document create --no-subscribe type=bool
-FLAG basecamp vaults document create --profile type=string
-FLAG basecamp vaults document create --project type=string
-FLAG basecamp vaults document create --quiet type=bool
-FLAG basecamp vaults document create --stats type=bool
-FLAG basecamp vaults document create --styled type=bool
-FLAG basecamp vaults document create --subscribe type=string
-FLAG basecamp vaults document create --todolist type=string
-FLAG basecamp vaults document create --vault type=string
-FLAG basecamp vaults document create --verbose type=count
-FLAG basecamp vaults document create --version type=bool
-FLAG basecamp vaults document list --account type=string
-FLAG basecamp vaults document list --agent type=bool
-FLAG basecamp vaults document list --all type=bool
-FLAG basecamp vaults document list --cache-dir type=string
-FLAG basecamp vaults document list --count type=bool
-FLAG basecamp vaults document list --folder type=string
-FLAG basecamp vaults document list --help type=bool
-FLAG basecamp vaults document list --hints type=bool
-FLAG basecamp vaults document list --ids-only type=bool
-FLAG basecamp vaults document list --in type=string
-FLAG basecamp vaults document list --jq type=string
-FLAG basecamp vaults document list --json type=bool
-FLAG basecamp vaults document list --limit type=int
-FLAG basecamp vaults document list --markdown type=bool
-FLAG basecamp vaults document list --md type=bool
-FLAG basecamp vaults document list --no-hints type=bool
-FLAG basecamp vaults document list --no-stats type=bool
-FLAG basecamp vaults document list --page type=int
-FLAG basecamp vaults document list --profile type=string
-FLAG basecamp vaults document list --project type=string
-FLAG basecamp vaults document list --quiet type=bool
-FLAG basecamp vaults document list --stats type=bool
-FLAG basecamp vaults document list --styled type=bool
-FLAG basecamp vaults document list --todolist type=string
-FLAG basecamp vaults document list --vault type=string
-FLAG basecamp vaults document list --verbose type=count
-FLAG basecamp vaults document list --version type=bool
 FLAG basecamp vaults documents --account type=string
 FLAG basecamp vaults documents --agent type=bool
 FLAG basecamp vaults documents --all type=bool
 FLAG basecamp vaults documents --cache-dir type=string
 FLAG basecamp vaults documents --count type=bool
 FLAG basecamp vaults documents --folder type=string
-FLAG basecamp vaults documents --help type=bool
 FLAG basecamp vaults documents --hints type=bool
 FLAG basecamp vaults documents --ids-only type=bool
 FLAG basecamp vaults documents --in type=string
@@ -15128,7 +7466,6 @@ FLAG basecamp vaults documents --styled type=bool
 FLAG basecamp vaults documents --todolist type=string
 FLAG basecamp vaults documents --vault type=string
 FLAG basecamp vaults documents --verbose type=count
-FLAG basecamp vaults documents --version type=bool
 FLAG basecamp vaults documents create --account type=string
 FLAG basecamp vaults documents create --agent type=bool
 FLAG basecamp vaults documents create --attach type=stringArray
@@ -15136,7 +7473,6 @@ FLAG basecamp vaults documents create --cache-dir type=string
 FLAG basecamp vaults documents create --count type=bool
 FLAG basecamp vaults documents create --draft type=bool
 FLAG basecamp vaults documents create --folder type=string
-FLAG basecamp vaults documents create --help type=bool
 FLAG basecamp vaults documents create --hints type=bool
 FLAG basecamp vaults documents create --ids-only type=bool
 FLAG basecamp vaults documents create --in type=string
@@ -15156,14 +7492,12 @@ FLAG basecamp vaults documents create --subscribe type=string
 FLAG basecamp vaults documents create --todolist type=string
 FLAG basecamp vaults documents create --vault type=string
 FLAG basecamp vaults documents create --verbose type=count
-FLAG basecamp vaults documents create --version type=bool
 FLAG basecamp vaults documents list --account type=string
 FLAG basecamp vaults documents list --agent type=bool
 FLAG basecamp vaults documents list --all type=bool
 FLAG basecamp vaults documents list --cache-dir type=string
 FLAG basecamp vaults documents list --count type=bool
 FLAG basecamp vaults documents list --folder type=string
-FLAG basecamp vaults documents list --help type=bool
 FLAG basecamp vaults documents list --hints type=bool
 FLAG basecamp vaults documents list --ids-only type=bool
 FLAG basecamp vaults documents list --in type=string
@@ -15183,13 +7517,11 @@ FLAG basecamp vaults documents list --styled type=bool
 FLAG basecamp vaults documents list --todolist type=string
 FLAG basecamp vaults documents list --vault type=string
 FLAG basecamp vaults documents list --verbose type=count
-FLAG basecamp vaults documents list --version type=bool
 FLAG basecamp vaults download --account type=string
 FLAG basecamp vaults download --agent type=bool
 FLAG basecamp vaults download --cache-dir type=string
 FLAG basecamp vaults download --count type=bool
 FLAG basecamp vaults download --folder type=string
-FLAG basecamp vaults download --help type=bool
 FLAG basecamp vaults download --hints type=bool
 FLAG basecamp vaults download --ids-only type=bool
 FLAG basecamp vaults download --in type=string
@@ -15208,92 +7540,12 @@ FLAG basecamp vaults download --styled type=bool
 FLAG basecamp vaults download --todolist type=string
 FLAG basecamp vaults download --vault type=string
 FLAG basecamp vaults download --verbose type=count
-FLAG basecamp vaults download --version type=bool
-FLAG basecamp vaults folder --account type=string
-FLAG basecamp vaults folder --agent type=bool
-FLAG basecamp vaults folder --all type=bool
-FLAG basecamp vaults folder --cache-dir type=string
-FLAG basecamp vaults folder --count type=bool
-FLAG basecamp vaults folder --folder type=string
-FLAG basecamp vaults folder --help type=bool
-FLAG basecamp vaults folder --hints type=bool
-FLAG basecamp vaults folder --ids-only type=bool
-FLAG basecamp vaults folder --in type=string
-FLAG basecamp vaults folder --jq type=string
-FLAG basecamp vaults folder --json type=bool
-FLAG basecamp vaults folder --limit type=int
-FLAG basecamp vaults folder --markdown type=bool
-FLAG basecamp vaults folder --md type=bool
-FLAG basecamp vaults folder --no-hints type=bool
-FLAG basecamp vaults folder --no-stats type=bool
-FLAG basecamp vaults folder --page type=int
-FLAG basecamp vaults folder --profile type=string
-FLAG basecamp vaults folder --project type=string
-FLAG basecamp vaults folder --quiet type=bool
-FLAG basecamp vaults folder --stats type=bool
-FLAG basecamp vaults folder --styled type=bool
-FLAG basecamp vaults folder --todolist type=string
-FLAG basecamp vaults folder --vault type=string
-FLAG basecamp vaults folder --verbose type=count
-FLAG basecamp vaults folder --version type=bool
-FLAG basecamp vaults folder create --account type=string
-FLAG basecamp vaults folder create --agent type=bool
-FLAG basecamp vaults folder create --cache-dir type=string
-FLAG basecamp vaults folder create --count type=bool
-FLAG basecamp vaults folder create --folder type=string
-FLAG basecamp vaults folder create --help type=bool
-FLAG basecamp vaults folder create --hints type=bool
-FLAG basecamp vaults folder create --ids-only type=bool
-FLAG basecamp vaults folder create --in type=string
-FLAG basecamp vaults folder create --jq type=string
-FLAG basecamp vaults folder create --json type=bool
-FLAG basecamp vaults folder create --markdown type=bool
-FLAG basecamp vaults folder create --md type=bool
-FLAG basecamp vaults folder create --no-hints type=bool
-FLAG basecamp vaults folder create --no-stats type=bool
-FLAG basecamp vaults folder create --profile type=string
-FLAG basecamp vaults folder create --project type=string
-FLAG basecamp vaults folder create --quiet type=bool
-FLAG basecamp vaults folder create --stats type=bool
-FLAG basecamp vaults folder create --styled type=bool
-FLAG basecamp vaults folder create --todolist type=string
-FLAG basecamp vaults folder create --vault type=string
-FLAG basecamp vaults folder create --verbose type=count
-FLAG basecamp vaults folder create --version type=bool
-FLAG basecamp vaults folder list --account type=string
-FLAG basecamp vaults folder list --agent type=bool
-FLAG basecamp vaults folder list --all type=bool
-FLAG basecamp vaults folder list --cache-dir type=string
-FLAG basecamp vaults folder list --count type=bool
-FLAG basecamp vaults folder list --folder type=string
-FLAG basecamp vaults folder list --help type=bool
-FLAG basecamp vaults folder list --hints type=bool
-FLAG basecamp vaults folder list --ids-only type=bool
-FLAG basecamp vaults folder list --in type=string
-FLAG basecamp vaults folder list --jq type=string
-FLAG basecamp vaults folder list --json type=bool
-FLAG basecamp vaults folder list --limit type=int
-FLAG basecamp vaults folder list --markdown type=bool
-FLAG basecamp vaults folder list --md type=bool
-FLAG basecamp vaults folder list --no-hints type=bool
-FLAG basecamp vaults folder list --no-stats type=bool
-FLAG basecamp vaults folder list --page type=int
-FLAG basecamp vaults folder list --profile type=string
-FLAG basecamp vaults folder list --project type=string
-FLAG basecamp vaults folder list --quiet type=bool
-FLAG basecamp vaults folder list --stats type=bool
-FLAG basecamp vaults folder list --styled type=bool
-FLAG basecamp vaults folder list --todolist type=string
-FLAG basecamp vaults folder list --vault type=string
-FLAG basecamp vaults folder list --verbose type=count
-FLAG basecamp vaults folder list --version type=bool
 FLAG basecamp vaults folders --account type=string
 FLAG basecamp vaults folders --agent type=bool
 FLAG basecamp vaults folders --all type=bool
 FLAG basecamp vaults folders --cache-dir type=string
 FLAG basecamp vaults folders --count type=bool
 FLAG basecamp vaults folders --folder type=string
-FLAG basecamp vaults folders --help type=bool
 FLAG basecamp vaults folders --hints type=bool
 FLAG basecamp vaults folders --ids-only type=bool
 FLAG basecamp vaults folders --in type=string
@@ -15313,13 +7565,11 @@ FLAG basecamp vaults folders --styled type=bool
 FLAG basecamp vaults folders --todolist type=string
 FLAG basecamp vaults folders --vault type=string
 FLAG basecamp vaults folders --verbose type=count
-FLAG basecamp vaults folders --version type=bool
 FLAG basecamp vaults folders create --account type=string
 FLAG basecamp vaults folders create --agent type=bool
 FLAG basecamp vaults folders create --cache-dir type=string
 FLAG basecamp vaults folders create --count type=bool
 FLAG basecamp vaults folders create --folder type=string
-FLAG basecamp vaults folders create --help type=bool
 FLAG basecamp vaults folders create --hints type=bool
 FLAG basecamp vaults folders create --ids-only type=bool
 FLAG basecamp vaults folders create --in type=string
@@ -15337,14 +7587,12 @@ FLAG basecamp vaults folders create --styled type=bool
 FLAG basecamp vaults folders create --todolist type=string
 FLAG basecamp vaults folders create --vault type=string
 FLAG basecamp vaults folders create --verbose type=count
-FLAG basecamp vaults folders create --version type=bool
 FLAG basecamp vaults folders list --account type=string
 FLAG basecamp vaults folders list --agent type=bool
 FLAG basecamp vaults folders list --all type=bool
 FLAG basecamp vaults folders list --cache-dir type=string
 FLAG basecamp vaults folders list --count type=bool
 FLAG basecamp vaults folders list --folder type=string
-FLAG basecamp vaults folders list --help type=bool
 FLAG basecamp vaults folders list --hints type=bool
 FLAG basecamp vaults folders list --ids-only type=bool
 FLAG basecamp vaults folders list --in type=string
@@ -15364,13 +7612,11 @@ FLAG basecamp vaults folders list --styled type=bool
 FLAG basecamp vaults folders list --todolist type=string
 FLAG basecamp vaults folders list --vault type=string
 FLAG basecamp vaults folders list --verbose type=count
-FLAG basecamp vaults folders list --version type=bool
 FLAG basecamp vaults list --account type=string
 FLAG basecamp vaults list --agent type=bool
 FLAG basecamp vaults list --cache-dir type=string
 FLAG basecamp vaults list --count type=bool
 FLAG basecamp vaults list --folder type=string
-FLAG basecamp vaults list --help type=bool
 FLAG basecamp vaults list --hints type=bool
 FLAG basecamp vaults list --ids-only type=bool
 FLAG basecamp vaults list --in type=string
@@ -15388,13 +7634,11 @@ FLAG basecamp vaults list --styled type=bool
 FLAG basecamp vaults list --todolist type=string
 FLAG basecamp vaults list --vault type=string
 FLAG basecamp vaults list --verbose type=count
-FLAG basecamp vaults list --version type=bool
 FLAG basecamp vaults restore --account type=string
 FLAG basecamp vaults restore --agent type=bool
 FLAG basecamp vaults restore --cache-dir type=string
 FLAG basecamp vaults restore --count type=bool
 FLAG basecamp vaults restore --folder type=string
-FLAG basecamp vaults restore --help type=bool
 FLAG basecamp vaults restore --hints type=bool
 FLAG basecamp vaults restore --ids-only type=bool
 FLAG basecamp vaults restore --in type=string
@@ -15412,13 +7656,11 @@ FLAG basecamp vaults restore --styled type=bool
 FLAG basecamp vaults restore --todolist type=string
 FLAG basecamp vaults restore --vault type=string
 FLAG basecamp vaults restore --verbose type=count
-FLAG basecamp vaults restore --version type=bool
 FLAG basecamp vaults show --account type=string
 FLAG basecamp vaults show --agent type=bool
 FLAG basecamp vaults show --cache-dir type=string
 FLAG basecamp vaults show --count type=bool
 FLAG basecamp vaults show --folder type=string
-FLAG basecamp vaults show --help type=bool
 FLAG basecamp vaults show --hints type=bool
 FLAG basecamp vaults show --ids-only type=bool
 FLAG basecamp vaults show --in type=string
@@ -15437,13 +7679,11 @@ FLAG basecamp vaults show --todolist type=string
 FLAG basecamp vaults show --type type=string
 FLAG basecamp vaults show --vault type=string
 FLAG basecamp vaults show --verbose type=count
-FLAG basecamp vaults show --version type=bool
 FLAG basecamp vaults trash --account type=string
 FLAG basecamp vaults trash --agent type=bool
 FLAG basecamp vaults trash --cache-dir type=string
 FLAG basecamp vaults trash --count type=bool
 FLAG basecamp vaults trash --folder type=string
-FLAG basecamp vaults trash --help type=bool
 FLAG basecamp vaults trash --hints type=bool
 FLAG basecamp vaults trash --ids-only type=bool
 FLAG basecamp vaults trash --in type=string
@@ -15461,14 +7701,12 @@ FLAG basecamp vaults trash --styled type=bool
 FLAG basecamp vaults trash --todolist type=string
 FLAG basecamp vaults trash --vault type=string
 FLAG basecamp vaults trash --verbose type=count
-FLAG basecamp vaults trash --version type=bool
 FLAG basecamp vaults update --account type=string
 FLAG basecamp vaults update --agent type=bool
 FLAG basecamp vaults update --cache-dir type=string
 FLAG basecamp vaults update --content type=string
 FLAG basecamp vaults update --count type=bool
 FLAG basecamp vaults update --folder type=string
-FLAG basecamp vaults update --help type=bool
 FLAG basecamp vaults update --hints type=bool
 FLAG basecamp vaults update --ids-only type=bool
 FLAG basecamp vaults update --in type=string
@@ -15488,93 +7726,12 @@ FLAG basecamp vaults update --todolist type=string
 FLAG basecamp vaults update --type type=string
 FLAG basecamp vaults update --vault type=string
 FLAG basecamp vaults update --verbose type=count
-FLAG basecamp vaults update --version type=bool
-FLAG basecamp vaults upload --account type=string
-FLAG basecamp vaults upload --agent type=bool
-FLAG basecamp vaults upload --all type=bool
-FLAG basecamp vaults upload --cache-dir type=string
-FLAG basecamp vaults upload --count type=bool
-FLAG basecamp vaults upload --folder type=string
-FLAG basecamp vaults upload --help type=bool
-FLAG basecamp vaults upload --hints type=bool
-FLAG basecamp vaults upload --ids-only type=bool
-FLAG basecamp vaults upload --in type=string
-FLAG basecamp vaults upload --jq type=string
-FLAG basecamp vaults upload --json type=bool
-FLAG basecamp vaults upload --limit type=int
-FLAG basecamp vaults upload --markdown type=bool
-FLAG basecamp vaults upload --md type=bool
-FLAG basecamp vaults upload --no-hints type=bool
-FLAG basecamp vaults upload --no-stats type=bool
-FLAG basecamp vaults upload --page type=int
-FLAG basecamp vaults upload --profile type=string
-FLAG basecamp vaults upload --project type=string
-FLAG basecamp vaults upload --quiet type=bool
-FLAG basecamp vaults upload --stats type=bool
-FLAG basecamp vaults upload --styled type=bool
-FLAG basecamp vaults upload --todolist type=string
-FLAG basecamp vaults upload --vault type=string
-FLAG basecamp vaults upload --verbose type=count
-FLAG basecamp vaults upload --version type=bool
-FLAG basecamp vaults upload create --account type=string
-FLAG basecamp vaults upload create --agent type=bool
-FLAG basecamp vaults upload create --cache-dir type=string
-FLAG basecamp vaults upload create --count type=bool
-FLAG basecamp vaults upload create --description type=string
-FLAG basecamp vaults upload create --folder type=string
-FLAG basecamp vaults upload create --help type=bool
-FLAG basecamp vaults upload create --hints type=bool
-FLAG basecamp vaults upload create --ids-only type=bool
-FLAG basecamp vaults upload create --in type=string
-FLAG basecamp vaults upload create --jq type=string
-FLAG basecamp vaults upload create --json type=bool
-FLAG basecamp vaults upload create --markdown type=bool
-FLAG basecamp vaults upload create --md type=bool
-FLAG basecamp vaults upload create --no-hints type=bool
-FLAG basecamp vaults upload create --no-stats type=bool
-FLAG basecamp vaults upload create --profile type=string
-FLAG basecamp vaults upload create --project type=string
-FLAG basecamp vaults upload create --quiet type=bool
-FLAG basecamp vaults upload create --stats type=bool
-FLAG basecamp vaults upload create --styled type=bool
-FLAG basecamp vaults upload create --todolist type=string
-FLAG basecamp vaults upload create --vault type=string
-FLAG basecamp vaults upload create --verbose type=count
-FLAG basecamp vaults upload create --version type=bool
-FLAG basecamp vaults upload list --account type=string
-FLAG basecamp vaults upload list --agent type=bool
-FLAG basecamp vaults upload list --all type=bool
-FLAG basecamp vaults upload list --cache-dir type=string
-FLAG basecamp vaults upload list --count type=bool
-FLAG basecamp vaults upload list --folder type=string
-FLAG basecamp vaults upload list --help type=bool
-FLAG basecamp vaults upload list --hints type=bool
-FLAG basecamp vaults upload list --ids-only type=bool
-FLAG basecamp vaults upload list --in type=string
-FLAG basecamp vaults upload list --jq type=string
-FLAG basecamp vaults upload list --json type=bool
-FLAG basecamp vaults upload list --limit type=int
-FLAG basecamp vaults upload list --markdown type=bool
-FLAG basecamp vaults upload list --md type=bool
-FLAG basecamp vaults upload list --no-hints type=bool
-FLAG basecamp vaults upload list --no-stats type=bool
-FLAG basecamp vaults upload list --page type=int
-FLAG basecamp vaults upload list --profile type=string
-FLAG basecamp vaults upload list --project type=string
-FLAG basecamp vaults upload list --quiet type=bool
-FLAG basecamp vaults upload list --stats type=bool
-FLAG basecamp vaults upload list --styled type=bool
-FLAG basecamp vaults upload list --todolist type=string
-FLAG basecamp vaults upload list --vault type=string
-FLAG basecamp vaults upload list --verbose type=count
-FLAG basecamp vaults upload list --version type=bool
 FLAG basecamp vaults uploads --account type=string
 FLAG basecamp vaults uploads --agent type=bool
 FLAG basecamp vaults uploads --all type=bool
 FLAG basecamp vaults uploads --cache-dir type=string
 FLAG basecamp vaults uploads --count type=bool
 FLAG basecamp vaults uploads --folder type=string
-FLAG basecamp vaults uploads --help type=bool
 FLAG basecamp vaults uploads --hints type=bool
 FLAG basecamp vaults uploads --ids-only type=bool
 FLAG basecamp vaults uploads --in type=string
@@ -15594,14 +7751,12 @@ FLAG basecamp vaults uploads --styled type=bool
 FLAG basecamp vaults uploads --todolist type=string
 FLAG basecamp vaults uploads --vault type=string
 FLAG basecamp vaults uploads --verbose type=count
-FLAG basecamp vaults uploads --version type=bool
 FLAG basecamp vaults uploads create --account type=string
 FLAG basecamp vaults uploads create --agent type=bool
 FLAG basecamp vaults uploads create --cache-dir type=string
 FLAG basecamp vaults uploads create --count type=bool
 FLAG basecamp vaults uploads create --description type=string
 FLAG basecamp vaults uploads create --folder type=string
-FLAG basecamp vaults uploads create --help type=bool
 FLAG basecamp vaults uploads create --hints type=bool
 FLAG basecamp vaults uploads create --ids-only type=bool
 FLAG basecamp vaults uploads create --in type=string
@@ -15619,14 +7774,12 @@ FLAG basecamp vaults uploads create --styled type=bool
 FLAG basecamp vaults uploads create --todolist type=string
 FLAG basecamp vaults uploads create --vault type=string
 FLAG basecamp vaults uploads create --verbose type=count
-FLAG basecamp vaults uploads create --version type=bool
 FLAG basecamp vaults uploads list --account type=string
 FLAG basecamp vaults uploads list --agent type=bool
 FLAG basecamp vaults uploads list --all type=bool
 FLAG basecamp vaults uploads list --cache-dir type=string
 FLAG basecamp vaults uploads list --count type=bool
 FLAG basecamp vaults uploads list --folder type=string
-FLAG basecamp vaults uploads list --help type=bool
 FLAG basecamp vaults uploads list --hints type=bool
 FLAG basecamp vaults uploads list --ids-only type=bool
 FLAG basecamp vaults uploads list --in type=string
@@ -15646,168 +7799,10 @@ FLAG basecamp vaults uploads list --styled type=bool
 FLAG basecamp vaults uploads list --todolist type=string
 FLAG basecamp vaults uploads list --vault type=string
 FLAG basecamp vaults uploads list --verbose type=count
-FLAG basecamp vaults uploads list --version type=bool
-FLAG basecamp vaults vault --account type=string
-FLAG basecamp vaults vault --agent type=bool
-FLAG basecamp vaults vault --all type=bool
-FLAG basecamp vaults vault --cache-dir type=string
-FLAG basecamp vaults vault --count type=bool
-FLAG basecamp vaults vault --folder type=string
-FLAG basecamp vaults vault --help type=bool
-FLAG basecamp vaults vault --hints type=bool
-FLAG basecamp vaults vault --ids-only type=bool
-FLAG basecamp vaults vault --in type=string
-FLAG basecamp vaults vault --jq type=string
-FLAG basecamp vaults vault --json type=bool
-FLAG basecamp vaults vault --limit type=int
-FLAG basecamp vaults vault --markdown type=bool
-FLAG basecamp vaults vault --md type=bool
-FLAG basecamp vaults vault --no-hints type=bool
-FLAG basecamp vaults vault --no-stats type=bool
-FLAG basecamp vaults vault --page type=int
-FLAG basecamp vaults vault --profile type=string
-FLAG basecamp vaults vault --project type=string
-FLAG basecamp vaults vault --quiet type=bool
-FLAG basecamp vaults vault --stats type=bool
-FLAG basecamp vaults vault --styled type=bool
-FLAG basecamp vaults vault --todolist type=string
-FLAG basecamp vaults vault --vault type=string
-FLAG basecamp vaults vault --verbose type=count
-FLAG basecamp vaults vault --version type=bool
-FLAG basecamp vaults vault create --account type=string
-FLAG basecamp vaults vault create --agent type=bool
-FLAG basecamp vaults vault create --cache-dir type=string
-FLAG basecamp vaults vault create --count type=bool
-FLAG basecamp vaults vault create --folder type=string
-FLAG basecamp vaults vault create --help type=bool
-FLAG basecamp vaults vault create --hints type=bool
-FLAG basecamp vaults vault create --ids-only type=bool
-FLAG basecamp vaults vault create --in type=string
-FLAG basecamp vaults vault create --jq type=string
-FLAG basecamp vaults vault create --json type=bool
-FLAG basecamp vaults vault create --markdown type=bool
-FLAG basecamp vaults vault create --md type=bool
-FLAG basecamp vaults vault create --no-hints type=bool
-FLAG basecamp vaults vault create --no-stats type=bool
-FLAG basecamp vaults vault create --profile type=string
-FLAG basecamp vaults vault create --project type=string
-FLAG basecamp vaults vault create --quiet type=bool
-FLAG basecamp vaults vault create --stats type=bool
-FLAG basecamp vaults vault create --styled type=bool
-FLAG basecamp vaults vault create --todolist type=string
-FLAG basecamp vaults vault create --vault type=string
-FLAG basecamp vaults vault create --verbose type=count
-FLAG basecamp vaults vault create --version type=bool
-FLAG basecamp vaults vault list --account type=string
-FLAG basecamp vaults vault list --agent type=bool
-FLAG basecamp vaults vault list --all type=bool
-FLAG basecamp vaults vault list --cache-dir type=string
-FLAG basecamp vaults vault list --count type=bool
-FLAG basecamp vaults vault list --folder type=string
-FLAG basecamp vaults vault list --help type=bool
-FLAG basecamp vaults vault list --hints type=bool
-FLAG basecamp vaults vault list --ids-only type=bool
-FLAG basecamp vaults vault list --in type=string
-FLAG basecamp vaults vault list --jq type=string
-FLAG basecamp vaults vault list --json type=bool
-FLAG basecamp vaults vault list --limit type=int
-FLAG basecamp vaults vault list --markdown type=bool
-FLAG basecamp vaults vault list --md type=bool
-FLAG basecamp vaults vault list --no-hints type=bool
-FLAG basecamp vaults vault list --no-stats type=bool
-FLAG basecamp vaults vault list --page type=int
-FLAG basecamp vaults vault list --profile type=string
-FLAG basecamp vaults vault list --project type=string
-FLAG basecamp vaults vault list --quiet type=bool
-FLAG basecamp vaults vault list --stats type=bool
-FLAG basecamp vaults vault list --styled type=bool
-FLAG basecamp vaults vault list --todolist type=string
-FLAG basecamp vaults vault list --vault type=string
-FLAG basecamp vaults vault list --verbose type=count
-FLAG basecamp vaults vault list --version type=bool
-FLAG basecamp vaults vaults --account type=string
-FLAG basecamp vaults vaults --agent type=bool
-FLAG basecamp vaults vaults --all type=bool
-FLAG basecamp vaults vaults --cache-dir type=string
-FLAG basecamp vaults vaults --count type=bool
-FLAG basecamp vaults vaults --folder type=string
-FLAG basecamp vaults vaults --help type=bool
-FLAG basecamp vaults vaults --hints type=bool
-FLAG basecamp vaults vaults --ids-only type=bool
-FLAG basecamp vaults vaults --in type=string
-FLAG basecamp vaults vaults --jq type=string
-FLAG basecamp vaults vaults --json type=bool
-FLAG basecamp vaults vaults --limit type=int
-FLAG basecamp vaults vaults --markdown type=bool
-FLAG basecamp vaults vaults --md type=bool
-FLAG basecamp vaults vaults --no-hints type=bool
-FLAG basecamp vaults vaults --no-stats type=bool
-FLAG basecamp vaults vaults --page type=int
-FLAG basecamp vaults vaults --profile type=string
-FLAG basecamp vaults vaults --project type=string
-FLAG basecamp vaults vaults --quiet type=bool
-FLAG basecamp vaults vaults --stats type=bool
-FLAG basecamp vaults vaults --styled type=bool
-FLAG basecamp vaults vaults --todolist type=string
-FLAG basecamp vaults vaults --vault type=string
-FLAG basecamp vaults vaults --verbose type=count
-FLAG basecamp vaults vaults --version type=bool
-FLAG basecamp vaults vaults create --account type=string
-FLAG basecamp vaults vaults create --agent type=bool
-FLAG basecamp vaults vaults create --cache-dir type=string
-FLAG basecamp vaults vaults create --count type=bool
-FLAG basecamp vaults vaults create --folder type=string
-FLAG basecamp vaults vaults create --help type=bool
-FLAG basecamp vaults vaults create --hints type=bool
-FLAG basecamp vaults vaults create --ids-only type=bool
-FLAG basecamp vaults vaults create --in type=string
-FLAG basecamp vaults vaults create --jq type=string
-FLAG basecamp vaults vaults create --json type=bool
-FLAG basecamp vaults vaults create --markdown type=bool
-FLAG basecamp vaults vaults create --md type=bool
-FLAG basecamp vaults vaults create --no-hints type=bool
-FLAG basecamp vaults vaults create --no-stats type=bool
-FLAG basecamp vaults vaults create --profile type=string
-FLAG basecamp vaults vaults create --project type=string
-FLAG basecamp vaults vaults create --quiet type=bool
-FLAG basecamp vaults vaults create --stats type=bool
-FLAG basecamp vaults vaults create --styled type=bool
-FLAG basecamp vaults vaults create --todolist type=string
-FLAG basecamp vaults vaults create --vault type=string
-FLAG basecamp vaults vaults create --verbose type=count
-FLAG basecamp vaults vaults create --version type=bool
-FLAG basecamp vaults vaults list --account type=string
-FLAG basecamp vaults vaults list --agent type=bool
-FLAG basecamp vaults vaults list --all type=bool
-FLAG basecamp vaults vaults list --cache-dir type=string
-FLAG basecamp vaults vaults list --count type=bool
-FLAG basecamp vaults vaults list --folder type=string
-FLAG basecamp vaults vaults list --help type=bool
-FLAG basecamp vaults vaults list --hints type=bool
-FLAG basecamp vaults vaults list --ids-only type=bool
-FLAG basecamp vaults vaults list --in type=string
-FLAG basecamp vaults vaults list --jq type=string
-FLAG basecamp vaults vaults list --json type=bool
-FLAG basecamp vaults vaults list --limit type=int
-FLAG basecamp vaults vaults list --markdown type=bool
-FLAG basecamp vaults vaults list --md type=bool
-FLAG basecamp vaults vaults list --no-hints type=bool
-FLAG basecamp vaults vaults list --no-stats type=bool
-FLAG basecamp vaults vaults list --page type=int
-FLAG basecamp vaults vaults list --profile type=string
-FLAG basecamp vaults vaults list --project type=string
-FLAG basecamp vaults vaults list --quiet type=bool
-FLAG basecamp vaults vaults list --stats type=bool
-FLAG basecamp vaults vaults list --styled type=bool
-FLAG basecamp vaults vaults list --todolist type=string
-FLAG basecamp vaults vaults list --vault type=string
-FLAG basecamp vaults vaults list --verbose type=count
-FLAG basecamp vaults vaults list --version type=bool
 FLAG basecamp version --account type=string
 FLAG basecamp version --agent type=bool
 FLAG basecamp version --cache-dir type=string
 FLAG basecamp version --count type=bool
-FLAG basecamp version --help type=bool
 FLAG basecamp version --hints type=bool
 FLAG basecamp version --ids-only type=bool
 FLAG basecamp version --in type=string
@@ -15824,149 +7819,10 @@ FLAG basecamp version --stats type=bool
 FLAG basecamp version --styled type=bool
 FLAG basecamp version --todolist type=string
 FLAG basecamp version --verbose type=count
-FLAG basecamp version --version type=bool
-FLAG basecamp webhook --account type=string
-FLAG basecamp webhook --agent type=bool
-FLAG basecamp webhook --cache-dir type=string
-FLAG basecamp webhook --count type=bool
-FLAG basecamp webhook --help type=bool
-FLAG basecamp webhook --hints type=bool
-FLAG basecamp webhook --ids-only type=bool
-FLAG basecamp webhook --in type=string
-FLAG basecamp webhook --jq type=string
-FLAG basecamp webhook --json type=bool
-FLAG basecamp webhook --markdown type=bool
-FLAG basecamp webhook --md type=bool
-FLAG basecamp webhook --no-hints type=bool
-FLAG basecamp webhook --no-stats type=bool
-FLAG basecamp webhook --profile type=string
-FLAG basecamp webhook --project type=string
-FLAG basecamp webhook --quiet type=bool
-FLAG basecamp webhook --stats type=bool
-FLAG basecamp webhook --styled type=bool
-FLAG basecamp webhook --todolist type=string
-FLAG basecamp webhook --verbose type=count
-FLAG basecamp webhook --version type=bool
-FLAG basecamp webhook create --account type=string
-FLAG basecamp webhook create --agent type=bool
-FLAG basecamp webhook create --cache-dir type=string
-FLAG basecamp webhook create --count type=bool
-FLAG basecamp webhook create --help type=bool
-FLAG basecamp webhook create --hints type=bool
-FLAG basecamp webhook create --ids-only type=bool
-FLAG basecamp webhook create --in type=string
-FLAG basecamp webhook create --jq type=string
-FLAG basecamp webhook create --json type=bool
-FLAG basecamp webhook create --markdown type=bool
-FLAG basecamp webhook create --md type=bool
-FLAG basecamp webhook create --no-hints type=bool
-FLAG basecamp webhook create --no-stats type=bool
-FLAG basecamp webhook create --profile type=string
-FLAG basecamp webhook create --project type=string
-FLAG basecamp webhook create --quiet type=bool
-FLAG basecamp webhook create --stats type=bool
-FLAG basecamp webhook create --styled type=bool
-FLAG basecamp webhook create --todolist type=string
-FLAG basecamp webhook create --types type=string
-FLAG basecamp webhook create --verbose type=count
-FLAG basecamp webhook create --version type=bool
-FLAG basecamp webhook delete --account type=string
-FLAG basecamp webhook delete --agent type=bool
-FLAG basecamp webhook delete --cache-dir type=string
-FLAG basecamp webhook delete --count type=bool
-FLAG basecamp webhook delete --help type=bool
-FLAG basecamp webhook delete --hints type=bool
-FLAG basecamp webhook delete --ids-only type=bool
-FLAG basecamp webhook delete --in type=string
-FLAG basecamp webhook delete --jq type=string
-FLAG basecamp webhook delete --json type=bool
-FLAG basecamp webhook delete --markdown type=bool
-FLAG basecamp webhook delete --md type=bool
-FLAG basecamp webhook delete --no-hints type=bool
-FLAG basecamp webhook delete --no-stats type=bool
-FLAG basecamp webhook delete --profile type=string
-FLAG basecamp webhook delete --project type=string
-FLAG basecamp webhook delete --quiet type=bool
-FLAG basecamp webhook delete --stats type=bool
-FLAG basecamp webhook delete --styled type=bool
-FLAG basecamp webhook delete --todolist type=string
-FLAG basecamp webhook delete --verbose type=count
-FLAG basecamp webhook delete --version type=bool
-FLAG basecamp webhook list --account type=string
-FLAG basecamp webhook list --agent type=bool
-FLAG basecamp webhook list --cache-dir type=string
-FLAG basecamp webhook list --count type=bool
-FLAG basecamp webhook list --help type=bool
-FLAG basecamp webhook list --hints type=bool
-FLAG basecamp webhook list --ids-only type=bool
-FLAG basecamp webhook list --in type=string
-FLAG basecamp webhook list --jq type=string
-FLAG basecamp webhook list --json type=bool
-FLAG basecamp webhook list --markdown type=bool
-FLAG basecamp webhook list --md type=bool
-FLAG basecamp webhook list --no-hints type=bool
-FLAG basecamp webhook list --no-stats type=bool
-FLAG basecamp webhook list --profile type=string
-FLAG basecamp webhook list --project type=string
-FLAG basecamp webhook list --quiet type=bool
-FLAG basecamp webhook list --stats type=bool
-FLAG basecamp webhook list --styled type=bool
-FLAG basecamp webhook list --todolist type=string
-FLAG basecamp webhook list --verbose type=count
-FLAG basecamp webhook list --version type=bool
-FLAG basecamp webhook show --account type=string
-FLAG basecamp webhook show --agent type=bool
-FLAG basecamp webhook show --cache-dir type=string
-FLAG basecamp webhook show --count type=bool
-FLAG basecamp webhook show --help type=bool
-FLAG basecamp webhook show --hints type=bool
-FLAG basecamp webhook show --ids-only type=bool
-FLAG basecamp webhook show --in type=string
-FLAG basecamp webhook show --jq type=string
-FLAG basecamp webhook show --json type=bool
-FLAG basecamp webhook show --markdown type=bool
-FLAG basecamp webhook show --md type=bool
-FLAG basecamp webhook show --no-hints type=bool
-FLAG basecamp webhook show --no-stats type=bool
-FLAG basecamp webhook show --profile type=string
-FLAG basecamp webhook show --project type=string
-FLAG basecamp webhook show --quiet type=bool
-FLAG basecamp webhook show --stats type=bool
-FLAG basecamp webhook show --styled type=bool
-FLAG basecamp webhook show --todolist type=string
-FLAG basecamp webhook show --verbose type=count
-FLAG basecamp webhook show --version type=bool
-FLAG basecamp webhook update --account type=string
-FLAG basecamp webhook update --active type=bool
-FLAG basecamp webhook update --agent type=bool
-FLAG basecamp webhook update --cache-dir type=string
-FLAG basecamp webhook update --count type=bool
-FLAG basecamp webhook update --help type=bool
-FLAG basecamp webhook update --hints type=bool
-FLAG basecamp webhook update --ids-only type=bool
-FLAG basecamp webhook update --in type=string
-FLAG basecamp webhook update --inactive type=bool
-FLAG basecamp webhook update --jq type=string
-FLAG basecamp webhook update --json type=bool
-FLAG basecamp webhook update --markdown type=bool
-FLAG basecamp webhook update --md type=bool
-FLAG basecamp webhook update --no-hints type=bool
-FLAG basecamp webhook update --no-stats type=bool
-FLAG basecamp webhook update --profile type=string
-FLAG basecamp webhook update --project type=string
-FLAG basecamp webhook update --quiet type=bool
-FLAG basecamp webhook update --stats type=bool
-FLAG basecamp webhook update --styled type=bool
-FLAG basecamp webhook update --todolist type=string
-FLAG basecamp webhook update --types type=string
-FLAG basecamp webhook update --url type=string
-FLAG basecamp webhook update --verbose type=count
-FLAG basecamp webhook update --version type=bool
 FLAG basecamp webhooks --account type=string
 FLAG basecamp webhooks --agent type=bool
 FLAG basecamp webhooks --cache-dir type=string
 FLAG basecamp webhooks --count type=bool
-FLAG basecamp webhooks --help type=bool
 FLAG basecamp webhooks --hints type=bool
 FLAG basecamp webhooks --ids-only type=bool
 FLAG basecamp webhooks --in type=string
@@ -15983,12 +7839,10 @@ FLAG basecamp webhooks --stats type=bool
 FLAG basecamp webhooks --styled type=bool
 FLAG basecamp webhooks --todolist type=string
 FLAG basecamp webhooks --verbose type=count
-FLAG basecamp webhooks --version type=bool
 FLAG basecamp webhooks create --account type=string
 FLAG basecamp webhooks create --agent type=bool
 FLAG basecamp webhooks create --cache-dir type=string
 FLAG basecamp webhooks create --count type=bool
-FLAG basecamp webhooks create --help type=bool
 FLAG basecamp webhooks create --hints type=bool
 FLAG basecamp webhooks create --ids-only type=bool
 FLAG basecamp webhooks create --in type=string
@@ -16006,12 +7860,10 @@ FLAG basecamp webhooks create --styled type=bool
 FLAG basecamp webhooks create --todolist type=string
 FLAG basecamp webhooks create --types type=string
 FLAG basecamp webhooks create --verbose type=count
-FLAG basecamp webhooks create --version type=bool
 FLAG basecamp webhooks delete --account type=string
 FLAG basecamp webhooks delete --agent type=bool
 FLAG basecamp webhooks delete --cache-dir type=string
 FLAG basecamp webhooks delete --count type=bool
-FLAG basecamp webhooks delete --help type=bool
 FLAG basecamp webhooks delete --hints type=bool
 FLAG basecamp webhooks delete --ids-only type=bool
 FLAG basecamp webhooks delete --in type=string
@@ -16028,12 +7880,10 @@ FLAG basecamp webhooks delete --stats type=bool
 FLAG basecamp webhooks delete --styled type=bool
 FLAG basecamp webhooks delete --todolist type=string
 FLAG basecamp webhooks delete --verbose type=count
-FLAG basecamp webhooks delete --version type=bool
 FLAG basecamp webhooks list --account type=string
 FLAG basecamp webhooks list --agent type=bool
 FLAG basecamp webhooks list --cache-dir type=string
 FLAG basecamp webhooks list --count type=bool
-FLAG basecamp webhooks list --help type=bool
 FLAG basecamp webhooks list --hints type=bool
 FLAG basecamp webhooks list --ids-only type=bool
 FLAG basecamp webhooks list --in type=string
@@ -16050,12 +7900,10 @@ FLAG basecamp webhooks list --stats type=bool
 FLAG basecamp webhooks list --styled type=bool
 FLAG basecamp webhooks list --todolist type=string
 FLAG basecamp webhooks list --verbose type=count
-FLAG basecamp webhooks list --version type=bool
 FLAG basecamp webhooks show --account type=string
 FLAG basecamp webhooks show --agent type=bool
 FLAG basecamp webhooks show --cache-dir type=string
 FLAG basecamp webhooks show --count type=bool
-FLAG basecamp webhooks show --help type=bool
 FLAG basecamp webhooks show --hints type=bool
 FLAG basecamp webhooks show --ids-only type=bool
 FLAG basecamp webhooks show --in type=string
@@ -16072,13 +7920,11 @@ FLAG basecamp webhooks show --stats type=bool
 FLAG basecamp webhooks show --styled type=bool
 FLAG basecamp webhooks show --todolist type=string
 FLAG basecamp webhooks show --verbose type=count
-FLAG basecamp webhooks show --version type=bool
 FLAG basecamp webhooks update --account type=string
 FLAG basecamp webhooks update --active type=bool
 FLAG basecamp webhooks update --agent type=bool
 FLAG basecamp webhooks update --cache-dir type=string
 FLAG basecamp webhooks update --count type=bool
-FLAG basecamp webhooks update --help type=bool
 FLAG basecamp webhooks update --hints type=bool
 FLAG basecamp webhooks update --ids-only type=bool
 FLAG basecamp webhooks update --in type=string
@@ -16098,12 +7944,13 @@ FLAG basecamp webhooks update --todolist type=string
 FLAG basecamp webhooks update --types type=string
 FLAG basecamp webhooks update --url type=string
 FLAG basecamp webhooks update --verbose type=count
-FLAG basecamp webhooks update --version type=bool
-SUB basecamp account
-SUB basecamp account list
-SUB basecamp account use
 SUB basecamp accounts
 SUB basecamp accounts list
+SUB basecamp accounts logo
+SUB basecamp accounts logo remove
+SUB basecamp accounts logo set
+SUB basecamp accounts rename
+SUB basecamp accounts show
 SUB basecamp accounts use
 SUB basecamp api
 SUB basecamp api delete
@@ -16131,22 +7978,8 @@ SUB basecamp boost create
 SUB basecamp boost delete
 SUB basecamp boost list
 SUB basecamp boost show
-SUB basecamp boosts
-SUB basecamp boosts create
-SUB basecamp boosts delete
-SUB basecamp boosts list
-SUB basecamp boosts show
-SUB basecamp campfire
-SUB basecamp campfire delete
-SUB basecamp campfire line
-SUB basecamp campfire list
-SUB basecamp campfire messages
-SUB basecamp campfire post
-SUB basecamp campfire show
-SUB basecamp campfire upload
 SUB basecamp card
 SUB basecamp card move
-SUB basecamp card mv
 SUB basecamp card update
 SUB basecamp cards
 SUB basecamp cards archive
@@ -16164,7 +7997,6 @@ SUB basecamp cards columns
 SUB basecamp cards create
 SUB basecamp cards list
 SUB basecamp cards move
-SUB basecamp cards mv
 SUB basecamp cards restore
 SUB basecamp cards show
 SUB basecamp cards step
@@ -16183,19 +8015,7 @@ SUB basecamp chat line
 SUB basecamp chat list
 SUB basecamp chat messages
 SUB basecamp chat post
-SUB basecamp chat show
 SUB basecamp chat upload
-SUB basecamp checkin
-SUB basecamp checkin answer
-SUB basecamp checkin answer create
-SUB basecamp checkin answer show
-SUB basecamp checkin answer update
-SUB basecamp checkin answers
-SUB basecamp checkin question
-SUB basecamp checkin question create
-SUB basecamp checkin question show
-SUB basecamp checkin question update
-SUB basecamp checkin questions
 SUB basecamp checkins
 SUB basecamp checkins answer
 SUB basecamp checkins answer create
@@ -16207,7 +8027,6 @@ SUB basecamp checkins question create
 SUB basecamp checkins question show
 SUB basecamp checkins question update
 SUB basecamp checkins questions
-SUB basecamp cmds
 SUB basecamp commands
 SUB basecamp comment
 SUB basecamp comments
@@ -16235,19 +8054,10 @@ SUB basecamp config unset
 SUB basecamp config untrust
 SUB basecamp docs
 SUB basecamp docs archive
-SUB basecamp docs doc
-SUB basecamp docs doc create
-SUB basecamp docs doc list
-SUB basecamp docs document
-SUB basecamp docs document create
-SUB basecamp docs document list
 SUB basecamp docs documents
 SUB basecamp docs documents create
 SUB basecamp docs documents list
 SUB basecamp docs download
-SUB basecamp docs folder
-SUB basecamp docs folder create
-SUB basecamp docs folder list
 SUB basecamp docs folders
 SUB basecamp docs folders create
 SUB basecamp docs folders list
@@ -16256,106 +8066,18 @@ SUB basecamp docs restore
 SUB basecamp docs show
 SUB basecamp docs trash
 SUB basecamp docs update
-SUB basecamp docs upload
-SUB basecamp docs upload create
-SUB basecamp docs upload list
 SUB basecamp docs uploads
 SUB basecamp docs uploads create
 SUB basecamp docs uploads list
-SUB basecamp docs vault
-SUB basecamp docs vault create
-SUB basecamp docs vault list
-SUB basecamp docs vaults
-SUB basecamp docs vaults create
-SUB basecamp docs vaults list
 SUB basecamp doctor
-SUB basecamp documents
-SUB basecamp documents archive
-SUB basecamp documents doc
-SUB basecamp documents doc create
-SUB basecamp documents doc list
-SUB basecamp documents document
-SUB basecamp documents document create
-SUB basecamp documents document list
-SUB basecamp documents documents
-SUB basecamp documents documents create
-SUB basecamp documents documents list
-SUB basecamp documents download
-SUB basecamp documents folder
-SUB basecamp documents folder create
-SUB basecamp documents folder list
-SUB basecamp documents folders
-SUB basecamp documents folders create
-SUB basecamp documents folders list
-SUB basecamp documents list
-SUB basecamp documents restore
-SUB basecamp documents show
-SUB basecamp documents trash
-SUB basecamp documents update
-SUB basecamp documents upload
-SUB basecamp documents upload create
-SUB basecamp documents upload list
-SUB basecamp documents uploads
-SUB basecamp documents uploads create
-SUB basecamp documents uploads list
-SUB basecamp documents vault
-SUB basecamp documents vault create
-SUB basecamp documents vault list
-SUB basecamp documents vaults
-SUB basecamp documents vaults create
-SUB basecamp documents vaults list
 SUB basecamp done
 SUB basecamp events
-SUB basecamp file
-SUB basecamp file archive
-SUB basecamp file doc
-SUB basecamp file doc create
-SUB basecamp file doc list
-SUB basecamp file document
-SUB basecamp file document create
-SUB basecamp file document list
-SUB basecamp file documents
-SUB basecamp file documents create
-SUB basecamp file documents list
-SUB basecamp file download
-SUB basecamp file folder
-SUB basecamp file folder create
-SUB basecamp file folder list
-SUB basecamp file folders
-SUB basecamp file folders create
-SUB basecamp file folders list
-SUB basecamp file list
-SUB basecamp file restore
-SUB basecamp file show
-SUB basecamp file trash
-SUB basecamp file update
-SUB basecamp file upload
-SUB basecamp file upload create
-SUB basecamp file upload list
-SUB basecamp file uploads
-SUB basecamp file uploads create
-SUB basecamp file uploads list
-SUB basecamp file vault
-SUB basecamp file vault create
-SUB basecamp file vault list
-SUB basecamp file vaults
-SUB basecamp file vaults create
-SUB basecamp file vaults list
 SUB basecamp files
 SUB basecamp files archive
-SUB basecamp files doc
-SUB basecamp files doc create
-SUB basecamp files doc list
-SUB basecamp files document
-SUB basecamp files document create
-SUB basecamp files document list
 SUB basecamp files documents
 SUB basecamp files documents create
 SUB basecamp files documents list
 SUB basecamp files download
-SUB basecamp files folder
-SUB basecamp files folder create
-SUB basecamp files folder list
 SUB basecamp files folders
 SUB basecamp files folders create
 SUB basecamp files folders list
@@ -16364,59 +8086,24 @@ SUB basecamp files restore
 SUB basecamp files show
 SUB basecamp files trash
 SUB basecamp files update
-SUB basecamp files upload
-SUB basecamp files upload create
-SUB basecamp files upload list
 SUB basecamp files uploads
 SUB basecamp files uploads create
 SUB basecamp files uploads list
-SUB basecamp files vault
-SUB basecamp files vault create
-SUB basecamp files vault list
-SUB basecamp files vaults
-SUB basecamp files vaults create
-SUB basecamp files vaults list
-SUB basecamp folders
-SUB basecamp folders archive
-SUB basecamp folders doc
-SUB basecamp folders doc create
-SUB basecamp folders doc list
-SUB basecamp folders document
-SUB basecamp folders document create
-SUB basecamp folders document list
-SUB basecamp folders documents
-SUB basecamp folders documents create
-SUB basecamp folders documents list
-SUB basecamp folders download
-SUB basecamp folders folder
-SUB basecamp folders folder create
-SUB basecamp folders folder list
-SUB basecamp folders folders
-SUB basecamp folders folders create
-SUB basecamp folders folders list
-SUB basecamp folders list
-SUB basecamp folders restore
-SUB basecamp folders show
-SUB basecamp folders trash
-SUB basecamp folders update
-SUB basecamp folders upload
-SUB basecamp folders upload create
-SUB basecamp folders upload list
-SUB basecamp folders uploads
-SUB basecamp folders uploads create
-SUB basecamp folders uploads list
-SUB basecamp folders vault
-SUB basecamp folders vault create
-SUB basecamp folders vault list
-SUB basecamp folders vaults
-SUB basecamp folders vaults create
-SUB basecamp folders vaults list
 SUB basecamp forwards
 SUB basecamp forwards inbox
 SUB basecamp forwards list
 SUB basecamp forwards replies
 SUB basecamp forwards reply
 SUB basecamp forwards show
+SUB basecamp gauges
+SUB basecamp gauges create
+SUB basecamp gauges delete
+SUB basecamp gauges disable
+SUB basecamp gauges enable
+SUB basecamp gauges list
+SUB basecamp gauges needles
+SUB basecamp gauges show
+SUB basecamp gauges update
 SUB basecamp help
 SUB basecamp hillcharts
 SUB basecamp hillcharts show
@@ -16429,6 +8116,7 @@ SUB basecamp lineup list
 SUB basecamp lineup update
 SUB basecamp login
 SUB basecamp logout
+SUB basecamp mcp
 SUB basecamp me
 SUB basecamp message
 SUB basecamp messageboards
@@ -16451,21 +8139,23 @@ SUB basecamp messagetypes list
 SUB basecamp messagetypes show
 SUB basecamp messagetypes update
 SUB basecamp migrate
-SUB basecamp msgs
-SUB basecamp msgs archive
-SUB basecamp msgs create
-SUB basecamp msgs list
-SUB basecamp msgs pin
-SUB basecamp msgs publish
-SUB basecamp msgs restore
-SUB basecamp msgs show
-SUB basecamp msgs trash
-SUB basecamp msgs unpin
-SUB basecamp msgs update
+SUB basecamp notifications
+SUB basecamp notifications list
+SUB basecamp notifications read
 SUB basecamp people
 SUB basecamp people add
 SUB basecamp people list
+SUB basecamp people out-of-office
+SUB basecamp people out-of-office disable
+SUB basecamp people out-of-office enable
+SUB basecamp people out-of-office show
 SUB basecamp people pingable
+SUB basecamp people preferences
+SUB basecamp people preferences show
+SUB basecamp people preferences update
+SUB basecamp people profile
+SUB basecamp people profile show
+SUB basecamp people profile update
 SUB basecamp people remove
 SUB basecamp people show
 SUB basecamp profile
@@ -16474,35 +8164,26 @@ SUB basecamp profile delete
 SUB basecamp profile list
 SUB basecamp profile set-default
 SUB basecamp profile show
-SUB basecamp project
-SUB basecamp project create
-SUB basecamp project delete
-SUB basecamp project list
-SUB basecamp project show
-SUB basecamp project trash
-SUB basecamp project update
 SUB basecamp projects
 SUB basecamp projects create
 SUB basecamp projects delete
 SUB basecamp projects list
 SUB basecamp projects show
-SUB basecamp projects trash
 SUB basecamp projects update
 SUB basecamp react
 SUB basecamp recordings
-SUB basecamp recordings active
 SUB basecamp recordings archive
-SUB basecamp recordings archived
-SUB basecamp recordings client-visibility
 SUB basecamp recordings list
 SUB basecamp recordings restore
 SUB basecamp recordings trash
-SUB basecamp recordings trashed
 SUB basecamp recordings visibility
 SUB basecamp reopen
 SUB basecamp reports
 SUB basecamp reports assignable
 SUB basecamp reports assigned
+SUB basecamp reports completed
+SUB basecamp reports due
+SUB basecamp reports mine
 SUB basecamp reports overdue
 SUB basecamp reports schedule
 SUB basecamp schedule
@@ -16514,7 +8195,6 @@ SUB basecamp schedule show
 SUB basecamp schedule update
 SUB basecamp search
 SUB basecamp search metadata
-SUB basecamp search types
 SUB basecamp setup
 SUB basecamp setup claude
 SUB basecamp show
@@ -16538,47 +8218,12 @@ SUB basecamp timeline
 SUB basecamp timesheet
 SUB basecamp timesheet item
 SUB basecamp timesheet project
-SUB basecamp timesheet recording
 SUB basecamp timesheet report
-SUB basecamp tlgroup
-SUB basecamp tlgroup create
-SUB basecamp tlgroup list
-SUB basecamp tlgroup move
-SUB basecamp tlgroup position
-SUB basecamp tlgroup rename
-SUB basecamp tlgroup show
-SUB basecamp tlgroup update
-SUB basecamp tlgroups
-SUB basecamp tlgroups create
-SUB basecamp tlgroups list
-SUB basecamp tlgroups move
-SUB basecamp tlgroups position
-SUB basecamp tlgroups rename
-SUB basecamp tlgroups show
-SUB basecamp tlgroups update
 SUB basecamp todo
-SUB basecamp todolist
-SUB basecamp todolist archive
-SUB basecamp todolist create
-SUB basecamp todolist list
-SUB basecamp todolist restore
-SUB basecamp todolist show
-SUB basecamp todolist trash
-SUB basecamp todolist update
-SUB basecamp todolistgroup
-SUB basecamp todolistgroup create
-SUB basecamp todolistgroup list
-SUB basecamp todolistgroup move
-SUB basecamp todolistgroup position
-SUB basecamp todolistgroup rename
-SUB basecamp todolistgroup show
-SUB basecamp todolistgroup update
 SUB basecamp todolistgroups
 SUB basecamp todolistgroups create
 SUB basecamp todolistgroups list
-SUB basecamp todolistgroups move
 SUB basecamp todolistgroups position
-SUB basecamp todolistgroups rename
 SUB basecamp todolistgroups show
 SUB basecamp todolistgroups update
 SUB basecamp todolists
@@ -16594,10 +8239,7 @@ SUB basecamp todos archive
 SUB basecamp todos complete
 SUB basecamp todos create
 SUB basecamp todos list
-SUB basecamp todos move
 SUB basecamp todos position
-SUB basecamp todos reopen
-SUB basecamp todos reorder
 SUB basecamp todos restore
 SUB basecamp todos show
 SUB basecamp todos sweep
@@ -16609,11 +8251,8 @@ SUB basecamp todosets list
 SUB basecamp todosets show
 SUB basecamp tools
 SUB basecamp tools create
-SUB basecamp tools delete
 SUB basecamp tools disable
 SUB basecamp tools enable
-SUB basecamp tools move
-SUB basecamp tools rename
 SUB basecamp tools reposition
 SUB basecamp tools show
 SUB basecamp tools trash
@@ -16628,56 +8267,12 @@ SUB basecamp uploads list
 SUB basecamp uploads show
 SUB basecamp url
 SUB basecamp url parse
-SUB basecamp vault
-SUB basecamp vault archive
-SUB basecamp vault doc
-SUB basecamp vault doc create
-SUB basecamp vault doc list
-SUB basecamp vault document
-SUB basecamp vault document create
-SUB basecamp vault document list
-SUB basecamp vault documents
-SUB basecamp vault documents create
-SUB basecamp vault documents list
-SUB basecamp vault download
-SUB basecamp vault folder
-SUB basecamp vault folder create
-SUB basecamp vault folder list
-SUB basecamp vault folders
-SUB basecamp vault folders create
-SUB basecamp vault folders list
-SUB basecamp vault list
-SUB basecamp vault restore
-SUB basecamp vault show
-SUB basecamp vault trash
-SUB basecamp vault update
-SUB basecamp vault upload
-SUB basecamp vault upload create
-SUB basecamp vault upload list
-SUB basecamp vault uploads
-SUB basecamp vault uploads create
-SUB basecamp vault uploads list
-SUB basecamp vault vault
-SUB basecamp vault vault create
-SUB basecamp vault vault list
-SUB basecamp vault vaults
-SUB basecamp vault vaults create
-SUB basecamp vault vaults list
 SUB basecamp vaults
 SUB basecamp vaults archive
-SUB basecamp vaults doc
-SUB basecamp vaults doc create
-SUB basecamp vaults doc list
-SUB basecamp vaults document
-SUB basecamp vaults document create
-SUB basecamp vaults document list
 SUB basecamp vaults documents
 SUB basecamp vaults documents create
 SUB basecamp vaults documents list
 SUB basecamp vaults download
-SUB basecamp vaults folder
-SUB basecamp vaults folder create
-SUB basecamp vaults folder list
 SUB basecamp vaults folders
 SUB basecamp vaults folders create
 SUB basecamp vaults folders list
@@ -16686,25 +8281,10 @@ SUB basecamp vaults restore
 SUB basecamp vaults show
 SUB basecamp vaults trash
 SUB basecamp vaults update
-SUB basecamp vaults upload
-SUB basecamp vaults upload create
-SUB basecamp vaults upload list
 SUB basecamp vaults uploads
 SUB basecamp vaults uploads create
 SUB basecamp vaults uploads list
-SUB basecamp vaults vault
-SUB basecamp vaults vault create
-SUB basecamp vaults vault list
-SUB basecamp vaults vaults
-SUB basecamp vaults vaults create
-SUB basecamp vaults vaults list
 SUB basecamp version
-SUB basecamp webhook
-SUB basecamp webhook create
-SUB basecamp webhook delete
-SUB basecamp webhook list
-SUB basecamp webhook show
-SUB basecamp webhook update
 SUB basecamp webhooks
 SUB basecamp webhooks create
 SUB basecamp webhooks delete

--- a/e2e/smoke/smoke_sdk_sync.bats
+++ b/e2e/smoke/smoke_sdk_sync.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+# smoke_sdk_sync.bats - SDK sync command coverage
+
+load smoke_helper
+
+setup_file() {
+  ensure_token || return 1
+  ensure_account || return 1
+  ensure_project || return 1
+}
+
+@test "accounts show returns account detail" {
+  run_smoke basecamp accounts show --json
+  assert_success
+  assert_json_value '.ok' 'true'
+  assert_json_not_null '.data.id'
+}
+
+@test "accounts rename is out of scope" {
+  mark_out_of_scope "Renaming the shared smoke-test account is not safe for routine smoke coverage"
+}
+
+@test "accounts logo set is out of scope" {
+  mark_out_of_scope "Uploading a shared account logo mutates global account state"
+}
+
+@test "accounts logo remove is out of scope" {
+  mark_out_of_scope "Removing a shared account logo mutates global account state"
+}
+
+@test "gauges list returns gauges" {
+  run_smoke basecamp gauges list --json
+  [[ "$status" -ne 0 ]] && mark_unverifiable "Gauges are not available in this environment"
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "gauges needles returns project gauge needles" {
+  run_smoke basecamp gauges needles -p "$QA_PROJECT" --json
+  [[ "$status" -ne 0 ]] && mark_unverifiable "Project gauge needles are not available in this environment"
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "gauges show returns gauge needle detail" {
+  local out
+  out=$(basecamp gauges needles -p "$QA_PROJECT" --json 2>/dev/null) || mark_unverifiable "Cannot list gauge needles"
+  local needle_id
+  needle_id=$(echo "$out" | jq -r '.data[0].id // empty')
+  [[ -n "$needle_id" ]] || mark_unverifiable "No gauge needles found"
+
+  run_smoke basecamp gauges show "$needle_id" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+  assert_json_not_null '.data.id'
+}
+
+@test "gauges create" {
+  mark_unverifiable "Gauge write smoke coverage needs a dedicated writable gauge fixture"
+}
+
+@test "gauges update" {
+  mark_unverifiable "Gauge write smoke coverage needs a dedicated writable gauge fixture"
+}
+
+@test "gauges delete" {
+  mark_unverifiable "Gauge write smoke coverage needs a dedicated writable gauge fixture"
+}
+
+@test "gauges enable" {
+  mark_unverifiable "Gauge toggle smoke coverage needs a dedicated writable project fixture"
+}
+
+@test "gauges disable" {
+  mark_unverifiable "Gauge toggle smoke coverage needs a dedicated writable project fixture"
+}
+
+@test "notifications list returns notification groups" {
+  run_smoke basecamp notifications list --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "notifications read marks a notification as read" {
+  local out
+  out=$(basecamp notifications list --json 2>/dev/null) || mark_unverifiable "Cannot list notifications"
+  local readable_sgid
+  readable_sgid=$(echo "$out" | jq -r '.data.unreads[0].readable_sgid // empty')
+  [[ -n "$readable_sgid" ]] || mark_unverifiable "No unread notifications available to mark read"
+
+  run_smoke basecamp notifications read "$readable_sgid" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "people profile show returns profile detail" {
+  run_smoke basecamp people profile show --json
+  assert_success
+  assert_json_value '.ok' 'true'
+  assert_json_not_null '.data.id'
+}
+
+@test "people profile update round-trips the current name" {
+  local out
+  out=$(basecamp people profile show --json 2>/dev/null) || mark_unverifiable "Cannot show current profile"
+  local current_name
+  current_name=$(echo "$out" | jq -r '.data.name // empty')
+  [[ -n "$current_name" ]] || mark_unverifiable "Profile name is empty"
+
+  run_smoke basecamp people profile update --name "$current_name" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "people preferences show returns preferences" {
+  run_smoke basecamp people preferences show --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "people preferences update round-trips current preferences" {
+  local out
+  out=$(basecamp people preferences show --json 2>/dev/null) || mark_unverifiable "Cannot show current preferences"
+  local time_format
+  local time_zone
+  time_format=$(echo "$out" | jq -r '.data.time_format // empty')
+  time_zone=$(echo "$out" | jq -r '.data.time_zone_name // empty')
+  [[ -n "$time_format" ]] || mark_unverifiable "Time format is empty"
+  [[ -n "$time_zone" ]] || mark_unverifiable "Time zone is empty"
+
+  run_smoke basecamp people preferences update \
+    --time-format "$time_format" \
+    --time-zone "$time_zone" \
+    --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "people out-of-office show returns status" {
+  run_smoke basecamp people out-of-office show --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "people out-of-office enable is out of scope" {
+  mark_out_of_scope "Enabling out-of-office mutates personal availability state"
+}
+
+@test "people out-of-office disable is out of scope" {
+  mark_out_of_scope "Disabling out-of-office mutates personal availability state"
+}
+
+@test "reports mine returns current assignments" {
+  run_smoke basecamp reports mine --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "reports completed returns completed assignments" {
+  run_smoke basecamp reports completed --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}
+
+@test "reports due returns due assignments" {
+  run_smoke basecamp reports due --scope overdue --json
+  assert_success
+  assert_json_value '.ok' 'true'
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -304,6 +304,7 @@ func Execute() {
 	cmd.AddCommand(commands.NewVersionCmd())
 	cmd.AddCommand(commands.NewTimelineCmd())
 	cmd.AddCommand(commands.NewReportsCmd())
+	cmd.AddCommand(commands.NewNotificationsCmd())
 	cmd.AddCommand(commands.NewCompletionCmd())
 	cmd.AddCommand(commands.NewSetupCmd())
 	cmd.AddCommand(commands.NewLoginCmd())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -295,6 +295,7 @@ func Execute() {
 	cmd.AddCommand(commands.NewBoostShortcutCmd())
 	cmd.AddCommand(commands.NewTodosetsCmd())
 	cmd.AddCommand(commands.NewHillchartsCmd())
+	cmd.AddCommand(commands.NewGaugesCmd())
 	cmd.AddCommand(commands.NewToolsCmd())
 	cmd.AddCommand(commands.NewConfigCmd())
 	cmd.AddCommand(commands.NewTodolistgroupsCmd())

--- a/internal/commands/accounts.go
+++ b/internal/commands/accounts.go
@@ -2,12 +2,15 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/output"
+	"github.com/basecamp/basecamp-cli/internal/richtext"
 	"github.com/basecamp/basecamp-cli/internal/tui/resolve"
 )
 
@@ -22,10 +25,51 @@ func NewAccountsCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newAccountsListCmd(),
+		newAccountsShowCmd(),
 		newAccountsUseCmd(),
+		newAccountsRenameCmd(),
+		newAccountsLogoCmd(),
 	)
 
 	return cmd
+}
+
+func newAccountsShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show current account details",
+		Long:  "Show details for the currently selected Basecamp account.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+			if err := app.RequireAccount(); err != nil {
+				return err
+			}
+
+			account, err := app.Account().Account().GetAccount(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(account,
+				output.WithSummary(fmt.Sprintf("Account: %s", account.Name)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "rename",
+						Cmd:         "basecamp accounts rename <name>",
+						Description: "Rename this account",
+					},
+					output.Breadcrumb{
+						Action:      "logo",
+						Cmd:         "basecamp accounts logo set <path>",
+						Description: "Update the account logo",
+					},
+				),
+			)
+		},
+	}
 }
 
 func newAccountsListCmd() *cobra.Command {
@@ -160,4 +204,165 @@ func newAccountsUseCmd() *cobra.Command {
 	cmd.Flags().StringVar(&scope, "scope", "global", "Config scope (global or local)")
 
 	return cmd
+}
+
+func newAccountsRenameCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rename <name>",
+		Short: "Rename the current account",
+		Long:  "Rename the currently selected Basecamp account.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+			if err := app.RequireAccount(); err != nil {
+				return err
+			}
+
+			account, err := app.Account().Account().UpdateName(cmd.Context(), args[0])
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(account,
+				output.WithSummary(fmt.Sprintf("Renamed account to %s", account.Name)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp accounts show",
+						Description: "Show account details",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newAccountsLogoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logo",
+		Short: "Manage the current account logo",
+		Long:  "Upload, replace, or remove the logo for the currently selected Basecamp account.",
+	}
+
+	cmd.AddCommand(
+		newAccountsLogoSetCmd(),
+		newAccountsLogoRemoveCmd(),
+	)
+
+	return cmd
+}
+
+func newAccountsLogoSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <path>",
+		Short: "Upload or replace the account logo",
+		Long:  "Upload or replace the logo for the currently selected Basecamp account.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+			if err := app.RequireAccount(); err != nil {
+				return err
+			}
+
+			path := filepath.Clean(args[0])
+			if err := validateAccountLogoFile(path); err != nil {
+				return output.ErrUsage(err.Error())
+			}
+
+			f, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("open logo: %w", err)
+			}
+			defer f.Close()
+
+			filename := filepath.Base(path)
+			contentType := richtext.DetectMIME(path)
+			if err := app.Account().Account().UpdateLogo(cmd.Context(), f, filename, contentType); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{
+				"logo":         filename,
+				"content_type": contentType,
+				"updated":      true,
+			},
+				output.WithSummary(fmt.Sprintf("Updated account logo from %s", filename)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp accounts show",
+						Description: "Show account details",
+					},
+					output.Breadcrumb{
+						Action:      "remove",
+						Cmd:         "basecamp accounts logo remove",
+						Description: "Remove the account logo",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newAccountsLogoRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove",
+		Short: "Remove the account logo",
+		Long:  "Remove the logo from the currently selected Basecamp account.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+			if err := app.RequireAccount(); err != nil {
+				return err
+			}
+
+			if err := app.Account().Account().RemoveLogo(cmd.Context()); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"removed": true},
+				output.WithSummary("Removed account logo"),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp accounts show",
+						Description: "Show account details",
+					},
+					output.Breadcrumb{
+						Action:      "set",
+						Cmd:         "basecamp accounts logo set <path>",
+						Description: "Upload a new account logo",
+					},
+				),
+			)
+		},
+	}
+}
+
+func validateAccountLogoFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("cannot access %s: %w", filepath.Base(path), err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", filepath.Base(path))
+	}
+	if info.Size() > 5*1024*1024 {
+		return fmt.Errorf("%s exceeds maximum size of 5MB", filepath.Base(path))
+	}
+	contentType := richtext.DetectMIME(path)
+	switch contentType {
+	case "image/png", "image/jpeg", "image/gif", "image/webp", "image/avif", "image/heic":
+		return nil
+	default:
+		return fmt.Errorf("%s must be PNG, JPEG, GIF, WebP, AVIF, or HEIC", filepath.Base(path))
+	}
 }

--- a/internal/commands/accounts_test.go
+++ b/internal/commands/accounts_test.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+)
+
+type mockAccountsTransport struct {
+	capturedPath        string
+	capturedMethod      string
+	capturedBody        []byte
+	capturedContentType string
+}
+
+func (t *mockAccountsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.capturedMethod = req.Method
+	t.capturedPath = req.URL.Path
+	t.capturedContentType = req.Header.Get("Content-Type")
+
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		t.capturedBody = body
+		_ = req.Body.Close()
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/account.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id": 99999,
+				"name": "Acme",
+				"created_at": "2026-03-01T00:00:00Z",
+				"updated_at": "2026-03-01T00:00:00Z"
+			}`)),
+		}, nil
+	case req.Method == http.MethodPut && req.URL.Path == "/99999/account/name.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id": 99999,
+				"name": "Renamed",
+				"created_at": "2026-03-01T00:00:00Z",
+				"updated_at": "2026-03-24T00:00:00Z"
+			}`)),
+		}, nil
+	case req.Method == http.MethodPut && req.URL.Path == "/99999/account/logo.json":
+		return &http.Response{
+			StatusCode: 204,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	case req.Method == http.MethodDelete && req.URL.Path == "/99999/account/logo.json":
+		return &http.Response{
+			StatusCode: 204,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	default:
+		return &http.Response{
+			StatusCode: 404,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+		}, nil
+	}
+}
+
+func executeAccountsCommand(cmd *cobra.Command, app *appctx.App, args ...string) error {
+	cmd.SetArgs(args)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd.Execute()
+}
+
+func TestAccountsShow(t *testing.T) {
+	transport := &mockAccountsTransport{}
+	app, buf := newTestAppWithTransport(t, transport)
+
+	cmd := NewAccountsCmd()
+	err := executeAccountsCommand(cmd, app, "show")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, transport.capturedMethod)
+	assert.Equal(t, "/99999/account.json", transport.capturedPath)
+
+	var envelope struct {
+		Data struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.Equal(t, "Acme", envelope.Data.Name)
+}
+
+func TestAccountsRename(t *testing.T) {
+	transport := &mockAccountsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewAccountsCmd()
+	err := executeAccountsCommand(cmd, app, "rename", "Renamed")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, transport.capturedMethod)
+	assert.Equal(t, "/99999/account/name.json", transport.capturedPath)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	assert.Equal(t, "Renamed", body["name"])
+}
+
+func TestAccountsLogoSet(t *testing.T) {
+	transport := &mockAccountsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	logo := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+	path := filepath.Join(t.TempDir(), "logo.png")
+	require.NoError(t, os.WriteFile(path, logo, 0600))
+
+	cmd := NewAccountsCmd()
+	err := executeAccountsCommand(cmd, app, "logo", "set", path)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, transport.capturedMethod)
+	assert.Equal(t, "/99999/account/logo.json", transport.capturedPath)
+	assert.Contains(t, transport.capturedContentType, "multipart/form-data")
+	assert.Contains(t, string(transport.capturedBody), `filename="logo.png"`)
+}
+
+func TestAccountsLogoRemove(t *testing.T) {
+	transport := &mockAccountsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewAccountsCmd()
+	err := executeAccountsCommand(cmd, app, "logo", "remove")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodDelete, transport.capturedMethod)
+	assert.Equal(t, "/99999/account/logo.json", transport.capturedPath)
+}
+
+func TestAccountsLogoSetRejectsUnsupportedType(t *testing.T) {
+	transport := &mockAccountsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	path := filepath.Join(t.TempDir(), "logo.txt")
+	require.NoError(t, os.WriteFile(path, []byte("not an image"), 0600))
+
+	cmd := NewAccountsCmd()
+	err := executeAccountsCommand(cmd, app, "logo", "set", path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be PNG, JPEG, GIF, WebP, AVIF, or HEIC")
+}

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -773,19 +773,11 @@ You can pass either a card ID or a Basecamp URL:
 				}
 			}
 
+			var moveOpts *basecamp.MoveCardOptions
 			if positionSet && position > 0 {
-				cardTableIDInt, parseErr := strconv.ParseInt(cardTableIDVal, 10, 64)
-				if parseErr != nil {
-					return output.ErrUsage("Invalid card table ID")
-				}
-				err = app.Account().CardColumns().Move(cmd.Context(), cardTableIDInt, &basecamp.MoveColumnRequest{
-					SourceID: cardID,
-					TargetID: columnID,
-					Position: position,
-				})
-			} else {
-				err = app.Account().Cards().Move(cmd.Context(), cardID, columnID)
+				moveOpts = &basecamp.MoveCardOptions{Position: int32(position)}
 			}
+			err = app.Account().Cards().Move(cmd.Context(), cardID, columnID, moveOpts)
 			if err != nil {
 				return convertSDKError(err)
 			}
@@ -895,7 +887,7 @@ func moveCardOnHold(cmd *cobra.Command, app *appctx.App, cardID int64, cardIDStr
 		)
 	}
 
-	err := app.Account().Cards().Move(cmd.Context(), cardID, column.OnHold.ID)
+	err := app.Account().Cards().Move(cmd.Context(), cardID, column.OnHold.ID, nil)
 	if err != nil {
 		return convertSDKError(err)
 	}

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -775,6 +776,9 @@ You can pass either a card ID or a Basecamp URL:
 
 			var moveOpts *basecamp.MoveCardOptions
 			if positionSet && position > 0 {
+				if position > math.MaxInt32 {
+					return output.ErrUsage("Position is too large")
+				}
 				moveOpts = &basecamp.MoveCardOptions{Position: int32(position)}
 			}
 			err = app.Account().Cards().Move(cmd.Context(), cardID, columnID, moveOpts)

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -947,10 +947,8 @@ func (t *mockCardMoveTransport) RoundTrip(req *http.Request) (*http.Response, er
 	return nil, errors.New("unexpected request")
 }
 
-// TestCardsMovePositionPayload verifies the CLI sends the intended request contract
-// (source_id=card, target_id=column, position) to /card_tables/{id}/moves.json.
-// This proves the CLI wiring is correct; it does not prove the BC3 API accepts
-// card-as-source on this endpoint — that requires manual/integration validation.
+// TestCardsMovePositionPayload verifies the CLI sends the SDK move-card contract
+// (column_id + position) to /card_tables/cards/{id}/moves.json.
 func TestCardsMovePositionPayload(t *testing.T) {
 	transport := &mockCardMoveTransport{}
 	app, _ := newTestAppWithTransport(t, transport)
@@ -962,19 +960,18 @@ func TestCardsMovePositionPayload(t *testing.T) {
 	err := executeCommand(cmd, app, "456", "--to", "Done", "--position", "1")
 	require.NoError(t, err)
 
-	// Verify URL path hits the card_tables moves endpoint
-	assert.Contains(t, transport.capturedPath, "/card_tables/555/moves.json")
+	// Verify URL path hits the cards move endpoint
+	assert.Contains(t, transport.capturedPath, "/card_tables/cards/456/moves.json")
 
 	// Verify payload shape
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
-	assert.Equal(t, float64(456), body["source_id"])
-	assert.Equal(t, float64(777), body["target_id"])
+	assert.Equal(t, float64(777), body["column_id"])
 	assert.Equal(t, float64(1), body["position"])
 }
 
-// TestCardsMovePositionPosAlias verifies that --pos triggers the same
-// positioned-move contract as --position.
+// TestCardsMovePositionPosAlias verifies that --pos triggers the same payload
+// contract as --position.
 func TestCardsMovePositionPosAlias(t *testing.T) {
 	transport := &mockCardMoveTransport{}
 	app, _ := newTestAppWithTransport(t, transport)
@@ -986,36 +983,32 @@ func TestCardsMovePositionPosAlias(t *testing.T) {
 	err := executeCommand(cmd, app, "456", "--to", "Done", "--pos", "2")
 	require.NoError(t, err)
 
-	assert.Contains(t, transport.capturedPath, "/card_tables/555/moves.json")
+	assert.Contains(t, transport.capturedPath, "/card_tables/cards/456/moves.json")
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
-	assert.Equal(t, float64(456), body["source_id"])
-	assert.Equal(t, float64(777), body["target_id"])
+	assert.Equal(t, float64(777), body["column_id"])
 	assert.Equal(t, float64(2), body["position"])
 }
 
-// TestCardsMovePositionNumericToSingleTableAutoResolves verifies that a
-// positioned move with numeric --to and no --card-table auto-resolves
-// the card table when the project has exactly one.
-func TestCardsMovePositionNumericToSingleTableAutoResolves(t *testing.T) {
+// TestCardsMovePositionNumericToColumnID verifies that the SDK move endpoint
+// accepts a numeric destination column directly with position.
+func TestCardsMovePositionNumericToColumnID(t *testing.T) {
 	transport := &mockCardMoveTransport{}
 	app, _ := newTestAppWithTransport(t, transport)
 
 	project := ""
-	cardTable := "" // no --card-table
+	cardTable := ""
 	cmd := newCardsMoveCmd(&project, &cardTable)
 
 	err := executeCommand(cmd, app, "456", "--to", "777", "--position", "1")
 	require.NoError(t, err)
 
-	// Should auto-resolve to card table 555 (single table in mock dock)
-	assert.Contains(t, transport.capturedPath, "/card_tables/555/moves.json")
+	assert.Contains(t, transport.capturedPath, "/card_tables/cards/456/moves.json")
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
-	assert.Equal(t, float64(456), body["source_id"])
-	assert.Equal(t, float64(777), body["target_id"])
+	assert.Equal(t, float64(777), body["column_id"])
 	assert.Equal(t, float64(1), body["position"])
 }
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -114,7 +114,7 @@ func CommandCategories() []CommandCategory {
 		{
 			Name: "Auth & Config",
 			Commands: []CommandInfo{
-				{Name: "accounts", Category: "auth", Description: "Manage accounts", Actions: []string{"list", "use"}},
+				{Name: "accounts", Category: "auth", Description: "Manage accounts", Actions: []string{"list", "show", "use", "rename", "logo"}},
 				{Name: "auth", Category: "auth", Description: "Authenticate with Basecamp", Actions: []string{"login", "logout", "status", "refresh"}},
 				{Name: "login", Category: "auth", Description: "Authenticate with Basecamp"},
 				{Name: "logout", Category: "auth", Description: "Remove stored credentials"},

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -43,6 +43,7 @@ func CommandCategories() []CommandCategory {
 				{Name: "messages", Category: "core", Description: "Manage messages", Actions: []string{"list", "show", "create", "update", "publish", "pin", "unpin", "trash", "archive", "restore"}},
 				{Name: "chat", Category: "core", Description: "Chat in real-time", Actions: []string{"list", "messages", "post", "upload", "line", "delete"}},
 				{Name: "cards", Category: "core", Description: "Manage Kanban cards", Actions: []string{"list", "show", "create", "update", "move", "columns", "steps", "trash", "archive", "restore"}},
+				{Name: "gauges", Category: "core", Description: "Manage project gauges", Actions: []string{"list", "needles", "show", "create", "update", "delete", "enable", "disable"}},
 			},
 		},
 		{

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -96,6 +96,7 @@ func CommandCategories() []CommandCategory {
 				{Name: "messageboards", Category: "communication", Description: "View message boards", Actions: []string{"show"}},
 				{Name: "messagetypes", Category: "communication", Description: "Manage message categories", Actions: []string{"list", "show", "create", "update", "delete"}},
 				{Name: "forwards", Category: "communication", Description: "Manage email forwards (inbox)", Actions: []string{"list", "show", "inbox", "replies", "reply"}},
+				{Name: "notifications", Category: "communication", Description: "Manage notifications", Actions: []string{"list", "read"}},
 				{Name: "subscriptions", Category: "communication", Description: "Manage notification subscriptions", Actions: []string{"show", "subscribe", "unsubscribe", "add", "remove"}},
 				{Name: "comments", Category: "communication", Description: "Manage comments", Actions: []string{"create", "list", "show", "update", "trash", "archive", "restore"}},
 				{Name: "attachments", Category: "communication", Description: "List attachments on items", Actions: []string{"list"}},

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -83,7 +83,7 @@ func CommandCategories() []CommandCategory {
 		{
 			Name: "Organization",
 			Commands: []CommandInfo{
-				{Name: "people", Category: "organization", Description: "Manage people and access", Actions: []string{"list", "show", "pingable", "add", "remove"}},
+				{Name: "people", Category: "organization", Description: "Manage people and access", Actions: []string{"list", "show", "profile", "preferences", "out-of-office", "pingable", "add", "remove"}},
 				{Name: "templates", Category: "organization", Description: "Manage project templates", Actions: []string{"list", "show", "create", "update", "delete", "construct"}},
 				{Name: "webhooks", Category: "organization", Description: "Manage webhooks", Actions: []string{"list", "show", "create", "update", "delete"}},
 				{Name: "lineup", Category: "organization", Description: "Manage lineup markers", Actions: []string{"list", "create", "update", "delete"}},

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -78,7 +78,7 @@ func CommandCategories() []CommandCategory {
 				{Name: "timesheet", Category: "scheduling", Description: "Manage time tracking", Actions: []string{"report", "project", "item"}},
 				{Name: "checkins", Category: "scheduling", Description: "View automatic check-ins", Actions: []string{"questions", "question", "answers", "answer"}},
 				{Name: "timeline", Category: "scheduling", Description: "View activity timelines", Actions: []string{}},
-				{Name: "reports", Category: "scheduling", Description: "View reports", Actions: []string{"assignable", "assigned", "overdue", "schedule"}},
+				{Name: "reports", Category: "scheduling", Description: "View reports", Actions: []string{"assignable", "assigned", "mine", "completed", "due", "overdue", "schedule"}},
 			},
 		},
 		{

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -107,6 +107,7 @@ func buildRootWithAllCommands() *cobra.Command {
 	root.AddCommand(commands.NewVersionCmd())
 	root.AddCommand(commands.NewTimelineCmd())
 	root.AddCommand(commands.NewReportsCmd())
+	root.AddCommand(commands.NewNotificationsCmd())
 	root.AddCommand(commands.NewCompletionCmd())
 	root.AddCommand(commands.NewSetupCmd())
 	root.AddCommand(commands.NewLoginCmd())

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -98,6 +98,7 @@ func buildRootWithAllCommands() *cobra.Command {
 	root.AddCommand(commands.NewBoostShortcutCmd())
 	root.AddCommand(commands.NewTodosetsCmd())
 	root.AddCommand(commands.NewHillchartsCmd())
+	root.AddCommand(commands.NewGaugesCmd())
 	root.AddCommand(commands.NewToolsCmd())
 	root.AddCommand(commands.NewConfigCmd())
 	root.AddCommand(commands.NewTodolistgroupsCmd())

--- a/internal/commands/forwards.go
+++ b/internal/commands/forwards.go
@@ -51,24 +51,28 @@ func newForwardsListCmd(project, inboxID *string) *cobra.Command {
 	var limit int
 	var page int
 	var all bool
+	var sortField string
+	var reverse bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List forwards in project inbox",
 		Long:  "List all email forwards in the project inbox.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runForwardsList(cmd, *project, *inboxID, limit, page, all)
+			return runForwardsList(cmd, *project, *inboxID, limit, page, all, sortField, reverse)
 		},
 	}
 
 	cmd.Flags().IntVarP(&limit, "limit", "n", 0, "Maximum number of forwards to fetch (0 = all)")
 	cmd.Flags().BoolVar(&all, "all", false, "Fetch all forwards (no limit)")
 	cmd.Flags().IntVar(&page, "page", 0, "Fetch a single page (use --all for everything)")
+	cmd.Flags().StringVar(&sortField, "sort", "", "Sort by field (created or updated)")
+	cmd.Flags().BoolVar(&reverse, "reverse", false, "Reverse sort order")
 
 	return cmd
 }
 
-func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page int, all bool) error {
+func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page int, all bool, sortField string, reverse bool) error {
 	app := appctx.FromContext(cmd.Context())
 
 	// Validate flag combinations
@@ -80,6 +84,11 @@ func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page in
 	}
 	if page > 1 {
 		return output.ErrUsage("only --page 1 is supported; use --all to fetch everything")
+	}
+	switch sortField {
+	case "", "created", "updated":
+	default:
+		return output.ErrUsage("--sort must be created or updated")
 	}
 
 	if err := ensureAccount(cmd, app); err != nil {
@@ -126,6 +135,18 @@ func runForwardsList(cmd *cobra.Command, project, inboxID string, limit, page in
 	}
 	if page > 0 {
 		opts.Page = page
+	}
+	if sortField != "" {
+		if sortField == "created" {
+			opts.Sort = "created_at"
+		} else {
+			opts.Sort = "updated_at"
+		}
+		if reverse {
+			opts.Direction = "desc"
+		} else {
+			opts.Direction = "asc"
+		}
 	}
 
 	forwardsResult, err := app.Account().Forwards().List(cmd.Context(), inboxIDInt, opts)

--- a/internal/commands/forwards_test.go
+++ b/internal/commands/forwards_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockForwardsSortTransport struct {
+	query string
+}
+
+func (t *mockForwardsSortTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.query = req.URL.RawQuery
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch req.URL.Path {
+	case "/99999/projects.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":123,"name":"Project"}]`)),
+		}, nil
+	case "/99999/projects/123.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"id":123,"dock":[{"name":"inbox","id":456,"title":"Inbox","enabled":true}]}`)),
+		}, nil
+	case "/99999/inboxes/456/forwards.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	default:
+		return &http.Response{
+			StatusCode: 404,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+		}, nil
+	}
+}
+
+func TestForwardsListSort(t *testing.T) {
+	transport := &mockForwardsSortTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewForwardsCmd()
+	err := executeCommand(cmd, app, "list", "--in", "123", "--sort", "updated", "--reverse")
+	require.NoError(t, err)
+
+	assert.Equal(t, "direction=desc&sort=updated_at", transport.query)
+}
+
+func TestForwardsListRejectsBadSort(t *testing.T) {
+	app, _ := setupTestApp(t)
+
+	cmd := NewForwardsCmd()
+	err := executeCommand(cmd, app, "list", "--sort", "subject")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--sort must be created or updated")
+}

--- a/internal/commands/gauges.go
+++ b/internal/commands/gauges.go
@@ -1,0 +1,463 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/completion"
+	"github.com/basecamp/basecamp-cli/internal/output"
+	"github.com/basecamp/basecamp-cli/internal/richtext"
+)
+
+func NewGaugesCmd() *cobra.Command {
+	var project string
+
+	cmd := &cobra.Command{
+		Use:   "gauges",
+		Short: "Manage project gauges",
+		Long:  "List gauges across projects and manage gauge needles for a project.",
+		Annotations: map[string]string{
+			"agent_notes": "Gauges are account-wide to list, but needle operations are project-scoped. Use --in when creating or toggling gauges.",
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&project, "project", "p", "", "Project ID or name")
+	cmd.PersistentFlags().StringVar(&project, "in", "", "Project ID or name (alias for --project)")
+
+	completer := completion.NewCompleter(nil)
+	_ = cmd.RegisterFlagCompletionFunc("project", completer.ProjectNameCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("in", completer.ProjectNameCompletion())
+
+	cmd.AddCommand(
+		newGaugesListCmd(),
+		newGaugesNeedlesCmd(&project),
+		newGaugesShowCmd(),
+		newGaugesCreateCmd(&project),
+		newGaugesUpdateCmd(),
+		newGaugesDeleteCmd(),
+		newGaugesEnableCmd(&project),
+		newGaugesDisableCmd(&project),
+	)
+
+	return cmd
+}
+
+func newGaugesListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List gauges",
+		Long:  "List gauges across all projects visible to the current user.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			gauges, err := app.Account().Gauges().List(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(gauges,
+				output.WithSummary(fmt.Sprintf("%d gauges", len(gauges))),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "needles",
+						Cmd:         "basecamp gauges needles --in <project>",
+						Description: "List gauge needles for a project",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newGaugesNeedlesCmd(project *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "needles",
+		Short: "List gauge needles",
+		Long:  "List gauge needles for a project, ordered newest first.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			projectID, err := resolveGaugeProjectID(cmd, app, *project)
+			if err != nil {
+				return err
+			}
+
+			needles, err := app.Account().Gauges().ListNeedles(cmd.Context(), projectID)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(needles,
+				output.WithSummary(fmt.Sprintf("%d gauge needles", len(needles))),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp gauges show <needle-id>",
+						Description: "Show a gauge needle",
+					},
+					output.Breadcrumb{
+						Action:      "create",
+						Cmd:         "basecamp gauges create --position <0-100> --in <project>",
+						Description: "Create a gauge needle",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newGaugesShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <needle-id|url>",
+		Short: "Show a gauge needle",
+		Long:  "Show details for a single gauge needle.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			needleID, err := strconv.ParseInt(extractID(args[0]), 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid gauge needle ID")
+			}
+
+			needle, err := app.Account().Gauges().GetNeedle(cmd.Context(), needleID)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(needle,
+				output.WithSummary(fmt.Sprintf("Gauge needle #%d", needleID)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "update",
+						Cmd:         fmt.Sprintf("basecamp gauges update %d --description <text>", needleID),
+						Description: "Update this gauge needle",
+					},
+					output.Breadcrumb{
+						Action:      "delete",
+						Cmd:         fmt.Sprintf("basecamp gauges delete %d", needleID),
+						Description: "Delete this gauge needle",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newGaugesCreateCmd(project *string) *cobra.Command {
+	var position int
+	var color string
+	var description string
+	var notify string
+	var subscriptions []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a gauge needle",
+		Long:  "Create a gauge needle (progress update) for a project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+			if position < 0 || position > 100 {
+				return output.ErrUsage("--position must be between 0 and 100")
+			}
+			if err := validateGaugeColor(color); err != nil {
+				return err
+			}
+			if err := validateGaugeNotify(notify); err != nil {
+				return err
+			}
+
+			projectID, err := resolveGaugeProjectID(cmd, app, *project)
+			if err != nil {
+				return err
+			}
+
+			html, mentionNotice, err := gaugeDescriptionHTML(cmd, app, description)
+			if err != nil {
+				return err
+			}
+
+			peopleIDs, err := resolveGaugeSubscriptions(cmd, app, subscriptions, notify)
+			if err != nil {
+				return err
+			}
+			if len(peopleIDs) > 0 && notify == "" {
+				notify = "custom"
+			}
+
+			needle, err := app.Account().Gauges().CreateNeedle(cmd.Context(), projectID, &basecamp.CreateGaugeNeedleRequest{
+				Position:      int32(position),
+				Color:         color,
+				Description:   html,
+				Notify:        notify,
+				Subscriptions: peopleIDs,
+			})
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			respOpts := []output.ResponseOption{
+				output.WithSummary(fmt.Sprintf("Created gauge needle at %d", position)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         fmt.Sprintf("basecamp gauges show %d", needle.ID),
+						Description: "Show this gauge needle",
+					},
+				),
+			}
+			if mentionNotice != "" {
+				respOpts = append(respOpts, output.WithDiagnostic(mentionNotice))
+			}
+
+			return app.OK(needle, respOpts...)
+		},
+	}
+
+	cmd.Flags().IntVar(&position, "position", -1, "Needle position from 0 to 100")
+	cmd.Flags().StringVar(&color, "color", "", "Status color (green, yellow, or red)")
+	cmd.Flags().StringVar(&description, "description", "", "Gauge description in Markdown")
+	cmd.Flags().StringVar(&notify, "notify", "", "Who to notify (everyone, working_on, or custom)")
+	cmd.Flags().StringSliceVar(&subscriptions, "subscribe", nil, "People to notify when --notify custom")
+
+	completer := completion.NewCompleter(nil)
+	_ = cmd.RegisterFlagCompletionFunc("subscribe", completer.PeopleNameCompletion())
+
+	return cmd
+}
+
+func newGaugesUpdateCmd() *cobra.Command {
+	var description string
+
+	cmd := &cobra.Command{
+		Use:   "update <needle-id|url>",
+		Short: "Update a gauge needle",
+		Long:  "Update the description of a gauge needle.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if description == "" {
+				return missingArg(cmd, "--description")
+			}
+
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			needleID, err := strconv.ParseInt(extractID(args[0]), 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid gauge needle ID")
+			}
+
+			html, mentionNotice, err := gaugeDescriptionHTML(cmd, app, description)
+			if err != nil {
+				return err
+			}
+
+			needle, err := app.Account().Gauges().UpdateNeedle(cmd.Context(), needleID, &basecamp.UpdateGaugeNeedleRequest{
+				Description: html,
+			})
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			respOpts := []output.ResponseOption{
+				output.WithSummary(fmt.Sprintf("Updated gauge needle #%d", needleID)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         fmt.Sprintf("basecamp gauges show %d", needleID),
+						Description: "Show this gauge needle",
+					},
+				),
+			}
+			if mentionNotice != "" {
+				respOpts = append(respOpts, output.WithDiagnostic(mentionNotice))
+			}
+
+			return app.OK(needle, respOpts...)
+		},
+	}
+
+	cmd.Flags().StringVar(&description, "description", "", "Gauge description in Markdown")
+
+	return cmd
+}
+
+func newGaugesDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <needle-id|url>",
+		Short: "Delete a gauge needle",
+		Long:  "Delete a gauge needle.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			needleID, err := strconv.ParseInt(extractID(args[0]), 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid gauge needle ID")
+			}
+
+			if err := app.Account().Gauges().DestroyNeedle(cmd.Context(), needleID); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"deleted": true},
+				output.WithSummary(fmt.Sprintf("Deleted gauge needle #%d", needleID)),
+			)
+		},
+	}
+}
+
+func newGaugesEnableCmd(project *string) *cobra.Command {
+	return newGaugesToggleCmd("enable", true, project)
+}
+
+func newGaugesDisableCmd(project *string) *cobra.Command {
+	return newGaugesToggleCmd("disable", false, project)
+}
+
+func newGaugesToggleCmd(use string, enabled bool, project *string) *cobra.Command {
+	summaryVerb := "Enabled"
+	if !enabled {
+		summaryVerb = "Disabled"
+	}
+
+	return &cobra.Command{
+		Use:   use,
+		Short: strings.ToLower(summaryVerb) + " a project gauge",
+		Long:  summaryVerb + " the gauge for a project.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			projectID, err := resolveGaugeProjectID(cmd, app, *project)
+			if err != nil {
+				return err
+			}
+
+			if err := app.Account().Gauges().Toggle(cmd.Context(), projectID, enabled); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"enabled": enabled},
+				output.WithSummary(fmt.Sprintf("%s gauge for project #%d", summaryVerb, projectID)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "needles",
+						Cmd:         "basecamp gauges needles --in <project>",
+						Description: "List gauge needles",
+					},
+				),
+			)
+		},
+	}
+}
+
+func resolveGaugeProjectID(cmd *cobra.Command, app *appctx.App, project string) (int64, error) {
+	projectID := project
+	if projectID == "" {
+		projectID = app.Flags.Project
+	}
+	if projectID == "" {
+		projectID = app.Config.ProjectID
+	}
+	if projectID == "" {
+		if err := ensureProject(cmd, app); err != nil {
+			return 0, err
+		}
+		projectID = app.Config.ProjectID
+	}
+
+	resolvedID, _, err := app.Names.ResolveProject(cmd.Context(), projectID)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.ParseInt(resolvedID, 10, 64)
+	if err != nil {
+		return 0, output.ErrUsage("Invalid project ID")
+	}
+	return value, nil
+}
+
+func validateGaugeColor(color string) error {
+	switch color {
+	case "", "green", "yellow", "red":
+		return nil
+	default:
+		return output.ErrUsage("--color must be green, yellow, or red")
+	}
+}
+
+func validateGaugeNotify(notify string) error {
+	switch notify {
+	case "", "everyone", "working_on", "custom":
+		return nil
+	default:
+		return output.ErrUsage("--notify must be everyone, working_on, or custom")
+	}
+}
+
+func resolveGaugeSubscriptions(cmd *cobra.Command, app *appctx.App, subscriptions []string, notify string) ([]int64, error) {
+	if len(subscriptions) == 0 {
+		return nil, nil
+	}
+	if notify != "" && notify != "custom" {
+		return nil, output.ErrUsage("--subscribe requires --notify custom")
+	}
+
+	ids := make([]int64, 0, len(subscriptions))
+	for _, person := range subscriptions {
+		id, _, err := app.Names.ResolvePerson(cmd.Context(), person)
+		if err != nil {
+			return nil, err
+		}
+		value, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			return nil, output.ErrUsage("Invalid person ID")
+		}
+		ids = append(ids, value)
+	}
+	return ids, nil
+}
+
+func gaugeDescriptionHTML(cmd *cobra.Command, app *appctx.App, description string) (string, string, error) {
+	if description == "" {
+		return "", "", nil
+	}
+
+	html := richtext.MarkdownToHTML(description)
+	var err error
+	html, err = resolveLocalImages(cmd, app, html)
+	if err != nil {
+		return "", "", err
+	}
+	mentionResult, err := resolveMentions(cmd.Context(), app.Names, html)
+	if err != nil {
+		return "", "", err
+	}
+	return mentionResult.HTML, unresolvedMentionWarning(mentionResult.Unresolved), nil
+}

--- a/internal/commands/gauges_test.go
+++ b/internal/commands/gauges_test.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockGaugesTransport struct {
+	capturedPath   string
+	capturedMethod string
+	capturedBody   []byte
+}
+
+func (t *mockGaugesTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	t.capturedPath = req.URL.Path
+	t.capturedMethod = req.Method
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		t.capturedBody = body
+		_ = req.Body.Close()
+	}
+
+	switch {
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/reports/gauges.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`[
+				{"id":1,"title":"Delivery","created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"}
+			]`)),
+		}, nil
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/projects/123/gauge/needles.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`[
+				{"id":99,"position":75,"created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"}
+			]`)),
+		}, nil
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/gauge_needles/99":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":99,"position":75,"created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"
+			}`)),
+		}, nil
+	case req.Method == http.MethodPost && req.URL.Path == "/99999/projects/123/gauge/needles.json":
+		return &http.Response{StatusCode: 201, Header: header, Body: io.NopCloser(strings.NewReader(`{
+			"id":99,"position":75,"created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"
+		}`))}, nil
+	case req.Method == http.MethodPut && req.URL.Path == "/99999/gauge_needles/99":
+		return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(strings.NewReader(`{
+			"id":99,"position":75,"created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"
+		}`))}, nil
+	case req.Method == http.MethodDelete && req.URL.Path == "/99999/gauge_needles/99":
+		return &http.Response{StatusCode: 204, Header: header, Body: io.NopCloser(strings.NewReader(""))}, nil
+	case req.Method == http.MethodPut && req.URL.Path == "/99999/projects/123/gauge.json":
+		return &http.Response{StatusCode: 204, Header: header, Body: io.NopCloser(strings.NewReader(""))}, nil
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/projects/123.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"id":123,"name":"Project"}`)),
+		}, nil
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/projects.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":123,"name":"Project"}]`)),
+		}, nil
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/people.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1001,"name":"Alice"}]`)),
+		}, nil
+	default:
+		return nil, errors.New("unexpected request")
+	}
+}
+
+func TestGaugesList(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, buf := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "list")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, transport.capturedMethod)
+	assert.Equal(t, "/99999/reports/gauges.json", transport.capturedPath)
+	assert.Contains(t, buf.String(), `"title": "Delivery"`)
+}
+
+func TestGaugesNeedles(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "needles", "--in", "123")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, transport.capturedMethod)
+	assert.Equal(t, "/99999/projects/123/gauge/needles.json", transport.capturedPath)
+}
+
+func TestGaugesCreate(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "create", "--in", "123", "--position", "75", "--color", "yellow", "--description", "On track")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, transport.capturedMethod)
+	assert.Equal(t, "/99999/projects/123/gauge/needles.json", transport.capturedPath)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	needle := body["gauge_needle"].(map[string]any)
+	assert.Equal(t, "yellow", needle["color"])
+}
+
+func TestGaugesUpdate(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "update", "99", "--description", "Updated")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, transport.capturedMethod)
+	assert.Equal(t, "/99999/gauge_needles/99", transport.capturedPath)
+}
+
+func TestGaugesDelete(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "delete", "99")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodDelete, transport.capturedMethod)
+	assert.Equal(t, "/99999/gauge_needles/99", transport.capturedPath)
+}
+
+func TestGaugesEnable(t *testing.T) {
+	transport := &mockGaugesTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewGaugesCmd()
+	err := executeCommand(cmd, app, "enable", "--in", "123")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, transport.capturedMethod)
+	assert.Equal(t, "/99999/projects/123/gauge.json", transport.capturedPath)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	gauge := body["gauge"].(map[string]any)
+	assert.Equal(t, true, gauge["enabled"])
+}

--- a/internal/commands/notifications.go
+++ b/internal/commands/notifications.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/output"
+)
+
+func NewNotificationsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notifications",
+		Short: "Manage your notifications",
+		Long:  "View and mark read the current user's Basecamp notifications.",
+	}
+
+	cmd.AddCommand(
+		newNotificationsListCmd(),
+		newNotificationsReadCmd(),
+	)
+
+	return cmd
+}
+
+func newNotificationsListCmd() *cobra.Command {
+	var page int32
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List notifications",
+		Long:  "List the current user's notifications grouped into unreads, reads, and memories.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			result, err := app.Account().MyNotifications().Get(cmd.Context(), page)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			summaryParts := []string{
+				fmt.Sprintf("%d unread", len(result.Unreads)),
+				fmt.Sprintf("%d read", len(result.Reads)),
+			}
+			if len(result.Memories) > 0 {
+				summaryParts = append(summaryParts, fmt.Sprintf("%d memories", len(result.Memories)))
+			}
+
+			return app.OK(result,
+				output.WithSummary("Notifications: "+strings.Join(summaryParts, ", ")),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "read",
+						Cmd:         "basecamp notifications read <readable-sgid>",
+						Description: "Mark notifications as read",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().Int32Var(&page, "page", 0, "Page of read notifications to fetch")
+
+	return cmd
+}
+
+func newNotificationsReadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "read <readable-sgid>...",
+		Short: "Mark notifications as read",
+		Long:  "Mark one or more notifications as read by readable SGID.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			if err := app.Account().MyNotifications().MarkAsRead(cmd.Context(), args); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{
+				"readables": args,
+				"updated":   true,
+			},
+				output.WithSummary(fmt.Sprintf("Marked %d notification(s) as read", len(args))),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "list",
+						Cmd:         "basecamp notifications list",
+						Description: "List notifications",
+					},
+				),
+			)
+		},
+	}
+}

--- a/internal/commands/notifications_test.go
+++ b/internal/commands/notifications_test.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockNotificationsTransport struct {
+	capturedPath   string
+	capturedMethod string
+	capturedBody   []byte
+}
+
+func (t *mockNotificationsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.capturedPath = req.URL.Path
+	t.capturedMethod = req.Method
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		t.capturedBody = body
+		_ = req.Body.Close()
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && req.URL.Path == "/99999/my/readings.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`{
+				"unreads": [{"id":1,"readable_sgid":"sgid-1","created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"}],
+				"reads": [{"id":2,"readable_sgid":"sgid-2","created_at":"2026-03-24T00:00:00Z","updated_at":"2026-03-24T00:00:00Z"}],
+				"memories": []
+			}`)),
+		}, nil
+	case req.Method == http.MethodPut && req.URL.Path == "/99999/my/unreads.json":
+		return &http.Response{
+			StatusCode: 204,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	default:
+		return &http.Response{
+			StatusCode: 404,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+		}, nil
+	}
+}
+
+func TestNotificationsList(t *testing.T) {
+	transport := &mockNotificationsTransport{}
+	app, buf := newTestAppWithTransport(t, transport)
+
+	cmd := NewNotificationsCmd()
+	err := executeCommand(cmd, app, "list")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodGet, transport.capturedMethod)
+	assert.Equal(t, "/99999/my/readings.json", transport.capturedPath)
+	assert.Contains(t, buf.String(), `"readable_sgid": "sgid-1"`)
+}
+
+func TestNotificationsRead(t *testing.T) {
+	transport := &mockNotificationsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewNotificationsCmd()
+	err := executeCommand(cmd, app, "read", "sgid-1", "sgid-2")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, transport.capturedMethod)
+	assert.Equal(t, "/99999/my/unreads.json", transport.capturedPath)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	assert.Equal(t, []any{"sgid-1", "sgid-2"}, body["readables"])
+}

--- a/internal/commands/people.go
+++ b/internal/commands/people.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/completion"
+	"github.com/basecamp/basecamp-cli/internal/dateparse"
 	"github.com/basecamp/basecamp-cli/internal/output"
 )
 
@@ -149,6 +150,9 @@ func NewPeopleCmd() *cobra.Command {
 
 	cmd.AddCommand(newPeopleListCmd())
 	cmd.AddCommand(newPeopleShowCmd())
+	cmd.AddCommand(newPeopleProfileCmd())
+	cmd.AddCommand(newPeoplePreferencesCmd())
+	cmd.AddCommand(newPeopleOutOfOfficeCmd())
 	cmd.AddCommand(newPeoplePingableCmd())
 	cmd.AddCommand(newPeopleAddCmd())
 	cmd.AddCommand(newPeopleRemoveCmd())
@@ -364,6 +368,407 @@ func runPeopleShow(cmd *cobra.Command, args []string) error {
 	return app.OK(person, output.WithSummary(person.Name))
 }
 
+func newPeopleProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Manage your profile",
+		Long:  "Show or update the current authenticated person's Basecamp profile.",
+	}
+
+	cmd.AddCommand(
+		newPeopleProfileShowCmd(),
+		newPeopleProfileUpdateCmd(),
+	)
+
+	return cmd
+}
+
+func newPeopleProfileShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show your profile",
+		Long:  "Show the current authenticated person's Basecamp profile.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			person, err := app.Account().People().Me(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(person,
+				output.WithSummary(person.Name),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "update",
+						Cmd:         "basecamp people profile update --name <name>",
+						Description: "Update your profile",
+					},
+					output.Breadcrumb{
+						Action:      "preferences",
+						Cmd:         "basecamp people preferences show",
+						Description: "Show your preferences",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newPeopleProfileUpdateCmd() *cobra.Command {
+	var name string
+	var email string
+	var title string
+	var bio string
+	var location string
+	var timeZone string
+	var firstWeekDay string
+	var timeFormat string
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update your profile",
+		Long:  "Update the current authenticated person's Basecamp profile fields.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("name") &&
+				!cmd.Flags().Changed("email") &&
+				!cmd.Flags().Changed("title") &&
+				!cmd.Flags().Changed("bio") &&
+				!cmd.Flags().Changed("location") &&
+				!cmd.Flags().Changed("time-zone") &&
+				!cmd.Flags().Changed("first-week-day") &&
+				!cmd.Flags().Changed("time-format") {
+				return noChanges(cmd)
+			}
+
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			req := &basecamp.UpdateMyProfileRequest{}
+			if cmd.Flags().Changed("name") {
+				req.Name = &name
+			}
+			if cmd.Flags().Changed("email") {
+				req.EmailAddress = &email
+			}
+			if cmd.Flags().Changed("title") {
+				req.Title = &title
+			}
+			if cmd.Flags().Changed("bio") {
+				req.Bio = &bio
+			}
+			if cmd.Flags().Changed("location") {
+				req.Location = &location
+			}
+			if cmd.Flags().Changed("time-zone") {
+				req.TimeZoneName = &timeZone
+			}
+			if cmd.Flags().Changed("first-week-day") {
+				day, err := parseFirstWeekDay(firstWeekDay)
+				if err != nil {
+					return err
+				}
+				req.FirstWeekDay = &day
+			}
+			if cmd.Flags().Changed("time-format") {
+				req.TimeFormat = &timeFormat
+			}
+
+			if err := app.Account().People().UpdateMyProfile(cmd.Context(), req); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"updated": true},
+				output.WithSummary("Updated your profile"),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp people profile show",
+						Description: "Show your profile",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Display name")
+	cmd.Flags().StringVar(&email, "email", "", "Email address")
+	cmd.Flags().StringVar(&title, "title", "", "Job title")
+	cmd.Flags().StringVar(&bio, "bio", "", "Short biography")
+	cmd.Flags().StringVar(&location, "location", "", "Location")
+	cmd.Flags().StringVar(&timeZone, "time-zone", "", "Rails time zone name (for example America/Chicago)")
+	cmd.Flags().StringVar(&firstWeekDay, "first-week-day", "", "First day of the week (Sunday through Saturday)")
+	cmd.Flags().StringVar(&timeFormat, "time-format", "", "Time display format (twelve_hour or twenty_four_hour)")
+
+	return cmd
+}
+
+func newPeoplePreferencesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "preferences",
+		Short: "Manage your preferences",
+		Long:  "Show or update the current authenticated person's Basecamp preferences.",
+	}
+
+	cmd.AddCommand(
+		newPeoplePreferencesShowCmd(),
+		newPeoplePreferencesUpdateCmd(),
+	)
+
+	return cmd
+}
+
+func newPeoplePreferencesShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show your preferences",
+		Long:  "Show the current authenticated person's Basecamp preferences.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			prefs, err := app.Account().People().GetMyPreferences(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(prefs,
+				output.WithSummary("Your preferences"),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "update",
+						Cmd:         "basecamp people preferences update --time-format twenty_four_hour",
+						Description: "Update your preferences",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newPeoplePreferencesUpdateCmd() *cobra.Command {
+	var firstWeekDay string
+	var timeFormat string
+	var timeZone string
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update your preferences",
+		Long:  "Update the current authenticated person's Basecamp preferences.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("first-week-day") &&
+				!cmd.Flags().Changed("time-format") &&
+				!cmd.Flags().Changed("time-zone") {
+				return noChanges(cmd)
+			}
+
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			req := &basecamp.UpdateMyPreferencesRequest{}
+			if cmd.Flags().Changed("first-week-day") {
+				day, err := parseFirstWeekDay(firstWeekDay)
+				if err != nil {
+					return err
+				}
+				req.FirstWeekDay = string(day)
+			}
+			if cmd.Flags().Changed("time-format") {
+				req.TimeFormat = timeFormat
+			}
+			if cmd.Flags().Changed("time-zone") {
+				req.TimeZoneName = timeZone
+			}
+
+			if err := app.Account().People().UpdateMyPreferences(cmd.Context(), req); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"updated": true},
+				output.WithSummary("Updated your preferences"),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp people preferences show",
+						Description: "Show your preferences",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&firstWeekDay, "first-week-day", "", "First day of the week (Sunday through Saturday)")
+	cmd.Flags().StringVar(&timeFormat, "time-format", "", "Time display format (twelve_hour or twenty_four_hour)")
+	cmd.Flags().StringVar(&timeZone, "time-zone", "", "Rails time zone name (for example America/Chicago)")
+
+	return cmd
+}
+
+func newPeopleOutOfOfficeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "out-of-office",
+		Aliases: []string{"ooo"},
+		Short:   "Manage out-of-office status",
+		Long:    "Show, enable, or disable out-of-office status for yourself or another visible person.",
+	}
+
+	cmd.AddCommand(
+		newPeopleOutOfOfficeShowCmd(),
+		newPeopleOutOfOfficeEnableCmd(),
+		newPeopleOutOfOfficeDisableCmd(),
+	)
+
+	return cmd
+}
+
+func newPeopleOutOfOfficeShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show [person]",
+		Short: "Show out-of-office status",
+		Long:  "Show out-of-office status for a person. Defaults to the current user.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			personID, displayName, err := resolvePersonArg(cmd, app, args)
+			if err != nil {
+				return err
+			}
+
+			ooo, err := app.Account().People().GetOutOfOffice(cmd.Context(), personID)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			summary := fmt.Sprintf("Out of office for %s", displayName)
+			if ooo.Enabled {
+				summary = fmt.Sprintf("%s: %s to %s", summary, ooo.StartDate, ooo.EndDate)
+			}
+
+			return app.OK(ooo,
+				output.WithSummary(summary),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "enable",
+						Cmd:         "basecamp people out-of-office enable --from <date> --to <date>",
+						Description: "Enable out-of-office",
+					},
+					output.Breadcrumb{
+						Action:      "disable",
+						Cmd:         "basecamp people out-of-office disable",
+						Description: "Disable out-of-office",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newPeopleOutOfOfficeEnableCmd() *cobra.Command {
+	var startDate string
+	var endDate string
+
+	cmd := &cobra.Command{
+		Use:   "enable [person]",
+		Short: "Enable out-of-office status",
+		Long:  "Enable out-of-office status for a person. Defaults to the current user.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if startDate == "" || endDate == "" {
+				return output.ErrUsage("--from and --to are required")
+			}
+
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			personID, displayName, err := resolvePersonArg(cmd, app, args)
+			if err != nil {
+				return err
+			}
+
+			ooo, err := app.Account().People().EnableOutOfOffice(cmd.Context(), personID, &basecamp.EnableOutOfOfficeRequest{
+				StartDate: dateparse.Parse(startDate),
+				EndDate:   dateparse.Parse(endDate),
+			})
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(ooo,
+				output.WithSummary(fmt.Sprintf("Enabled out-of-office for %s", displayName)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp people out-of-office show",
+						Description: "Show out-of-office status",
+					},
+					output.Breadcrumb{
+						Action:      "disable",
+						Cmd:         "basecamp people out-of-office disable",
+						Description: "Disable out-of-office",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&startDate, "from", "", "Start date (natural language or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&endDate, "to", "", "End date (natural language or YYYY-MM-DD)")
+
+	return cmd
+}
+
+func newPeopleOutOfOfficeDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable [person]",
+		Short: "Disable out-of-office status",
+		Long:  "Disable out-of-office status for a person. Defaults to the current user.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			personID, displayName, err := resolvePersonArg(cmd, app, args)
+			if err != nil {
+				return err
+			}
+
+			if err := app.Account().People().DisableOutOfOffice(cmd.Context(), personID); err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(map[string]any{"disabled": true},
+				output.WithSummary(fmt.Sprintf("Disabled out-of-office for %s", displayName)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "show",
+						Cmd:         "basecamp people out-of-office show",
+						Description: "Show out-of-office status",
+					},
+				),
+			)
+		},
+	}
+}
+
 func newPeoplePingableCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pingable",
@@ -389,6 +794,47 @@ func runPeoplePingable(cmd *cobra.Command, args []string) error {
 	summary := fmt.Sprintf("%d pingable people", len(result.People))
 
 	return app.OK(result.People, output.WithSummary(summary))
+}
+
+func resolvePersonArg(cmd *cobra.Command, app *appctx.App, args []string) (int64, string, error) {
+	person := "me"
+	if len(args) > 0 {
+		person = args[0]
+	}
+
+	personIDStr, personName, err := app.Names.ResolvePerson(cmd.Context(), person)
+	if err != nil {
+		return 0, "", err
+	}
+	personID, err := strconv.ParseInt(personIDStr, 10, 64)
+	if err != nil {
+		return 0, "", output.ErrUsage("Invalid person ID")
+	}
+	if personName == "" {
+		personName = personIDStr
+	}
+	return personID, personName, nil
+}
+
+func parseFirstWeekDay(value string) (basecamp.FirstWeekDay, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "sunday":
+		return basecamp.FirstWeekDaySunday, nil
+	case "monday":
+		return basecamp.FirstWeekDayMonday, nil
+	case "tuesday":
+		return basecamp.FirstWeekDayTuesday, nil
+	case "wednesday":
+		return basecamp.FirstWeekDayWednesday, nil
+	case "thursday":
+		return basecamp.FirstWeekDayThursday, nil
+	case "friday":
+		return basecamp.FirstWeekDayFriday, nil
+	case "saturday":
+		return basecamp.FirstWeekDaySaturday, nil
+	default:
+		return "", output.ErrUsage("first week day must be Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, or Saturday")
+	}
 }
 
 func newPeopleAddCmd() *cobra.Command {

--- a/internal/commands/people_test.go
+++ b/internal/commands/people_test.go
@@ -524,6 +524,9 @@ func setupPeopleMockServer(t *testing.T, accountID string, projectID int64) *htt
 		projectPeoplePath := fmt.Sprintf("/%s/projects/%d/people.json", accountID, projectID)
 		accountPeoplePath := fmt.Sprintf("/%s/people.json", accountID)
 		accessPath := fmt.Sprintf("/%s/projects/%d/people/users.json", accountID, projectID)
+		mePath := fmt.Sprintf("/%s/my/profile.json", accountID)
+		prefsPath := fmt.Sprintf("/%s/my/preferences.json", accountID)
+		outOfOfficePath := fmt.Sprintf("/%s/people/%d/out_of_office.json", accountID, 1001)
 
 		switch {
 		case r.URL.Path == projectsPath && r.Method == http.MethodGet:
@@ -538,6 +541,59 @@ func setupPeopleMockServer(t *testing.T, accountID string, projectID int64) *htt
 				{"id": 2001, "name": "Account Bob", "title": "PM", "employee": true, "admin": true, "email_address": "bob@example.com"},
 				{"id": 2002, "name": "Account Carol", "title": "Design", "employee": true, "admin": false, "email_address": "carol@example.com"},
 			})
+		case r.URL.Path == mePath && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":            1001,
+				"name":          "Alice Test",
+				"email_address": "alice@example.com",
+			})
+		case r.URL.Path == mePath && r.Method == http.MethodPut:
+			var req map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, fmt.Sprintf("bad request body: %v", err), http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(req)
+		case r.URL.Path == prefsPath && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{
+				"first_week_day": "Monday",
+				"time_format":    "twenty_four_hour",
+				"time_zone_name": "America/Chicago",
+			})
+		case r.URL.Path == prefsPath && r.Method == http.MethodPut:
+			var req map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, fmt.Sprintf("bad request body: %v", err), http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(req)
+		case r.URL.Path == outOfOfficePath && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{
+				"enabled":    true,
+				"start_date": "2026-03-24",
+				"end_date":   "2026-03-28",
+				"person": map[string]any{
+					"id":   1001,
+					"name": "Alice Test",
+				},
+			})
+		case r.URL.Path == outOfOfficePath && r.Method == http.MethodPost:
+			var req map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, fmt.Sprintf("bad request body: %v", err), http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"enabled":    true,
+				"start_date": req["out_of_office"].(map[string]any)["start_date"],
+				"end_date":   req["out_of_office"].(map[string]any)["end_date"],
+				"person": map[string]any{
+					"id":   1001,
+					"name": "Alice Test",
+				},
+			})
+		case r.URL.Path == outOfOfficePath && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
 		case r.URL.Path == projectPeoplePath && r.Method == http.MethodGet:
 			// Project-scoped people list — return a distinct set
 			json.NewEncoder(w).Encode([]map[string]any{
@@ -718,4 +774,74 @@ func TestPeopleRemoveNoProject(t *testing.T) {
 	require.True(t, errors.As(err, &e))
 	assert.Equal(t, output.CodeUsage, e.Code)
 	assert.Contains(t, e.Message, "--project (or --in) is required")
+}
+
+func TestPeopleProfileUpdate(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, _ := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "profile", "update", "--name", "Alice Example", "--first-week-day", "Monday")
+	require.NoError(t, err)
+}
+
+func TestPeoplePreferencesShow(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, buf := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "preferences", "show")
+	require.NoError(t, err)
+
+	var result struct {
+		Data struct {
+			TimeFormat string `json:"time_format"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output: %s", buf.String())
+	assert.Equal(t, "twenty_four_hour", result.Data.TimeFormat)
+}
+
+func TestPeoplePreferencesUpdate(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, _ := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "preferences", "update", "--time-format", "twelve_hour", "--time-zone", "America/New_York")
+	require.NoError(t, err)
+}
+
+func TestPeopleOutOfOfficeShow(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, buf := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "out-of-office", "show", "1001")
+	require.NoError(t, err)
+
+	var result struct {
+		Data struct {
+			Enabled bool `json:"enabled"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output: %s", buf.String())
+	assert.True(t, result.Data.Enabled)
+}
+
+func TestPeopleOutOfOfficeEnable(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, _ := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "out-of-office", "enable", "1001", "--from", "2026-03-24", "--to", "2026-03-28")
+	require.NoError(t, err)
+}
+
+func TestPeopleOutOfOfficeDisable(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, _ := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "out-of-office", "disable", "1001")
+	require.NoError(t, err)
 }

--- a/internal/commands/reports.go
+++ b/internal/commands/reports.go
@@ -27,9 +27,136 @@ Reports provide cross-project views of assignments and schedules.`,
 	cmd.AddCommand(
 		newReportsAssignableCmd(),
 		newReportsAssignedCmd(),
+		newReportsMineCmd(),
+		newReportsCompletedCmd(),
+		newReportsDueCmd(),
 		newReportsOverdueCmd(),
 		newReportsScheduleCmd(),
 	)
+
+	return cmd
+}
+
+func newReportsMineCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "mine",
+		Short: "View your active assignments",
+		Long:  "View the current user's active assignments, split into priorities and non-priorities.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			result, err := app.Account().MyAssignments().Get(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			total := len(result.Priorities) + len(result.NonPriorities)
+			return app.OK(result,
+				output.WithSummary(fmt.Sprintf("%d active assignments", total)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "due",
+						Cmd:         "basecamp reports due",
+						Description: "View due assignments",
+					},
+					output.Breadcrumb{
+						Action:      "completed",
+						Cmd:         "basecamp reports completed",
+						Description: "View completed assignments",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newReportsCompletedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "completed",
+		Short: "View your completed assignments",
+		Long:  "View assignments the current user has completed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			result, err := app.Account().MyAssignments().Completed(cmd.Context())
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(result,
+				output.WithSummary(fmt.Sprintf("%d completed assignments", len(result))),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "mine",
+						Cmd:         "basecamp reports mine",
+						Description: "View active assignments",
+					},
+					output.Breadcrumb{
+						Action:      "due",
+						Cmd:         "basecamp reports due",
+						Description: "View due assignments",
+					},
+				),
+			)
+		},
+	}
+}
+
+func newReportsDueCmd() *cobra.Command {
+	var scope string
+
+	cmd := &cobra.Command{
+		Use:   "due",
+		Short: "View your due assignments",
+		Long:  "View due assignments for the current user, optionally filtered by due-date scope.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			if err := validateReportsDueScope(scope); err != nil {
+				return err
+			}
+
+			result, err := app.Account().MyAssignments().Due(cmd.Context(), scope)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			summary := fmt.Sprintf("%d due assignments", len(result))
+			if scope != "" {
+				summary += fmt.Sprintf(" (%s)", scope)
+			}
+
+			return app.OK(result,
+				output.WithSummary(summary),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "mine",
+						Cmd:         "basecamp reports mine",
+						Description: "View active assignments",
+					},
+					output.Breadcrumb{
+						Action:      "completed",
+						Cmd:         "basecamp reports completed",
+						Description: "View completed assignments",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&scope, "scope", "", "Filter due assignments (overdue, due_today, due_tomorrow, due_later_this_week, due_next_week, due_later)")
 
 	return cmd
 }
@@ -249,6 +376,15 @@ Todos are grouped into categories:
 				),
 			)
 		},
+	}
+}
+
+func validateReportsDueScope(scope string) error {
+	switch scope {
+	case "", "overdue", "due_today", "due_tomorrow", "due_later_this_week", "due_next_week", "due_later":
+		return nil
+	default:
+		return output.ErrUsage("--scope must be overdue, due_today, due_tomorrow, due_later_this_week, due_next_week, or due_later")
 	}
 }
 

--- a/internal/commands/reports_test.go
+++ b/internal/commands/reports_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReportsAssignmentsTransport struct {
+	capturedPath string
+	query        string
+}
+
+func (t *mockReportsAssignmentsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.capturedPath = req.URL.Path
+	t.query = req.URL.RawQuery
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch req.URL.Path {
+	case "/99999/my/assignments.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body: io.NopCloser(strings.NewReader(`{
+				"priorities": [{"id":1,"content":"Priority","bucket":{"id":123,"name":"Project"}}],
+				"non_priorities": [{"id":2,"content":"Normal","bucket":{"id":123,"name":"Project"}}]
+			}`)),
+		}, nil
+	case "/99999/my/assignments/completed.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":3,"content":"Done"}]`)),
+		}, nil
+	case "/99999/my/assignments/due.json":
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":4,"content":"Due soon"}]`)),
+		}, nil
+	default:
+		return &http.Response{
+			StatusCode: 404,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+		}, nil
+	}
+}
+
+func TestReportsMine(t *testing.T) {
+	transport := &mockReportsAssignmentsTransport{}
+	app, buf := newTestAppWithTransport(t, transport)
+
+	cmd := NewReportsCmd()
+	err := executeCommand(cmd, app, "mine")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/99999/my/assignments.json", transport.capturedPath)
+
+	var envelope struct {
+		Data struct {
+			Priorities []map[string]any `json:"priorities"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.Len(t, envelope.Data.Priorities, 1)
+}
+
+func TestReportsCompleted(t *testing.T) {
+	transport := &mockReportsAssignmentsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewReportsCmd()
+	err := executeCommand(cmd, app, "completed")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/99999/my/assignments/completed.json", transport.capturedPath)
+}
+
+func TestReportsDue(t *testing.T) {
+	transport := &mockReportsAssignmentsTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	cmd := NewReportsCmd()
+	err := executeCommand(cmd, app, "due", "--scope", "due_today")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/99999/my/assignments/due.json", transport.capturedPath)
+	assert.Equal(t, "scope=due_today", transport.query)
+}
+
+func TestReportsDueRejectsBadScope(t *testing.T) {
+	app, _ := setupTestApp(t)
+
+	cmd := NewReportsCmd()
+	err := executeCommand(cmd, app, "due", "--scope", "tomorrowish")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--scope must be overdue")
+}

--- a/internal/commands/schedule.go
+++ b/internal/commands/schedule.go
@@ -650,7 +650,6 @@ You can pass either an entry ID or a Basecamp URL:
 						return attachErr
 					}
 					html = richtext.EmbedAttachments(html, refs)
-					hasChanges = true
 				}
 
 				req.Description = html

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -1647,7 +1647,7 @@ You can pass either a todo ID or a Basecamp URL:
 				return output.ErrUsage("Invalid todo ID")
 			}
 
-			err = app.Account().Todos().Reposition(cmd.Context(), todoID, position)
+			err = app.Account().Todos().Reposition(cmd.Context(), todoID, position, nil)
 			if err != nil {
 				return convertSDKError(err)
 			}

--- a/internal/tui/workspace/data/mutations_card.go
+++ b/internal/tui/workspace/data/mutations_card.go
@@ -64,7 +64,7 @@ func (m CardMoveMutation) ApplyLocally(columns []CardColumnInfo) []CardColumnInf
 
 // ApplyRemotely calls the SDK to move the card.
 func (m CardMoveMutation) ApplyRemotely(ctx context.Context) error {
-	return m.Client.Cards().Move(ctx, m.CardID, m.TargetColumnID)
+	return m.Client.Cards().Move(ctx, m.CardID, m.TargetColumnID, nil)
 }
 
 // IsReflectedIn returns true when the card appears in the target column


### PR DESCRIPTION
## Summary
This draft prepares the CLI for the upcoming SDK sync branch and keeps the work split into service-focused commits so reviewers can walk the changes commit by commit.

This branch was developed and validated locally against the SDK sync branch at `97fde17` via a temporary `go.work` override. The final SDK bump is intentionally **not** included here yet.

## Dependency Status
This PR is draft-only until the SDK work lands.

Blocking items before this can merge:
- the SDK sync branch needs to merge
- the notifications follow-up SDK PR needs to merge: https://github.com/robzolkos/basecamp-sdk/pull/1
- this branch then needs the normal `make bump-sdk` follow-up
- `internal/version/sdk-provenance.json` and `API-COVERAGE.md` should be updated once the SDK ref is final

Because the SDK bump is intentionally deferred, reviewers should treat this as a prepared CLI implementation branch rather than a merge-ready PR.

## What Changed
### Compatibility updates for existing CLI behavior
- adapted card move calls to the new SDK `Cards().Move(..., opts)` signature
- replaced the old positioned-card move workaround with the SDK's native move-position option
- added an overflow guard around the new card position conversion path
- added forwards sorting support with `--sort created|updated` and `--reverse`

### Account management
Added account-scoped management commands under `accounts`:
- `basecamp accounts show`
- `basecamp accounts rename <name>`
- `basecamp accounts logo set <path>`
- `basecamp accounts logo remove`

I kept these under `accounts` rather than introducing a new top-level `account` group because `account` is already an alias for `accounts`.

### People profile, preferences, and out-of-office
Extended `people` with current-user settings and out-of-office operations:
- `basecamp people profile show`
- `basecamp people profile update ...`
- `basecamp people preferences show`
- `basecamp people preferences update ...`
- `basecamp people out-of-office show [person]`
- `basecamp people out-of-office enable --from <date> --to <date> [person]`
- `basecamp people out-of-office disable [person]`

### Gauges
Added a new top-level `gauges` command group covering both account-wide listing and project-scoped needle management:
- `basecamp gauges list`
- `basecamp gauges needles --in <project>`
- `basecamp gauges show <needle-id|url>`
- `basecamp gauges create --position <0-100> --in <project> ...`
- `basecamp gauges update <needle-id|url> --description <text>`
- `basecamp gauges delete <needle-id|url>`
- `basecamp gauges enable --in <project>`
- `basecamp gauges disable --in <project>`

### Notifications
Added a new top-level `notifications` command group:
- `basecamp notifications list [--page]`
- `basecamp notifications read <readable-sgid>...`

One live-data issue showed up while testing this surface: notification creators can be local people with string IDs like `"bulletins"` or `"onboarding"`. That turned out to be an SDK bug rather than a CLI bug, which is why the stacked SDK PR above exists.

### My assignments
Extended `reports` with current-user assignment views:
- `basecamp reports mine`
- `basecamp reports completed`
- `basecamp reports due [--scope overdue|due_today|due_tomorrow|due_later_this_week|due_next_week|due_later]`

I kept these under `reports` rather than adding another top-level command so they stay discoverable alongside the existing account-wide report commands.

## Review Guide
This branch is intentionally organized as service-focused commits:
- `176d049` Adapt card moves to SDK sync branch
- `3389677` Add account management commands
- `9965106` Add people profile and preferences commands
- `16eef9d` Add gauges command group
- `be5f8ae` Add notifications command group
- `dbd9c60` Add my assignments reports commands
- `489fa2d` Add forwards sorting options
- `7497f40` Fix lint regressions after main rebase
- `10c9177` Refresh surface baseline and smoke coverage

The intent is that a reviewer can read this top-down and see the CLI surface expand one service at a time.

## Validation
Local validation on this branch was done with the SDK sync worktree wired in through `GOWORK=/tmp/basecamp-cli-sdk-sync.go.work`:
- `bin/ci`
- `make check-surface`
- targeted service tests for the new command groups

I also ran live read-only checks against account `5978679` for the new surfaces:
- accounts
- people profile/preferences/out-of-office
- reports mine/completed/due
- gauges list
- notifications list (after pairing with the SDK follow-up fix)

## Intentionally Deferred
These are intentionally not in this draft yet because they should reflect the final merged SDK ref rather than the local prep setup:
- `make bump-sdk`
- `internal/version/sdk-provenance.json`
- `API-COVERAGE.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the CLI for the upcoming `basecamp-sdk` sync by adding new surfaces (accounts, people, gauges, notifications, my assignments) and adapting card and todo moves to the new SDK APIs. The SDK bump is intentionally deferred; this is the CLI implementation only.

- **New Features**
  - Accounts: show, rename, logo set/remove.
  - People: profile show/update; preferences show/update; out-of-office show/enable/disable.
  - Gauges: list; project needles; show/create/update/delete; enable/disable.
  - Notifications: list; read by readable SGID.
  - Reports: mine, completed, due [overdue|due_today|due_tomorrow|due_later_this_week|due_next_week|due_later].
  - Forwards: add --sort created|updated and --reverse.
  - Cards: switch to `Cards().Move(..., opts)` with position support and overflow guard; update TUI move call.
  - Todos: switch to `Todos().Reposition(..., opts)`.

- **Dependencies**
  - Blocked on the SDK sync merge and the notifications fix in `basecamp-sdk`.
  - After SDK lands: run `make bump-sdk`, then update `internal/version/sdk-provenance.json` and `API-COVERAGE.md`.

<sup>Written for commit 58101252cde125a100d9209794015c9536c3ec89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

