### PR TITLE
Fix blank-line-after-list suppressing paragraph break

### DIFF
--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -229,6 +229,7 @@ func MarkdownToHTML(md string) string {
 				inList = true
 				listType = "ul"
 			}
+			pendingBreak = false // blank was between items, not after the list
 			listItems = append(listItems, convertInline(ulMatch[2]))
 			continue
 		}
@@ -241,6 +242,7 @@ func MarkdownToHTML(md string) string {
 				inList = true
 				listType = "ol"
 			}
+			pendingBreak = false // blank was between items, not after the list
 			listItems = append(listItems, convertInline(olMatch[2]))
 			continue
 		}
@@ -270,6 +272,7 @@ func MarkdownToHTML(md string) string {
 				// Append to last list item with <br> separator
 				lastItemIndex := len(listItems) - 1
 				listItems[lastItemIndex] = listItems[lastItemIndex] + "<br>\n" + convertInline(trimmedLine)
+				pendingBreak = false // blank was before continuation, not after the list
 				continue
 			}
 		}

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -88,6 +88,11 @@ func TestMarkdownToHTML(t *testing.T) {
 			expected: "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>\n<br>\n<p>Following paragraph.</p>",
 		},
 		{
+			name:     "blank between list items does not leak break after list",
+			input:    "- One\n\n- Two\nAfter",
+			expected: "<ul>\n<li>One</li>\n<li>Two</li>\n</ul>\n<p>After</p>",
+		},
+		{
 			name:     "blockquote",
 			input:    "> This is a quote",
 			expected: "<blockquote>This is a quote</blockquote>",


### PR DESCRIPTION
## Summary
- The list continuation fix (6ed164f) swallowed blank lines inside lists without setting `pendingBreak`, so a blank line between a list and the following paragraph no longer produced the `<br>` separator
- Sets `pendingBreak = true` when eating blank lines inside lists — safe because list item processing never consumes `pendingBreak`, so it only fires when content follows the list
- Adds test case for list → blank line → paragraph

## Test plan
- [x] `go test ./internal/richtext/` — all existing tests pass, new test case validates the fix
- [x] `make lint` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where a blank line after a list didn’t insert the `<br>` before the next paragraph. Sets `pendingBreak` on blank lines inside lists and clears it when the list continues (new item or continuation), so only the last blank before exiting the list adds the separator; tests cover list → blank → paragraph and ensure blanks between items don’t leak a break.

<sup>Written for commit b18c144cc6bf8e9779bce4220cb390547eda0080. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

