### PR TITLE
Fix schedule update silently dropping --attach without --description

### DIFF
--- a/internal/commands/schedule.go
+++ b/internal/commands/schedule.go
@@ -677,8 +677,8 @@ You can pass either an entry ID or a Basecamp URL:
 				}
 			}
 
-			// Handle attachments-only updates (no description text provided)
-			if !hasChanges && len(attachFiles) > 0 {
+			// Handle attachments when no description text provided
+			if description == "" && len(attachFiles) > 0 {
 				refs, attachErr := uploadAttachments(cmd, app, attachFiles)
 				if attachErr != nil {
 					return attachErr


### PR DESCRIPTION
## Summary
- `basecamp schedule update <id> --summary "New" --attach foo.pdf` silently dropped the attachment because the attach-only fallback was gated on `!hasChanges` — any other flag (summary, starts-at, etc.) set `hasChanges = true` first, skipping the fallback
- Changes guard from `!hasChanges` to `description == ""` so attachments are processed whenever no description text is provided, regardless of other flags
- The `cards update` command handles this correctly (attach block is outside the content guard); this aligns schedule with that pattern

## Test plan
- [x] `make test` — all pass
- [x] `make lint` — clean
- [ ] Manual: `basecamp schedule update <id> --summary "test" --attach <file>` should upload the attachment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `basecamp schedule update` dropping `--attach` when used with other flags like `--summary` and no description. Attachments now process whenever the description is empty, matching `cards update`.

- **Bug Fixes**
  - Changed guard from `!hasChanges` to `description == ""` for attachment handling.
  - Honors `--attach` alongside flags like `--summary` and `--starts-at` when no description text is passed.

<sup>Written for commit 8a9343ac1f91c9ea892060fbb6469f97d1d7f2ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

