### PR TITLE
Fix chat post JSON output contract and upload error handling

### DIFF
--- a/internal/commands/chat.go
+++ b/internal/commands/chat.go
@@ -420,7 +420,12 @@ func runChatPost(cmd *cobra.Command, app *appctx.App, chatID, project, content, 
 		uploadLine, err := app.Account().Campfires().CreateUpload(cmd.Context(), chatIDInt, filename, mimeType, f)
 		f.Close()
 		if err != nil {
-			return convertSDKError(fmt.Errorf("%s: %w", filePath, err))
+			sdkErr := convertSDKError(err)
+			if outErr, ok := sdkErr.(*output.Error); ok {
+				outErr.Message = fmt.Sprintf("%s: %s", filePath, outErr.Message)
+				return outErr
+			}
+			return fmt.Errorf("%s: %w", filePath, err)
 		}
 		uploadIDs = append(uploadIDs, uploadLine.ID)
 	}


### PR DESCRIPTION
## Summary
- The `--attach` addition (cbaf4c5) replaced the `CampfireLine` return with a synthetic `{"message_id", "upload_ids"}` map, breaking `--json` consumers expecting Line fields and mismatching the `chat_line` schema presenter
- Restores `*basecamp.CampfireLine` return for text-only posts (preserves backward compatibility); uses composite map only when uploads are involved, without the `chat_line` entity hint
- Routes upload errors through `convertSDKError` (was using raw `fmt.Errorf`, losing SDK error code/hint extraction)
- Renames `contentType` variable shadow to `mimeType` in the upload loop

## Test plan
- [x] `make test` — all pass
- [x] `make lint` — clean
- [ ] Manual: `basecamp chat post "hello" --in <project> --json` should return full CampfireLine JSON
- [ ] Manual: `basecamp chat post "hello" --attach <file> --in <project>` should return composite result

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the chat post JSON contract. Text-only posts return the full `*basecamp.CampfireLine` with display data; uploads return a compact map with `message_id` and/or `upload_ids`. Improves error handling and keeps SDK error codes, including file path context for failed uploads.

- **Bug Fixes**
  - Return `*basecamp.CampfireLine` for text-only posts; set entity to `chat_line` and add `WithDisplayData(chatLineDisplayData(line))`.
  - For uploads, return a composite result without the `chat_line` entity; include `message_id` when present and `upload_ids` for attachments.
  - Route `CreateLine` and `CreateUpload` errors through `convertSDKError`; preserve the failing file path in structured SDK errors; rename shadowed `contentType` to `mimeType`.

<sup>Written for commit 49eb2fc96c44db58e557761d8d437620b7cec0e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

