### PR TITLE
Regenerate .surface from Go walker with ARG and alias support

### DIFF
--- a/.surface
+++ b/.surface
@@ -1,4 +1,420 @@
+ARG basecamp account use 00 <id>
+ARG basecamp accounts use 00 <id>
+ARG basecamp api delete 00 <path>
+ARG basecamp api get 00 <path>
+ARG basecamp api post 00 <path>
+ARG basecamp api put 00 <path>
+ARG basecamp assign 00 <id|url>...
+ARG basecamp attach 00 <file>
+ARG basecamp attach 01 [<file2]
+ARG basecamp attachments list 00 <id|url>
+ARG basecamp bonfire layout load 00 <name>
+ARG basecamp bonfire layout save 00 <name>
+ARG basecamp bonfire layout save 01 <url>...
+ARG basecamp bonfire split 00 <room-url>
+ARG basecamp boost create 00 <id|url>
+ARG basecamp boost create 01 <content>
+ARG basecamp boost delete 00 <boost-id|url>
+ARG basecamp boost list 00 <id|url>
+ARG basecamp boost show 00 <boost-id|url>
+ARG basecamp boosts create 00 <id|url>
+ARG basecamp boosts create 01 <content>
+ARG basecamp boosts delete 00 <boost-id|url>
+ARG basecamp boosts list 00 <id|url>
+ARG basecamp boosts show 00 <boost-id|url>
+ARG basecamp campfire delete 00 <id|url>
+ARG basecamp campfire line 00 <id|url>
+ARG basecamp campfire post 00 <message>
+ARG basecamp campfire show 00 <id|url>
+ARG basecamp campfire upload 00 <file>
+ARG basecamp card 00 <title>
+ARG basecamp card 01 [body]
+ARG basecamp card move 00 <id|url>
+ARG basecamp card mv 00 <id|url>
+ARG basecamp card update 00 <id|url>
+ARG basecamp cards archive 00 <id|url>
+ARG basecamp cards column color 00 <id|url>
+ARG basecamp cards column create 00 <title>
+ARG basecamp cards column move 00 <id|url>
+ARG basecamp cards column no-on-hold 00 <id|url>
+ARG basecamp cards column on-hold 00 <id|url>
+ARG basecamp cards column show 00 <id|url>
+ARG basecamp cards column unwatch 00 <id|url>
+ARG basecamp cards column update 00 <id|url>
+ARG basecamp cards column watch 00 <id|url>
+ARG basecamp cards create 00 <title>
+ARG basecamp cards create 01 [body]
+ARG basecamp cards move 00 <id|url>
+ARG basecamp cards mv 00 <id|url>
+ARG basecamp cards restore 00 <id|url>
+ARG basecamp cards show 00 <id|url>
+ARG basecamp cards step complete 00 <step_id|url>
+ARG basecamp cards step create 00 <title>
+ARG basecamp cards step delete 00 <step_id|url>
+ARG basecamp cards step move 00 <step_id|url>
+ARG basecamp cards step uncomplete 00 <step_id|url>
+ARG basecamp cards step update 00 <step_id|url>
+ARG basecamp cards step update 01 [title]
+ARG basecamp cards steps 00 <card-id|url>
+ARG basecamp cards trash 00 <id|url>
+ARG basecamp cards update 00 <id|url>
+ARG basecamp chat delete 00 <id|url>
+ARG basecamp chat line 00 <id|url>
+ARG basecamp chat post 00 <message>
+ARG basecamp chat show 00 <id|url>
+ARG basecamp chat upload 00 <file>
+ARG basecamp checkin answer 00 <id|url>
+ARG basecamp checkin answer create 00 <question-id>
+ARG basecamp checkin answer create 01 <content>
+ARG basecamp checkin answer show 00 <id|url>
+ARG basecamp checkin answer update 00 <id|url>
+ARG basecamp checkin answer update 01 <content>
+ARG basecamp checkin answers 00 <question_id|url>
+ARG basecamp checkin question 00 <id|url>
+ARG basecamp checkin question create 00 <title>
+ARG basecamp checkin question show 00 <id|url>
+ARG basecamp checkin question update 00 <id|url>
+ARG basecamp checkin question update 01 [title]
+ARG basecamp checkins answer 00 <id|url>
+ARG basecamp checkins answer create 00 <question-id>
+ARG basecamp checkins answer create 01 <content>
+ARG basecamp checkins answer show 00 <id|url>
+ARG basecamp checkins answer update 00 <id|url>
+ARG basecamp checkins answer update 01 <content>
+ARG basecamp checkins answers 00 <question_id|url>
+ARG basecamp checkins question 00 <id|url>
+ARG basecamp checkins question create 00 <title>
+ARG basecamp checkins question show 00 <id|url>
+ARG basecamp checkins question update 00 <id|url>
+ARG basecamp checkins question update 01 [title]
+ARG basecamp comment 00 <id|url>
+ARG basecamp comment 01 <content>
+ARG basecamp comments archive 00 <id|url>
+ARG basecamp comments create 00 <id|url>
+ARG basecamp comments create 01 <content>
+ARG basecamp comments list 00 <id|url>
+ARG basecamp comments restore 00 <id|url>
+ARG basecamp comments show 00 <id|url>
+ARG basecamp comments trash 00 <id|url>
+ARG basecamp comments update 00 <id|url>
+ARG basecamp comments update 01 <content>
+ARG basecamp completion 00 [shell]
+ARG basecamp config set 00 <key>
+ARG basecamp config set 01 <value>
+ARG basecamp config trust 00 [path]
+ARG basecamp config unset 00 <key>
+ARG basecamp config untrust 00 [path]
+ARG basecamp docs archive 00 <id|url>
+ARG basecamp docs doc create 00 <title>
+ARG basecamp docs doc create 01 [content]
+ARG basecamp docs document create 00 <title>
+ARG basecamp docs document create 01 [content]
+ARG basecamp docs documents create 00 <title>
+ARG basecamp docs documents create 01 [content]
+ARG basecamp docs download 00 <upload-id|url>
+ARG basecamp docs folder create 00 <name>
+ARG basecamp docs folders create 00 <name>
+ARG basecamp docs restore 00 <id|url>
+ARG basecamp docs show 00 <id|url>
+ARG basecamp docs trash 00 <id|url>
+ARG basecamp docs update 00 <id|url>
+ARG basecamp docs upload create 00 <file>
+ARG basecamp docs uploads create 00 <file>
+ARG basecamp docs vault create 00 <name>
+ARG basecamp docs vaults create 00 <name>
+ARG basecamp documents archive 00 <id|url>
+ARG basecamp documents doc create 00 <title>
+ARG basecamp documents doc create 01 [content]
+ARG basecamp documents document create 00 <title>
+ARG basecamp documents document create 01 [content]
+ARG basecamp documents documents create 00 <title>
+ARG basecamp documents documents create 01 [content]
+ARG basecamp documents download 00 <upload-id|url>
+ARG basecamp documents folder create 00 <name>
+ARG basecamp documents folders create 00 <name>
+ARG basecamp documents restore 00 <id|url>
+ARG basecamp documents show 00 <id|url>
+ARG basecamp documents trash 00 <id|url>
+ARG basecamp documents update 00 <id|url>
+ARG basecamp documents upload create 00 <file>
+ARG basecamp documents uploads create 00 <file>
+ARG basecamp documents vault create 00 <name>
+ARG basecamp documents vaults create 00 <name>
+ARG basecamp done 00 <id|url>...
+ARG basecamp events 00 <id|url>
+ARG basecamp file archive 00 <id|url>
+ARG basecamp file doc create 00 <title>
+ARG basecamp file doc create 01 [content]
+ARG basecamp file document create 00 <title>
+ARG basecamp file document create 01 [content]
+ARG basecamp file documents create 00 <title>
+ARG basecamp file documents create 01 [content]
+ARG basecamp file download 00 <upload-id|url>
+ARG basecamp file folder create 00 <name>
+ARG basecamp file folders create 00 <name>
+ARG basecamp file restore 00 <id|url>
+ARG basecamp file show 00 <id|url>
+ARG basecamp file trash 00 <id|url>
+ARG basecamp file update 00 <id|url>
+ARG basecamp file upload create 00 <file>
+ARG basecamp file uploads create 00 <file>
+ARG basecamp file vault create 00 <name>
+ARG basecamp file vaults create 00 <name>
+ARG basecamp files archive 00 <id|url>
+ARG basecamp files doc create 00 <title>
+ARG basecamp files doc create 01 [content]
+ARG basecamp files document create 00 <title>
+ARG basecamp files document create 01 [content]
+ARG basecamp files documents create 00 <title>
+ARG basecamp files documents create 01 [content]
+ARG basecamp files download 00 <upload-id|url>
+ARG basecamp files folder create 00 <name>
+ARG basecamp files folders create 00 <name>
+ARG basecamp files restore 00 <id|url>
+ARG basecamp files show 00 <id|url>
+ARG basecamp files trash 00 <id|url>
+ARG basecamp files update 00 <id|url>
+ARG basecamp files upload create 00 <file>
+ARG basecamp files uploads create 00 <file>
+ARG basecamp files vault create 00 <name>
+ARG basecamp files vaults create 00 <name>
+ARG basecamp folders archive 00 <id|url>
+ARG basecamp folders doc create 00 <title>
+ARG basecamp folders doc create 01 [content]
+ARG basecamp folders document create 00 <title>
+ARG basecamp folders document create 01 [content]
+ARG basecamp folders documents create 00 <title>
+ARG basecamp folders documents create 01 [content]
+ARG basecamp folders download 00 <upload-id|url>
+ARG basecamp folders folder create 00 <name>
+ARG basecamp folders folders create 00 <name>
+ARG basecamp folders restore 00 <id|url>
+ARG basecamp folders show 00 <id|url>
+ARG basecamp folders trash 00 <id|url>
+ARG basecamp folders update 00 <id|url>
+ARG basecamp folders upload create 00 <file>
+ARG basecamp folders uploads create 00 <file>
+ARG basecamp folders vault create 00 <name>
+ARG basecamp folders vaults create 00 <name>
+ARG basecamp forwards replies 00 <forward_id|url>
+ARG basecamp forwards reply 00 <forward_id|url>
+ARG basecamp forwards reply 01 <reply_id|url>
+ARG basecamp forwards show 00 <id|url>
+ARG basecamp help 00 [command]
+ARG basecamp hillcharts track 00 <todolist-ids>
+ARG basecamp hillcharts untrack 00 <todolist-ids>
+ARG basecamp lineup create 00 <name>
+ARG basecamp lineup create 01 <date>
+ARG basecamp lineup delete 00 <id|url>
+ARG basecamp lineup update 00 <id|url>
+ARG basecamp lineup update 01 [name]
+ARG basecamp lineup update 02 [date]
+ARG basecamp message 00 <title>
+ARG basecamp message 01 [body]
+ARG basecamp messageboards show 00 [id]
+ARG basecamp messages archive 00 <id|url>
+ARG basecamp messages create 00 <title>
+ARG basecamp messages create 01 [body]
+ARG basecamp messages pin 00 <id|url>
+ARG basecamp messages publish 00 <id|url>
+ARG basecamp messages restore 00 <id|url>
+ARG basecamp messages show 00 <id|url>
+ARG basecamp messages trash 00 <id|url>
+ARG basecamp messages unpin 00 <id|url>
+ARG basecamp messages update 00 <id|url>
+ARG basecamp messagetypes create 00 <name>
+ARG basecamp messagetypes delete 00 <id>
+ARG basecamp messagetypes show 00 <id>
+ARG basecamp messagetypes update 00 <id>
+ARG basecamp msgs archive 00 <id|url>
+ARG basecamp msgs create 00 <title>
+ARG basecamp msgs create 01 [body]
+ARG basecamp msgs pin 00 <id|url>
+ARG basecamp msgs publish 00 <id|url>
+ARG basecamp msgs restore 00 <id|url>
+ARG basecamp msgs show 00 <id|url>
+ARG basecamp msgs trash 00 <id|url>
+ARG basecamp msgs unpin 00 <id|url>
+ARG basecamp msgs update 00 <id|url>
+ARG basecamp people add 00 <person-id>...
+ARG basecamp people remove 00 <person-id>...
+ARG basecamp people show 00 <id|name>
+ARG basecamp profile create 00 <name>
+ARG basecamp profile delete 00 <name>
+ARG basecamp profile set-default 00 <name>
+ARG basecamp profile show 00 [name]
+ARG basecamp project create 00 <name>
+ARG basecamp project delete 00 <id>
+ARG basecamp project show 00 <id>
+ARG basecamp project trash 00 <id>
+ARG basecamp project update 00 <id>
+ARG basecamp projects create 00 <name>
+ARG basecamp projects delete 00 <id>
+ARG basecamp projects show 00 <id>
+ARG basecamp projects trash 00 <id>
+ARG basecamp projects update 00 <id>
+ARG basecamp react 00 <content>
+ARG basecamp recordings 00 [type]
+ARG basecamp recordings active 00 <id|url>
+ARG basecamp recordings archive 00 <id|url>
+ARG basecamp recordings archived 00 <id|url>
+ARG basecamp recordings client-visibility 00 <id|url>
+ARG basecamp recordings list 00 [type]
+ARG basecamp recordings restore 00 <id|url>
+ARG basecamp recordings trash 00 <id|url>
+ARG basecamp recordings trashed 00 <id|url>
+ARG basecamp recordings visibility 00 <id|url>
+ARG basecamp reopen 00 <id|url>...
+ARG basecamp reports assigned 00 [person]
+ARG basecamp schedule create 00 <summary>
+ARG basecamp schedule show 00 <id|url>
+ARG basecamp schedule update 00 <id|url>
+ARG basecamp search 00 <query>
+ARG basecamp show 00 [type]
+ARG basecamp show 01 <id|url>
+ARG basecamp subscriptions add 00 <id|url>
+ARG basecamp subscriptions add 01 [person_ids]
+ARG basecamp subscriptions remove 00 <id|url>
+ARG basecamp subscriptions remove 01 [person_ids]
+ARG basecamp subscriptions show 00 <id|url>
+ARG basecamp subscriptions subscribe 00 <id|url>
+ARG basecamp subscriptions unsubscribe 00 <id|url>
+ARG basecamp templates construct 00 <template_id>
+ARG basecamp templates construction 00 <template_id>
+ARG basecamp templates construction 01 <construction_id>
+ARG basecamp templates create 00 <name>
+ARG basecamp templates delete 00 <id>
+ARG basecamp templates show 00 <id>
+ARG basecamp templates update 00 <id>
+ARG basecamp timeline 00 [me]
+ARG basecamp timesheet item 00 <id>
+ARG basecamp timesheet recording 00 <id>
+ARG basecamp tlgroup create 00 <name>
+ARG basecamp tlgroup move 00 <id>
+ARG basecamp tlgroup position 00 <id>
+ARG basecamp tlgroup rename 00 <id>
+ARG basecamp tlgroup rename 01 <name>
+ARG basecamp tlgroup show 00 <id>
+ARG basecamp tlgroup update 00 <id>
+ARG basecamp tlgroup update 01 <name>
+ARG basecamp tlgroups create 00 <name>
+ARG basecamp tlgroups move 00 <id>
+ARG basecamp tlgroups position 00 <id>
+ARG basecamp tlgroups rename 00 <id>
+ARG basecamp tlgroups rename 01 <name>
+ARG basecamp tlgroups show 00 <id>
+ARG basecamp tlgroups update 00 <id>
+ARG basecamp tlgroups update 01 <name>
+ARG basecamp todo 00 <content>
+ARG basecamp todolist archive 00 <id|url>
+ARG basecamp todolist create 00 <name>
+ARG basecamp todolist restore 00 <id|url>
+ARG basecamp todolist show 00 <id|url>
+ARG basecamp todolist trash 00 <id|url>
+ARG basecamp todolist update 00 <id|url>
+ARG basecamp todolistgroup create 00 <name>
+ARG basecamp todolistgroup move 00 <id>
+ARG basecamp todolistgroup position 00 <id>
+ARG basecamp todolistgroup rename 00 <id>
+ARG basecamp todolistgroup rename 01 <name>
+ARG basecamp todolistgroup show 00 <id>
+ARG basecamp todolistgroup update 00 <id>
+ARG basecamp todolistgroup update 01 <name>
+ARG basecamp todolistgroups create 00 <name>
+ARG basecamp todolistgroups move 00 <id>
+ARG basecamp todolistgroups position 00 <id>
+ARG basecamp todolistgroups rename 00 <id>
+ARG basecamp todolistgroups rename 01 <name>
+ARG basecamp todolistgroups show 00 <id>
+ARG basecamp todolistgroups update 00 <id>
+ARG basecamp todolistgroups update 01 <name>
+ARG basecamp todolists archive 00 <id|url>
+ARG basecamp todolists create 00 <name>
+ARG basecamp todolists restore 00 <id|url>
+ARG basecamp todolists show 00 <id|url>
+ARG basecamp todolists trash 00 <id|url>
+ARG basecamp todolists update 00 <id|url>
+ARG basecamp todos archive 00 <id|url>
+ARG basecamp todos complete 00 <id|url>...
+ARG basecamp todos create 00 <content>
+ARG basecamp todos move 00 <id|url>
+ARG basecamp todos position 00 <id|url>
+ARG basecamp todos reopen 00 <id|url>...
+ARG basecamp todos reorder 00 <id|url>
+ARG basecamp todos restore 00 <id|url>
+ARG basecamp todos show 00 <id|url>
+ARG basecamp todos trash 00 <id|url>
+ARG basecamp todos uncomplete 00 <id|url>...
+ARG basecamp todos update 00 <id|url>
+ARG basecamp todos update 01 [title]
+ARG basecamp todosets show 00 [id]
+ARG basecamp tools create 00 [title]
+ARG basecamp tools delete 00 <id>
+ARG basecamp tools disable 00 <id>
+ARG basecamp tools enable 00 <id>
+ARG basecamp tools move 00 <id>
+ARG basecamp tools rename 00 <id>
+ARG basecamp tools rename 01 <title>
+ARG basecamp tools reposition 00 <id>
+ARG basecamp tools show 00 <id>
+ARG basecamp tools trash 00 <id>
+ARG basecamp tools update 00 <id>
+ARG basecamp tools update 01 <title>
+ARG basecamp tui 00 [url]
+ARG basecamp unassign 00 <id|url>...
+ARG basecamp upload 00 <file>
+ARG basecamp uploads create 00 <file>
+ARG basecamp uploads show 00 <id|url>
+ARG basecamp url 00 <url>
+ARG basecamp url parse 00 <url>
+ARG basecamp vault archive 00 <id|url>
+ARG basecamp vault doc create 00 <title>
+ARG basecamp vault doc create 01 [content]
+ARG basecamp vault document create 00 <title>
+ARG basecamp vault document create 01 [content]
+ARG basecamp vault documents create 00 <title>
+ARG basecamp vault documents create 01 [content]
+ARG basecamp vault download 00 <upload-id|url>
+ARG basecamp vault folder create 00 <name>
+ARG basecamp vault folders create 00 <name>
+ARG basecamp vault restore 00 <id|url>
+ARG basecamp vault show 00 <id|url>
+ARG basecamp vault trash 00 <id|url>
+ARG basecamp vault update 00 <id|url>
+ARG basecamp vault upload create 00 <file>
+ARG basecamp vault uploads create 00 <file>
+ARG basecamp vault vault create 00 <name>
+ARG basecamp vault vaults create 00 <name>
+ARG basecamp vaults archive 00 <id|url>
+ARG basecamp vaults doc create 00 <title>
+ARG basecamp vaults doc create 01 [content]
+ARG basecamp vaults document create 00 <title>
+ARG basecamp vaults document create 01 [content]
+ARG basecamp vaults documents create 00 <title>
+ARG basecamp vaults documents create 01 [content]
+ARG basecamp vaults download 00 <upload-id|url>
+ARG basecamp vaults folder create 00 <name>
+ARG basecamp vaults folders create 00 <name>
+ARG basecamp vaults restore 00 <id|url>
+ARG basecamp vaults show 00 <id|url>
+ARG basecamp vaults trash 00 <id|url>
+ARG basecamp vaults update 00 <id|url>
+ARG basecamp vaults upload create 00 <file>
+ARG basecamp vaults uploads create 00 <file>
+ARG basecamp vaults vault create 00 <name>
+ARG basecamp vaults vaults create 00 <name>
+ARG basecamp webhook create 00 <url>
+ARG basecamp webhook delete 00 <id>
+ARG basecamp webhook show 00 <id>
+ARG basecamp webhook update 00 <id>
+ARG basecamp webhooks create 00 <url>
+ARG basecamp webhooks delete 00 <id>
+ARG basecamp webhooks show 00 <id>
+ARG basecamp webhooks update 00 <id>
 CMD basecamp
+CMD basecamp account
+CMD basecamp account list
+CMD basecamp account use
 CMD basecamp accounts
 CMD basecamp accounts list
 CMD basecamp accounts use
@@ -28,8 +444,22 @@ CMD basecamp boost create
 CMD basecamp boost delete
 CMD basecamp boost list
 CMD basecamp boost show
+CMD basecamp boosts
+CMD basecamp boosts create
+CMD basecamp boosts delete
+CMD basecamp boosts list
+CMD basecamp boosts show
+CMD basecamp campfire
+CMD basecamp campfire delete
+CMD basecamp campfire line
+CMD basecamp campfire list
+CMD basecamp campfire messages
+CMD basecamp campfire post
+CMD basecamp campfire show
+CMD basecamp campfire upload
 CMD basecamp card
 CMD basecamp card move
+CMD basecamp card mv
 CMD basecamp card update
 CMD basecamp cards
 CMD basecamp cards archive
@@ -47,6 +477,7 @@ CMD basecamp cards columns
 CMD basecamp cards create
 CMD basecamp cards list
 CMD basecamp cards move
+CMD basecamp cards mv
 CMD basecamp cards restore
 CMD basecamp cards show
 CMD basecamp cards step
@@ -65,7 +496,19 @@ CMD basecamp chat line
 CMD basecamp chat list
 CMD basecamp chat messages
 CMD basecamp chat post
+CMD basecamp chat show
 CMD basecamp chat upload
+CMD basecamp checkin
+CMD basecamp checkin answer
+CMD basecamp checkin answer create
+CMD basecamp checkin answer show
+CMD basecamp checkin answer update
+CMD basecamp checkin answers
+CMD basecamp checkin question
+CMD basecamp checkin question create
+CMD basecamp checkin question show
+CMD basecamp checkin question update
+CMD basecamp checkin questions
 CMD basecamp checkins
 CMD basecamp checkins answer
 CMD basecamp checkins answer create
@@ -77,6 +520,7 @@ CMD basecamp checkins question create
 CMD basecamp checkins question show
 CMD basecamp checkins question update
 CMD basecamp checkins questions
+CMD basecamp cmds
 CMD basecamp commands
 CMD basecamp comment
 CMD basecamp comments
@@ -104,10 +548,19 @@ CMD basecamp config unset
 CMD basecamp config untrust
 CMD basecamp docs
 CMD basecamp docs archive
+CMD basecamp docs doc
+CMD basecamp docs doc create
+CMD basecamp docs doc list
+CMD basecamp docs document
+CMD basecamp docs document create
+CMD basecamp docs document list
 CMD basecamp docs documents
 CMD basecamp docs documents create
 CMD basecamp docs documents list
 CMD basecamp docs download
+CMD basecamp docs folder
+CMD basecamp docs folder create
+CMD basecamp docs folder list
 CMD basecamp docs folders
 CMD basecamp docs folders create
 CMD basecamp docs folders list
@@ -116,18 +569,106 @@ CMD basecamp docs restore
 CMD basecamp docs show
 CMD basecamp docs trash
 CMD basecamp docs update
+CMD basecamp docs upload
+CMD basecamp docs upload create
+CMD basecamp docs upload list
 CMD basecamp docs uploads
 CMD basecamp docs uploads create
 CMD basecamp docs uploads list
+CMD basecamp docs vault
+CMD basecamp docs vault create
+CMD basecamp docs vault list
+CMD basecamp docs vaults
+CMD basecamp docs vaults create
+CMD basecamp docs vaults list
 CMD basecamp doctor
+CMD basecamp documents
+CMD basecamp documents archive
+CMD basecamp documents doc
+CMD basecamp documents doc create
+CMD basecamp documents doc list
+CMD basecamp documents document
+CMD basecamp documents document create
+CMD basecamp documents document list
+CMD basecamp documents documents
+CMD basecamp documents documents create
+CMD basecamp documents documents list
+CMD basecamp documents download
+CMD basecamp documents folder
+CMD basecamp documents folder create
+CMD basecamp documents folder list
+CMD basecamp documents folders
+CMD basecamp documents folders create
+CMD basecamp documents folders list
+CMD basecamp documents list
+CMD basecamp documents restore
+CMD basecamp documents show
+CMD basecamp documents trash
+CMD basecamp documents update
+CMD basecamp documents upload
+CMD basecamp documents upload create
+CMD basecamp documents upload list
+CMD basecamp documents uploads
+CMD basecamp documents uploads create
+CMD basecamp documents uploads list
+CMD basecamp documents vault
+CMD basecamp documents vault create
+CMD basecamp documents vault list
+CMD basecamp documents vaults
+CMD basecamp documents vaults create
+CMD basecamp documents vaults list
 CMD basecamp done
 CMD basecamp events
+CMD basecamp file
+CMD basecamp file archive
+CMD basecamp file doc
+CMD basecamp file doc create
+CMD basecamp file doc list
+CMD basecamp file document
+CMD basecamp file document create
+CMD basecamp file document list
+CMD basecamp file documents
+CMD basecamp file documents create
+CMD basecamp file documents list
+CMD basecamp file download
+CMD basecamp file folder
+CMD basecamp file folder create
+CMD basecamp file folder list
+CMD basecamp file folders
+CMD basecamp file folders create
+CMD basecamp file folders list
+CMD basecamp file list
+CMD basecamp file restore
+CMD basecamp file show
+CMD basecamp file trash
+CMD basecamp file update
+CMD basecamp file upload
+CMD basecamp file upload create
+CMD basecamp file upload list
+CMD basecamp file uploads
+CMD basecamp file uploads create
+CMD basecamp file uploads list
+CMD basecamp file vault
+CMD basecamp file vault create
+CMD basecamp file vault list
+CMD basecamp file vaults
+CMD basecamp file vaults create
+CMD basecamp file vaults list
 CMD basecamp files
 CMD basecamp files archive
+CMD basecamp files doc
+CMD basecamp files doc create
+CMD basecamp files doc list
+CMD basecamp files document
+CMD basecamp files document create
+CMD basecamp files document list
 CMD basecamp files documents
 CMD basecamp files documents create
 CMD basecamp files documents list
 CMD basecamp files download
+CMD basecamp files folder
+CMD basecamp files folder create
+CMD basecamp files folder list
 CMD basecamp files folders
 CMD basecamp files folders create
 CMD basecamp files folders list
@@ -136,9 +677,53 @@ CMD basecamp files restore
 CMD basecamp files show
 CMD basecamp files trash
 CMD basecamp files update
+CMD basecamp files upload
+CMD basecamp files upload create
+CMD basecamp files upload list
 CMD basecamp files uploads
 CMD basecamp files uploads create
 CMD basecamp files uploads list
+CMD basecamp files vault
+CMD basecamp files vault create
+CMD basecamp files vault list
+CMD basecamp files vaults
+CMD basecamp files vaults create
+CMD basecamp files vaults list
+CMD basecamp folders
+CMD basecamp folders archive
+CMD basecamp folders doc
+CMD basecamp folders doc create
+CMD basecamp folders doc list
+CMD basecamp folders document
+CMD basecamp folders document create
+CMD basecamp folders document list
+CMD basecamp folders documents
+CMD basecamp folders documents create
+CMD basecamp folders documents list
+CMD basecamp folders download
+CMD basecamp folders folder
+CMD basecamp folders folder create
+CMD basecamp folders folder list
+CMD basecamp folders folders
+CMD basecamp folders folders create
+CMD basecamp folders folders list
+CMD basecamp folders list
+CMD basecamp folders restore
+CMD basecamp folders show
+CMD basecamp folders trash
+CMD basecamp folders update
+CMD basecamp folders upload
+CMD basecamp folders upload create
+CMD basecamp folders upload list
+CMD basecamp folders uploads
+CMD basecamp folders uploads create
+CMD basecamp folders uploads list
+CMD basecamp folders vault
+CMD basecamp folders vault create
+CMD basecamp folders vault list
+CMD basecamp folders vaults
+CMD basecamp folders vaults create
+CMD basecamp folders vaults list
 CMD basecamp forwards
 CMD basecamp forwards inbox
 CMD basecamp forwards list
@@ -179,6 +764,17 @@ CMD basecamp messagetypes list
 CMD basecamp messagetypes show
 CMD basecamp messagetypes update
 CMD basecamp migrate
+CMD basecamp msgs
+CMD basecamp msgs archive
+CMD basecamp msgs create
+CMD basecamp msgs list
+CMD basecamp msgs pin
+CMD basecamp msgs publish
+CMD basecamp msgs restore
+CMD basecamp msgs show
+CMD basecamp msgs trash
+CMD basecamp msgs unpin
+CMD basecamp msgs update
 CMD basecamp people
 CMD basecamp people add
 CMD basecamp people list
@@ -191,18 +787,30 @@ CMD basecamp profile delete
 CMD basecamp profile list
 CMD basecamp profile set-default
 CMD basecamp profile show
+CMD basecamp project
+CMD basecamp project create
+CMD basecamp project delete
+CMD basecamp project list
+CMD basecamp project show
+CMD basecamp project trash
+CMD basecamp project update
 CMD basecamp projects
 CMD basecamp projects create
 CMD basecamp projects delete
 CMD basecamp projects list
 CMD basecamp projects show
+CMD basecamp projects trash
 CMD basecamp projects update
 CMD basecamp react
 CMD basecamp recordings
+CMD basecamp recordings active
 CMD basecamp recordings archive
+CMD basecamp recordings archived
+CMD basecamp recordings client-visibility
 CMD basecamp recordings list
 CMD basecamp recordings restore
 CMD basecamp recordings trash
+CMD basecamp recordings trashed
 CMD basecamp recordings visibility
 CMD basecamp reopen
 CMD basecamp reports
@@ -219,6 +827,7 @@ CMD basecamp schedule show
 CMD basecamp schedule update
 CMD basecamp search
 CMD basecamp search metadata
+CMD basecamp search types
 CMD basecamp setup
 CMD basecamp setup claude
 CMD basecamp show
@@ -242,12 +851,47 @@ CMD basecamp timeline
 CMD basecamp timesheet
 CMD basecamp timesheet item
 CMD basecamp timesheet project
+CMD basecamp timesheet recording
 CMD basecamp timesheet report
+CMD basecamp tlgroup
+CMD basecamp tlgroup create
+CMD basecamp tlgroup list
+CMD basecamp tlgroup move
+CMD basecamp tlgroup position
+CMD basecamp tlgroup rename
+CMD basecamp tlgroup show
+CMD basecamp tlgroup update
+CMD basecamp tlgroups
+CMD basecamp tlgroups create
+CMD basecamp tlgroups list
+CMD basecamp tlgroups move
+CMD basecamp tlgroups position
+CMD basecamp tlgroups rename
+CMD basecamp tlgroups show
+CMD basecamp tlgroups update
 CMD basecamp todo
+CMD basecamp todolist
+CMD basecamp todolist archive
+CMD basecamp todolist create
+CMD basecamp todolist list
+CMD basecamp todolist restore
+CMD basecamp todolist show
+CMD basecamp todolist trash
+CMD basecamp todolist update
+CMD basecamp todolistgroup
+CMD basecamp todolistgroup create
+CMD basecamp todolistgroup list
+CMD basecamp todolistgroup move
+CMD basecamp todolistgroup position
+CMD basecamp todolistgroup rename
+CMD basecamp todolistgroup show
+CMD basecamp todolistgroup update
 CMD basecamp todolistgroups
 CMD basecamp todolistgroups create
 CMD basecamp todolistgroups list
+CMD basecamp todolistgroups move
 CMD basecamp todolistgroups position
+CMD basecamp todolistgroups rename
 CMD basecamp todolistgroups show
 CMD basecamp todolistgroups update
 CMD basecamp todolists
@@ -263,7 +907,10 @@ CMD basecamp todos archive
 CMD basecamp todos complete
 CMD basecamp todos create
 CMD basecamp todos list
+CMD basecamp todos move
 CMD basecamp todos position
+CMD basecamp todos reopen
+CMD basecamp todos reorder
 CMD basecamp todos restore
 CMD basecamp todos show
 CMD basecamp todos sweep
@@ -275,8 +922,11 @@ CMD basecamp todosets list
 CMD basecamp todosets show
 CMD basecamp tools
 CMD basecamp tools create
+CMD basecamp tools delete
 CMD basecamp tools disable
 CMD basecamp tools enable
+CMD basecamp tools move
+CMD basecamp tools rename
 CMD basecamp tools reposition
 CMD basecamp tools show
 CMD basecamp tools trash
@@ -291,12 +941,56 @@ CMD basecamp uploads list
 CMD basecamp uploads show
 CMD basecamp url
 CMD basecamp url parse
+CMD basecamp vault
+CMD basecamp vault archive
+CMD basecamp vault doc
+CMD basecamp vault doc create
+CMD basecamp vault doc list
+CMD basecamp vault document
+CMD basecamp vault document create
+CMD basecamp vault document list
+CMD basecamp vault documents
+CMD basecamp vault documents create
+CMD basecamp vault documents list
+CMD basecamp vault download
+CMD basecamp vault folder
+CMD basecamp vault folder create
+CMD basecamp vault folder list
+CMD basecamp vault folders
+CMD basecamp vault folders create
+CMD basecamp vault folders list
+CMD basecamp vault list
+CMD basecamp vault restore
+CMD basecamp vault show
+CMD basecamp vault trash
+CMD basecamp vault update
+CMD basecamp vault upload
+CMD basecamp vault upload create
+CMD basecamp vault upload list
+CMD basecamp vault uploads
+CMD basecamp vault uploads create
+CMD basecamp vault uploads list
+CMD basecamp vault vault
+CMD basecamp vault vault create
+CMD basecamp vault vault list
+CMD basecamp vault vaults
+CMD basecamp vault vaults create
+CMD basecamp vault vaults list
 CMD basecamp vaults
 CMD basecamp vaults archive
+CMD basecamp vaults doc
+CMD basecamp vaults doc create
+CMD basecamp vaults doc list
+CMD basecamp vaults document
+CMD basecamp vaults document create
+CMD basecamp vaults document list
 CMD basecamp vaults documents
 CMD basecamp vaults documents create
 CMD basecamp vaults documents list
 CMD basecamp vaults download
+CMD basecamp vaults folder
+CMD basecamp vaults folder create
+CMD basecamp vaults folder list
 CMD basecamp vaults folders
 CMD basecamp vaults folders create
 CMD basecamp vaults folders list
@@ -305,10 +999,25 @@ CMD basecamp vaults restore
 CMD basecamp vaults show
 CMD basecamp vaults trash
 CMD basecamp vaults update
+CMD basecamp vaults upload
+CMD basecamp vaults upload create
+CMD basecamp vaults upload list
 CMD basecamp vaults uploads
 CMD basecamp vaults uploads create
 CMD basecamp vaults uploads list
+CMD basecamp vaults vault
+CMD basecamp vaults vault create
+CMD basecamp vaults vault list
+CMD basecamp vaults vaults
+CMD basecamp vaults vaults create
+CMD basecamp vaults vaults list
 CMD basecamp version
+CMD basecamp webhook
+CMD basecamp webhook create
+CMD basecamp webhook delete
+CMD basecamp webhook list
+CMD basecamp webhook show
+CMD basecamp webhook update
 CMD basecamp webhooks
 CMD basecamp webhooks create
 CMD basecamp webhooks delete
@@ -319,6 +1028,7 @@ FLAG basecamp --account type=string
 FLAG basecamp --agent type=bool
 FLAG basecamp --cache-dir type=string
 FLAG basecamp --count type=bool
+FLAG basecamp --help type=bool
 FLAG basecamp --hints type=bool
 FLAG basecamp --ids-only type=bool
 FLAG basecamp --in type=string
@@ -335,10 +1045,76 @@ FLAG basecamp --stats type=bool
 FLAG basecamp --styled type=bool
 FLAG basecamp --todolist type=string
 FLAG basecamp --verbose type=count
+FLAG basecamp --version type=bool
+FLAG basecamp account --account type=string
+FLAG basecamp account --agent type=bool
+FLAG basecamp account --cache-dir type=string
+FLAG basecamp account --count type=bool
+FLAG basecamp account --help type=bool
+FLAG basecamp account --hints type=bool
+FLAG basecamp account --ids-only type=bool
+FLAG basecamp account --in type=string
+FLAG basecamp account --jq type=string
+FLAG basecamp account --json type=bool
+FLAG basecamp account --markdown type=bool
+FLAG basecamp account --md type=bool
+FLAG basecamp account --no-hints type=bool
+FLAG basecamp account --no-stats type=bool
+FLAG basecamp account --profile type=string
+FLAG basecamp account --project type=string
+FLAG basecamp account --quiet type=bool
+FLAG basecamp account --stats type=bool
+FLAG basecamp account --styled type=bool
+FLAG basecamp account --todolist type=string
+FLAG basecamp account --verbose type=count
+FLAG basecamp account list --account type=string
+FLAG basecamp account list --agent type=bool
+FLAG basecamp account list --cache-dir type=string
+FLAG basecamp account list --count type=bool
+FLAG basecamp account list --help type=bool
+FLAG basecamp account list --hints type=bool
+FLAG basecamp account list --ids-only type=bool
+FLAG basecamp account list --in type=string
+FLAG basecamp account list --jq type=string
+FLAG basecamp account list --json type=bool
+FLAG basecamp account list --markdown type=bool
+FLAG basecamp account list --md type=bool
+FLAG basecamp account list --no-hints type=bool
+FLAG basecamp account list --no-stats type=bool
+FLAG basecamp account list --profile type=string
+FLAG basecamp account list --project type=string
+FLAG basecamp account list --quiet type=bool
+FLAG basecamp account list --stats type=bool
+FLAG basecamp account list --styled type=bool
+FLAG basecamp account list --todolist type=string
+FLAG basecamp account list --verbose type=count
+FLAG basecamp account use --account type=string
+FLAG basecamp account use --agent type=bool
+FLAG basecamp account use --cache-dir type=string
+FLAG basecamp account use --count type=bool
+FLAG basecamp account use --help type=bool
+FLAG basecamp account use --hints type=bool
+FLAG basecamp account use --ids-only type=bool
+FLAG basecamp account use --in type=string
+FLAG basecamp account use --jq type=string
+FLAG basecamp account use --json type=bool
+FLAG basecamp account use --markdown type=bool
+FLAG basecamp account use --md type=bool
+FLAG basecamp account use --no-hints type=bool
+FLAG basecamp account use --no-stats type=bool
+FLAG basecamp account use --profile type=string
+FLAG basecamp account use --project type=string
+FLAG basecamp account use --quiet type=bool
+FLAG basecamp account use --scope type=string
+FLAG basecamp account use --stats type=bool
+FLAG basecamp account use --styled type=bool
+FLAG basecamp account use --todolist type=string
+FLAG basecamp account use --verbose type=count
 FLAG basecamp accounts --account type=string
 FLAG basecamp accounts --agent type=bool
 FLAG basecamp accounts --cache-dir type=string
 FLAG basecamp accounts --count type=bool
+FLAG basecamp accounts --help type=bool
 FLAG basecamp accounts --hints type=bool
 FLAG basecamp accounts --ids-only type=bool
 FLAG basecamp accounts --in type=string
@@ -359,6 +1135,7 @@ FLAG basecamp accounts list --account type=string
 FLAG basecamp accounts list --agent type=bool
 FLAG basecamp accounts list --cache-dir type=string
 FLAG basecamp accounts list --count type=bool
+FLAG basecamp accounts list --help type=bool
 FLAG basecamp accounts list --hints type=bool
 FLAG basecamp accounts list --ids-only type=bool
 FLAG basecamp accounts list --in type=string
@@ -379,6 +1156,7 @@ FLAG basecamp accounts use --account type=string
 FLAG basecamp accounts use --agent type=bool
 FLAG basecamp accounts use --cache-dir type=string
 FLAG basecamp accounts use --count type=bool
+FLAG basecamp accounts use --help type=bool
 FLAG basecamp accounts use --hints type=bool
 FLAG basecamp accounts use --ids-only type=bool
 FLAG basecamp accounts use --in type=string
@@ -400,6 +1178,7 @@ FLAG basecamp api --account type=string
 FLAG basecamp api --agent type=bool
 FLAG basecamp api --cache-dir type=string
 FLAG basecamp api --count type=bool
+FLAG basecamp api --help type=bool
 FLAG basecamp api --hints type=bool
 FLAG basecamp api --ids-only type=bool
 FLAG basecamp api --in type=string
@@ -420,6 +1199,7 @@ FLAG basecamp api delete --account type=string
 FLAG basecamp api delete --agent type=bool
 FLAG basecamp api delete --cache-dir type=string
 FLAG basecamp api delete --count type=bool
+FLAG basecamp api delete --help type=bool
 FLAG basecamp api delete --hints type=bool
 FLAG basecamp api delete --ids-only type=bool
 FLAG basecamp api delete --in type=string
@@ -440,6 +1220,7 @@ FLAG basecamp api get --account type=string
 FLAG basecamp api get --agent type=bool
 FLAG basecamp api get --cache-dir type=string
 FLAG basecamp api get --count type=bool
+FLAG basecamp api get --help type=bool
 FLAG basecamp api get --hints type=bool
 FLAG basecamp api get --ids-only type=bool
 FLAG basecamp api get --in type=string
@@ -461,6 +1242,7 @@ FLAG basecamp api post --agent type=bool
 FLAG basecamp api post --cache-dir type=string
 FLAG basecamp api post --count type=bool
 FLAG basecamp api post --data type=string
+FLAG basecamp api post --help type=bool
 FLAG basecamp api post --hints type=bool
 FLAG basecamp api post --ids-only type=bool
 FLAG basecamp api post --in type=string
@@ -482,6 +1264,7 @@ FLAG basecamp api put --agent type=bool
 FLAG basecamp api put --cache-dir type=string
 FLAG basecamp api put --count type=bool
 FLAG basecamp api put --data type=string
+FLAG basecamp api put --help type=bool
 FLAG basecamp api put --hints type=bool
 FLAG basecamp api put --ids-only type=bool
 FLAG basecamp api put --in type=string
@@ -503,6 +1286,7 @@ FLAG basecamp assign --agent type=bool
 FLAG basecamp assign --cache-dir type=string
 FLAG basecamp assign --card type=bool
 FLAG basecamp assign --count type=bool
+FLAG basecamp assign --help type=bool
 FLAG basecamp assign --hints type=bool
 FLAG basecamp assign --ids-only type=bool
 FLAG basecamp assign --in type=string
@@ -525,6 +1309,7 @@ FLAG basecamp attach --account type=string
 FLAG basecamp attach --agent type=bool
 FLAG basecamp attach --cache-dir type=string
 FLAG basecamp attach --count type=bool
+FLAG basecamp attach --help type=bool
 FLAG basecamp attach --hints type=bool
 FLAG basecamp attach --ids-only type=bool
 FLAG basecamp attach --in type=string
@@ -545,6 +1330,7 @@ FLAG basecamp attachments --account type=string
 FLAG basecamp attachments --agent type=bool
 FLAG basecamp attachments --cache-dir type=string
 FLAG basecamp attachments --count type=bool
+FLAG basecamp attachments --help type=bool
 FLAG basecamp attachments --hints type=bool
 FLAG basecamp attachments --ids-only type=bool
 FLAG basecamp attachments --in type=string
@@ -565,6 +1351,7 @@ FLAG basecamp attachments list --account type=string
 FLAG basecamp attachments list --agent type=bool
 FLAG basecamp attachments list --cache-dir type=string
 FLAG basecamp attachments list --count type=bool
+FLAG basecamp attachments list --help type=bool
 FLAG basecamp attachments list --hints type=bool
 FLAG basecamp attachments list --ids-only type=bool
 FLAG basecamp attachments list --in type=string
@@ -586,6 +1373,7 @@ FLAG basecamp auth --account type=string
 FLAG basecamp auth --agent type=bool
 FLAG basecamp auth --cache-dir type=string
 FLAG basecamp auth --count type=bool
+FLAG basecamp auth --help type=bool
 FLAG basecamp auth --hints type=bool
 FLAG basecamp auth --ids-only type=bool
 FLAG basecamp auth --in type=string
@@ -607,6 +1395,7 @@ FLAG basecamp auth login --agent type=bool
 FLAG basecamp auth login --cache-dir type=string
 FLAG basecamp auth login --count type=bool
 FLAG basecamp auth login --device-code type=bool
+FLAG basecamp auth login --help type=bool
 FLAG basecamp auth login --hints type=bool
 FLAG basecamp auth login --ids-only type=bool
 FLAG basecamp auth login --in type=string
@@ -631,6 +1420,7 @@ FLAG basecamp auth logout --account type=string
 FLAG basecamp auth logout --agent type=bool
 FLAG basecamp auth logout --cache-dir type=string
 FLAG basecamp auth logout --count type=bool
+FLAG basecamp auth logout --help type=bool
 FLAG basecamp auth logout --hints type=bool
 FLAG basecamp auth logout --ids-only type=bool
 FLAG basecamp auth logout --in type=string
@@ -651,6 +1441,7 @@ FLAG basecamp auth refresh --account type=string
 FLAG basecamp auth refresh --agent type=bool
 FLAG basecamp auth refresh --cache-dir type=string
 FLAG basecamp auth refresh --count type=bool
+FLAG basecamp auth refresh --help type=bool
 FLAG basecamp auth refresh --hints type=bool
 FLAG basecamp auth refresh --ids-only type=bool
 FLAG basecamp auth refresh --in type=string
@@ -671,6 +1462,7 @@ FLAG basecamp auth status --account type=string
 FLAG basecamp auth status --agent type=bool
 FLAG basecamp auth status --cache-dir type=string
 FLAG basecamp auth status --count type=bool
+FLAG basecamp auth status --help type=bool
 FLAG basecamp auth status --hints type=bool
 FLAG basecamp auth status --ids-only type=bool
 FLAG basecamp auth status --in type=string
@@ -691,6 +1483,7 @@ FLAG basecamp auth token --account type=string
 FLAG basecamp auth token --agent type=bool
 FLAG basecamp auth token --cache-dir type=string
 FLAG basecamp auth token --count type=bool
+FLAG basecamp auth token --help type=bool
 FLAG basecamp auth token --hints type=bool
 FLAG basecamp auth token --ids-only type=bool
 FLAG basecamp auth token --in type=string
@@ -712,6 +1505,7 @@ FLAG basecamp bonfire --account type=string
 FLAG basecamp bonfire --agent type=bool
 FLAG basecamp bonfire --cache-dir type=string
 FLAG basecamp bonfire --count type=bool
+FLAG basecamp bonfire --help type=bool
 FLAG basecamp bonfire --hints type=bool
 FLAG basecamp bonfire --ids-only type=bool
 FLAG basecamp bonfire --in type=string
@@ -732,6 +1526,7 @@ FLAG basecamp bonfire layout --account type=string
 FLAG basecamp bonfire layout --agent type=bool
 FLAG basecamp bonfire layout --cache-dir type=string
 FLAG basecamp bonfire layout --count type=bool
+FLAG basecamp bonfire layout --help type=bool
 FLAG basecamp bonfire layout --hints type=bool
 FLAG basecamp bonfire layout --ids-only type=bool
 FLAG basecamp bonfire layout --in type=string
@@ -752,6 +1547,7 @@ FLAG basecamp bonfire layout list --account type=string
 FLAG basecamp bonfire layout list --agent type=bool
 FLAG basecamp bonfire layout list --cache-dir type=string
 FLAG basecamp bonfire layout list --count type=bool
+FLAG basecamp bonfire layout list --help type=bool
 FLAG basecamp bonfire layout list --hints type=bool
 FLAG basecamp bonfire layout list --ids-only type=bool
 FLAG basecamp bonfire layout list --in type=string
@@ -772,6 +1568,7 @@ FLAG basecamp bonfire layout load --account type=string
 FLAG basecamp bonfire layout load --agent type=bool
 FLAG basecamp bonfire layout load --cache-dir type=string
 FLAG basecamp bonfire layout load --count type=bool
+FLAG basecamp bonfire layout load --help type=bool
 FLAG basecamp bonfire layout load --hints type=bool
 FLAG basecamp bonfire layout load --ids-only type=bool
 FLAG basecamp bonfire layout load --in type=string
@@ -792,6 +1589,7 @@ FLAG basecamp bonfire layout save --account type=string
 FLAG basecamp bonfire layout save --agent type=bool
 FLAG basecamp bonfire layout save --cache-dir type=string
 FLAG basecamp bonfire layout save --count type=bool
+FLAG basecamp bonfire layout save --help type=bool
 FLAG basecamp bonfire layout save --hints type=bool
 FLAG basecamp bonfire layout save --ids-only type=bool
 FLAG basecamp bonfire layout save --in type=string
@@ -812,6 +1610,7 @@ FLAG basecamp bonfire split --account type=string
 FLAG basecamp bonfire split --agent type=bool
 FLAG basecamp bonfire split --cache-dir type=string
 FLAG basecamp bonfire split --count type=bool
+FLAG basecamp bonfire split --help type=bool
 FLAG basecamp bonfire split --hints type=bool
 FLAG basecamp bonfire split --ids-only type=bool
 FLAG basecamp bonfire split --in type=string
@@ -832,6 +1631,7 @@ FLAG basecamp boost --account type=string
 FLAG basecamp boost --agent type=bool
 FLAG basecamp boost --cache-dir type=string
 FLAG basecamp boost --count type=bool
+FLAG basecamp boost --help type=bool
 FLAG basecamp boost --hints type=bool
 FLAG basecamp boost --ids-only type=bool
 FLAG basecamp boost --in type=string
@@ -853,6 +1653,7 @@ FLAG basecamp boost create --agent type=bool
 FLAG basecamp boost create --cache-dir type=string
 FLAG basecamp boost create --count type=bool
 FLAG basecamp boost create --event type=string
+FLAG basecamp boost create --help type=bool
 FLAG basecamp boost create --hints type=bool
 FLAG basecamp boost create --ids-only type=bool
 FLAG basecamp boost create --in type=string
@@ -873,6 +1674,7 @@ FLAG basecamp boost delete --account type=string
 FLAG basecamp boost delete --agent type=bool
 FLAG basecamp boost delete --cache-dir type=string
 FLAG basecamp boost delete --count type=bool
+FLAG basecamp boost delete --help type=bool
 FLAG basecamp boost delete --hints type=bool
 FLAG basecamp boost delete --ids-only type=bool
 FLAG basecamp boost delete --in type=string
@@ -894,6 +1696,7 @@ FLAG basecamp boost list --agent type=bool
 FLAG basecamp boost list --cache-dir type=string
 FLAG basecamp boost list --count type=bool
 FLAG basecamp boost list --event type=string
+FLAG basecamp boost list --help type=bool
 FLAG basecamp boost list --hints type=bool
 FLAG basecamp boost list --ids-only type=bool
 FLAG basecamp boost list --in type=string
@@ -914,6 +1717,7 @@ FLAG basecamp boost show --account type=string
 FLAG basecamp boost show --agent type=bool
 FLAG basecamp boost show --cache-dir type=string
 FLAG basecamp boost show --count type=bool
+FLAG basecamp boost show --help type=bool
 FLAG basecamp boost show --hints type=bool
 FLAG basecamp boost show --ids-only type=bool
 FLAG basecamp boost show --in type=string
@@ -930,6 +1734,295 @@ FLAG basecamp boost show --stats type=bool
 FLAG basecamp boost show --styled type=bool
 FLAG basecamp boost show --todolist type=string
 FLAG basecamp boost show --verbose type=count
+FLAG basecamp boosts --account type=string
+FLAG basecamp boosts --agent type=bool
+FLAG basecamp boosts --cache-dir type=string
+FLAG basecamp boosts --count type=bool
+FLAG basecamp boosts --help type=bool
+FLAG basecamp boosts --hints type=bool
+FLAG basecamp boosts --ids-only type=bool
+FLAG basecamp boosts --in type=string
+FLAG basecamp boosts --jq type=string
+FLAG basecamp boosts --json type=bool
+FLAG basecamp boosts --markdown type=bool
+FLAG basecamp boosts --md type=bool
+FLAG basecamp boosts --no-hints type=bool
+FLAG basecamp boosts --no-stats type=bool
+FLAG basecamp boosts --profile type=string
+FLAG basecamp boosts --project type=string
+FLAG basecamp boosts --quiet type=bool
+FLAG basecamp boosts --stats type=bool
+FLAG basecamp boosts --styled type=bool
+FLAG basecamp boosts --todolist type=string
+FLAG basecamp boosts --verbose type=count
+FLAG basecamp boosts create --account type=string
+FLAG basecamp boosts create --agent type=bool
+FLAG basecamp boosts create --cache-dir type=string
+FLAG basecamp boosts create --count type=bool
+FLAG basecamp boosts create --event type=string
+FLAG basecamp boosts create --help type=bool
+FLAG basecamp boosts create --hints type=bool
+FLAG basecamp boosts create --ids-only type=bool
+FLAG basecamp boosts create --in type=string
+FLAG basecamp boosts create --jq type=string
+FLAG basecamp boosts create --json type=bool
+FLAG basecamp boosts create --markdown type=bool
+FLAG basecamp boosts create --md type=bool
+FLAG basecamp boosts create --no-hints type=bool
+FLAG basecamp boosts create --no-stats type=bool
+FLAG basecamp boosts create --profile type=string
+FLAG basecamp boosts create --project type=string
+FLAG basecamp boosts create --quiet type=bool
+FLAG basecamp boosts create --stats type=bool
+FLAG basecamp boosts create --styled type=bool
+FLAG basecamp boosts create --todolist type=string
+FLAG basecamp boosts create --verbose type=count
+FLAG basecamp boosts delete --account type=string
+FLAG basecamp boosts delete --agent type=bool
+FLAG basecamp boosts delete --cache-dir type=string
+FLAG basecamp boosts delete --count type=bool
+FLAG basecamp boosts delete --help type=bool
+FLAG basecamp boosts delete --hints type=bool
+FLAG basecamp boosts delete --ids-only type=bool
+FLAG basecamp boosts delete --in type=string
+FLAG basecamp boosts delete --jq type=string
+FLAG basecamp boosts delete --json type=bool
+FLAG basecamp boosts delete --markdown type=bool
+FLAG basecamp boosts delete --md type=bool
+FLAG basecamp boosts delete --no-hints type=bool
+FLAG basecamp boosts delete --no-stats type=bool
+FLAG basecamp boosts delete --profile type=string
+FLAG basecamp boosts delete --project type=string
+FLAG basecamp boosts delete --quiet type=bool
+FLAG basecamp boosts delete --stats type=bool
+FLAG basecamp boosts delete --styled type=bool
+FLAG basecamp boosts delete --todolist type=string
+FLAG basecamp boosts delete --verbose type=count
+FLAG basecamp boosts list --account type=string
+FLAG basecamp boosts list --agent type=bool
+FLAG basecamp boosts list --cache-dir type=string
+FLAG basecamp boosts list --count type=bool
+FLAG basecamp boosts list --event type=string
+FLAG basecamp boosts list --help type=bool
+FLAG basecamp boosts list --hints type=bool
+FLAG basecamp boosts list --ids-only type=bool
+FLAG basecamp boosts list --in type=string
+FLAG basecamp boosts list --jq type=string
+FLAG basecamp boosts list --json type=bool
+FLAG basecamp boosts list --markdown type=bool
+FLAG basecamp boosts list --md type=bool
+FLAG basecamp boosts list --no-hints type=bool
+FLAG basecamp boosts list --no-stats type=bool
+FLAG basecamp boosts list --profile type=string
+FLAG basecamp boosts list --project type=string
+FLAG basecamp boosts list --quiet type=bool
+FLAG basecamp boosts list --stats type=bool
+FLAG basecamp boosts list --styled type=bool
+FLAG basecamp boosts list --todolist type=string
+FLAG basecamp boosts list --verbose type=count
+FLAG basecamp boosts show --account type=string
+FLAG basecamp boosts show --agent type=bool
+FLAG basecamp boosts show --cache-dir type=string
+FLAG basecamp boosts show --count type=bool
+FLAG basecamp boosts show --help type=bool
+FLAG basecamp boosts show --hints type=bool
+FLAG basecamp boosts show --ids-only type=bool
+FLAG basecamp boosts show --in type=string
+FLAG basecamp boosts show --jq type=string
+FLAG basecamp boosts show --json type=bool
+FLAG basecamp boosts show --markdown type=bool
+FLAG basecamp boosts show --md type=bool
+FLAG basecamp boosts show --no-hints type=bool
+FLAG basecamp boosts show --no-stats type=bool
+FLAG basecamp boosts show --profile type=string
+FLAG basecamp boosts show --project type=string
+FLAG basecamp boosts show --quiet type=bool
+FLAG basecamp boosts show --stats type=bool
+FLAG basecamp boosts show --styled type=bool
+FLAG basecamp boosts show --todolist type=string
+FLAG basecamp boosts show --verbose type=count
+FLAG basecamp campfire --account type=string
+FLAG basecamp campfire --agent type=bool
+FLAG basecamp campfire --cache-dir type=string
+FLAG basecamp campfire --count type=bool
+FLAG basecamp campfire --help type=bool
+FLAG basecamp campfire --hints type=bool
+FLAG basecamp campfire --ids-only type=bool
+FLAG basecamp campfire --in type=string
+FLAG basecamp campfire --jq type=string
+FLAG basecamp campfire --json type=bool
+FLAG basecamp campfire --markdown type=bool
+FLAG basecamp campfire --md type=bool
+FLAG basecamp campfire --no-hints type=bool
+FLAG basecamp campfire --no-stats type=bool
+FLAG basecamp campfire --profile type=string
+FLAG basecamp campfire --project type=string
+FLAG basecamp campfire --quiet type=bool
+FLAG basecamp campfire --room type=string
+FLAG basecamp campfire --stats type=bool
+FLAG basecamp campfire --styled type=bool
+FLAG basecamp campfire --todolist type=string
+FLAG basecamp campfire --verbose type=count
+FLAG basecamp campfire delete --account type=string
+FLAG basecamp campfire delete --agent type=bool
+FLAG basecamp campfire delete --cache-dir type=string
+FLAG basecamp campfire delete --count type=bool
+FLAG basecamp campfire delete --force type=bool
+FLAG basecamp campfire delete --help type=bool
+FLAG basecamp campfire delete --hints type=bool
+FLAG basecamp campfire delete --ids-only type=bool
+FLAG basecamp campfire delete --in type=string
+FLAG basecamp campfire delete --jq type=string
+FLAG basecamp campfire delete --json type=bool
+FLAG basecamp campfire delete --markdown type=bool
+FLAG basecamp campfire delete --md type=bool
+FLAG basecamp campfire delete --no-hints type=bool
+FLAG basecamp campfire delete --no-stats type=bool
+FLAG basecamp campfire delete --profile type=string
+FLAG basecamp campfire delete --project type=string
+FLAG basecamp campfire delete --quiet type=bool
+FLAG basecamp campfire delete --room type=string
+FLAG basecamp campfire delete --stats type=bool
+FLAG basecamp campfire delete --styled type=bool
+FLAG basecamp campfire delete --todolist type=string
+FLAG basecamp campfire delete --verbose type=count
+FLAG basecamp campfire line --account type=string
+FLAG basecamp campfire line --agent type=bool
+FLAG basecamp campfire line --cache-dir type=string
+FLAG basecamp campfire line --count type=bool
+FLAG basecamp campfire line --help type=bool
+FLAG basecamp campfire line --hints type=bool
+FLAG basecamp campfire line --ids-only type=bool
+FLAG basecamp campfire line --in type=string
+FLAG basecamp campfire line --jq type=string
+FLAG basecamp campfire line --json type=bool
+FLAG basecamp campfire line --markdown type=bool
+FLAG basecamp campfire line --md type=bool
+FLAG basecamp campfire line --no-hints type=bool
+FLAG basecamp campfire line --no-stats type=bool
+FLAG basecamp campfire line --profile type=string
+FLAG basecamp campfire line --project type=string
+FLAG basecamp campfire line --quiet type=bool
+FLAG basecamp campfire line --room type=string
+FLAG basecamp campfire line --stats type=bool
+FLAG basecamp campfire line --styled type=bool
+FLAG basecamp campfire line --todolist type=string
+FLAG basecamp campfire line --verbose type=count
+FLAG basecamp campfire list --account type=string
+FLAG basecamp campfire list --agent type=bool
+FLAG basecamp campfire list --all type=bool
+FLAG basecamp campfire list --cache-dir type=string
+FLAG basecamp campfire list --count type=bool
+FLAG basecamp campfire list --help type=bool
+FLAG basecamp campfire list --hints type=bool
+FLAG basecamp campfire list --ids-only type=bool
+FLAG basecamp campfire list --in type=string
+FLAG basecamp campfire list --jq type=string
+FLAG basecamp campfire list --json type=bool
+FLAG basecamp campfire list --markdown type=bool
+FLAG basecamp campfire list --md type=bool
+FLAG basecamp campfire list --no-hints type=bool
+FLAG basecamp campfire list --no-stats type=bool
+FLAG basecamp campfire list --profile type=string
+FLAG basecamp campfire list --project type=string
+FLAG basecamp campfire list --quiet type=bool
+FLAG basecamp campfire list --room type=string
+FLAG basecamp campfire list --stats type=bool
+FLAG basecamp campfire list --styled type=bool
+FLAG basecamp campfire list --todolist type=string
+FLAG basecamp campfire list --verbose type=count
+FLAG basecamp campfire messages --account type=string
+FLAG basecamp campfire messages --agent type=bool
+FLAG basecamp campfire messages --cache-dir type=string
+FLAG basecamp campfire messages --count type=bool
+FLAG basecamp campfire messages --help type=bool
+FLAG basecamp campfire messages --hints type=bool
+FLAG basecamp campfire messages --ids-only type=bool
+FLAG basecamp campfire messages --in type=string
+FLAG basecamp campfire messages --jq type=string
+FLAG basecamp campfire messages --json type=bool
+FLAG basecamp campfire messages --limit type=int
+FLAG basecamp campfire messages --markdown type=bool
+FLAG basecamp campfire messages --md type=bool
+FLAG basecamp campfire messages --no-hints type=bool
+FLAG basecamp campfire messages --no-stats type=bool
+FLAG basecamp campfire messages --profile type=string
+FLAG basecamp campfire messages --project type=string
+FLAG basecamp campfire messages --quiet type=bool
+FLAG basecamp campfire messages --room type=string
+FLAG basecamp campfire messages --stats type=bool
+FLAG basecamp campfire messages --styled type=bool
+FLAG basecamp campfire messages --todolist type=string
+FLAG basecamp campfire messages --verbose type=count
+FLAG basecamp campfire post --account type=string
+FLAG basecamp campfire post --agent type=bool
+FLAG basecamp campfire post --attach type=stringArray
+FLAG basecamp campfire post --cache-dir type=string
+FLAG basecamp campfire post --content type=string
+FLAG basecamp campfire post --content-type type=string
+FLAG basecamp campfire post --count type=bool
+FLAG basecamp campfire post --help type=bool
+FLAG basecamp campfire post --hints type=bool
+FLAG basecamp campfire post --ids-only type=bool
+FLAG basecamp campfire post --in type=string
+FLAG basecamp campfire post --jq type=string
+FLAG basecamp campfire post --json type=bool
+FLAG basecamp campfire post --markdown type=bool
+FLAG basecamp campfire post --md type=bool
+FLAG basecamp campfire post --no-hints type=bool
+FLAG basecamp campfire post --no-stats type=bool
+FLAG basecamp campfire post --profile type=string
+FLAG basecamp campfire post --project type=string
+FLAG basecamp campfire post --quiet type=bool
+FLAG basecamp campfire post --room type=string
+FLAG basecamp campfire post --stats type=bool
+FLAG basecamp campfire post --styled type=bool
+FLAG basecamp campfire post --todolist type=string
+FLAG basecamp campfire post --verbose type=count
+FLAG basecamp campfire show --account type=string
+FLAG basecamp campfire show --agent type=bool
+FLAG basecamp campfire show --cache-dir type=string
+FLAG basecamp campfire show --count type=bool
+FLAG basecamp campfire show --help type=bool
+FLAG basecamp campfire show --hints type=bool
+FLAG basecamp campfire show --ids-only type=bool
+FLAG basecamp campfire show --in type=string
+FLAG basecamp campfire show --jq type=string
+FLAG basecamp campfire show --json type=bool
+FLAG basecamp campfire show --markdown type=bool
+FLAG basecamp campfire show --md type=bool
+FLAG basecamp campfire show --no-hints type=bool
+FLAG basecamp campfire show --no-stats type=bool
+FLAG basecamp campfire show --profile type=string
+FLAG basecamp campfire show --project type=string
+FLAG basecamp campfire show --quiet type=bool
+FLAG basecamp campfire show --room type=string
+FLAG basecamp campfire show --stats type=bool
+FLAG basecamp campfire show --styled type=bool
+FLAG basecamp campfire show --todolist type=string
+FLAG basecamp campfire show --verbose type=count
+FLAG basecamp campfire upload --account type=string
+FLAG basecamp campfire upload --agent type=bool
+FLAG basecamp campfire upload --cache-dir type=string
+FLAG basecamp campfire upload --count type=bool
+FLAG basecamp campfire upload --help type=bool
+FLAG basecamp campfire upload --hints type=bool
+FLAG basecamp campfire upload --ids-only type=bool
+FLAG basecamp campfire upload --in type=string
+FLAG basecamp campfire upload --jq type=string
+FLAG basecamp campfire upload --json type=bool
+FLAG basecamp campfire upload --markdown type=bool
+FLAG basecamp campfire upload --md type=bool
+FLAG basecamp campfire upload --no-hints type=bool
+FLAG basecamp campfire upload --no-stats type=bool
+FLAG basecamp campfire upload --profile type=string
+FLAG basecamp campfire upload --project type=string
+FLAG basecamp campfire upload --quiet type=bool
+FLAG basecamp campfire upload --room type=string
+FLAG basecamp campfire upload --stats type=bool
+FLAG basecamp campfire upload --styled type=bool
+FLAG basecamp campfire upload --todolist type=string
+FLAG basecamp campfire upload --verbose type=count
 FLAG basecamp card --account type=string
 FLAG basecamp card --agent type=bool
 FLAG basecamp card --assignee type=string
@@ -938,6 +2031,7 @@ FLAG basecamp card --cache-dir type=string
 FLAG basecamp card --card-table type=string
 FLAG basecamp card --column type=string
 FLAG basecamp card --count type=bool
+FLAG basecamp card --help type=bool
 FLAG basecamp card --hints type=bool
 FLAG basecamp card --ids-only type=bool
 FLAG basecamp card --in type=string
@@ -960,6 +2054,7 @@ FLAG basecamp card move --agent type=bool
 FLAG basecamp card move --cache-dir type=string
 FLAG basecamp card move --card-table type=string
 FLAG basecamp card move --count type=bool
+FLAG basecamp card move --help type=bool
 FLAG basecamp card move --hints type=bool
 FLAG basecamp card move --ids-only type=bool
 FLAG basecamp card move --in type=string
@@ -980,6 +2075,32 @@ FLAG basecamp card move --styled type=bool
 FLAG basecamp card move --to type=string
 FLAG basecamp card move --todolist type=string
 FLAG basecamp card move --verbose type=count
+FLAG basecamp card mv --account type=string
+FLAG basecamp card mv --agent type=bool
+FLAG basecamp card mv --cache-dir type=string
+FLAG basecamp card mv --card-table type=string
+FLAG basecamp card mv --count type=bool
+FLAG basecamp card mv --help type=bool
+FLAG basecamp card mv --hints type=bool
+FLAG basecamp card mv --ids-only type=bool
+FLAG basecamp card mv --in type=string
+FLAG basecamp card mv --jq type=string
+FLAG basecamp card mv --json type=bool
+FLAG basecamp card mv --markdown type=bool
+FLAG basecamp card mv --md type=bool
+FLAG basecamp card mv --no-hints type=bool
+FLAG basecamp card mv --no-stats type=bool
+FLAG basecamp card mv --on-hold type=bool
+FLAG basecamp card mv --pos type=int
+FLAG basecamp card mv --position type=int
+FLAG basecamp card mv --profile type=string
+FLAG basecamp card mv --project type=string
+FLAG basecamp card mv --quiet type=bool
+FLAG basecamp card mv --stats type=bool
+FLAG basecamp card mv --styled type=bool
+FLAG basecamp card mv --to type=string
+FLAG basecamp card mv --todolist type=string
+FLAG basecamp card mv --verbose type=count
 FLAG basecamp card update --account type=string
 FLAG basecamp card update --agent type=bool
 FLAG basecamp card update --assignee type=string
@@ -989,6 +2110,7 @@ FLAG basecamp card update --cache-dir type=string
 FLAG basecamp card update --card-table type=string
 FLAG basecamp card update --count type=bool
 FLAG basecamp card update --due type=string
+FLAG basecamp card update --help type=bool
 FLAG basecamp card update --hints type=bool
 FLAG basecamp card update --ids-only type=bool
 FLAG basecamp card update --in type=string
@@ -1011,6 +2133,7 @@ FLAG basecamp cards --agent type=bool
 FLAG basecamp cards --cache-dir type=string
 FLAG basecamp cards --card-table type=string
 FLAG basecamp cards --count type=bool
+FLAG basecamp cards --help type=bool
 FLAG basecamp cards --hints type=bool
 FLAG basecamp cards --ids-only type=bool
 FLAG basecamp cards --in type=string
@@ -1032,6 +2155,7 @@ FLAG basecamp cards archive --agent type=bool
 FLAG basecamp cards archive --cache-dir type=string
 FLAG basecamp cards archive --card-table type=string
 FLAG basecamp cards archive --count type=bool
+FLAG basecamp cards archive --help type=bool
 FLAG basecamp cards archive --hints type=bool
 FLAG basecamp cards archive --ids-only type=bool
 FLAG basecamp cards archive --in type=string
@@ -1053,6 +2177,7 @@ FLAG basecamp cards column --agent type=bool
 FLAG basecamp cards column --cache-dir type=string
 FLAG basecamp cards column --card-table type=string
 FLAG basecamp cards column --count type=bool
+FLAG basecamp cards column --help type=bool
 FLAG basecamp cards column --hints type=bool
 FLAG basecamp cards column --ids-only type=bool
 FLAG basecamp cards column --in type=string
@@ -1075,6 +2200,7 @@ FLAG basecamp cards column color --cache-dir type=string
 FLAG basecamp cards column color --card-table type=string
 FLAG basecamp cards column color --color type=string
 FLAG basecamp cards column color --count type=bool
+FLAG basecamp cards column color --help type=bool
 FLAG basecamp cards column color --hints type=bool
 FLAG basecamp cards column color --ids-only type=bool
 FLAG basecamp cards column color --in type=string
@@ -1097,6 +2223,7 @@ FLAG basecamp cards column create --cache-dir type=string
 FLAG basecamp cards column create --card-table type=string
 FLAG basecamp cards column create --count type=bool
 FLAG basecamp cards column create --description type=string
+FLAG basecamp cards column create --help type=bool
 FLAG basecamp cards column create --hints type=bool
 FLAG basecamp cards column create --ids-only type=bool
 FLAG basecamp cards column create --in type=string
@@ -1118,6 +2245,7 @@ FLAG basecamp cards column move --agent type=bool
 FLAG basecamp cards column move --cache-dir type=string
 FLAG basecamp cards column move --card-table type=string
 FLAG basecamp cards column move --count type=bool
+FLAG basecamp cards column move --help type=bool
 FLAG basecamp cards column move --hints type=bool
 FLAG basecamp cards column move --ids-only type=bool
 FLAG basecamp cards column move --in type=string
@@ -1141,6 +2269,7 @@ FLAG basecamp cards column no-on-hold --agent type=bool
 FLAG basecamp cards column no-on-hold --cache-dir type=string
 FLAG basecamp cards column no-on-hold --card-table type=string
 FLAG basecamp cards column no-on-hold --count type=bool
+FLAG basecamp cards column no-on-hold --help type=bool
 FLAG basecamp cards column no-on-hold --hints type=bool
 FLAG basecamp cards column no-on-hold --ids-only type=bool
 FLAG basecamp cards column no-on-hold --in type=string
@@ -1162,6 +2291,7 @@ FLAG basecamp cards column on-hold --agent type=bool
 FLAG basecamp cards column on-hold --cache-dir type=string
 FLAG basecamp cards column on-hold --card-table type=string
 FLAG basecamp cards column on-hold --count type=bool
+FLAG basecamp cards column on-hold --help type=bool
 FLAG basecamp cards column on-hold --hints type=bool
 FLAG basecamp cards column on-hold --ids-only type=bool
 FLAG basecamp cards column on-hold --in type=string
@@ -1183,6 +2313,7 @@ FLAG basecamp cards column show --agent type=bool
 FLAG basecamp cards column show --cache-dir type=string
 FLAG basecamp cards column show --card-table type=string
 FLAG basecamp cards column show --count type=bool
+FLAG basecamp cards column show --help type=bool
 FLAG basecamp cards column show --hints type=bool
 FLAG basecamp cards column show --ids-only type=bool
 FLAG basecamp cards column show --in type=string
@@ -1204,6 +2335,7 @@ FLAG basecamp cards column unwatch --agent type=bool
 FLAG basecamp cards column unwatch --cache-dir type=string
 FLAG basecamp cards column unwatch --card-table type=string
 FLAG basecamp cards column unwatch --count type=bool
+FLAG basecamp cards column unwatch --help type=bool
 FLAG basecamp cards column unwatch --hints type=bool
 FLAG basecamp cards column unwatch --ids-only type=bool
 FLAG basecamp cards column unwatch --in type=string
@@ -1226,6 +2358,7 @@ FLAG basecamp cards column update --cache-dir type=string
 FLAG basecamp cards column update --card-table type=string
 FLAG basecamp cards column update --count type=bool
 FLAG basecamp cards column update --description type=string
+FLAG basecamp cards column update --help type=bool
 FLAG basecamp cards column update --hints type=bool
 FLAG basecamp cards column update --ids-only type=bool
 FLAG basecamp cards column update --in type=string
@@ -1248,6 +2381,7 @@ FLAG basecamp cards column watch --agent type=bool
 FLAG basecamp cards column watch --cache-dir type=string
 FLAG basecamp cards column watch --card-table type=string
 FLAG basecamp cards column watch --count type=bool
+FLAG basecamp cards column watch --help type=bool
 FLAG basecamp cards column watch --hints type=bool
 FLAG basecamp cards column watch --ids-only type=bool
 FLAG basecamp cards column watch --in type=string
@@ -1269,6 +2403,7 @@ FLAG basecamp cards columns --agent type=bool
 FLAG basecamp cards columns --cache-dir type=string
 FLAG basecamp cards columns --card-table type=string
 FLAG basecamp cards columns --count type=bool
+FLAG basecamp cards columns --help type=bool
 FLAG basecamp cards columns --hints type=bool
 FLAG basecamp cards columns --ids-only type=bool
 FLAG basecamp cards columns --in type=string
@@ -1293,6 +2428,7 @@ FLAG basecamp cards create --cache-dir type=string
 FLAG basecamp cards create --card-table type=string
 FLAG basecamp cards create --column type=string
 FLAG basecamp cards create --count type=bool
+FLAG basecamp cards create --help type=bool
 FLAG basecamp cards create --hints type=bool
 FLAG basecamp cards create --ids-only type=bool
 FLAG basecamp cards create --in type=string
@@ -1317,6 +2453,7 @@ FLAG basecamp cards list --cache-dir type=string
 FLAG basecamp cards list --card-table type=string
 FLAG basecamp cards list --column type=string
 FLAG basecamp cards list --count type=bool
+FLAG basecamp cards list --help type=bool
 FLAG basecamp cards list --hints type=bool
 FLAG basecamp cards list --ids-only type=bool
 FLAG basecamp cards list --in type=string
@@ -1342,6 +2479,7 @@ FLAG basecamp cards move --agent type=bool
 FLAG basecamp cards move --cache-dir type=string
 FLAG basecamp cards move --card-table type=string
 FLAG basecamp cards move --count type=bool
+FLAG basecamp cards move --help type=bool
 FLAG basecamp cards move --hints type=bool
 FLAG basecamp cards move --ids-only type=bool
 FLAG basecamp cards move --in type=string
@@ -1362,11 +2500,38 @@ FLAG basecamp cards move --styled type=bool
 FLAG basecamp cards move --to type=string
 FLAG basecamp cards move --todolist type=string
 FLAG basecamp cards move --verbose type=count
+FLAG basecamp cards mv --account type=string
+FLAG basecamp cards mv --agent type=bool
+FLAG basecamp cards mv --cache-dir type=string
+FLAG basecamp cards mv --card-table type=string
+FLAG basecamp cards mv --count type=bool
+FLAG basecamp cards mv --help type=bool
+FLAG basecamp cards mv --hints type=bool
+FLAG basecamp cards mv --ids-only type=bool
+FLAG basecamp cards mv --in type=string
+FLAG basecamp cards mv --jq type=string
+FLAG basecamp cards mv --json type=bool
+FLAG basecamp cards mv --markdown type=bool
+FLAG basecamp cards mv --md type=bool
+FLAG basecamp cards mv --no-hints type=bool
+FLAG basecamp cards mv --no-stats type=bool
+FLAG basecamp cards mv --on-hold type=bool
+FLAG basecamp cards mv --pos type=int
+FLAG basecamp cards mv --position type=int
+FLAG basecamp cards mv --profile type=string
+FLAG basecamp cards mv --project type=string
+FLAG basecamp cards mv --quiet type=bool
+FLAG basecamp cards mv --stats type=bool
+FLAG basecamp cards mv --styled type=bool
+FLAG basecamp cards mv --to type=string
+FLAG basecamp cards mv --todolist type=string
+FLAG basecamp cards mv --verbose type=count
 FLAG basecamp cards restore --account type=string
 FLAG basecamp cards restore --agent type=bool
 FLAG basecamp cards restore --cache-dir type=string
 FLAG basecamp cards restore --card-table type=string
 FLAG basecamp cards restore --count type=bool
+FLAG basecamp cards restore --help type=bool
 FLAG basecamp cards restore --hints type=bool
 FLAG basecamp cards restore --ids-only type=bool
 FLAG basecamp cards restore --in type=string
@@ -1388,6 +2553,7 @@ FLAG basecamp cards show --agent type=bool
 FLAG basecamp cards show --cache-dir type=string
 FLAG basecamp cards show --card-table type=string
 FLAG basecamp cards show --count type=bool
+FLAG basecamp cards show --help type=bool
 FLAG basecamp cards show --hints type=bool
 FLAG basecamp cards show --ids-only type=bool
 FLAG basecamp cards show --in type=string
@@ -1409,6 +2575,7 @@ FLAG basecamp cards step --agent type=bool
 FLAG basecamp cards step --cache-dir type=string
 FLAG basecamp cards step --card-table type=string
 FLAG basecamp cards step --count type=bool
+FLAG basecamp cards step --help type=bool
 FLAG basecamp cards step --hints type=bool
 FLAG basecamp cards step --ids-only type=bool
 FLAG basecamp cards step --in type=string
@@ -1430,6 +2597,7 @@ FLAG basecamp cards step complete --agent type=bool
 FLAG basecamp cards step complete --cache-dir type=string
 FLAG basecamp cards step complete --card-table type=string
 FLAG basecamp cards step complete --count type=bool
+FLAG basecamp cards step complete --help type=bool
 FLAG basecamp cards step complete --hints type=bool
 FLAG basecamp cards step complete --ids-only type=bool
 FLAG basecamp cards step complete --in type=string
@@ -1454,6 +2622,7 @@ FLAG basecamp cards step create --card type=string
 FLAG basecamp cards step create --card-table type=string
 FLAG basecamp cards step create --count type=bool
 FLAG basecamp cards step create --due type=string
+FLAG basecamp cards step create --help type=bool
 FLAG basecamp cards step create --hints type=bool
 FLAG basecamp cards step create --ids-only type=bool
 FLAG basecamp cards step create --in type=string
@@ -1475,6 +2644,7 @@ FLAG basecamp cards step delete --agent type=bool
 FLAG basecamp cards step delete --cache-dir type=string
 FLAG basecamp cards step delete --card-table type=string
 FLAG basecamp cards step delete --count type=bool
+FLAG basecamp cards step delete --help type=bool
 FLAG basecamp cards step delete --hints type=bool
 FLAG basecamp cards step delete --ids-only type=bool
 FLAG basecamp cards step delete --in type=string
@@ -1497,6 +2667,7 @@ FLAG basecamp cards step move --cache-dir type=string
 FLAG basecamp cards step move --card type=string
 FLAG basecamp cards step move --card-table type=string
 FLAG basecamp cards step move --count type=bool
+FLAG basecamp cards step move --help type=bool
 FLAG basecamp cards step move --hints type=bool
 FLAG basecamp cards step move --ids-only type=bool
 FLAG basecamp cards step move --in type=string
@@ -1520,6 +2691,7 @@ FLAG basecamp cards step uncomplete --agent type=bool
 FLAG basecamp cards step uncomplete --cache-dir type=string
 FLAG basecamp cards step uncomplete --card-table type=string
 FLAG basecamp cards step uncomplete --count type=bool
+FLAG basecamp cards step uncomplete --help type=bool
 FLAG basecamp cards step uncomplete --hints type=bool
 FLAG basecamp cards step uncomplete --ids-only type=bool
 FLAG basecamp cards step uncomplete --in type=string
@@ -1543,6 +2715,7 @@ FLAG basecamp cards step update --cache-dir type=string
 FLAG basecamp cards step update --card-table type=string
 FLAG basecamp cards step update --count type=bool
 FLAG basecamp cards step update --due type=string
+FLAG basecamp cards step update --help type=bool
 FLAG basecamp cards step update --hints type=bool
 FLAG basecamp cards step update --ids-only type=bool
 FLAG basecamp cards step update --in type=string
@@ -1565,6 +2738,7 @@ FLAG basecamp cards steps --cache-dir type=string
 FLAG basecamp cards steps --card type=string
 FLAG basecamp cards steps --card-table type=string
 FLAG basecamp cards steps --count type=bool
+FLAG basecamp cards steps --help type=bool
 FLAG basecamp cards steps --hints type=bool
 FLAG basecamp cards steps --ids-only type=bool
 FLAG basecamp cards steps --in type=string
@@ -1586,6 +2760,7 @@ FLAG basecamp cards trash --agent type=bool
 FLAG basecamp cards trash --cache-dir type=string
 FLAG basecamp cards trash --card-table type=string
 FLAG basecamp cards trash --count type=bool
+FLAG basecamp cards trash --help type=bool
 FLAG basecamp cards trash --hints type=bool
 FLAG basecamp cards trash --ids-only type=bool
 FLAG basecamp cards trash --in type=string
@@ -1611,6 +2786,7 @@ FLAG basecamp cards update --cache-dir type=string
 FLAG basecamp cards update --card-table type=string
 FLAG basecamp cards update --count type=bool
 FLAG basecamp cards update --due type=string
+FLAG basecamp cards update --help type=bool
 FLAG basecamp cards update --hints type=bool
 FLAG basecamp cards update --ids-only type=bool
 FLAG basecamp cards update --in type=string
@@ -1632,6 +2808,7 @@ FLAG basecamp chat --account type=string
 FLAG basecamp chat --agent type=bool
 FLAG basecamp chat --cache-dir type=string
 FLAG basecamp chat --count type=bool
+FLAG basecamp chat --help type=bool
 FLAG basecamp chat --hints type=bool
 FLAG basecamp chat --ids-only type=bool
 FLAG basecamp chat --in type=string
@@ -1654,6 +2831,7 @@ FLAG basecamp chat delete --agent type=bool
 FLAG basecamp chat delete --cache-dir type=string
 FLAG basecamp chat delete --count type=bool
 FLAG basecamp chat delete --force type=bool
+FLAG basecamp chat delete --help type=bool
 FLAG basecamp chat delete --hints type=bool
 FLAG basecamp chat delete --ids-only type=bool
 FLAG basecamp chat delete --in type=string
@@ -1675,6 +2853,7 @@ FLAG basecamp chat line --account type=string
 FLAG basecamp chat line --agent type=bool
 FLAG basecamp chat line --cache-dir type=string
 FLAG basecamp chat line --count type=bool
+FLAG basecamp chat line --help type=bool
 FLAG basecamp chat line --hints type=bool
 FLAG basecamp chat line --ids-only type=bool
 FLAG basecamp chat line --in type=string
@@ -1697,6 +2876,7 @@ FLAG basecamp chat list --agent type=bool
 FLAG basecamp chat list --all type=bool
 FLAG basecamp chat list --cache-dir type=string
 FLAG basecamp chat list --count type=bool
+FLAG basecamp chat list --help type=bool
 FLAG basecamp chat list --hints type=bool
 FLAG basecamp chat list --ids-only type=bool
 FLAG basecamp chat list --in type=string
@@ -1718,6 +2898,7 @@ FLAG basecamp chat messages --account type=string
 FLAG basecamp chat messages --agent type=bool
 FLAG basecamp chat messages --cache-dir type=string
 FLAG basecamp chat messages --count type=bool
+FLAG basecamp chat messages --help type=bool
 FLAG basecamp chat messages --hints type=bool
 FLAG basecamp chat messages --ids-only type=bool
 FLAG basecamp chat messages --in type=string
@@ -1743,6 +2924,7 @@ FLAG basecamp chat post --cache-dir type=string
 FLAG basecamp chat post --content type=string
 FLAG basecamp chat post --content-type type=string
 FLAG basecamp chat post --count type=bool
+FLAG basecamp chat post --help type=bool
 FLAG basecamp chat post --hints type=bool
 FLAG basecamp chat post --ids-only type=bool
 FLAG basecamp chat post --in type=string
@@ -1760,10 +2942,33 @@ FLAG basecamp chat post --stats type=bool
 FLAG basecamp chat post --styled type=bool
 FLAG basecamp chat post --todolist type=string
 FLAG basecamp chat post --verbose type=count
+FLAG basecamp chat show --account type=string
+FLAG basecamp chat show --agent type=bool
+FLAG basecamp chat show --cache-dir type=string
+FLAG basecamp chat show --count type=bool
+FLAG basecamp chat show --help type=bool
+FLAG basecamp chat show --hints type=bool
+FLAG basecamp chat show --ids-only type=bool
+FLAG basecamp chat show --in type=string
+FLAG basecamp chat show --jq type=string
+FLAG basecamp chat show --json type=bool
+FLAG basecamp chat show --markdown type=bool
+FLAG basecamp chat show --md type=bool
+FLAG basecamp chat show --no-hints type=bool
+FLAG basecamp chat show --no-stats type=bool
+FLAG basecamp chat show --profile type=string
+FLAG basecamp chat show --project type=string
+FLAG basecamp chat show --quiet type=bool
+FLAG basecamp chat show --room type=string
+FLAG basecamp chat show --stats type=bool
+FLAG basecamp chat show --styled type=bool
+FLAG basecamp chat show --todolist type=string
+FLAG basecamp chat show --verbose type=count
 FLAG basecamp chat upload --account type=string
 FLAG basecamp chat upload --agent type=bool
 FLAG basecamp chat upload --cache-dir type=string
 FLAG basecamp chat upload --count type=bool
+FLAG basecamp chat upload --help type=bool
 FLAG basecamp chat upload --hints type=bool
 FLAG basecamp chat upload --ids-only type=bool
 FLAG basecamp chat upload --in type=string
@@ -1781,10 +2986,267 @@ FLAG basecamp chat upload --stats type=bool
 FLAG basecamp chat upload --styled type=bool
 FLAG basecamp chat upload --todolist type=string
 FLAG basecamp chat upload --verbose type=count
+FLAG basecamp checkin --account type=string
+FLAG basecamp checkin --agent type=bool
+FLAG basecamp checkin --cache-dir type=string
+FLAG basecamp checkin --count type=bool
+FLAG basecamp checkin --help type=bool
+FLAG basecamp checkin --hints type=bool
+FLAG basecamp checkin --ids-only type=bool
+FLAG basecamp checkin --in type=string
+FLAG basecamp checkin --jq type=string
+FLAG basecamp checkin --json type=bool
+FLAG basecamp checkin --markdown type=bool
+FLAG basecamp checkin --md type=bool
+FLAG basecamp checkin --no-hints type=bool
+FLAG basecamp checkin --no-stats type=bool
+FLAG basecamp checkin --profile type=string
+FLAG basecamp checkin --project type=string
+FLAG basecamp checkin --questionnaire type=string
+FLAG basecamp checkin --quiet type=bool
+FLAG basecamp checkin --stats type=bool
+FLAG basecamp checkin --styled type=bool
+FLAG basecamp checkin --todolist type=string
+FLAG basecamp checkin --verbose type=count
+FLAG basecamp checkin answer --account type=string
+FLAG basecamp checkin answer --agent type=bool
+FLAG basecamp checkin answer --cache-dir type=string
+FLAG basecamp checkin answer --count type=bool
+FLAG basecamp checkin answer --help type=bool
+FLAG basecamp checkin answer --hints type=bool
+FLAG basecamp checkin answer --ids-only type=bool
+FLAG basecamp checkin answer --in type=string
+FLAG basecamp checkin answer --jq type=string
+FLAG basecamp checkin answer --json type=bool
+FLAG basecamp checkin answer --markdown type=bool
+FLAG basecamp checkin answer --md type=bool
+FLAG basecamp checkin answer --no-hints type=bool
+FLAG basecamp checkin answer --no-stats type=bool
+FLAG basecamp checkin answer --profile type=string
+FLAG basecamp checkin answer --project type=string
+FLAG basecamp checkin answer --questionnaire type=string
+FLAG basecamp checkin answer --quiet type=bool
+FLAG basecamp checkin answer --stats type=bool
+FLAG basecamp checkin answer --styled type=bool
+FLAG basecamp checkin answer --todolist type=string
+FLAG basecamp checkin answer --verbose type=count
+FLAG basecamp checkin answer create --account type=string
+FLAG basecamp checkin answer create --agent type=bool
+FLAG basecamp checkin answer create --attach type=stringArray
+FLAG basecamp checkin answer create --cache-dir type=string
+FLAG basecamp checkin answer create --count type=bool
+FLAG basecamp checkin answer create --date type=string
+FLAG basecamp checkin answer create --help type=bool
+FLAG basecamp checkin answer create --hints type=bool
+FLAG basecamp checkin answer create --ids-only type=bool
+FLAG basecamp checkin answer create --in type=string
+FLAG basecamp checkin answer create --jq type=string
+FLAG basecamp checkin answer create --json type=bool
+FLAG basecamp checkin answer create --markdown type=bool
+FLAG basecamp checkin answer create --md type=bool
+FLAG basecamp checkin answer create --no-hints type=bool
+FLAG basecamp checkin answer create --no-stats type=bool
+FLAG basecamp checkin answer create --profile type=string
+FLAG basecamp checkin answer create --project type=string
+FLAG basecamp checkin answer create --questionnaire type=string
+FLAG basecamp checkin answer create --quiet type=bool
+FLAG basecamp checkin answer create --stats type=bool
+FLAG basecamp checkin answer create --styled type=bool
+FLAG basecamp checkin answer create --todolist type=string
+FLAG basecamp checkin answer create --verbose type=count
+FLAG basecamp checkin answer show --account type=string
+FLAG basecamp checkin answer show --agent type=bool
+FLAG basecamp checkin answer show --cache-dir type=string
+FLAG basecamp checkin answer show --count type=bool
+FLAG basecamp checkin answer show --help type=bool
+FLAG basecamp checkin answer show --hints type=bool
+FLAG basecamp checkin answer show --ids-only type=bool
+FLAG basecamp checkin answer show --in type=string
+FLAG basecamp checkin answer show --jq type=string
+FLAG basecamp checkin answer show --json type=bool
+FLAG basecamp checkin answer show --markdown type=bool
+FLAG basecamp checkin answer show --md type=bool
+FLAG basecamp checkin answer show --no-hints type=bool
+FLAG basecamp checkin answer show --no-stats type=bool
+FLAG basecamp checkin answer show --profile type=string
+FLAG basecamp checkin answer show --project type=string
+FLAG basecamp checkin answer show --questionnaire type=string
+FLAG basecamp checkin answer show --quiet type=bool
+FLAG basecamp checkin answer show --stats type=bool
+FLAG basecamp checkin answer show --styled type=bool
+FLAG basecamp checkin answer show --todolist type=string
+FLAG basecamp checkin answer show --verbose type=count
+FLAG basecamp checkin answer update --account type=string
+FLAG basecamp checkin answer update --agent type=bool
+FLAG basecamp checkin answer update --cache-dir type=string
+FLAG basecamp checkin answer update --count type=bool
+FLAG basecamp checkin answer update --help type=bool
+FLAG basecamp checkin answer update --hints type=bool
+FLAG basecamp checkin answer update --ids-only type=bool
+FLAG basecamp checkin answer update --in type=string
+FLAG basecamp checkin answer update --jq type=string
+FLAG basecamp checkin answer update --json type=bool
+FLAG basecamp checkin answer update --markdown type=bool
+FLAG basecamp checkin answer update --md type=bool
+FLAG basecamp checkin answer update --no-hints type=bool
+FLAG basecamp checkin answer update --no-stats type=bool
+FLAG basecamp checkin answer update --profile type=string
+FLAG basecamp checkin answer update --project type=string
+FLAG basecamp checkin answer update --questionnaire type=string
+FLAG basecamp checkin answer update --quiet type=bool
+FLAG basecamp checkin answer update --stats type=bool
+FLAG basecamp checkin answer update --styled type=bool
+FLAG basecamp checkin answer update --todolist type=string
+FLAG basecamp checkin answer update --verbose type=count
+FLAG basecamp checkin answers --account type=string
+FLAG basecamp checkin answers --agent type=bool
+FLAG basecamp checkin answers --all type=bool
+FLAG basecamp checkin answers --cache-dir type=string
+FLAG basecamp checkin answers --count type=bool
+FLAG basecamp checkin answers --help type=bool
+FLAG basecamp checkin answers --hints type=bool
+FLAG basecamp checkin answers --ids-only type=bool
+FLAG basecamp checkin answers --in type=string
+FLAG basecamp checkin answers --jq type=string
+FLAG basecamp checkin answers --json type=bool
+FLAG basecamp checkin answers --limit type=int
+FLAG basecamp checkin answers --markdown type=bool
+FLAG basecamp checkin answers --md type=bool
+FLAG basecamp checkin answers --no-hints type=bool
+FLAG basecamp checkin answers --no-stats type=bool
+FLAG basecamp checkin answers --page type=int
+FLAG basecamp checkin answers --profile type=string
+FLAG basecamp checkin answers --project type=string
+FLAG basecamp checkin answers --questionnaire type=string
+FLAG basecamp checkin answers --quiet type=bool
+FLAG basecamp checkin answers --stats type=bool
+FLAG basecamp checkin answers --styled type=bool
+FLAG basecamp checkin answers --todolist type=string
+FLAG basecamp checkin answers --verbose type=count
+FLAG basecamp checkin question --account type=string
+FLAG basecamp checkin question --agent type=bool
+FLAG basecamp checkin question --cache-dir type=string
+FLAG basecamp checkin question --count type=bool
+FLAG basecamp checkin question --help type=bool
+FLAG basecamp checkin question --hints type=bool
+FLAG basecamp checkin question --ids-only type=bool
+FLAG basecamp checkin question --in type=string
+FLAG basecamp checkin question --jq type=string
+FLAG basecamp checkin question --json type=bool
+FLAG basecamp checkin question --markdown type=bool
+FLAG basecamp checkin question --md type=bool
+FLAG basecamp checkin question --no-hints type=bool
+FLAG basecamp checkin question --no-stats type=bool
+FLAG basecamp checkin question --profile type=string
+FLAG basecamp checkin question --project type=string
+FLAG basecamp checkin question --questionnaire type=string
+FLAG basecamp checkin question --quiet type=bool
+FLAG basecamp checkin question --stats type=bool
+FLAG basecamp checkin question --styled type=bool
+FLAG basecamp checkin question --todolist type=string
+FLAG basecamp checkin question --verbose type=count
+FLAG basecamp checkin question create --account type=string
+FLAG basecamp checkin question create --agent type=bool
+FLAG basecamp checkin question create --cache-dir type=string
+FLAG basecamp checkin question create --count type=bool
+FLAG basecamp checkin question create --days type=string
+FLAG basecamp checkin question create --frequency type=string
+FLAG basecamp checkin question create --help type=bool
+FLAG basecamp checkin question create --hints type=bool
+FLAG basecamp checkin question create --ids-only type=bool
+FLAG basecamp checkin question create --in type=string
+FLAG basecamp checkin question create --jq type=string
+FLAG basecamp checkin question create --json type=bool
+FLAG basecamp checkin question create --markdown type=bool
+FLAG basecamp checkin question create --md type=bool
+FLAG basecamp checkin question create --no-hints type=bool
+FLAG basecamp checkin question create --no-stats type=bool
+FLAG basecamp checkin question create --profile type=string
+FLAG basecamp checkin question create --project type=string
+FLAG basecamp checkin question create --questionnaire type=string
+FLAG basecamp checkin question create --quiet type=bool
+FLAG basecamp checkin question create --stats type=bool
+FLAG basecamp checkin question create --styled type=bool
+FLAG basecamp checkin question create --time type=string
+FLAG basecamp checkin question create --todolist type=string
+FLAG basecamp checkin question create --verbose type=count
+FLAG basecamp checkin question show --account type=string
+FLAG basecamp checkin question show --agent type=bool
+FLAG basecamp checkin question show --cache-dir type=string
+FLAG basecamp checkin question show --count type=bool
+FLAG basecamp checkin question show --help type=bool
+FLAG basecamp checkin question show --hints type=bool
+FLAG basecamp checkin question show --ids-only type=bool
+FLAG basecamp checkin question show --in type=string
+FLAG basecamp checkin question show --jq type=string
+FLAG basecamp checkin question show --json type=bool
+FLAG basecamp checkin question show --markdown type=bool
+FLAG basecamp checkin question show --md type=bool
+FLAG basecamp checkin question show --no-hints type=bool
+FLAG basecamp checkin question show --no-stats type=bool
+FLAG basecamp checkin question show --profile type=string
+FLAG basecamp checkin question show --project type=string
+FLAG basecamp checkin question show --questionnaire type=string
+FLAG basecamp checkin question show --quiet type=bool
+FLAG basecamp checkin question show --stats type=bool
+FLAG basecamp checkin question show --styled type=bool
+FLAG basecamp checkin question show --todolist type=string
+FLAG basecamp checkin question show --verbose type=count
+FLAG basecamp checkin question update --account type=string
+FLAG basecamp checkin question update --agent type=bool
+FLAG basecamp checkin question update --cache-dir type=string
+FLAG basecamp checkin question update --count type=bool
+FLAG basecamp checkin question update --days type=string
+FLAG basecamp checkin question update --frequency type=string
+FLAG basecamp checkin question update --help type=bool
+FLAG basecamp checkin question update --hints type=bool
+FLAG basecamp checkin question update --ids-only type=bool
+FLAG basecamp checkin question update --in type=string
+FLAG basecamp checkin question update --jq type=string
+FLAG basecamp checkin question update --json type=bool
+FLAG basecamp checkin question update --markdown type=bool
+FLAG basecamp checkin question update --md type=bool
+FLAG basecamp checkin question update --no-hints type=bool
+FLAG basecamp checkin question update --no-stats type=bool
+FLAG basecamp checkin question update --profile type=string
+FLAG basecamp checkin question update --project type=string
+FLAG basecamp checkin question update --questionnaire type=string
+FLAG basecamp checkin question update --quiet type=bool
+FLAG basecamp checkin question update --stats type=bool
+FLAG basecamp checkin question update --styled type=bool
+FLAG basecamp checkin question update --time type=string
+FLAG basecamp checkin question update --todolist type=string
+FLAG basecamp checkin question update --verbose type=count
+FLAG basecamp checkin questions --account type=string
+FLAG basecamp checkin questions --agent type=bool
+FLAG basecamp checkin questions --all type=bool
+FLAG basecamp checkin questions --cache-dir type=string
+FLAG basecamp checkin questions --count type=bool
+FLAG basecamp checkin questions --help type=bool
+FLAG basecamp checkin questions --hints type=bool
+FLAG basecamp checkin questions --ids-only type=bool
+FLAG basecamp checkin questions --in type=string
+FLAG basecamp checkin questions --jq type=string
+FLAG basecamp checkin questions --json type=bool
+FLAG basecamp checkin questions --limit type=int
+FLAG basecamp checkin questions --markdown type=bool
+FLAG basecamp checkin questions --md type=bool
+FLAG basecamp checkin questions --no-hints type=bool
+FLAG basecamp checkin questions --no-stats type=bool
+FLAG basecamp checkin questions --page type=int
+FLAG basecamp checkin questions --profile type=string
+FLAG basecamp checkin questions --project type=string
+FLAG basecamp checkin questions --questionnaire type=string
+FLAG basecamp checkin questions --quiet type=bool
+FLAG basecamp checkin questions --stats type=bool
+FLAG basecamp checkin questions --styled type=bool
+FLAG basecamp checkin questions --todolist type=string
+FLAG basecamp checkin questions --verbose type=count
 FLAG basecamp checkins --account type=string
 FLAG basecamp checkins --agent type=bool
 FLAG basecamp checkins --cache-dir type=string
 FLAG basecamp checkins --count type=bool
+FLAG basecamp checkins --help type=bool
 FLAG basecamp checkins --hints type=bool
 FLAG basecamp checkins --ids-only type=bool
 FLAG basecamp checkins --in type=string
@@ -1806,6 +3268,7 @@ FLAG basecamp checkins answer --account type=string
 FLAG basecamp checkins answer --agent type=bool
 FLAG basecamp checkins answer --cache-dir type=string
 FLAG basecamp checkins answer --count type=bool
+FLAG basecamp checkins answer --help type=bool
 FLAG basecamp checkins answer --hints type=bool
 FLAG basecamp checkins answer --ids-only type=bool
 FLAG basecamp checkins answer --in type=string
@@ -1829,6 +3292,7 @@ FLAG basecamp checkins answer create --attach type=stringArray
 FLAG basecamp checkins answer create --cache-dir type=string
 FLAG basecamp checkins answer create --count type=bool
 FLAG basecamp checkins answer create --date type=string
+FLAG basecamp checkins answer create --help type=bool
 FLAG basecamp checkins answer create --hints type=bool
 FLAG basecamp checkins answer create --ids-only type=bool
 FLAG basecamp checkins answer create --in type=string
@@ -1850,6 +3314,7 @@ FLAG basecamp checkins answer show --account type=string
 FLAG basecamp checkins answer show --agent type=bool
 FLAG basecamp checkins answer show --cache-dir type=string
 FLAG basecamp checkins answer show --count type=bool
+FLAG basecamp checkins answer show --help type=bool
 FLAG basecamp checkins answer show --hints type=bool
 FLAG basecamp checkins answer show --ids-only type=bool
 FLAG basecamp checkins answer show --in type=string
@@ -1871,6 +3336,7 @@ FLAG basecamp checkins answer update --account type=string
 FLAG basecamp checkins answer update --agent type=bool
 FLAG basecamp checkins answer update --cache-dir type=string
 FLAG basecamp checkins answer update --count type=bool
+FLAG basecamp checkins answer update --help type=bool
 FLAG basecamp checkins answer update --hints type=bool
 FLAG basecamp checkins answer update --ids-only type=bool
 FLAG basecamp checkins answer update --in type=string
@@ -1893,6 +3359,7 @@ FLAG basecamp checkins answers --agent type=bool
 FLAG basecamp checkins answers --all type=bool
 FLAG basecamp checkins answers --cache-dir type=string
 FLAG basecamp checkins answers --count type=bool
+FLAG basecamp checkins answers --help type=bool
 FLAG basecamp checkins answers --hints type=bool
 FLAG basecamp checkins answers --ids-only type=bool
 FLAG basecamp checkins answers --in type=string
@@ -1916,6 +3383,7 @@ FLAG basecamp checkins question --account type=string
 FLAG basecamp checkins question --agent type=bool
 FLAG basecamp checkins question --cache-dir type=string
 FLAG basecamp checkins question --count type=bool
+FLAG basecamp checkins question --help type=bool
 FLAG basecamp checkins question --hints type=bool
 FLAG basecamp checkins question --ids-only type=bool
 FLAG basecamp checkins question --in type=string
@@ -1939,6 +3407,7 @@ FLAG basecamp checkins question create --cache-dir type=string
 FLAG basecamp checkins question create --count type=bool
 FLAG basecamp checkins question create --days type=string
 FLAG basecamp checkins question create --frequency type=string
+FLAG basecamp checkins question create --help type=bool
 FLAG basecamp checkins question create --hints type=bool
 FLAG basecamp checkins question create --ids-only type=bool
 FLAG basecamp checkins question create --in type=string
@@ -1961,6 +3430,7 @@ FLAG basecamp checkins question show --account type=string
 FLAG basecamp checkins question show --agent type=bool
 FLAG basecamp checkins question show --cache-dir type=string
 FLAG basecamp checkins question show --count type=bool
+FLAG basecamp checkins question show --help type=bool
 FLAG basecamp checkins question show --hints type=bool
 FLAG basecamp checkins question show --ids-only type=bool
 FLAG basecamp checkins question show --in type=string
@@ -1984,6 +3454,7 @@ FLAG basecamp checkins question update --cache-dir type=string
 FLAG basecamp checkins question update --count type=bool
 FLAG basecamp checkins question update --days type=string
 FLAG basecamp checkins question update --frequency type=string
+FLAG basecamp checkins question update --help type=bool
 FLAG basecamp checkins question update --hints type=bool
 FLAG basecamp checkins question update --ids-only type=bool
 FLAG basecamp checkins question update --in type=string
@@ -2007,6 +3478,7 @@ FLAG basecamp checkins questions --agent type=bool
 FLAG basecamp checkins questions --all type=bool
 FLAG basecamp checkins questions --cache-dir type=string
 FLAG basecamp checkins questions --count type=bool
+FLAG basecamp checkins questions --help type=bool
 FLAG basecamp checkins questions --hints type=bool
 FLAG basecamp checkins questions --ids-only type=bool
 FLAG basecamp checkins questions --in type=string
@@ -2026,10 +3498,32 @@ FLAG basecamp checkins questions --stats type=bool
 FLAG basecamp checkins questions --styled type=bool
 FLAG basecamp checkins questions --todolist type=string
 FLAG basecamp checkins questions --verbose type=count
+FLAG basecamp cmds --account type=string
+FLAG basecamp cmds --agent type=bool
+FLAG basecamp cmds --cache-dir type=string
+FLAG basecamp cmds --count type=bool
+FLAG basecamp cmds --help type=bool
+FLAG basecamp cmds --hints type=bool
+FLAG basecamp cmds --ids-only type=bool
+FLAG basecamp cmds --in type=string
+FLAG basecamp cmds --jq type=string
+FLAG basecamp cmds --json type=bool
+FLAG basecamp cmds --markdown type=bool
+FLAG basecamp cmds --md type=bool
+FLAG basecamp cmds --no-hints type=bool
+FLAG basecamp cmds --no-stats type=bool
+FLAG basecamp cmds --profile type=string
+FLAG basecamp cmds --project type=string
+FLAG basecamp cmds --quiet type=bool
+FLAG basecamp cmds --stats type=bool
+FLAG basecamp cmds --styled type=bool
+FLAG basecamp cmds --todolist type=string
+FLAG basecamp cmds --verbose type=count
 FLAG basecamp commands --account type=string
 FLAG basecamp commands --agent type=bool
 FLAG basecamp commands --cache-dir type=string
 FLAG basecamp commands --count type=bool
+FLAG basecamp commands --help type=bool
 FLAG basecamp commands --hints type=bool
 FLAG basecamp commands --ids-only type=bool
 FLAG basecamp commands --in type=string
@@ -2052,6 +3546,7 @@ FLAG basecamp comment --attach type=stringArray
 FLAG basecamp comment --cache-dir type=string
 FLAG basecamp comment --count type=bool
 FLAG basecamp comment --edit type=bool
+FLAG basecamp comment --help type=bool
 FLAG basecamp comment --hints type=bool
 FLAG basecamp comment --ids-only type=bool
 FLAG basecamp comment --in type=string
@@ -2072,6 +3567,7 @@ FLAG basecamp comments --account type=string
 FLAG basecamp comments --agent type=bool
 FLAG basecamp comments --cache-dir type=string
 FLAG basecamp comments --count type=bool
+FLAG basecamp comments --help type=bool
 FLAG basecamp comments --hints type=bool
 FLAG basecamp comments --ids-only type=bool
 FLAG basecamp comments --in type=string
@@ -2092,6 +3588,7 @@ FLAG basecamp comments archive --account type=string
 FLAG basecamp comments archive --agent type=bool
 FLAG basecamp comments archive --cache-dir type=string
 FLAG basecamp comments archive --count type=bool
+FLAG basecamp comments archive --help type=bool
 FLAG basecamp comments archive --hints type=bool
 FLAG basecamp comments archive --ids-only type=bool
 FLAG basecamp comments archive --in type=string
@@ -2114,6 +3611,7 @@ FLAG basecamp comments create --attach type=stringArray
 FLAG basecamp comments create --cache-dir type=string
 FLAG basecamp comments create --count type=bool
 FLAG basecamp comments create --edit type=bool
+FLAG basecamp comments create --help type=bool
 FLAG basecamp comments create --hints type=bool
 FLAG basecamp comments create --ids-only type=bool
 FLAG basecamp comments create --in type=string
@@ -2135,6 +3633,7 @@ FLAG basecamp comments list --agent type=bool
 FLAG basecamp comments list --all type=bool
 FLAG basecamp comments list --cache-dir type=string
 FLAG basecamp comments list --count type=bool
+FLAG basecamp comments list --help type=bool
 FLAG basecamp comments list --hints type=bool
 FLAG basecamp comments list --ids-only type=bool
 FLAG basecamp comments list --in type=string
@@ -2157,6 +3656,7 @@ FLAG basecamp comments restore --account type=string
 FLAG basecamp comments restore --agent type=bool
 FLAG basecamp comments restore --cache-dir type=string
 FLAG basecamp comments restore --count type=bool
+FLAG basecamp comments restore --help type=bool
 FLAG basecamp comments restore --hints type=bool
 FLAG basecamp comments restore --ids-only type=bool
 FLAG basecamp comments restore --in type=string
@@ -2177,6 +3677,7 @@ FLAG basecamp comments show --account type=string
 FLAG basecamp comments show --agent type=bool
 FLAG basecamp comments show --cache-dir type=string
 FLAG basecamp comments show --count type=bool
+FLAG basecamp comments show --help type=bool
 FLAG basecamp comments show --hints type=bool
 FLAG basecamp comments show --ids-only type=bool
 FLAG basecamp comments show --in type=string
@@ -2197,6 +3698,7 @@ FLAG basecamp comments trash --account type=string
 FLAG basecamp comments trash --agent type=bool
 FLAG basecamp comments trash --cache-dir type=string
 FLAG basecamp comments trash --count type=bool
+FLAG basecamp comments trash --help type=bool
 FLAG basecamp comments trash --hints type=bool
 FLAG basecamp comments trash --ids-only type=bool
 FLAG basecamp comments trash --in type=string
@@ -2217,6 +3719,7 @@ FLAG basecamp comments update --account type=string
 FLAG basecamp comments update --agent type=bool
 FLAG basecamp comments update --cache-dir type=string
 FLAG basecamp comments update --count type=bool
+FLAG basecamp comments update --help type=bool
 FLAG basecamp comments update --hints type=bool
 FLAG basecamp comments update --ids-only type=bool
 FLAG basecamp comments update --in type=string
@@ -2237,6 +3740,7 @@ FLAG basecamp completion --account type=string
 FLAG basecamp completion --agent type=bool
 FLAG basecamp completion --cache-dir type=string
 FLAG basecamp completion --count type=bool
+FLAG basecamp completion --help type=bool
 FLAG basecamp completion --hints type=bool
 FLAG basecamp completion --ids-only type=bool
 FLAG basecamp completion --in type=string
@@ -2257,6 +3761,7 @@ FLAG basecamp completion bash --account type=string
 FLAG basecamp completion bash --agent type=bool
 FLAG basecamp completion bash --cache-dir type=string
 FLAG basecamp completion bash --count type=bool
+FLAG basecamp completion bash --help type=bool
 FLAG basecamp completion bash --hints type=bool
 FLAG basecamp completion bash --ids-only type=bool
 FLAG basecamp completion bash --in type=string
@@ -2277,6 +3782,7 @@ FLAG basecamp completion fish --account type=string
 FLAG basecamp completion fish --agent type=bool
 FLAG basecamp completion fish --cache-dir type=string
 FLAG basecamp completion fish --count type=bool
+FLAG basecamp completion fish --help type=bool
 FLAG basecamp completion fish --hints type=bool
 FLAG basecamp completion fish --ids-only type=bool
 FLAG basecamp completion fish --in type=string
@@ -2297,6 +3803,7 @@ FLAG basecamp completion powershell --account type=string
 FLAG basecamp completion powershell --agent type=bool
 FLAG basecamp completion powershell --cache-dir type=string
 FLAG basecamp completion powershell --count type=bool
+FLAG basecamp completion powershell --help type=bool
 FLAG basecamp completion powershell --hints type=bool
 FLAG basecamp completion powershell --ids-only type=bool
 FLAG basecamp completion powershell --in type=string
@@ -2317,6 +3824,7 @@ FLAG basecamp completion refresh --account type=string
 FLAG basecamp completion refresh --agent type=bool
 FLAG basecamp completion refresh --cache-dir type=string
 FLAG basecamp completion refresh --count type=bool
+FLAG basecamp completion refresh --help type=bool
 FLAG basecamp completion refresh --hints type=bool
 FLAG basecamp completion refresh --ids-only type=bool
 FLAG basecamp completion refresh --in type=string
@@ -2337,6 +3845,7 @@ FLAG basecamp completion status --account type=string
 FLAG basecamp completion status --agent type=bool
 FLAG basecamp completion status --cache-dir type=string
 FLAG basecamp completion status --count type=bool
+FLAG basecamp completion status --help type=bool
 FLAG basecamp completion status --hints type=bool
 FLAG basecamp completion status --ids-only type=bool
 FLAG basecamp completion status --in type=string
@@ -2357,6 +3866,7 @@ FLAG basecamp completion zsh --account type=string
 FLAG basecamp completion zsh --agent type=bool
 FLAG basecamp completion zsh --cache-dir type=string
 FLAG basecamp completion zsh --count type=bool
+FLAG basecamp completion zsh --help type=bool
 FLAG basecamp completion zsh --hints type=bool
 FLAG basecamp completion zsh --ids-only type=bool
 FLAG basecamp completion zsh --in type=string
@@ -2377,6 +3887,7 @@ FLAG basecamp config --account type=string
 FLAG basecamp config --agent type=bool
 FLAG basecamp config --cache-dir type=string
 FLAG basecamp config --count type=bool
+FLAG basecamp config --help type=bool
 FLAG basecamp config --hints type=bool
 FLAG basecamp config --ids-only type=bool
 FLAG basecamp config --in type=string
@@ -2397,6 +3908,7 @@ FLAG basecamp config init --account type=string
 FLAG basecamp config init --agent type=bool
 FLAG basecamp config init --cache-dir type=string
 FLAG basecamp config init --count type=bool
+FLAG basecamp config init --help type=bool
 FLAG basecamp config init --hints type=bool
 FLAG basecamp config init --ids-only type=bool
 FLAG basecamp config init --in type=string
@@ -2417,6 +3929,7 @@ FLAG basecamp config project --account type=string
 FLAG basecamp config project --agent type=bool
 FLAG basecamp config project --cache-dir type=string
 FLAG basecamp config project --count type=bool
+FLAG basecamp config project --help type=bool
 FLAG basecamp config project --hints type=bool
 FLAG basecamp config project --ids-only type=bool
 FLAG basecamp config project --in type=string
@@ -2438,6 +3951,7 @@ FLAG basecamp config set --agent type=bool
 FLAG basecamp config set --cache-dir type=string
 FLAG basecamp config set --count type=bool
 FLAG basecamp config set --global type=bool
+FLAG basecamp config set --help type=bool
 FLAG basecamp config set --hints type=bool
 FLAG basecamp config set --ids-only type=bool
 FLAG basecamp config set --in type=string
@@ -2458,6 +3972,7 @@ FLAG basecamp config show --account type=string
 FLAG basecamp config show --agent type=bool
 FLAG basecamp config show --cache-dir type=string
 FLAG basecamp config show --count type=bool
+FLAG basecamp config show --help type=bool
 FLAG basecamp config show --hints type=bool
 FLAG basecamp config show --ids-only type=bool
 FLAG basecamp config show --in type=string
@@ -2478,6 +3993,7 @@ FLAG basecamp config trust --account type=string
 FLAG basecamp config trust --agent type=bool
 FLAG basecamp config trust --cache-dir type=string
 FLAG basecamp config trust --count type=bool
+FLAG basecamp config trust --help type=bool
 FLAG basecamp config trust --hints type=bool
 FLAG basecamp config trust --ids-only type=bool
 FLAG basecamp config trust --in type=string
@@ -2500,6 +4016,7 @@ FLAG basecamp config unset --agent type=bool
 FLAG basecamp config unset --cache-dir type=string
 FLAG basecamp config unset --count type=bool
 FLAG basecamp config unset --global type=bool
+FLAG basecamp config unset --help type=bool
 FLAG basecamp config unset --hints type=bool
 FLAG basecamp config unset --ids-only type=bool
 FLAG basecamp config unset --in type=string
@@ -2520,6 +4037,7 @@ FLAG basecamp config untrust --account type=string
 FLAG basecamp config untrust --agent type=bool
 FLAG basecamp config untrust --cache-dir type=string
 FLAG basecamp config untrust --count type=bool
+FLAG basecamp config untrust --help type=bool
 FLAG basecamp config untrust --hints type=bool
 FLAG basecamp config untrust --ids-only type=bool
 FLAG basecamp config untrust --in type=string
@@ -2541,6 +4059,7 @@ FLAG basecamp docs --agent type=bool
 FLAG basecamp docs --cache-dir type=string
 FLAG basecamp docs --count type=bool
 FLAG basecamp docs --folder type=string
+FLAG basecamp docs --help type=bool
 FLAG basecamp docs --hints type=bool
 FLAG basecamp docs --ids-only type=bool
 FLAG basecamp docs --in type=string
@@ -2563,6 +4082,7 @@ FLAG basecamp docs archive --agent type=bool
 FLAG basecamp docs archive --cache-dir type=string
 FLAG basecamp docs archive --count type=bool
 FLAG basecamp docs archive --folder type=string
+FLAG basecamp docs archive --help type=bool
 FLAG basecamp docs archive --hints type=bool
 FLAG basecamp docs archive --ids-only type=bool
 FLAG basecamp docs archive --in type=string
@@ -2580,12 +4100,171 @@ FLAG basecamp docs archive --styled type=bool
 FLAG basecamp docs archive --todolist type=string
 FLAG basecamp docs archive --vault type=string
 FLAG basecamp docs archive --verbose type=count
+FLAG basecamp docs doc --account type=string
+FLAG basecamp docs doc --agent type=bool
+FLAG basecamp docs doc --all type=bool
+FLAG basecamp docs doc --cache-dir type=string
+FLAG basecamp docs doc --count type=bool
+FLAG basecamp docs doc --folder type=string
+FLAG basecamp docs doc --help type=bool
+FLAG basecamp docs doc --hints type=bool
+FLAG basecamp docs doc --ids-only type=bool
+FLAG basecamp docs doc --in type=string
+FLAG basecamp docs doc --jq type=string
+FLAG basecamp docs doc --json type=bool
+FLAG basecamp docs doc --limit type=int
+FLAG basecamp docs doc --markdown type=bool
+FLAG basecamp docs doc --md type=bool
+FLAG basecamp docs doc --no-hints type=bool
+FLAG basecamp docs doc --no-stats type=bool
+FLAG basecamp docs doc --page type=int
+FLAG basecamp docs doc --profile type=string
+FLAG basecamp docs doc --project type=string
+FLAG basecamp docs doc --quiet type=bool
+FLAG basecamp docs doc --stats type=bool
+FLAG basecamp docs doc --styled type=bool
+FLAG basecamp docs doc --todolist type=string
+FLAG basecamp docs doc --vault type=string
+FLAG basecamp docs doc --verbose type=count
+FLAG basecamp docs doc create --account type=string
+FLAG basecamp docs doc create --agent type=bool
+FLAG basecamp docs doc create --attach type=stringArray
+FLAG basecamp docs doc create --cache-dir type=string
+FLAG basecamp docs doc create --count type=bool
+FLAG basecamp docs doc create --draft type=bool
+FLAG basecamp docs doc create --folder type=string
+FLAG basecamp docs doc create --help type=bool
+FLAG basecamp docs doc create --hints type=bool
+FLAG basecamp docs doc create --ids-only type=bool
+FLAG basecamp docs doc create --in type=string
+FLAG basecamp docs doc create --jq type=string
+FLAG basecamp docs doc create --json type=bool
+FLAG basecamp docs doc create --markdown type=bool
+FLAG basecamp docs doc create --md type=bool
+FLAG basecamp docs doc create --no-hints type=bool
+FLAG basecamp docs doc create --no-stats type=bool
+FLAG basecamp docs doc create --no-subscribe type=bool
+FLAG basecamp docs doc create --profile type=string
+FLAG basecamp docs doc create --project type=string
+FLAG basecamp docs doc create --quiet type=bool
+FLAG basecamp docs doc create --stats type=bool
+FLAG basecamp docs doc create --styled type=bool
+FLAG basecamp docs doc create --subscribe type=string
+FLAG basecamp docs doc create --todolist type=string
+FLAG basecamp docs doc create --vault type=string
+FLAG basecamp docs doc create --verbose type=count
+FLAG basecamp docs doc list --account type=string
+FLAG basecamp docs doc list --agent type=bool
+FLAG basecamp docs doc list --all type=bool
+FLAG basecamp docs doc list --cache-dir type=string
+FLAG basecamp docs doc list --count type=bool
+FLAG basecamp docs doc list --folder type=string
+FLAG basecamp docs doc list --help type=bool
+FLAG basecamp docs doc list --hints type=bool
+FLAG basecamp docs doc list --ids-only type=bool
+FLAG basecamp docs doc list --in type=string
+FLAG basecamp docs doc list --jq type=string
+FLAG basecamp docs doc list --json type=bool
+FLAG basecamp docs doc list --limit type=int
+FLAG basecamp docs doc list --markdown type=bool
+FLAG basecamp docs doc list --md type=bool
+FLAG basecamp docs doc list --no-hints type=bool
+FLAG basecamp docs doc list --no-stats type=bool
+FLAG basecamp docs doc list --page type=int
+FLAG basecamp docs doc list --profile type=string
+FLAG basecamp docs doc list --project type=string
+FLAG basecamp docs doc list --quiet type=bool
+FLAG basecamp docs doc list --stats type=bool
+FLAG basecamp docs doc list --styled type=bool
+FLAG basecamp docs doc list --todolist type=string
+FLAG basecamp docs doc list --vault type=string
+FLAG basecamp docs doc list --verbose type=count
+FLAG basecamp docs document --account type=string
+FLAG basecamp docs document --agent type=bool
+FLAG basecamp docs document --all type=bool
+FLAG basecamp docs document --cache-dir type=string
+FLAG basecamp docs document --count type=bool
+FLAG basecamp docs document --folder type=string
+FLAG basecamp docs document --help type=bool
+FLAG basecamp docs document --hints type=bool
+FLAG basecamp docs document --ids-only type=bool
+FLAG basecamp docs document --in type=string
+FLAG basecamp docs document --jq type=string
+FLAG basecamp docs document --json type=bool
+FLAG basecamp docs document --limit type=int
+FLAG basecamp docs document --markdown type=bool
+FLAG basecamp docs document --md type=bool
+FLAG basecamp docs document --no-hints type=bool
+FLAG basecamp docs document --no-stats type=bool
+FLAG basecamp docs document --page type=int
+FLAG basecamp docs document --profile type=string
+FLAG basecamp docs document --project type=string
+FLAG basecamp docs document --quiet type=bool
+FLAG basecamp docs document --stats type=bool
+FLAG basecamp docs document --styled type=bool
+FLAG basecamp docs document --todolist type=string
+FLAG basecamp docs document --vault type=string
+FLAG basecamp docs document --verbose type=count
+FLAG basecamp docs document create --account type=string
+FLAG basecamp docs document create --agent type=bool
+FLAG basecamp docs document create --attach type=stringArray
+FLAG basecamp docs document create --cache-dir type=string
+FLAG basecamp docs document create --count type=bool
+FLAG basecamp docs document create --draft type=bool
+FLAG basecamp docs document create --folder type=string
+FLAG basecamp docs document create --help type=bool
+FLAG basecamp docs document create --hints type=bool
+FLAG basecamp docs document create --ids-only type=bool
+FLAG basecamp docs document create --in type=string
+FLAG basecamp docs document create --jq type=string
+FLAG basecamp docs document create --json type=bool
+FLAG basecamp docs document create --markdown type=bool
+FLAG basecamp docs document create --md type=bool
+FLAG basecamp docs document create --no-hints type=bool
+FLAG basecamp docs document create --no-stats type=bool
+FLAG basecamp docs document create --no-subscribe type=bool
+FLAG basecamp docs document create --profile type=string
+FLAG basecamp docs document create --project type=string
+FLAG basecamp docs document create --quiet type=bool
+FLAG basecamp docs document create --stats type=bool
+FLAG basecamp docs document create --styled type=bool
+FLAG basecamp docs document create --subscribe type=string
+FLAG basecamp docs document create --todolist type=string
+FLAG basecamp docs document create --vault type=string
+FLAG basecamp docs document create --verbose type=count
+FLAG basecamp docs document list --account type=string
+FLAG basecamp docs document list --agent type=bool
+FLAG basecamp docs document list --all type=bool
+FLAG basecamp docs document list --cache-dir type=string
+FLAG basecamp docs document list --count type=bool
+FLAG basecamp docs document list --folder type=string
+FLAG basecamp docs document list --help type=bool
+FLAG basecamp docs document list --hints type=bool
+FLAG basecamp docs document list --ids-only type=bool
+FLAG basecamp docs document list --in type=string
+FLAG basecamp docs document list --jq type=string
+FLAG basecamp docs document list --json type=bool
+FLAG basecamp docs document list --limit type=int
+FLAG basecamp docs document list --markdown type=bool
+FLAG basecamp docs document list --md type=bool
+FLAG basecamp docs document list --no-hints type=bool
+FLAG basecamp docs document list --no-stats type=bool
+FLAG basecamp docs document list --page type=int
+FLAG basecamp docs document list --profile type=string
+FLAG basecamp docs document list --project type=string
+FLAG basecamp docs document list --quiet type=bool
+FLAG basecamp docs document list --stats type=bool
+FLAG basecamp docs document list --styled type=bool
+FLAG basecamp docs document list --todolist type=string
+FLAG basecamp docs document list --vault type=string
+FLAG basecamp docs document list --verbose type=count
 FLAG basecamp docs documents --account type=string
 FLAG basecamp docs documents --agent type=bool
 FLAG basecamp docs documents --all type=bool
 FLAG basecamp docs documents --cache-dir type=string
 FLAG basecamp docs documents --count type=bool
 FLAG basecamp docs documents --folder type=string
+FLAG basecamp docs documents --help type=bool
 FLAG basecamp docs documents --hints type=bool
 FLAG basecamp docs documents --ids-only type=bool
 FLAG basecamp docs documents --in type=string
@@ -2612,6 +4291,7 @@ FLAG basecamp docs documents create --cache-dir type=string
 FLAG basecamp docs documents create --count type=bool
 FLAG basecamp docs documents create --draft type=bool
 FLAG basecamp docs documents create --folder type=string
+FLAG basecamp docs documents create --help type=bool
 FLAG basecamp docs documents create --hints type=bool
 FLAG basecamp docs documents create --ids-only type=bool
 FLAG basecamp docs documents create --in type=string
@@ -2637,6 +4317,7 @@ FLAG basecamp docs documents list --all type=bool
 FLAG basecamp docs documents list --cache-dir type=string
 FLAG basecamp docs documents list --count type=bool
 FLAG basecamp docs documents list --folder type=string
+FLAG basecamp docs documents list --help type=bool
 FLAG basecamp docs documents list --hints type=bool
 FLAG basecamp docs documents list --ids-only type=bool
 FLAG basecamp docs documents list --in type=string
@@ -2661,6 +4342,7 @@ FLAG basecamp docs download --agent type=bool
 FLAG basecamp docs download --cache-dir type=string
 FLAG basecamp docs download --count type=bool
 FLAG basecamp docs download --folder type=string
+FLAG basecamp docs download --help type=bool
 FLAG basecamp docs download --hints type=bool
 FLAG basecamp docs download --ids-only type=bool
 FLAG basecamp docs download --in type=string
@@ -2679,12 +4361,88 @@ FLAG basecamp docs download --styled type=bool
 FLAG basecamp docs download --todolist type=string
 FLAG basecamp docs download --vault type=string
 FLAG basecamp docs download --verbose type=count
+FLAG basecamp docs folder --account type=string
+FLAG basecamp docs folder --agent type=bool
+FLAG basecamp docs folder --all type=bool
+FLAG basecamp docs folder --cache-dir type=string
+FLAG basecamp docs folder --count type=bool
+FLAG basecamp docs folder --folder type=string
+FLAG basecamp docs folder --help type=bool
+FLAG basecamp docs folder --hints type=bool
+FLAG basecamp docs folder --ids-only type=bool
+FLAG basecamp docs folder --in type=string
+FLAG basecamp docs folder --jq type=string
+FLAG basecamp docs folder --json type=bool
+FLAG basecamp docs folder --limit type=int
+FLAG basecamp docs folder --markdown type=bool
+FLAG basecamp docs folder --md type=bool
+FLAG basecamp docs folder --no-hints type=bool
+FLAG basecamp docs folder --no-stats type=bool
+FLAG basecamp docs folder --page type=int
+FLAG basecamp docs folder --profile type=string
+FLAG basecamp docs folder --project type=string
+FLAG basecamp docs folder --quiet type=bool
+FLAG basecamp docs folder --stats type=bool
+FLAG basecamp docs folder --styled type=bool
+FLAG basecamp docs folder --todolist type=string
+FLAG basecamp docs folder --vault type=string
+FLAG basecamp docs folder --verbose type=count
+FLAG basecamp docs folder create --account type=string
+FLAG basecamp docs folder create --agent type=bool
+FLAG basecamp docs folder create --cache-dir type=string
+FLAG basecamp docs folder create --count type=bool
+FLAG basecamp docs folder create --folder type=string
+FLAG basecamp docs folder create --help type=bool
+FLAG basecamp docs folder create --hints type=bool
+FLAG basecamp docs folder create --ids-only type=bool
+FLAG basecamp docs folder create --in type=string
+FLAG basecamp docs folder create --jq type=string
+FLAG basecamp docs folder create --json type=bool
+FLAG basecamp docs folder create --markdown type=bool
+FLAG basecamp docs folder create --md type=bool
+FLAG basecamp docs folder create --no-hints type=bool
+FLAG basecamp docs folder create --no-stats type=bool
+FLAG basecamp docs folder create --profile type=string
+FLAG basecamp docs folder create --project type=string
+FLAG basecamp docs folder create --quiet type=bool
+FLAG basecamp docs folder create --stats type=bool
+FLAG basecamp docs folder create --styled type=bool
+FLAG basecamp docs folder create --todolist type=string
+FLAG basecamp docs folder create --vault type=string
+FLAG basecamp docs folder create --verbose type=count
+FLAG basecamp docs folder list --account type=string
+FLAG basecamp docs folder list --agent type=bool
+FLAG basecamp docs folder list --all type=bool
+FLAG basecamp docs folder list --cache-dir type=string
+FLAG basecamp docs folder list --count type=bool
+FLAG basecamp docs folder list --folder type=string
+FLAG basecamp docs folder list --help type=bool
+FLAG basecamp docs folder list --hints type=bool
+FLAG basecamp docs folder list --ids-only type=bool
+FLAG basecamp docs folder list --in type=string
+FLAG basecamp docs folder list --jq type=string
+FLAG basecamp docs folder list --json type=bool
+FLAG basecamp docs folder list --limit type=int
+FLAG basecamp docs folder list --markdown type=bool
+FLAG basecamp docs folder list --md type=bool
+FLAG basecamp docs folder list --no-hints type=bool
+FLAG basecamp docs folder list --no-stats type=bool
+FLAG basecamp docs folder list --page type=int
+FLAG basecamp docs folder list --profile type=string
+FLAG basecamp docs folder list --project type=string
+FLAG basecamp docs folder list --quiet type=bool
+FLAG basecamp docs folder list --stats type=bool
+FLAG basecamp docs folder list --styled type=bool
+FLAG basecamp docs folder list --todolist type=string
+FLAG basecamp docs folder list --vault type=string
+FLAG basecamp docs folder list --verbose type=count
 FLAG basecamp docs folders --account type=string
 FLAG basecamp docs folders --agent type=bool
 FLAG basecamp docs folders --all type=bool
 FLAG basecamp docs folders --cache-dir type=string
 FLAG basecamp docs folders --count type=bool
 FLAG basecamp docs folders --folder type=string
+FLAG basecamp docs folders --help type=bool
 FLAG basecamp docs folders --hints type=bool
 FLAG basecamp docs folders --ids-only type=bool
 FLAG basecamp docs folders --in type=string
@@ -2709,6 +4467,7 @@ FLAG basecamp docs folders create --agent type=bool
 FLAG basecamp docs folders create --cache-dir type=string
 FLAG basecamp docs folders create --count type=bool
 FLAG basecamp docs folders create --folder type=string
+FLAG basecamp docs folders create --help type=bool
 FLAG basecamp docs folders create --hints type=bool
 FLAG basecamp docs folders create --ids-only type=bool
 FLAG basecamp docs folders create --in type=string
@@ -2732,6 +4491,7 @@ FLAG basecamp docs folders list --all type=bool
 FLAG basecamp docs folders list --cache-dir type=string
 FLAG basecamp docs folders list --count type=bool
 FLAG basecamp docs folders list --folder type=string
+FLAG basecamp docs folders list --help type=bool
 FLAG basecamp docs folders list --hints type=bool
 FLAG basecamp docs folders list --ids-only type=bool
 FLAG basecamp docs folders list --in type=string
@@ -2756,6 +4516,7 @@ FLAG basecamp docs list --agent type=bool
 FLAG basecamp docs list --cache-dir type=string
 FLAG basecamp docs list --count type=bool
 FLAG basecamp docs list --folder type=string
+FLAG basecamp docs list --help type=bool
 FLAG basecamp docs list --hints type=bool
 FLAG basecamp docs list --ids-only type=bool
 FLAG basecamp docs list --in type=string
@@ -2778,6 +4539,7 @@ FLAG basecamp docs restore --agent type=bool
 FLAG basecamp docs restore --cache-dir type=string
 FLAG basecamp docs restore --count type=bool
 FLAG basecamp docs restore --folder type=string
+FLAG basecamp docs restore --help type=bool
 FLAG basecamp docs restore --hints type=bool
 FLAG basecamp docs restore --ids-only type=bool
 FLAG basecamp docs restore --in type=string
@@ -2800,6 +4562,7 @@ FLAG basecamp docs show --agent type=bool
 FLAG basecamp docs show --cache-dir type=string
 FLAG basecamp docs show --count type=bool
 FLAG basecamp docs show --folder type=string
+FLAG basecamp docs show --help type=bool
 FLAG basecamp docs show --hints type=bool
 FLAG basecamp docs show --ids-only type=bool
 FLAG basecamp docs show --in type=string
@@ -2823,6 +4586,7 @@ FLAG basecamp docs trash --agent type=bool
 FLAG basecamp docs trash --cache-dir type=string
 FLAG basecamp docs trash --count type=bool
 FLAG basecamp docs trash --folder type=string
+FLAG basecamp docs trash --help type=bool
 FLAG basecamp docs trash --hints type=bool
 FLAG basecamp docs trash --ids-only type=bool
 FLAG basecamp docs trash --in type=string
@@ -2846,6 +4610,7 @@ FLAG basecamp docs update --cache-dir type=string
 FLAG basecamp docs update --content type=string
 FLAG basecamp docs update --count type=bool
 FLAG basecamp docs update --folder type=string
+FLAG basecamp docs update --help type=bool
 FLAG basecamp docs update --hints type=bool
 FLAG basecamp docs update --ids-only type=bool
 FLAG basecamp docs update --in type=string
@@ -2865,12 +4630,89 @@ FLAG basecamp docs update --todolist type=string
 FLAG basecamp docs update --type type=string
 FLAG basecamp docs update --vault type=string
 FLAG basecamp docs update --verbose type=count
+FLAG basecamp docs upload --account type=string
+FLAG basecamp docs upload --agent type=bool
+FLAG basecamp docs upload --all type=bool
+FLAG basecamp docs upload --cache-dir type=string
+FLAG basecamp docs upload --count type=bool
+FLAG basecamp docs upload --folder type=string
+FLAG basecamp docs upload --help type=bool
+FLAG basecamp docs upload --hints type=bool
+FLAG basecamp docs upload --ids-only type=bool
+FLAG basecamp docs upload --in type=string
+FLAG basecamp docs upload --jq type=string
+FLAG basecamp docs upload --json type=bool
+FLAG basecamp docs upload --limit type=int
+FLAG basecamp docs upload --markdown type=bool
+FLAG basecamp docs upload --md type=bool
+FLAG basecamp docs upload --no-hints type=bool
+FLAG basecamp docs upload --no-stats type=bool
+FLAG basecamp docs upload --page type=int
+FLAG basecamp docs upload --profile type=string
+FLAG basecamp docs upload --project type=string
+FLAG basecamp docs upload --quiet type=bool
+FLAG basecamp docs upload --stats type=bool
+FLAG basecamp docs upload --styled type=bool
+FLAG basecamp docs upload --todolist type=string
+FLAG basecamp docs upload --vault type=string
+FLAG basecamp docs upload --verbose type=count
+FLAG basecamp docs upload create --account type=string
+FLAG basecamp docs upload create --agent type=bool
+FLAG basecamp docs upload create --cache-dir type=string
+FLAG basecamp docs upload create --count type=bool
+FLAG basecamp docs upload create --description type=string
+FLAG basecamp docs upload create --folder type=string
+FLAG basecamp docs upload create --help type=bool
+FLAG basecamp docs upload create --hints type=bool
+FLAG basecamp docs upload create --ids-only type=bool
+FLAG basecamp docs upload create --in type=string
+FLAG basecamp docs upload create --jq type=string
+FLAG basecamp docs upload create --json type=bool
+FLAG basecamp docs upload create --markdown type=bool
+FLAG basecamp docs upload create --md type=bool
+FLAG basecamp docs upload create --no-hints type=bool
+FLAG basecamp docs upload create --no-stats type=bool
+FLAG basecamp docs upload create --profile type=string
+FLAG basecamp docs upload create --project type=string
+FLAG basecamp docs upload create --quiet type=bool
+FLAG basecamp docs upload create --stats type=bool
+FLAG basecamp docs upload create --styled type=bool
+FLAG basecamp docs upload create --todolist type=string
+FLAG basecamp docs upload create --vault type=string
+FLAG basecamp docs upload create --verbose type=count
+FLAG basecamp docs upload list --account type=string
+FLAG basecamp docs upload list --agent type=bool
+FLAG basecamp docs upload list --all type=bool
+FLAG basecamp docs upload list --cache-dir type=string
+FLAG basecamp docs upload list --count type=bool
+FLAG basecamp docs upload list --folder type=string
+FLAG basecamp docs upload list --help type=bool
+FLAG basecamp docs upload list --hints type=bool
+FLAG basecamp docs upload list --ids-only type=bool
+FLAG basecamp docs upload list --in type=string
+FLAG basecamp docs upload list --jq type=string
+FLAG basecamp docs upload list --json type=bool
+FLAG basecamp docs upload list --limit type=int
+FLAG basecamp docs upload list --markdown type=bool
+FLAG basecamp docs upload list --md type=bool
+FLAG basecamp docs upload list --no-hints type=bool
+FLAG basecamp docs upload list --no-stats type=bool
+FLAG basecamp docs upload list --page type=int
+FLAG basecamp docs upload list --profile type=string
+FLAG basecamp docs upload list --project type=string
+FLAG basecamp docs upload list --quiet type=bool
+FLAG basecamp docs upload list --stats type=bool
+FLAG basecamp docs upload list --styled type=bool
+FLAG basecamp docs upload list --todolist type=string
+FLAG basecamp docs upload list --vault type=string
+FLAG basecamp docs upload list --verbose type=count
 FLAG basecamp docs uploads --account type=string
 FLAG basecamp docs uploads --agent type=bool
 FLAG basecamp docs uploads --all type=bool
 FLAG basecamp docs uploads --cache-dir type=string
 FLAG basecamp docs uploads --count type=bool
 FLAG basecamp docs uploads --folder type=string
+FLAG basecamp docs uploads --help type=bool
 FLAG basecamp docs uploads --hints type=bool
 FLAG basecamp docs uploads --ids-only type=bool
 FLAG basecamp docs uploads --in type=string
@@ -2896,6 +4738,7 @@ FLAG basecamp docs uploads create --cache-dir type=string
 FLAG basecamp docs uploads create --count type=bool
 FLAG basecamp docs uploads create --description type=string
 FLAG basecamp docs uploads create --folder type=string
+FLAG basecamp docs uploads create --help type=bool
 FLAG basecamp docs uploads create --hints type=bool
 FLAG basecamp docs uploads create --ids-only type=bool
 FLAG basecamp docs uploads create --in type=string
@@ -2919,6 +4762,7 @@ FLAG basecamp docs uploads list --all type=bool
 FLAG basecamp docs uploads list --cache-dir type=string
 FLAG basecamp docs uploads list --count type=bool
 FLAG basecamp docs uploads list --folder type=string
+FLAG basecamp docs uploads list --help type=bool
 FLAG basecamp docs uploads list --hints type=bool
 FLAG basecamp docs uploads list --ids-only type=bool
 FLAG basecamp docs uploads list --in type=string
@@ -2938,10 +4782,161 @@ FLAG basecamp docs uploads list --styled type=bool
 FLAG basecamp docs uploads list --todolist type=string
 FLAG basecamp docs uploads list --vault type=string
 FLAG basecamp docs uploads list --verbose type=count
+FLAG basecamp docs vault --account type=string
+FLAG basecamp docs vault --agent type=bool
+FLAG basecamp docs vault --all type=bool
+FLAG basecamp docs vault --cache-dir type=string
+FLAG basecamp docs vault --count type=bool
+FLAG basecamp docs vault --folder type=string
+FLAG basecamp docs vault --help type=bool
+FLAG basecamp docs vault --hints type=bool
+FLAG basecamp docs vault --ids-only type=bool
+FLAG basecamp docs vault --in type=string
+FLAG basecamp docs vault --jq type=string
+FLAG basecamp docs vault --json type=bool
+FLAG basecamp docs vault --limit type=int
+FLAG basecamp docs vault --markdown type=bool
+FLAG basecamp docs vault --md type=bool
+FLAG basecamp docs vault --no-hints type=bool
+FLAG basecamp docs vault --no-stats type=bool
+FLAG basecamp docs vault --page type=int
+FLAG basecamp docs vault --profile type=string
+FLAG basecamp docs vault --project type=string
+FLAG basecamp docs vault --quiet type=bool
+FLAG basecamp docs vault --stats type=bool
+FLAG basecamp docs vault --styled type=bool
+FLAG basecamp docs vault --todolist type=string
+FLAG basecamp docs vault --vault type=string
+FLAG basecamp docs vault --verbose type=count
+FLAG basecamp docs vault create --account type=string
+FLAG basecamp docs vault create --agent type=bool
+FLAG basecamp docs vault create --cache-dir type=string
+FLAG basecamp docs vault create --count type=bool
+FLAG basecamp docs vault create --folder type=string
+FLAG basecamp docs vault create --help type=bool
+FLAG basecamp docs vault create --hints type=bool
+FLAG basecamp docs vault create --ids-only type=bool
+FLAG basecamp docs vault create --in type=string
+FLAG basecamp docs vault create --jq type=string
+FLAG basecamp docs vault create --json type=bool
+FLAG basecamp docs vault create --markdown type=bool
+FLAG basecamp docs vault create --md type=bool
+FLAG basecamp docs vault create --no-hints type=bool
+FLAG basecamp docs vault create --no-stats type=bool
+FLAG basecamp docs vault create --profile type=string
+FLAG basecamp docs vault create --project type=string
+FLAG basecamp docs vault create --quiet type=bool
+FLAG basecamp docs vault create --stats type=bool
+FLAG basecamp docs vault create --styled type=bool
+FLAG basecamp docs vault create --todolist type=string
+FLAG basecamp docs vault create --vault type=string
+FLAG basecamp docs vault create --verbose type=count
+FLAG basecamp docs vault list --account type=string
+FLAG basecamp docs vault list --agent type=bool
+FLAG basecamp docs vault list --all type=bool
+FLAG basecamp docs vault list --cache-dir type=string
+FLAG basecamp docs vault list --count type=bool
+FLAG basecamp docs vault list --folder type=string
+FLAG basecamp docs vault list --help type=bool
+FLAG basecamp docs vault list --hints type=bool
+FLAG basecamp docs vault list --ids-only type=bool
+FLAG basecamp docs vault list --in type=string
+FLAG basecamp docs vault list --jq type=string
+FLAG basecamp docs vault list --json type=bool
+FLAG basecamp docs vault list --limit type=int
+FLAG basecamp docs vault list --markdown type=bool
+FLAG basecamp docs vault list --md type=bool
+FLAG basecamp docs vault list --no-hints type=bool
+FLAG basecamp docs vault list --no-stats type=bool
+FLAG basecamp docs vault list --page type=int
+FLAG basecamp docs vault list --profile type=string
+FLAG basecamp docs vault list --project type=string
+FLAG basecamp docs vault list --quiet type=bool
+FLAG basecamp docs vault list --stats type=bool
+FLAG basecamp docs vault list --styled type=bool
+FLAG basecamp docs vault list --todolist type=string
+FLAG basecamp docs vault list --vault type=string
+FLAG basecamp docs vault list --verbose type=count
+FLAG basecamp docs vaults --account type=string
+FLAG basecamp docs vaults --agent type=bool
+FLAG basecamp docs vaults --all type=bool
+FLAG basecamp docs vaults --cache-dir type=string
+FLAG basecamp docs vaults --count type=bool
+FLAG basecamp docs vaults --folder type=string
+FLAG basecamp docs vaults --help type=bool
+FLAG basecamp docs vaults --hints type=bool
+FLAG basecamp docs vaults --ids-only type=bool
+FLAG basecamp docs vaults --in type=string
+FLAG basecamp docs vaults --jq type=string
+FLAG basecamp docs vaults --json type=bool
+FLAG basecamp docs vaults --limit type=int
+FLAG basecamp docs vaults --markdown type=bool
+FLAG basecamp docs vaults --md type=bool
+FLAG basecamp docs vaults --no-hints type=bool
+FLAG basecamp docs vaults --no-stats type=bool
+FLAG basecamp docs vaults --page type=int
+FLAG basecamp docs vaults --profile type=string
+FLAG basecamp docs vaults --project type=string
+FLAG basecamp docs vaults --quiet type=bool
+FLAG basecamp docs vaults --stats type=bool
+FLAG basecamp docs vaults --styled type=bool
+FLAG basecamp docs vaults --todolist type=string
+FLAG basecamp docs vaults --vault type=string
+FLAG basecamp docs vaults --verbose type=count
+FLAG basecamp docs vaults create --account type=string
+FLAG basecamp docs vaults create --agent type=bool
+FLAG basecamp docs vaults create --cache-dir type=string
+FLAG basecamp docs vaults create --count type=bool
+FLAG basecamp docs vaults create --folder type=string
+FLAG basecamp docs vaults create --help type=bool
+FLAG basecamp docs vaults create --hints type=bool
+FLAG basecamp docs vaults create --ids-only type=bool
+FLAG basecamp docs vaults create --in type=string
+FLAG basecamp docs vaults create --jq type=string
+FLAG basecamp docs vaults create --json type=bool
+FLAG basecamp docs vaults create --markdown type=bool
+FLAG basecamp docs vaults create --md type=bool
+FLAG basecamp docs vaults create --no-hints type=bool
+FLAG basecamp docs vaults create --no-stats type=bool
+FLAG basecamp docs vaults create --profile type=string
+FLAG basecamp docs vaults create --project type=string
+FLAG basecamp docs vaults create --quiet type=bool
+FLAG basecamp docs vaults create --stats type=bool
+FLAG basecamp docs vaults create --styled type=bool
+FLAG basecamp docs vaults create --todolist type=string
+FLAG basecamp docs vaults create --vault type=string
+FLAG basecamp docs vaults create --verbose type=count
+FLAG basecamp docs vaults list --account type=string
+FLAG basecamp docs vaults list --agent type=bool
+FLAG basecamp docs vaults list --all type=bool
+FLAG basecamp docs vaults list --cache-dir type=string
+FLAG basecamp docs vaults list --count type=bool
+FLAG basecamp docs vaults list --folder type=string
+FLAG basecamp docs vaults list --help type=bool
+FLAG basecamp docs vaults list --hints type=bool
+FLAG basecamp docs vaults list --ids-only type=bool
+FLAG basecamp docs vaults list --in type=string
+FLAG basecamp docs vaults list --jq type=string
+FLAG basecamp docs vaults list --json type=bool
+FLAG basecamp docs vaults list --limit type=int
+FLAG basecamp docs vaults list --markdown type=bool
+FLAG basecamp docs vaults list --md type=bool
+FLAG basecamp docs vaults list --no-hints type=bool
+FLAG basecamp docs vaults list --no-stats type=bool
+FLAG basecamp docs vaults list --page type=int
+FLAG basecamp docs vaults list --profile type=string
+FLAG basecamp docs vaults list --project type=string
+FLAG basecamp docs vaults list --quiet type=bool
+FLAG basecamp docs vaults list --stats type=bool
+FLAG basecamp docs vaults list --styled type=bool
+FLAG basecamp docs vaults list --todolist type=string
+FLAG basecamp docs vaults list --vault type=string
+FLAG basecamp docs vaults list --verbose type=count
 FLAG basecamp doctor --account type=string
 FLAG basecamp doctor --agent type=bool
 FLAG basecamp doctor --cache-dir type=string
 FLAG basecamp doctor --count type=bool
+FLAG basecamp doctor --help type=bool
 FLAG basecamp doctor --hints type=bool
 FLAG basecamp doctor --ids-only type=bool
 FLAG basecamp doctor --in type=string
@@ -2958,10 +4953,889 @@ FLAG basecamp doctor --stats type=bool
 FLAG basecamp doctor --styled type=bool
 FLAG basecamp doctor --todolist type=string
 FLAG basecamp doctor --verbose type=bool
+FLAG basecamp documents --account type=string
+FLAG basecamp documents --agent type=bool
+FLAG basecamp documents --cache-dir type=string
+FLAG basecamp documents --count type=bool
+FLAG basecamp documents --folder type=string
+FLAG basecamp documents --help type=bool
+FLAG basecamp documents --hints type=bool
+FLAG basecamp documents --ids-only type=bool
+FLAG basecamp documents --in type=string
+FLAG basecamp documents --jq type=string
+FLAG basecamp documents --json type=bool
+FLAG basecamp documents --markdown type=bool
+FLAG basecamp documents --md type=bool
+FLAG basecamp documents --no-hints type=bool
+FLAG basecamp documents --no-stats type=bool
+FLAG basecamp documents --profile type=string
+FLAG basecamp documents --project type=string
+FLAG basecamp documents --quiet type=bool
+FLAG basecamp documents --stats type=bool
+FLAG basecamp documents --styled type=bool
+FLAG basecamp documents --todolist type=string
+FLAG basecamp documents --vault type=string
+FLAG basecamp documents --verbose type=count
+FLAG basecamp documents archive --account type=string
+FLAG basecamp documents archive --agent type=bool
+FLAG basecamp documents archive --cache-dir type=string
+FLAG basecamp documents archive --count type=bool
+FLAG basecamp documents archive --folder type=string
+FLAG basecamp documents archive --help type=bool
+FLAG basecamp documents archive --hints type=bool
+FLAG basecamp documents archive --ids-only type=bool
+FLAG basecamp documents archive --in type=string
+FLAG basecamp documents archive --jq type=string
+FLAG basecamp documents archive --json type=bool
+FLAG basecamp documents archive --markdown type=bool
+FLAG basecamp documents archive --md type=bool
+FLAG basecamp documents archive --no-hints type=bool
+FLAG basecamp documents archive --no-stats type=bool
+FLAG basecamp documents archive --profile type=string
+FLAG basecamp documents archive --project type=string
+FLAG basecamp documents archive --quiet type=bool
+FLAG basecamp documents archive --stats type=bool
+FLAG basecamp documents archive --styled type=bool
+FLAG basecamp documents archive --todolist type=string
+FLAG basecamp documents archive --vault type=string
+FLAG basecamp documents archive --verbose type=count
+FLAG basecamp documents doc --account type=string
+FLAG basecamp documents doc --agent type=bool
+FLAG basecamp documents doc --all type=bool
+FLAG basecamp documents doc --cache-dir type=string
+FLAG basecamp documents doc --count type=bool
+FLAG basecamp documents doc --folder type=string
+FLAG basecamp documents doc --help type=bool
+FLAG basecamp documents doc --hints type=bool
+FLAG basecamp documents doc --ids-only type=bool
+FLAG basecamp documents doc --in type=string
+FLAG basecamp documents doc --jq type=string
+FLAG basecamp documents doc --json type=bool
+FLAG basecamp documents doc --limit type=int
+FLAG basecamp documents doc --markdown type=bool
+FLAG basecamp documents doc --md type=bool
+FLAG basecamp documents doc --no-hints type=bool
+FLAG basecamp documents doc --no-stats type=bool
+FLAG basecamp documents doc --page type=int
+FLAG basecamp documents doc --profile type=string
+FLAG basecamp documents doc --project type=string
+FLAG basecamp documents doc --quiet type=bool
+FLAG basecamp documents doc --stats type=bool
+FLAG basecamp documents doc --styled type=bool
+FLAG basecamp documents doc --todolist type=string
+FLAG basecamp documents doc --vault type=string
+FLAG basecamp documents doc --verbose type=count
+FLAG basecamp documents doc create --account type=string
+FLAG basecamp documents doc create --agent type=bool
+FLAG basecamp documents doc create --attach type=stringArray
+FLAG basecamp documents doc create --cache-dir type=string
+FLAG basecamp documents doc create --count type=bool
+FLAG basecamp documents doc create --draft type=bool
+FLAG basecamp documents doc create --folder type=string
+FLAG basecamp documents doc create --help type=bool
+FLAG basecamp documents doc create --hints type=bool
+FLAG basecamp documents doc create --ids-only type=bool
+FLAG basecamp documents doc create --in type=string
+FLAG basecamp documents doc create --jq type=string
+FLAG basecamp documents doc create --json type=bool
+FLAG basecamp documents doc create --markdown type=bool
+FLAG basecamp documents doc create --md type=bool
+FLAG basecamp documents doc create --no-hints type=bool
+FLAG basecamp documents doc create --no-stats type=bool
+FLAG basecamp documents doc create --no-subscribe type=bool
+FLAG basecamp documents doc create --profile type=string
+FLAG basecamp documents doc create --project type=string
+FLAG basecamp documents doc create --quiet type=bool
+FLAG basecamp documents doc create --stats type=bool
+FLAG basecamp documents doc create --styled type=bool
+FLAG basecamp documents doc create --subscribe type=string
+FLAG basecamp documents doc create --todolist type=string
+FLAG basecamp documents doc create --vault type=string
+FLAG basecamp documents doc create --verbose type=count
+FLAG basecamp documents doc list --account type=string
+FLAG basecamp documents doc list --agent type=bool
+FLAG basecamp documents doc list --all type=bool
+FLAG basecamp documents doc list --cache-dir type=string
+FLAG basecamp documents doc list --count type=bool
+FLAG basecamp documents doc list --folder type=string
+FLAG basecamp documents doc list --help type=bool
+FLAG basecamp documents doc list --hints type=bool
+FLAG basecamp documents doc list --ids-only type=bool
+FLAG basecamp documents doc list --in type=string
+FLAG basecamp documents doc list --jq type=string
+FLAG basecamp documents doc list --json type=bool
+FLAG basecamp documents doc list --limit type=int
+FLAG basecamp documents doc list --markdown type=bool
+FLAG basecamp documents doc list --md type=bool
+FLAG basecamp documents doc list --no-hints type=bool
+FLAG basecamp documents doc list --no-stats type=bool
+FLAG basecamp documents doc list --page type=int
+FLAG basecamp documents doc list --profile type=string
+FLAG basecamp documents doc list --project type=string
+FLAG basecamp documents doc list --quiet type=bool
+FLAG basecamp documents doc list --stats type=bool
+FLAG basecamp documents doc list --styled type=bool
+FLAG basecamp documents doc list --todolist type=string
+FLAG basecamp documents doc list --vault type=string
+FLAG basecamp documents doc list --verbose type=count
+FLAG basecamp documents document --account type=string
+FLAG basecamp documents document --agent type=bool
+FLAG basecamp documents document --all type=bool
+FLAG basecamp documents document --cache-dir type=string
+FLAG basecamp documents document --count type=bool
+FLAG basecamp documents document --folder type=string
+FLAG basecamp documents document --help type=bool
+FLAG basecamp documents document --hints type=bool
+FLAG basecamp documents document --ids-only type=bool
+FLAG basecamp documents document --in type=string
+FLAG basecamp documents document --jq type=string
+FLAG basecamp documents document --json type=bool
+FLAG basecamp documents document --limit type=int
+FLAG basecamp documents document --markdown type=bool
+FLAG basecamp documents document --md type=bool
+FLAG basecamp documents document --no-hints type=bool
+FLAG basecamp documents document --no-stats type=bool
+FLAG basecamp documents document --page type=int
+FLAG basecamp documents document --profile type=string
+FLAG basecamp documents document --project type=string
+FLAG basecamp documents document --quiet type=bool
+FLAG basecamp documents document --stats type=bool
+FLAG basecamp documents document --styled type=bool
+FLAG basecamp documents document --todolist type=string
+FLAG basecamp documents document --vault type=string
+FLAG basecamp documents document --verbose type=count
+FLAG basecamp documents document create --account type=string
+FLAG basecamp documents document create --agent type=bool
+FLAG basecamp documents document create --attach type=stringArray
+FLAG basecamp documents document create --cache-dir type=string
+FLAG basecamp documents document create --count type=bool
+FLAG basecamp documents document create --draft type=bool
+FLAG basecamp documents document create --folder type=string
+FLAG basecamp documents document create --help type=bool
+FLAG basecamp documents document create --hints type=bool
+FLAG basecamp documents document create --ids-only type=bool
+FLAG basecamp documents document create --in type=string
+FLAG basecamp documents document create --jq type=string
+FLAG basecamp documents document create --json type=bool
+FLAG basecamp documents document create --markdown type=bool
+FLAG basecamp documents document create --md type=bool
+FLAG basecamp documents document create --no-hints type=bool
+FLAG basecamp documents document create --no-stats type=bool
+FLAG basecamp documents document create --no-subscribe type=bool
+FLAG basecamp documents document create --profile type=string
+FLAG basecamp documents document create --project type=string
+FLAG basecamp documents document create --quiet type=bool
+FLAG basecamp documents document create --stats type=bool
+FLAG basecamp documents document create --styled type=bool
+FLAG basecamp documents document create --subscribe type=string
+FLAG basecamp documents document create --todolist type=string
+FLAG basecamp documents document create --vault type=string
+FLAG basecamp documents document create --verbose type=count
+FLAG basecamp documents document list --account type=string
+FLAG basecamp documents document list --agent type=bool
+FLAG basecamp documents document list --all type=bool
+FLAG basecamp documents document list --cache-dir type=string
+FLAG basecamp documents document list --count type=bool
+FLAG basecamp documents document list --folder type=string
+FLAG basecamp documents document list --help type=bool
+FLAG basecamp documents document list --hints type=bool
+FLAG basecamp documents document list --ids-only type=bool
+FLAG basecamp documents document list --in type=string
+FLAG basecamp documents document list --jq type=string
+FLAG basecamp documents document list --json type=bool
+FLAG basecamp documents document list --limit type=int
+FLAG basecamp documents document list --markdown type=bool
+FLAG basecamp documents document list --md type=bool
+FLAG basecamp documents document list --no-hints type=bool
+FLAG basecamp documents document list --no-stats type=bool
+FLAG basecamp documents document list --page type=int
+FLAG basecamp documents document list --profile type=string
+FLAG basecamp documents document list --project type=string
+FLAG basecamp documents document list --quiet type=bool
+FLAG basecamp documents document list --stats type=bool
+FLAG basecamp documents document list --styled type=bool
+FLAG basecamp documents document list --todolist type=string
+FLAG basecamp documents document list --vault type=string
+FLAG basecamp documents document list --verbose type=count
+FLAG basecamp documents documents --account type=string
+FLAG basecamp documents documents --agent type=bool
+FLAG basecamp documents documents --all type=bool
+FLAG basecamp documents documents --cache-dir type=string
+FLAG basecamp documents documents --count type=bool
+FLAG basecamp documents documents --folder type=string
+FLAG basecamp documents documents --help type=bool
+FLAG basecamp documents documents --hints type=bool
+FLAG basecamp documents documents --ids-only type=bool
+FLAG basecamp documents documents --in type=string
+FLAG basecamp documents documents --jq type=string
+FLAG basecamp documents documents --json type=bool
+FLAG basecamp documents documents --limit type=int
+FLAG basecamp documents documents --markdown type=bool
+FLAG basecamp documents documents --md type=bool
+FLAG basecamp documents documents --no-hints type=bool
+FLAG basecamp documents documents --no-stats type=bool
+FLAG basecamp documents documents --page type=int
+FLAG basecamp documents documents --profile type=string
+FLAG basecamp documents documents --project type=string
+FLAG basecamp documents documents --quiet type=bool
+FLAG basecamp documents documents --stats type=bool
+FLAG basecamp documents documents --styled type=bool
+FLAG basecamp documents documents --todolist type=string
+FLAG basecamp documents documents --vault type=string
+FLAG basecamp documents documents --verbose type=count
+FLAG basecamp documents documents create --account type=string
+FLAG basecamp documents documents create --agent type=bool
+FLAG basecamp documents documents create --attach type=stringArray
+FLAG basecamp documents documents create --cache-dir type=string
+FLAG basecamp documents documents create --count type=bool
+FLAG basecamp documents documents create --draft type=bool
+FLAG basecamp documents documents create --folder type=string
+FLAG basecamp documents documents create --help type=bool
+FLAG basecamp documents documents create --hints type=bool
+FLAG basecamp documents documents create --ids-only type=bool
+FLAG basecamp documents documents create --in type=string
+FLAG basecamp documents documents create --jq type=string
+FLAG basecamp documents documents create --json type=bool
+FLAG basecamp documents documents create --markdown type=bool
+FLAG basecamp documents documents create --md type=bool
+FLAG basecamp documents documents create --no-hints type=bool
+FLAG basecamp documents documents create --no-stats type=bool
+FLAG basecamp documents documents create --no-subscribe type=bool
+FLAG basecamp documents documents create --profile type=string
+FLAG basecamp documents documents create --project type=string
+FLAG basecamp documents documents create --quiet type=bool
+FLAG basecamp documents documents create --stats type=bool
+FLAG basecamp documents documents create --styled type=bool
+FLAG basecamp documents documents create --subscribe type=string
+FLAG basecamp documents documents create --todolist type=string
+FLAG basecamp documents documents create --vault type=string
+FLAG basecamp documents documents create --verbose type=count
+FLAG basecamp documents documents list --account type=string
+FLAG basecamp documents documents list --agent type=bool
+FLAG basecamp documents documents list --all type=bool
+FLAG basecamp documents documents list --cache-dir type=string
+FLAG basecamp documents documents list --count type=bool
+FLAG basecamp documents documents list --folder type=string
+FLAG basecamp documents documents list --help type=bool
+FLAG basecamp documents documents list --hints type=bool
+FLAG basecamp documents documents list --ids-only type=bool
+FLAG basecamp documents documents list --in type=string
+FLAG basecamp documents documents list --jq type=string
+FLAG basecamp documents documents list --json type=bool
+FLAG basecamp documents documents list --limit type=int
+FLAG basecamp documents documents list --markdown type=bool
+FLAG basecamp documents documents list --md type=bool
+FLAG basecamp documents documents list --no-hints type=bool
+FLAG basecamp documents documents list --no-stats type=bool
+FLAG basecamp documents documents list --page type=int
+FLAG basecamp documents documents list --profile type=string
+FLAG basecamp documents documents list --project type=string
+FLAG basecamp documents documents list --quiet type=bool
+FLAG basecamp documents documents list --stats type=bool
+FLAG basecamp documents documents list --styled type=bool
+FLAG basecamp documents documents list --todolist type=string
+FLAG basecamp documents documents list --vault type=string
+FLAG basecamp documents documents list --verbose type=count
+FLAG basecamp documents download --account type=string
+FLAG basecamp documents download --agent type=bool
+FLAG basecamp documents download --cache-dir type=string
+FLAG basecamp documents download --count type=bool
+FLAG basecamp documents download --folder type=string
+FLAG basecamp documents download --help type=bool
+FLAG basecamp documents download --hints type=bool
+FLAG basecamp documents download --ids-only type=bool
+FLAG basecamp documents download --in type=string
+FLAG basecamp documents download --jq type=string
+FLAG basecamp documents download --json type=bool
+FLAG basecamp documents download --markdown type=bool
+FLAG basecamp documents download --md type=bool
+FLAG basecamp documents download --no-hints type=bool
+FLAG basecamp documents download --no-stats type=bool
+FLAG basecamp documents download --out type=string
+FLAG basecamp documents download --profile type=string
+FLAG basecamp documents download --project type=string
+FLAG basecamp documents download --quiet type=bool
+FLAG basecamp documents download --stats type=bool
+FLAG basecamp documents download --styled type=bool
+FLAG basecamp documents download --todolist type=string
+FLAG basecamp documents download --vault type=string
+FLAG basecamp documents download --verbose type=count
+FLAG basecamp documents folder --account type=string
+FLAG basecamp documents folder --agent type=bool
+FLAG basecamp documents folder --all type=bool
+FLAG basecamp documents folder --cache-dir type=string
+FLAG basecamp documents folder --count type=bool
+FLAG basecamp documents folder --folder type=string
+FLAG basecamp documents folder --help type=bool
+FLAG basecamp documents folder --hints type=bool
+FLAG basecamp documents folder --ids-only type=bool
+FLAG basecamp documents folder --in type=string
+FLAG basecamp documents folder --jq type=string
+FLAG basecamp documents folder --json type=bool
+FLAG basecamp documents folder --limit type=int
+FLAG basecamp documents folder --markdown type=bool
+FLAG basecamp documents folder --md type=bool
+FLAG basecamp documents folder --no-hints type=bool
+FLAG basecamp documents folder --no-stats type=bool
+FLAG basecamp documents folder --page type=int
+FLAG basecamp documents folder --profile type=string
+FLAG basecamp documents folder --project type=string
+FLAG basecamp documents folder --quiet type=bool
+FLAG basecamp documents folder --stats type=bool
+FLAG basecamp documents folder --styled type=bool
+FLAG basecamp documents folder --todolist type=string
+FLAG basecamp documents folder --vault type=string
+FLAG basecamp documents folder --verbose type=count
+FLAG basecamp documents folder create --account type=string
+FLAG basecamp documents folder create --agent type=bool
+FLAG basecamp documents folder create --cache-dir type=string
+FLAG basecamp documents folder create --count type=bool
+FLAG basecamp documents folder create --folder type=string
+FLAG basecamp documents folder create --help type=bool
+FLAG basecamp documents folder create --hints type=bool
+FLAG basecamp documents folder create --ids-only type=bool
+FLAG basecamp documents folder create --in type=string
+FLAG basecamp documents folder create --jq type=string
+FLAG basecamp documents folder create --json type=bool
+FLAG basecamp documents folder create --markdown type=bool
+FLAG basecamp documents folder create --md type=bool
+FLAG basecamp documents folder create --no-hints type=bool
+FLAG basecamp documents folder create --no-stats type=bool
+FLAG basecamp documents folder create --profile type=string
+FLAG basecamp documents folder create --project type=string
+FLAG basecamp documents folder create --quiet type=bool
+FLAG basecamp documents folder create --stats type=bool
+FLAG basecamp documents folder create --styled type=bool
+FLAG basecamp documents folder create --todolist type=string
+FLAG basecamp documents folder create --vault type=string
+FLAG basecamp documents folder create --verbose type=count
+FLAG basecamp documents folder list --account type=string
+FLAG basecamp documents folder list --agent type=bool
+FLAG basecamp documents folder list --all type=bool
+FLAG basecamp documents folder list --cache-dir type=string
+FLAG basecamp documents folder list --count type=bool
+FLAG basecamp documents folder list --folder type=string
+FLAG basecamp documents folder list --help type=bool
+FLAG basecamp documents folder list --hints type=bool
+FLAG basecamp documents folder list --ids-only type=bool
+FLAG basecamp documents folder list --in type=string
+FLAG basecamp documents folder list --jq type=string
+FLAG basecamp documents folder list --json type=bool
+FLAG basecamp documents folder list --limit type=int
+FLAG basecamp documents folder list --markdown type=bool
+FLAG basecamp documents folder list --md type=bool
+FLAG basecamp documents folder list --no-hints type=bool
+FLAG basecamp documents folder list --no-stats type=bool
+FLAG basecamp documents folder list --page type=int
+FLAG basecamp documents folder list --profile type=string
+FLAG basecamp documents folder list --project type=string
+FLAG basecamp documents folder list --quiet type=bool
+FLAG basecamp documents folder list --stats type=bool
+FLAG basecamp documents folder list --styled type=bool
+FLAG basecamp documents folder list --todolist type=string
+FLAG basecamp documents folder list --vault type=string
+FLAG basecamp documents folder list --verbose type=count
+FLAG basecamp documents folders --account type=string
+FLAG basecamp documents folders --agent type=bool
+FLAG basecamp documents folders --all type=bool
+FLAG basecamp documents folders --cache-dir type=string
+FLAG basecamp documents folders --count type=bool
+FLAG basecamp documents folders --folder type=string
+FLAG basecamp documents folders --help type=bool
+FLAG basecamp documents folders --hints type=bool
+FLAG basecamp documents folders --ids-only type=bool
+FLAG basecamp documents folders --in type=string
+FLAG basecamp documents folders --jq type=string
+FLAG basecamp documents folders --json type=bool
+FLAG basecamp documents folders --limit type=int
+FLAG basecamp documents folders --markdown type=bool
+FLAG basecamp documents folders --md type=bool
+FLAG basecamp documents folders --no-hints type=bool
+FLAG basecamp documents folders --no-stats type=bool
+FLAG basecamp documents folders --page type=int
+FLAG basecamp documents folders --profile type=string
+FLAG basecamp documents folders --project type=string
+FLAG basecamp documents folders --quiet type=bool
+FLAG basecamp documents folders --stats type=bool
+FLAG basecamp documents folders --styled type=bool
+FLAG basecamp documents folders --todolist type=string
+FLAG basecamp documents folders --vault type=string
+FLAG basecamp documents folders --verbose type=count
+FLAG basecamp documents folders create --account type=string
+FLAG basecamp documents folders create --agent type=bool
+FLAG basecamp documents folders create --cache-dir type=string
+FLAG basecamp documents folders create --count type=bool
+FLAG basecamp documents folders create --folder type=string
+FLAG basecamp documents folders create --help type=bool
+FLAG basecamp documents folders create --hints type=bool
+FLAG basecamp documents folders create --ids-only type=bool
+FLAG basecamp documents folders create --in type=string
+FLAG basecamp documents folders create --jq type=string
+FLAG basecamp documents folders create --json type=bool
+FLAG basecamp documents folders create --markdown type=bool
+FLAG basecamp documents folders create --md type=bool
+FLAG basecamp documents folders create --no-hints type=bool
+FLAG basecamp documents folders create --no-stats type=bool
+FLAG basecamp documents folders create --profile type=string
+FLAG basecamp documents folders create --project type=string
+FLAG basecamp documents folders create --quiet type=bool
+FLAG basecamp documents folders create --stats type=bool
+FLAG basecamp documents folders create --styled type=bool
+FLAG basecamp documents folders create --todolist type=string
+FLAG basecamp documents folders create --vault type=string
+FLAG basecamp documents folders create --verbose type=count
+FLAG basecamp documents folders list --account type=string
+FLAG basecamp documents folders list --agent type=bool
+FLAG basecamp documents folders list --all type=bool
+FLAG basecamp documents folders list --cache-dir type=string
+FLAG basecamp documents folders list --count type=bool
+FLAG basecamp documents folders list --folder type=string
+FLAG basecamp documents folders list --help type=bool
+FLAG basecamp documents folders list --hints type=bool
+FLAG basecamp documents folders list --ids-only type=bool
+FLAG basecamp documents folders list --in type=string
+FLAG basecamp documents folders list --jq type=string
+FLAG basecamp documents folders list --json type=bool
+FLAG basecamp documents folders list --limit type=int
+FLAG basecamp documents folders list --markdown type=bool
+FLAG basecamp documents folders list --md type=bool
+FLAG basecamp documents folders list --no-hints type=bool
+FLAG basecamp documents folders list --no-stats type=bool
+FLAG basecamp documents folders list --page type=int
+FLAG basecamp documents folders list --profile type=string
+FLAG basecamp documents folders list --project type=string
+FLAG basecamp documents folders list --quiet type=bool
+FLAG basecamp documents folders list --stats type=bool
+FLAG basecamp documents folders list --styled type=bool
+FLAG basecamp documents folders list --todolist type=string
+FLAG basecamp documents folders list --vault type=string
+FLAG basecamp documents folders list --verbose type=count
+FLAG basecamp documents list --account type=string
+FLAG basecamp documents list --agent type=bool
+FLAG basecamp documents list --cache-dir type=string
+FLAG basecamp documents list --count type=bool
+FLAG basecamp documents list --folder type=string
+FLAG basecamp documents list --help type=bool
+FLAG basecamp documents list --hints type=bool
+FLAG basecamp documents list --ids-only type=bool
+FLAG basecamp documents list --in type=string
+FLAG basecamp documents list --jq type=string
+FLAG basecamp documents list --json type=bool
+FLAG basecamp documents list --markdown type=bool
+FLAG basecamp documents list --md type=bool
+FLAG basecamp documents list --no-hints type=bool
+FLAG basecamp documents list --no-stats type=bool
+FLAG basecamp documents list --profile type=string
+FLAG basecamp documents list --project type=string
+FLAG basecamp documents list --quiet type=bool
+FLAG basecamp documents list --stats type=bool
+FLAG basecamp documents list --styled type=bool
+FLAG basecamp documents list --todolist type=string
+FLAG basecamp documents list --vault type=string
+FLAG basecamp documents list --verbose type=count
+FLAG basecamp documents restore --account type=string
+FLAG basecamp documents restore --agent type=bool
+FLAG basecamp documents restore --cache-dir type=string
+FLAG basecamp documents restore --count type=bool
+FLAG basecamp documents restore --folder type=string
+FLAG basecamp documents restore --help type=bool
+FLAG basecamp documents restore --hints type=bool
+FLAG basecamp documents restore --ids-only type=bool
+FLAG basecamp documents restore --in type=string
+FLAG basecamp documents restore --jq type=string
+FLAG basecamp documents restore --json type=bool
+FLAG basecamp documents restore --markdown type=bool
+FLAG basecamp documents restore --md type=bool
+FLAG basecamp documents restore --no-hints type=bool
+FLAG basecamp documents restore --no-stats type=bool
+FLAG basecamp documents restore --profile type=string
+FLAG basecamp documents restore --project type=string
+FLAG basecamp documents restore --quiet type=bool
+FLAG basecamp documents restore --stats type=bool
+FLAG basecamp documents restore --styled type=bool
+FLAG basecamp documents restore --todolist type=string
+FLAG basecamp documents restore --vault type=string
+FLAG basecamp documents restore --verbose type=count
+FLAG basecamp documents show --account type=string
+FLAG basecamp documents show --agent type=bool
+FLAG basecamp documents show --cache-dir type=string
+FLAG basecamp documents show --count type=bool
+FLAG basecamp documents show --folder type=string
+FLAG basecamp documents show --help type=bool
+FLAG basecamp documents show --hints type=bool
+FLAG basecamp documents show --ids-only type=bool
+FLAG basecamp documents show --in type=string
+FLAG basecamp documents show --jq type=string
+FLAG basecamp documents show --json type=bool
+FLAG basecamp documents show --markdown type=bool
+FLAG basecamp documents show --md type=bool
+FLAG basecamp documents show --no-hints type=bool
+FLAG basecamp documents show --no-stats type=bool
+FLAG basecamp documents show --profile type=string
+FLAG basecamp documents show --project type=string
+FLAG basecamp documents show --quiet type=bool
+FLAG basecamp documents show --stats type=bool
+FLAG basecamp documents show --styled type=bool
+FLAG basecamp documents show --todolist type=string
+FLAG basecamp documents show --type type=string
+FLAG basecamp documents show --vault type=string
+FLAG basecamp documents show --verbose type=count
+FLAG basecamp documents trash --account type=string
+FLAG basecamp documents trash --agent type=bool
+FLAG basecamp documents trash --cache-dir type=string
+FLAG basecamp documents trash --count type=bool
+FLAG basecamp documents trash --folder type=string
+FLAG basecamp documents trash --help type=bool
+FLAG basecamp documents trash --hints type=bool
+FLAG basecamp documents trash --ids-only type=bool
+FLAG basecamp documents trash --in type=string
+FLAG basecamp documents trash --jq type=string
+FLAG basecamp documents trash --json type=bool
+FLAG basecamp documents trash --markdown type=bool
+FLAG basecamp documents trash --md type=bool
+FLAG basecamp documents trash --no-hints type=bool
+FLAG basecamp documents trash --no-stats type=bool
+FLAG basecamp documents trash --profile type=string
+FLAG basecamp documents trash --project type=string
+FLAG basecamp documents trash --quiet type=bool
+FLAG basecamp documents trash --stats type=bool
+FLAG basecamp documents trash --styled type=bool
+FLAG basecamp documents trash --todolist type=string
+FLAG basecamp documents trash --vault type=string
+FLAG basecamp documents trash --verbose type=count
+FLAG basecamp documents update --account type=string
+FLAG basecamp documents update --agent type=bool
+FLAG basecamp documents update --cache-dir type=string
+FLAG basecamp documents update --content type=string
+FLAG basecamp documents update --count type=bool
+FLAG basecamp documents update --folder type=string
+FLAG basecamp documents update --help type=bool
+FLAG basecamp documents update --hints type=bool
+FLAG basecamp documents update --ids-only type=bool
+FLAG basecamp documents update --in type=string
+FLAG basecamp documents update --jq type=string
+FLAG basecamp documents update --json type=bool
+FLAG basecamp documents update --markdown type=bool
+FLAG basecamp documents update --md type=bool
+FLAG basecamp documents update --no-hints type=bool
+FLAG basecamp documents update --no-stats type=bool
+FLAG basecamp documents update --profile type=string
+FLAG basecamp documents update --project type=string
+FLAG basecamp documents update --quiet type=bool
+FLAG basecamp documents update --stats type=bool
+FLAG basecamp documents update --styled type=bool
+FLAG basecamp documents update --title type=string
+FLAG basecamp documents update --todolist type=string
+FLAG basecamp documents update --type type=string
+FLAG basecamp documents update --vault type=string
+FLAG basecamp documents update --verbose type=count
+FLAG basecamp documents upload --account type=string
+FLAG basecamp documents upload --agent type=bool
+FLAG basecamp documents upload --all type=bool
+FLAG basecamp documents upload --cache-dir type=string
+FLAG basecamp documents upload --count type=bool
+FLAG basecamp documents upload --folder type=string
+FLAG basecamp documents upload --help type=bool
+FLAG basecamp documents upload --hints type=bool
+FLAG basecamp documents upload --ids-only type=bool
+FLAG basecamp documents upload --in type=string
+FLAG basecamp documents upload --jq type=string
+FLAG basecamp documents upload --json type=bool
+FLAG basecamp documents upload --limit type=int
+FLAG basecamp documents upload --markdown type=bool
+FLAG basecamp documents upload --md type=bool
+FLAG basecamp documents upload --no-hints type=bool
+FLAG basecamp documents upload --no-stats type=bool
+FLAG basecamp documents upload --page type=int
+FLAG basecamp documents upload --profile type=string
+FLAG basecamp documents upload --project type=string
+FLAG basecamp documents upload --quiet type=bool
+FLAG basecamp documents upload --stats type=bool
+FLAG basecamp documents upload --styled type=bool
+FLAG basecamp documents upload --todolist type=string
+FLAG basecamp documents upload --vault type=string
+FLAG basecamp documents upload --verbose type=count
+FLAG basecamp documents upload create --account type=string
+FLAG basecamp documents upload create --agent type=bool
+FLAG basecamp documents upload create --cache-dir type=string
+FLAG basecamp documents upload create --count type=bool
+FLAG basecamp documents upload create --description type=string
+FLAG basecamp documents upload create --folder type=string
+FLAG basecamp documents upload create --help type=bool
+FLAG basecamp documents upload create --hints type=bool
+FLAG basecamp documents upload create --ids-only type=bool
+FLAG basecamp documents upload create --in type=string
+FLAG basecamp documents upload create --jq type=string
+FLAG basecamp documents upload create --json type=bool
+FLAG basecamp documents upload create --markdown type=bool
+FLAG basecamp documents upload create --md type=bool
+FLAG basecamp documents upload create --no-hints type=bool
+FLAG basecamp documents upload create --no-stats type=bool
+FLAG basecamp documents upload create --profile type=string
+FLAG basecamp documents upload create --project type=string
+FLAG basecamp documents upload create --quiet type=bool
+FLAG basecamp documents upload create --stats type=bool
+FLAG basecamp documents upload create --styled type=bool
+FLAG basecamp documents upload create --todolist type=string
+FLAG basecamp documents upload create --vault type=string
+FLAG basecamp documents upload create --verbose type=count
+FLAG basecamp documents upload list --account type=string
+FLAG basecamp documents upload list --agent type=bool
+FLAG basecamp documents upload list --all type=bool
+FLAG basecamp documents upload list --cache-dir type=string
+FLAG basecamp documents upload list --count type=bool
+FLAG basecamp documents upload list --folder type=string
+FLAG basecamp documents upload list --help type=bool
+FLAG basecamp documents upload list --hints type=bool
+FLAG basecamp documents upload list --ids-only type=bool
+FLAG basecamp documents upload list --in type=string
+FLAG basecamp documents upload list --jq type=string
+FLAG basecamp documents upload list --json type=bool
+FLAG basecamp documents upload list --limit type=int
+FLAG basecamp documents upload list --markdown type=bool
+FLAG basecamp documents upload list --md type=bool
+FLAG basecamp documents upload list --no-hints type=bool
+FLAG basecamp documents upload list --no-stats type=bool
+FLAG basecamp documents upload list --page type=int
+FLAG basecamp documents upload list --profile type=string
+FLAG basecamp documents upload list --project type=string
+FLAG basecamp documents upload list --quiet type=bool
+FLAG basecamp documents upload list --stats type=bool
+FLAG basecamp documents upload list --styled type=bool
+FLAG basecamp documents upload list --todolist type=string
+FLAG basecamp documents upload list --vault type=string
+FLAG basecamp documents upload list --verbose type=count
+FLAG basecamp documents uploads --account type=string
+FLAG basecamp documents uploads --agent type=bool
+FLAG basecamp documents uploads --all type=bool
+FLAG basecamp documents uploads --cache-dir type=string
+FLAG basecamp documents uploads --count type=bool
+FLAG basecamp documents uploads --folder type=string
+FLAG basecamp documents uploads --help type=bool
+FLAG basecamp documents uploads --hints type=bool
+FLAG basecamp documents uploads --ids-only type=bool
+FLAG basecamp documents uploads --in type=string
+FLAG basecamp documents uploads --jq type=string
+FLAG basecamp documents uploads --json type=bool
+FLAG basecamp documents uploads --limit type=int
+FLAG basecamp documents uploads --markdown type=bool
+FLAG basecamp documents uploads --md type=bool
+FLAG basecamp documents uploads --no-hints type=bool
+FLAG basecamp documents uploads --no-stats type=bool
+FLAG basecamp documents uploads --page type=int
+FLAG basecamp documents uploads --profile type=string
+FLAG basecamp documents uploads --project type=string
+FLAG basecamp documents uploads --quiet type=bool
+FLAG basecamp documents uploads --stats type=bool
+FLAG basecamp documents uploads --styled type=bool
+FLAG basecamp documents uploads --todolist type=string
+FLAG basecamp documents uploads --vault type=string
+FLAG basecamp documents uploads --verbose type=count
+FLAG basecamp documents uploads create --account type=string
+FLAG basecamp documents uploads create --agent type=bool
+FLAG basecamp documents uploads create --cache-dir type=string
+FLAG basecamp documents uploads create --count type=bool
+FLAG basecamp documents uploads create --description type=string
+FLAG basecamp documents uploads create --folder type=string
+FLAG basecamp documents uploads create --help type=bool
+FLAG basecamp documents uploads create --hints type=bool
+FLAG basecamp documents uploads create --ids-only type=bool
+FLAG basecamp documents uploads create --in type=string
+FLAG basecamp documents uploads create --jq type=string
+FLAG basecamp documents uploads create --json type=bool
+FLAG basecamp documents uploads create --markdown type=bool
+FLAG basecamp documents uploads create --md type=bool
+FLAG basecamp documents uploads create --no-hints type=bool
+FLAG basecamp documents uploads create --no-stats type=bool
+FLAG basecamp documents uploads create --profile type=string
+FLAG basecamp documents uploads create --project type=string
+FLAG basecamp documents uploads create --quiet type=bool
+FLAG basecamp documents uploads create --stats type=bool
+FLAG basecamp documents uploads create --styled type=bool
+FLAG basecamp documents uploads create --todolist type=string
+FLAG basecamp documents uploads create --vault type=string
+FLAG basecamp documents uploads create --verbose type=count
+FLAG basecamp documents uploads list --account type=string
+FLAG basecamp documents uploads list --agent type=bool
+FLAG basecamp documents uploads list --all type=bool
+FLAG basecamp documents uploads list --cache-dir type=string
+FLAG basecamp documents uploads list --count type=bool
+FLAG basecamp documents uploads list --folder type=string
+FLAG basecamp documents uploads list --help type=bool
+FLAG basecamp documents uploads list --hints type=bool
+FLAG basecamp documents uploads list --ids-only type=bool
+FLAG basecamp documents uploads list --in type=string
+FLAG basecamp documents uploads list --jq type=string
+FLAG basecamp documents uploads list --json type=bool
+FLAG basecamp documents uploads list --limit type=int
+FLAG basecamp documents uploads list --markdown type=bool
+FLAG basecamp documents uploads list --md type=bool
+FLAG basecamp documents uploads list --no-hints type=bool
+FLAG basecamp documents uploads list --no-stats type=bool
+FLAG basecamp documents uploads list --page type=int
+FLAG basecamp documents uploads list --profile type=string
+FLAG basecamp documents uploads list --project type=string
+FLAG basecamp documents uploads list --quiet type=bool
+FLAG basecamp documents uploads list --stats type=bool
+FLAG basecamp documents uploads list --styled type=bool
+FLAG basecamp documents uploads list --todolist type=string
+FLAG basecamp documents uploads list --vault type=string
+FLAG basecamp documents uploads list --verbose type=count
+FLAG basecamp documents vault --account type=string
+FLAG basecamp documents vault --agent type=bool
+FLAG basecamp documents vault --all type=bool
+FLAG basecamp documents vault --cache-dir type=string
+FLAG basecamp documents vault --count type=bool
+FLAG basecamp documents vault --folder type=string
+FLAG basecamp documents vault --help type=bool
+FLAG basecamp documents vault --hints type=bool
+FLAG basecamp documents vault --ids-only type=bool
+FLAG basecamp documents vault --in type=string
+FLAG basecamp documents vault --jq type=string
+FLAG basecamp documents vault --json type=bool
+FLAG basecamp documents vault --limit type=int
+FLAG basecamp documents vault --markdown type=bool
+FLAG basecamp documents vault --md type=bool
+FLAG basecamp documents vault --no-hints type=bool
+FLAG basecamp documents vault --no-stats type=bool
+FLAG basecamp documents vault --page type=int
+FLAG basecamp documents vault --profile type=string
+FLAG basecamp documents vault --project type=string
+FLAG basecamp documents vault --quiet type=bool
+FLAG basecamp documents vault --stats type=bool
+FLAG basecamp documents vault --styled type=bool
+FLAG basecamp documents vault --todolist type=string
+FLAG basecamp documents vault --vault type=string
+FLAG basecamp documents vault --verbose type=count
+FLAG basecamp documents vault create --account type=string
+FLAG basecamp documents vault create --agent type=bool
+FLAG basecamp documents vault create --cache-dir type=string
+FLAG basecamp documents vault create --count type=bool
+FLAG basecamp documents vault create --folder type=string
+FLAG basecamp documents vault create --help type=bool
+FLAG basecamp documents vault create --hints type=bool
+FLAG basecamp documents vault create --ids-only type=bool
+FLAG basecamp documents vault create --in type=string
+FLAG basecamp documents vault create --jq type=string
+FLAG basecamp documents vault create --json type=bool
+FLAG basecamp documents vault create --markdown type=bool
+FLAG basecamp documents vault create --md type=bool
+FLAG basecamp documents vault create --no-hints type=bool
+FLAG basecamp documents vault create --no-stats type=bool
+FLAG basecamp documents vault create --profile type=string
+FLAG basecamp documents vault create --project type=string
+FLAG basecamp documents vault create --quiet type=bool
+FLAG basecamp documents vault create --stats type=bool
+FLAG basecamp documents vault create --styled type=bool
+FLAG basecamp documents vault create --todolist type=string
+FLAG basecamp documents vault create --vault type=string
+FLAG basecamp documents vault create --verbose type=count
+FLAG basecamp documents vault list --account type=string
+FLAG basecamp documents vault list --agent type=bool
+FLAG basecamp documents vault list --all type=bool
+FLAG basecamp documents vault list --cache-dir type=string
+FLAG basecamp documents vault list --count type=bool
+FLAG basecamp documents vault list --folder type=string
+FLAG basecamp documents vault list --help type=bool
+FLAG basecamp documents vault list --hints type=bool
+FLAG basecamp documents vault list --ids-only type=bool
+FLAG basecamp documents vault list --in type=string
+FLAG basecamp documents vault list --jq type=string
+FLAG basecamp documents vault list --json type=bool
+FLAG basecamp documents vault list --limit type=int
+FLAG basecamp documents vault list --markdown type=bool
+FLAG basecamp documents vault list --md type=bool
+FLAG basecamp documents vault list --no-hints type=bool
+FLAG basecamp documents vault list --no-stats type=bool
+FLAG basecamp documents vault list --page type=int
+FLAG basecamp documents vault list --profile type=string
+FLAG basecamp documents vault list --project type=string
+FLAG basecamp documents vault list --quiet type=bool
+FLAG basecamp documents vault list --stats type=bool
+FLAG basecamp documents vault list --styled type=bool
+FLAG basecamp documents vault list --todolist type=string
+FLAG basecamp documents vault list --vault type=string
+FLAG basecamp documents vault list --verbose type=count
+FLAG basecamp documents vaults --account type=string
+FLAG basecamp documents vaults --agent type=bool
+FLAG basecamp documents vaults --all type=bool
+FLAG basecamp documents vaults --cache-dir type=string
+FLAG basecamp documents vaults --count type=bool
+FLAG basecamp documents vaults --folder type=string
+FLAG basecamp documents vaults --help type=bool
+FLAG basecamp documents vaults --hints type=bool
+FLAG basecamp documents vaults --ids-only type=bool
+FLAG basecamp documents vaults --in type=string
+FLAG basecamp documents vaults --jq type=string
+FLAG basecamp documents vaults --json type=bool
+FLAG basecamp documents vaults --limit type=int
+FLAG basecamp documents vaults --markdown type=bool
+FLAG basecamp documents vaults --md type=bool
+FLAG basecamp documents vaults --no-hints type=bool
+FLAG basecamp documents vaults --no-stats type=bool
+FLAG basecamp documents vaults --page type=int
+FLAG basecamp documents vaults --profile type=string
+FLAG basecamp documents vaults --project type=string
+FLAG basecamp documents vaults --quiet type=bool
+FLAG basecamp documents vaults --stats type=bool
+FLAG basecamp documents vaults --styled type=bool
+FLAG basecamp documents vaults --todolist type=string
+FLAG basecamp documents vaults --vault type=string
+FLAG basecamp documents vaults --verbose type=count
+FLAG basecamp documents vaults create --account type=string
+FLAG basecamp documents vaults create --agent type=bool
+FLAG basecamp documents vaults create --cache-dir type=string
+FLAG basecamp documents vaults create --count type=bool
+FLAG basecamp documents vaults create --folder type=string
+FLAG basecamp documents vaults create --help type=bool
+FLAG basecamp documents vaults create --hints type=bool
+FLAG basecamp documents vaults create --ids-only type=bool
+FLAG basecamp documents vaults create --in type=string
+FLAG basecamp documents vaults create --jq type=string
+FLAG basecamp documents vaults create --json type=bool
+FLAG basecamp documents vaults create --markdown type=bool
+FLAG basecamp documents vaults create --md type=bool
+FLAG basecamp documents vaults create --no-hints type=bool
+FLAG basecamp documents vaults create --no-stats type=bool
+FLAG basecamp documents vaults create --profile type=string
+FLAG basecamp documents vaults create --project type=string
+FLAG basecamp documents vaults create --quiet type=bool
+FLAG basecamp documents vaults create --stats type=bool
+FLAG basecamp documents vaults create --styled type=bool
+FLAG basecamp documents vaults create --todolist type=string
+FLAG basecamp documents vaults create --vault type=string
+FLAG basecamp documents vaults create --verbose type=count
+FLAG basecamp documents vaults list --account type=string
+FLAG basecamp documents vaults list --agent type=bool
+FLAG basecamp documents vaults list --all type=bool
+FLAG basecamp documents vaults list --cache-dir type=string
+FLAG basecamp documents vaults list --count type=bool
+FLAG basecamp documents vaults list --folder type=string
+FLAG basecamp documents vaults list --help type=bool
+FLAG basecamp documents vaults list --hints type=bool
+FLAG basecamp documents vaults list --ids-only type=bool
+FLAG basecamp documents vaults list --in type=string
+FLAG basecamp documents vaults list --jq type=string
+FLAG basecamp documents vaults list --json type=bool
+FLAG basecamp documents vaults list --limit type=int
+FLAG basecamp documents vaults list --markdown type=bool
+FLAG basecamp documents vaults list --md type=bool
+FLAG basecamp documents vaults list --no-hints type=bool
+FLAG basecamp documents vaults list --no-stats type=bool
+FLAG basecamp documents vaults list --page type=int
+FLAG basecamp documents vaults list --profile type=string
+FLAG basecamp documents vaults list --project type=string
+FLAG basecamp documents vaults list --quiet type=bool
+FLAG basecamp documents vaults list --stats type=bool
+FLAG basecamp documents vaults list --styled type=bool
+FLAG basecamp documents vaults list --todolist type=string
+FLAG basecamp documents vaults list --vault type=string
+FLAG basecamp documents vaults list --verbose type=count
 FLAG basecamp done --account type=string
 FLAG basecamp done --agent type=bool
 FLAG basecamp done --cache-dir type=string
 FLAG basecamp done --count type=bool
+FLAG basecamp done --help type=bool
 FLAG basecamp done --hints type=bool
 FLAG basecamp done --ids-only type=bool
 FLAG basecamp done --in type=string
@@ -2983,6 +5857,7 @@ FLAG basecamp events --agent type=bool
 FLAG basecamp events --all type=bool
 FLAG basecamp events --cache-dir type=string
 FLAG basecamp events --count type=bool
+FLAG basecamp events --help type=bool
 FLAG basecamp events --hints type=bool
 FLAG basecamp events --ids-only type=bool
 FLAG basecamp events --in type=string
@@ -3001,11 +5876,890 @@ FLAG basecamp events --stats type=bool
 FLAG basecamp events --styled type=bool
 FLAG basecamp events --todolist type=string
 FLAG basecamp events --verbose type=count
+FLAG basecamp file --account type=string
+FLAG basecamp file --agent type=bool
+FLAG basecamp file --cache-dir type=string
+FLAG basecamp file --count type=bool
+FLAG basecamp file --folder type=string
+FLAG basecamp file --help type=bool
+FLAG basecamp file --hints type=bool
+FLAG basecamp file --ids-only type=bool
+FLAG basecamp file --in type=string
+FLAG basecamp file --jq type=string
+FLAG basecamp file --json type=bool
+FLAG basecamp file --markdown type=bool
+FLAG basecamp file --md type=bool
+FLAG basecamp file --no-hints type=bool
+FLAG basecamp file --no-stats type=bool
+FLAG basecamp file --profile type=string
+FLAG basecamp file --project type=string
+FLAG basecamp file --quiet type=bool
+FLAG basecamp file --stats type=bool
+FLAG basecamp file --styled type=bool
+FLAG basecamp file --todolist type=string
+FLAG basecamp file --vault type=string
+FLAG basecamp file --verbose type=count
+FLAG basecamp file archive --account type=string
+FLAG basecamp file archive --agent type=bool
+FLAG basecamp file archive --cache-dir type=string
+FLAG basecamp file archive --count type=bool
+FLAG basecamp file archive --folder type=string
+FLAG basecamp file archive --help type=bool
+FLAG basecamp file archive --hints type=bool
+FLAG basecamp file archive --ids-only type=bool
+FLAG basecamp file archive --in type=string
+FLAG basecamp file archive --jq type=string
+FLAG basecamp file archive --json type=bool
+FLAG basecamp file archive --markdown type=bool
+FLAG basecamp file archive --md type=bool
+FLAG basecamp file archive --no-hints type=bool
+FLAG basecamp file archive --no-stats type=bool
+FLAG basecamp file archive --profile type=string
+FLAG basecamp file archive --project type=string
+FLAG basecamp file archive --quiet type=bool
+FLAG basecamp file archive --stats type=bool
+FLAG basecamp file archive --styled type=bool
+FLAG basecamp file archive --todolist type=string
+FLAG basecamp file archive --vault type=string
+FLAG basecamp file archive --verbose type=count
+FLAG basecamp file doc --account type=string
+FLAG basecamp file doc --agent type=bool
+FLAG basecamp file doc --all type=bool
+FLAG basecamp file doc --cache-dir type=string
+FLAG basecamp file doc --count type=bool
+FLAG basecamp file doc --folder type=string
+FLAG basecamp file doc --help type=bool
+FLAG basecamp file doc --hints type=bool
+FLAG basecamp file doc --ids-only type=bool
+FLAG basecamp file doc --in type=string
+FLAG basecamp file doc --jq type=string
+FLAG basecamp file doc --json type=bool
+FLAG basecamp file doc --limit type=int
+FLAG basecamp file doc --markdown type=bool
+FLAG basecamp file doc --md type=bool
+FLAG basecamp file doc --no-hints type=bool
+FLAG basecamp file doc --no-stats type=bool
+FLAG basecamp file doc --page type=int
+FLAG basecamp file doc --profile type=string
+FLAG basecamp file doc --project type=string
+FLAG basecamp file doc --quiet type=bool
+FLAG basecamp file doc --stats type=bool
+FLAG basecamp file doc --styled type=bool
+FLAG basecamp file doc --todolist type=string
+FLAG basecamp file doc --vault type=string
+FLAG basecamp file doc --verbose type=count
+FLAG basecamp file doc create --account type=string
+FLAG basecamp file doc create --agent type=bool
+FLAG basecamp file doc create --attach type=stringArray
+FLAG basecamp file doc create --cache-dir type=string
+FLAG basecamp file doc create --count type=bool
+FLAG basecamp file doc create --draft type=bool
+FLAG basecamp file doc create --folder type=string
+FLAG basecamp file doc create --help type=bool
+FLAG basecamp file doc create --hints type=bool
+FLAG basecamp file doc create --ids-only type=bool
+FLAG basecamp file doc create --in type=string
+FLAG basecamp file doc create --jq type=string
+FLAG basecamp file doc create --json type=bool
+FLAG basecamp file doc create --markdown type=bool
+FLAG basecamp file doc create --md type=bool
+FLAG basecamp file doc create --no-hints type=bool
+FLAG basecamp file doc create --no-stats type=bool
+FLAG basecamp file doc create --no-subscribe type=bool
+FLAG basecamp file doc create --profile type=string
+FLAG basecamp file doc create --project type=string
+FLAG basecamp file doc create --quiet type=bool
+FLAG basecamp file doc create --stats type=bool
+FLAG basecamp file doc create --styled type=bool
+FLAG basecamp file doc create --subscribe type=string
+FLAG basecamp file doc create --todolist type=string
+FLAG basecamp file doc create --vault type=string
+FLAG basecamp file doc create --verbose type=count
+FLAG basecamp file doc list --account type=string
+FLAG basecamp file doc list --agent type=bool
+FLAG basecamp file doc list --all type=bool
+FLAG basecamp file doc list --cache-dir type=string
+FLAG basecamp file doc list --count type=bool
+FLAG basecamp file doc list --folder type=string
+FLAG basecamp file doc list --help type=bool
+FLAG basecamp file doc list --hints type=bool
+FLAG basecamp file doc list --ids-only type=bool
+FLAG basecamp file doc list --in type=string
+FLAG basecamp file doc list --jq type=string
+FLAG basecamp file doc list --json type=bool
+FLAG basecamp file doc list --limit type=int
+FLAG basecamp file doc list --markdown type=bool
+FLAG basecamp file doc list --md type=bool
+FLAG basecamp file doc list --no-hints type=bool
+FLAG basecamp file doc list --no-stats type=bool
+FLAG basecamp file doc list --page type=int
+FLAG basecamp file doc list --profile type=string
+FLAG basecamp file doc list --project type=string
+FLAG basecamp file doc list --quiet type=bool
+FLAG basecamp file doc list --stats type=bool
+FLAG basecamp file doc list --styled type=bool
+FLAG basecamp file doc list --todolist type=string
+FLAG basecamp file doc list --vault type=string
+FLAG basecamp file doc list --verbose type=count
+FLAG basecamp file document --account type=string
+FLAG basecamp file document --agent type=bool
+FLAG basecamp file document --all type=bool
+FLAG basecamp file document --cache-dir type=string
+FLAG basecamp file document --count type=bool
+FLAG basecamp file document --folder type=string
+FLAG basecamp file document --help type=bool
+FLAG basecamp file document --hints type=bool
+FLAG basecamp file document --ids-only type=bool
+FLAG basecamp file document --in type=string
+FLAG basecamp file document --jq type=string
+FLAG basecamp file document --json type=bool
+FLAG basecamp file document --limit type=int
+FLAG basecamp file document --markdown type=bool
+FLAG basecamp file document --md type=bool
+FLAG basecamp file document --no-hints type=bool
+FLAG basecamp file document --no-stats type=bool
+FLAG basecamp file document --page type=int
+FLAG basecamp file document --profile type=string
+FLAG basecamp file document --project type=string
+FLAG basecamp file document --quiet type=bool
+FLAG basecamp file document --stats type=bool
+FLAG basecamp file document --styled type=bool
+FLAG basecamp file document --todolist type=string
+FLAG basecamp file document --vault type=string
+FLAG basecamp file document --verbose type=count
+FLAG basecamp file document create --account type=string
+FLAG basecamp file document create --agent type=bool
+FLAG basecamp file document create --attach type=stringArray
+FLAG basecamp file document create --cache-dir type=string
+FLAG basecamp file document create --count type=bool
+FLAG basecamp file document create --draft type=bool
+FLAG basecamp file document create --folder type=string
+FLAG basecamp file document create --help type=bool
+FLAG basecamp file document create --hints type=bool
+FLAG basecamp file document create --ids-only type=bool
+FLAG basecamp file document create --in type=string
+FLAG basecamp file document create --jq type=string
+FLAG basecamp file document create --json type=bool
+FLAG basecamp file document create --markdown type=bool
+FLAG basecamp file document create --md type=bool
+FLAG basecamp file document create --no-hints type=bool
+FLAG basecamp file document create --no-stats type=bool
+FLAG basecamp file document create --no-subscribe type=bool
+FLAG basecamp file document create --profile type=string
+FLAG basecamp file document create --project type=string
+FLAG basecamp file document create --quiet type=bool
+FLAG basecamp file document create --stats type=bool
+FLAG basecamp file document create --styled type=bool
+FLAG basecamp file document create --subscribe type=string
+FLAG basecamp file document create --todolist type=string
+FLAG basecamp file document create --vault type=string
+FLAG basecamp file document create --verbose type=count
+FLAG basecamp file document list --account type=string
+FLAG basecamp file document list --agent type=bool
+FLAG basecamp file document list --all type=bool
+FLAG basecamp file document list --cache-dir type=string
+FLAG basecamp file document list --count type=bool
+FLAG basecamp file document list --folder type=string
+FLAG basecamp file document list --help type=bool
+FLAG basecamp file document list --hints type=bool
+FLAG basecamp file document list --ids-only type=bool
+FLAG basecamp file document list --in type=string
+FLAG basecamp file document list --jq type=string
+FLAG basecamp file document list --json type=bool
+FLAG basecamp file document list --limit type=int
+FLAG basecamp file document list --markdown type=bool
+FLAG basecamp file document list --md type=bool
+FLAG basecamp file document list --no-hints type=bool
+FLAG basecamp file document list --no-stats type=bool
+FLAG basecamp file document list --page type=int
+FLAG basecamp file document list --profile type=string
+FLAG basecamp file document list --project type=string
+FLAG basecamp file document list --quiet type=bool
+FLAG basecamp file document list --stats type=bool
+FLAG basecamp file document list --styled type=bool
+FLAG basecamp file document list --todolist type=string
+FLAG basecamp file document list --vault type=string
+FLAG basecamp file document list --verbose type=count
+FLAG basecamp file documents --account type=string
+FLAG basecamp file documents --agent type=bool
+FLAG basecamp file documents --all type=bool
+FLAG basecamp file documents --cache-dir type=string
+FLAG basecamp file documents --count type=bool
+FLAG basecamp file documents --folder type=string
+FLAG basecamp file documents --help type=bool
+FLAG basecamp file documents --hints type=bool
+FLAG basecamp file documents --ids-only type=bool
+FLAG basecamp file documents --in type=string
+FLAG basecamp file documents --jq type=string
+FLAG basecamp file documents --json type=bool
+FLAG basecamp file documents --limit type=int
+FLAG basecamp file documents --markdown type=bool
+FLAG basecamp file documents --md type=bool
+FLAG basecamp file documents --no-hints type=bool
+FLAG basecamp file documents --no-stats type=bool
+FLAG basecamp file documents --page type=int
+FLAG basecamp file documents --profile type=string
+FLAG basecamp file documents --project type=string
+FLAG basecamp file documents --quiet type=bool
+FLAG basecamp file documents --stats type=bool
+FLAG basecamp file documents --styled type=bool
+FLAG basecamp file documents --todolist type=string
+FLAG basecamp file documents --vault type=string
+FLAG basecamp file documents --verbose type=count
+FLAG basecamp file documents create --account type=string
+FLAG basecamp file documents create --agent type=bool
+FLAG basecamp file documents create --attach type=stringArray
+FLAG basecamp file documents create --cache-dir type=string
+FLAG basecamp file documents create --count type=bool
+FLAG basecamp file documents create --draft type=bool
+FLAG basecamp file documents create --folder type=string
+FLAG basecamp file documents create --help type=bool
+FLAG basecamp file documents create --hints type=bool
+FLAG basecamp file documents create --ids-only type=bool
+FLAG basecamp file documents create --in type=string
+FLAG basecamp file documents create --jq type=string
+FLAG basecamp file documents create --json type=bool
+FLAG basecamp file documents create --markdown type=bool
+FLAG basecamp file documents create --md type=bool
+FLAG basecamp file documents create --no-hints type=bool
+FLAG basecamp file documents create --no-stats type=bool
+FLAG basecamp file documents create --no-subscribe type=bool
+FLAG basecamp file documents create --profile type=string
+FLAG basecamp file documents create --project type=string
+FLAG basecamp file documents create --quiet type=bool
+FLAG basecamp file documents create --stats type=bool
+FLAG basecamp file documents create --styled type=bool
+FLAG basecamp file documents create --subscribe type=string
+FLAG basecamp file documents create --todolist type=string
+FLAG basecamp file documents create --vault type=string
+FLAG basecamp file documents create --verbose type=count
+FLAG basecamp file documents list --account type=string
+FLAG basecamp file documents list --agent type=bool
+FLAG basecamp file documents list --all type=bool
+FLAG basecamp file documents list --cache-dir type=string
+FLAG basecamp file documents list --count type=bool
+FLAG basecamp file documents list --folder type=string
+FLAG basecamp file documents list --help type=bool
+FLAG basecamp file documents list --hints type=bool
+FLAG basecamp file documents list --ids-only type=bool
+FLAG basecamp file documents list --in type=string
+FLAG basecamp file documents list --jq type=string
+FLAG basecamp file documents list --json type=bool
+FLAG basecamp file documents list --limit type=int
+FLAG basecamp file documents list --markdown type=bool
+FLAG basecamp file documents list --md type=bool
+FLAG basecamp file documents list --no-hints type=bool
+FLAG basecamp file documents list --no-stats type=bool
+FLAG basecamp file documents list --page type=int
+FLAG basecamp file documents list --profile type=string
+FLAG basecamp file documents list --project type=string
+FLAG basecamp file documents list --quiet type=bool
+FLAG basecamp file documents list --stats type=bool
+FLAG basecamp file documents list --styled type=bool
+FLAG basecamp file documents list --todolist type=string
+FLAG basecamp file documents list --vault type=string
+FLAG basecamp file documents list --verbose type=count
+FLAG basecamp file download --account type=string
+FLAG basecamp file download --agent type=bool
+FLAG basecamp file download --cache-dir type=string
+FLAG basecamp file download --count type=bool
+FLAG basecamp file download --folder type=string
+FLAG basecamp file download --help type=bool
+FLAG basecamp file download --hints type=bool
+FLAG basecamp file download --ids-only type=bool
+FLAG basecamp file download --in type=string
+FLAG basecamp file download --jq type=string
+FLAG basecamp file download --json type=bool
+FLAG basecamp file download --markdown type=bool
+FLAG basecamp file download --md type=bool
+FLAG basecamp file download --no-hints type=bool
+FLAG basecamp file download --no-stats type=bool
+FLAG basecamp file download --out type=string
+FLAG basecamp file download --profile type=string
+FLAG basecamp file download --project type=string
+FLAG basecamp file download --quiet type=bool
+FLAG basecamp file download --stats type=bool
+FLAG basecamp file download --styled type=bool
+FLAG basecamp file download --todolist type=string
+FLAG basecamp file download --vault type=string
+FLAG basecamp file download --verbose type=count
+FLAG basecamp file folder --account type=string
+FLAG basecamp file folder --agent type=bool
+FLAG basecamp file folder --all type=bool
+FLAG basecamp file folder --cache-dir type=string
+FLAG basecamp file folder --count type=bool
+FLAG basecamp file folder --folder type=string
+FLAG basecamp file folder --help type=bool
+FLAG basecamp file folder --hints type=bool
+FLAG basecamp file folder --ids-only type=bool
+FLAG basecamp file folder --in type=string
+FLAG basecamp file folder --jq type=string
+FLAG basecamp file folder --json type=bool
+FLAG basecamp file folder --limit type=int
+FLAG basecamp file folder --markdown type=bool
+FLAG basecamp file folder --md type=bool
+FLAG basecamp file folder --no-hints type=bool
+FLAG basecamp file folder --no-stats type=bool
+FLAG basecamp file folder --page type=int
+FLAG basecamp file folder --profile type=string
+FLAG basecamp file folder --project type=string
+FLAG basecamp file folder --quiet type=bool
+FLAG basecamp file folder --stats type=bool
+FLAG basecamp file folder --styled type=bool
+FLAG basecamp file folder --todolist type=string
+FLAG basecamp file folder --vault type=string
+FLAG basecamp file folder --verbose type=count
+FLAG basecamp file folder create --account type=string
+FLAG basecamp file folder create --agent type=bool
+FLAG basecamp file folder create --cache-dir type=string
+FLAG basecamp file folder create --count type=bool
+FLAG basecamp file folder create --folder type=string
+FLAG basecamp file folder create --help type=bool
+FLAG basecamp file folder create --hints type=bool
+FLAG basecamp file folder create --ids-only type=bool
+FLAG basecamp file folder create --in type=string
+FLAG basecamp file folder create --jq type=string
+FLAG basecamp file folder create --json type=bool
+FLAG basecamp file folder create --markdown type=bool
+FLAG basecamp file folder create --md type=bool
+FLAG basecamp file folder create --no-hints type=bool
+FLAG basecamp file folder create --no-stats type=bool
+FLAG basecamp file folder create --profile type=string
+FLAG basecamp file folder create --project type=string
+FLAG basecamp file folder create --quiet type=bool
+FLAG basecamp file folder create --stats type=bool
+FLAG basecamp file folder create --styled type=bool
+FLAG basecamp file folder create --todolist type=string
+FLAG basecamp file folder create --vault type=string
+FLAG basecamp file folder create --verbose type=count
+FLAG basecamp file folder list --account type=string
+FLAG basecamp file folder list --agent type=bool
+FLAG basecamp file folder list --all type=bool
+FLAG basecamp file folder list --cache-dir type=string
+FLAG basecamp file folder list --count type=bool
+FLAG basecamp file folder list --folder type=string
+FLAG basecamp file folder list --help type=bool
+FLAG basecamp file folder list --hints type=bool
+FLAG basecamp file folder list --ids-only type=bool
+FLAG basecamp file folder list --in type=string
+FLAG basecamp file folder list --jq type=string
+FLAG basecamp file folder list --json type=bool
+FLAG basecamp file folder list --limit type=int
+FLAG basecamp file folder list --markdown type=bool
+FLAG basecamp file folder list --md type=bool
+FLAG basecamp file folder list --no-hints type=bool
+FLAG basecamp file folder list --no-stats type=bool
+FLAG basecamp file folder list --page type=int
+FLAG basecamp file folder list --profile type=string
+FLAG basecamp file folder list --project type=string
+FLAG basecamp file folder list --quiet type=bool
+FLAG basecamp file folder list --stats type=bool
+FLAG basecamp file folder list --styled type=bool
+FLAG basecamp file folder list --todolist type=string
+FLAG basecamp file folder list --vault type=string
+FLAG basecamp file folder list --verbose type=count
+FLAG basecamp file folders --account type=string
+FLAG basecamp file folders --agent type=bool
+FLAG basecamp file folders --all type=bool
+FLAG basecamp file folders --cache-dir type=string
+FLAG basecamp file folders --count type=bool
+FLAG basecamp file folders --folder type=string
+FLAG basecamp file folders --help type=bool
+FLAG basecamp file folders --hints type=bool
+FLAG basecamp file folders --ids-only type=bool
+FLAG basecamp file folders --in type=string
+FLAG basecamp file folders --jq type=string
+FLAG basecamp file folders --json type=bool
+FLAG basecamp file folders --limit type=int
+FLAG basecamp file folders --markdown type=bool
+FLAG basecamp file folders --md type=bool
+FLAG basecamp file folders --no-hints type=bool
+FLAG basecamp file folders --no-stats type=bool
+FLAG basecamp file folders --page type=int
+FLAG basecamp file folders --profile type=string
+FLAG basecamp file folders --project type=string
+FLAG basecamp file folders --quiet type=bool
+FLAG basecamp file folders --stats type=bool
+FLAG basecamp file folders --styled type=bool
+FLAG basecamp file folders --todolist type=string
+FLAG basecamp file folders --vault type=string
+FLAG basecamp file folders --verbose type=count
+FLAG basecamp file folders create --account type=string
+FLAG basecamp file folders create --agent type=bool
+FLAG basecamp file folders create --cache-dir type=string
+FLAG basecamp file folders create --count type=bool
+FLAG basecamp file folders create --folder type=string
+FLAG basecamp file folders create --help type=bool
+FLAG basecamp file folders create --hints type=bool
+FLAG basecamp file folders create --ids-only type=bool
+FLAG basecamp file folders create --in type=string
+FLAG basecamp file folders create --jq type=string
+FLAG basecamp file folders create --json type=bool
+FLAG basecamp file folders create --markdown type=bool
+FLAG basecamp file folders create --md type=bool
+FLAG basecamp file folders create --no-hints type=bool
+FLAG basecamp file folders create --no-stats type=bool
+FLAG basecamp file folders create --profile type=string
+FLAG basecamp file folders create --project type=string
+FLAG basecamp file folders create --quiet type=bool
+FLAG basecamp file folders create --stats type=bool
+FLAG basecamp file folders create --styled type=bool
+FLAG basecamp file folders create --todolist type=string
+FLAG basecamp file folders create --vault type=string
+FLAG basecamp file folders create --verbose type=count
+FLAG basecamp file folders list --account type=string
+FLAG basecamp file folders list --agent type=bool
+FLAG basecamp file folders list --all type=bool
+FLAG basecamp file folders list --cache-dir type=string
+FLAG basecamp file folders list --count type=bool
+FLAG basecamp file folders list --folder type=string
+FLAG basecamp file folders list --help type=bool
+FLAG basecamp file folders list --hints type=bool
+FLAG basecamp file folders list --ids-only type=bool
+FLAG basecamp file folders list --in type=string
+FLAG basecamp file folders list --jq type=string
+FLAG basecamp file folders list --json type=bool
+FLAG basecamp file folders list --limit type=int
+FLAG basecamp file folders list --markdown type=bool
+FLAG basecamp file folders list --md type=bool
+FLAG basecamp file folders list --no-hints type=bool
+FLAG basecamp file folders list --no-stats type=bool
+FLAG basecamp file folders list --page type=int
+FLAG basecamp file folders list --profile type=string
+FLAG basecamp file folders list --project type=string
+FLAG basecamp file folders list --quiet type=bool
+FLAG basecamp file folders list --stats type=bool
+FLAG basecamp file folders list --styled type=bool
+FLAG basecamp file folders list --todolist type=string
+FLAG basecamp file folders list --vault type=string
+FLAG basecamp file folders list --verbose type=count
+FLAG basecamp file list --account type=string
+FLAG basecamp file list --agent type=bool
+FLAG basecamp file list --cache-dir type=string
+FLAG basecamp file list --count type=bool
+FLAG basecamp file list --folder type=string
+FLAG basecamp file list --help type=bool
+FLAG basecamp file list --hints type=bool
+FLAG basecamp file list --ids-only type=bool
+FLAG basecamp file list --in type=string
+FLAG basecamp file list --jq type=string
+FLAG basecamp file list --json type=bool
+FLAG basecamp file list --markdown type=bool
+FLAG basecamp file list --md type=bool
+FLAG basecamp file list --no-hints type=bool
+FLAG basecamp file list --no-stats type=bool
+FLAG basecamp file list --profile type=string
+FLAG basecamp file list --project type=string
+FLAG basecamp file list --quiet type=bool
+FLAG basecamp file list --stats type=bool
+FLAG basecamp file list --styled type=bool
+FLAG basecamp file list --todolist type=string
+FLAG basecamp file list --vault type=string
+FLAG basecamp file list --verbose type=count
+FLAG basecamp file restore --account type=string
+FLAG basecamp file restore --agent type=bool
+FLAG basecamp file restore --cache-dir type=string
+FLAG basecamp file restore --count type=bool
+FLAG basecamp file restore --folder type=string
+FLAG basecamp file restore --help type=bool
+FLAG basecamp file restore --hints type=bool
+FLAG basecamp file restore --ids-only type=bool
+FLAG basecamp file restore --in type=string
+FLAG basecamp file restore --jq type=string
+FLAG basecamp file restore --json type=bool
+FLAG basecamp file restore --markdown type=bool
+FLAG basecamp file restore --md type=bool
+FLAG basecamp file restore --no-hints type=bool
+FLAG basecamp file restore --no-stats type=bool
+FLAG basecamp file restore --profile type=string
+FLAG basecamp file restore --project type=string
+FLAG basecamp file restore --quiet type=bool
+FLAG basecamp file restore --stats type=bool
+FLAG basecamp file restore --styled type=bool
+FLAG basecamp file restore --todolist type=string
+FLAG basecamp file restore --vault type=string
+FLAG basecamp file restore --verbose type=count
+FLAG basecamp file show --account type=string
+FLAG basecamp file show --agent type=bool
+FLAG basecamp file show --cache-dir type=string
+FLAG basecamp file show --count type=bool
+FLAG basecamp file show --folder type=string
+FLAG basecamp file show --help type=bool
+FLAG basecamp file show --hints type=bool
+FLAG basecamp file show --ids-only type=bool
+FLAG basecamp file show --in type=string
+FLAG basecamp file show --jq type=string
+FLAG basecamp file show --json type=bool
+FLAG basecamp file show --markdown type=bool
+FLAG basecamp file show --md type=bool
+FLAG basecamp file show --no-hints type=bool
+FLAG basecamp file show --no-stats type=bool
+FLAG basecamp file show --profile type=string
+FLAG basecamp file show --project type=string
+FLAG basecamp file show --quiet type=bool
+FLAG basecamp file show --stats type=bool
+FLAG basecamp file show --styled type=bool
+FLAG basecamp file show --todolist type=string
+FLAG basecamp file show --type type=string
+FLAG basecamp file show --vault type=string
+FLAG basecamp file show --verbose type=count
+FLAG basecamp file trash --account type=string
+FLAG basecamp file trash --agent type=bool
+FLAG basecamp file trash --cache-dir type=string
+FLAG basecamp file trash --count type=bool
+FLAG basecamp file trash --folder type=string
+FLAG basecamp file trash --help type=bool
+FLAG basecamp file trash --hints type=bool
+FLAG basecamp file trash --ids-only type=bool
+FLAG basecamp file trash --in type=string
+FLAG basecamp file trash --jq type=string
+FLAG basecamp file trash --json type=bool
+FLAG basecamp file trash --markdown type=bool
+FLAG basecamp file trash --md type=bool
+FLAG basecamp file trash --no-hints type=bool
+FLAG basecamp file trash --no-stats type=bool
+FLAG basecamp file trash --profile type=string
+FLAG basecamp file trash --project type=string
+FLAG basecamp file trash --quiet type=bool
+FLAG basecamp file trash --stats type=bool
+FLAG basecamp file trash --styled type=bool
+FLAG basecamp file trash --todolist type=string
+FLAG basecamp file trash --vault type=string
+FLAG basecamp file trash --verbose type=count
+FLAG basecamp file update --account type=string
+FLAG basecamp file update --agent type=bool
+FLAG basecamp file update --cache-dir type=string
+FLAG basecamp file update --content type=string
+FLAG basecamp file update --count type=bool
+FLAG basecamp file update --folder type=string
+FLAG basecamp file update --help type=bool
+FLAG basecamp file update --hints type=bool
+FLAG basecamp file update --ids-only type=bool
+FLAG basecamp file update --in type=string
+FLAG basecamp file update --jq type=string
+FLAG basecamp file update --json type=bool
+FLAG basecamp file update --markdown type=bool
+FLAG basecamp file update --md type=bool
+FLAG basecamp file update --no-hints type=bool
+FLAG basecamp file update --no-stats type=bool
+FLAG basecamp file update --profile type=string
+FLAG basecamp file update --project type=string
+FLAG basecamp file update --quiet type=bool
+FLAG basecamp file update --stats type=bool
+FLAG basecamp file update --styled type=bool
+FLAG basecamp file update --title type=string
+FLAG basecamp file update --todolist type=string
+FLAG basecamp file update --type type=string
+FLAG basecamp file update --vault type=string
+FLAG basecamp file update --verbose type=count
+FLAG basecamp file upload --account type=string
+FLAG basecamp file upload --agent type=bool
+FLAG basecamp file upload --all type=bool
+FLAG basecamp file upload --cache-dir type=string
+FLAG basecamp file upload --count type=bool
+FLAG basecamp file upload --folder type=string
+FLAG basecamp file upload --help type=bool
+FLAG basecamp file upload --hints type=bool
+FLAG basecamp file upload --ids-only type=bool
+FLAG basecamp file upload --in type=string
+FLAG basecamp file upload --jq type=string
+FLAG basecamp file upload --json type=bool
+FLAG basecamp file upload --limit type=int
+FLAG basecamp file upload --markdown type=bool
+FLAG basecamp file upload --md type=bool
+FLAG basecamp file upload --no-hints type=bool
+FLAG basecamp file upload --no-stats type=bool
+FLAG basecamp file upload --page type=int
+FLAG basecamp file upload --profile type=string
+FLAG basecamp file upload --project type=string
+FLAG basecamp file upload --quiet type=bool
+FLAG basecamp file upload --stats type=bool
+FLAG basecamp file upload --styled type=bool
+FLAG basecamp file upload --todolist type=string
+FLAG basecamp file upload --vault type=string
+FLAG basecamp file upload --verbose type=count
+FLAG basecamp file upload create --account type=string
+FLAG basecamp file upload create --agent type=bool
+FLAG basecamp file upload create --cache-dir type=string
+FLAG basecamp file upload create --count type=bool
+FLAG basecamp file upload create --description type=string
+FLAG basecamp file upload create --folder type=string
+FLAG basecamp file upload create --help type=bool
+FLAG basecamp file upload create --hints type=bool
+FLAG basecamp file upload create --ids-only type=bool
+FLAG basecamp file upload create --in type=string
+FLAG basecamp file upload create --jq type=string
+FLAG basecamp file upload create --json type=bool
+FLAG basecamp file upload create --markdown type=bool
+FLAG basecamp file upload create --md type=bool
+FLAG basecamp file upload create --no-hints type=bool
+FLAG basecamp file upload create --no-stats type=bool
+FLAG basecamp file upload create --profile type=string
+FLAG basecamp file upload create --project type=string
+FLAG basecamp file upload create --quiet type=bool
+FLAG basecamp file upload create --stats type=bool
+FLAG basecamp file upload create --styled type=bool
+FLAG basecamp file upload create --todolist type=string
+FLAG basecamp file upload create --vault type=string
+FLAG basecamp file upload create --verbose type=count
+FLAG basecamp file upload list --account type=string
+FLAG basecamp file upload list --agent type=bool
+FLAG basecamp file upload list --all type=bool
+FLAG basecamp file upload list --cache-dir type=string
+FLAG basecamp file upload list --count type=bool
+FLAG basecamp file upload list --folder type=string
+FLAG basecamp file upload list --help type=bool
+FLAG basecamp file upload list --hints type=bool
+FLAG basecamp file upload list --ids-only type=bool
+FLAG basecamp file upload list --in type=string
+FLAG basecamp file upload list --jq type=string
+FLAG basecamp file upload list --json type=bool
+FLAG basecamp file upload list --limit type=int
+FLAG basecamp file upload list --markdown type=bool
+FLAG basecamp file upload list --md type=bool
+FLAG basecamp file upload list --no-hints type=bool
+FLAG basecamp file upload list --no-stats type=bool
+FLAG basecamp file upload list --page type=int
+FLAG basecamp file upload list --profile type=string
+FLAG basecamp file upload list --project type=string
+FLAG basecamp file upload list --quiet type=bool
+FLAG basecamp file upload list --stats type=bool
+FLAG basecamp file upload list --styled type=bool
+FLAG basecamp file upload list --todolist type=string
+FLAG basecamp file upload list --vault type=string
+FLAG basecamp file upload list --verbose type=count
+FLAG basecamp file uploads --account type=string
+FLAG basecamp file uploads --agent type=bool
+FLAG basecamp file uploads --all type=bool
+FLAG basecamp file uploads --cache-dir type=string
+FLAG basecamp file uploads --count type=bool
+FLAG basecamp file uploads --folder type=string
+FLAG basecamp file uploads --help type=bool
+FLAG basecamp file uploads --hints type=bool
+FLAG basecamp file uploads --ids-only type=bool
+FLAG basecamp file uploads --in type=string
+FLAG basecamp file uploads --jq type=string
+FLAG basecamp file uploads --json type=bool
+FLAG basecamp file uploads --limit type=int
+FLAG basecamp file uploads --markdown type=bool
+FLAG basecamp file uploads --md type=bool
+FLAG basecamp file uploads --no-hints type=bool
+FLAG basecamp file uploads --no-stats type=bool
+FLAG basecamp file uploads --page type=int
+FLAG basecamp file uploads --profile type=string
+FLAG basecamp file uploads --project type=string
+FLAG basecamp file uploads --quiet type=bool
+FLAG basecamp file uploads --stats type=bool
+FLAG basecamp file uploads --styled type=bool
+FLAG basecamp file uploads --todolist type=string
+FLAG basecamp file uploads --vault type=string
+FLAG basecamp file uploads --verbose type=count
+FLAG basecamp file uploads create --account type=string
+FLAG basecamp file uploads create --agent type=bool
+FLAG basecamp file uploads create --cache-dir type=string
+FLAG basecamp file uploads create --count type=bool
+FLAG basecamp file uploads create --description type=string
+FLAG basecamp file uploads create --folder type=string
+FLAG basecamp file uploads create --help type=bool
+FLAG basecamp file uploads create --hints type=bool
+FLAG basecamp file uploads create --ids-only type=bool
+FLAG basecamp file uploads create --in type=string
+FLAG basecamp file uploads create --jq type=string
+FLAG basecamp file uploads create --json type=bool
+FLAG basecamp file uploads create --markdown type=bool
+FLAG basecamp file uploads create --md type=bool
+FLAG basecamp file uploads create --no-hints type=bool
+FLAG basecamp file uploads create --no-stats type=bool
+FLAG basecamp file uploads create --profile type=string
+FLAG basecamp file uploads create --project type=string
+FLAG basecamp file uploads create --quiet type=bool
+FLAG basecamp file uploads create --stats type=bool
+FLAG basecamp file uploads create --styled type=bool
+FLAG basecamp file uploads create --todolist type=string
+FLAG basecamp file uploads create --vault type=string
+FLAG basecamp file uploads create --verbose type=count
+FLAG basecamp file uploads list --account type=string
+FLAG basecamp file uploads list --agent type=bool
+FLAG basecamp file uploads list --all type=bool
+FLAG basecamp file uploads list --cache-dir type=string
+FLAG basecamp file uploads list --count type=bool
+FLAG basecamp file uploads list --folder type=string
+FLAG basecamp file uploads list --help type=bool
+FLAG basecamp file uploads list --hints type=bool
+FLAG basecamp file uploads list --ids-only type=bool
+FLAG basecamp file uploads list --in type=string
+FLAG basecamp file uploads list --jq type=string
+FLAG basecamp file uploads list --json type=bool
+FLAG basecamp file uploads list --limit type=int
+FLAG basecamp file uploads list --markdown type=bool
+FLAG basecamp file uploads list --md type=bool
+FLAG basecamp file uploads list --no-hints type=bool
+FLAG basecamp file uploads list --no-stats type=bool
+FLAG basecamp file uploads list --page type=int
+FLAG basecamp file uploads list --profile type=string
+FLAG basecamp file uploads list --project type=string
+FLAG basecamp file uploads list --quiet type=bool
+FLAG basecamp file uploads list --stats type=bool
+FLAG basecamp file uploads list --styled type=bool
+FLAG basecamp file uploads list --todolist type=string
+FLAG basecamp file uploads list --vault type=string
+FLAG basecamp file uploads list --verbose type=count
+FLAG basecamp file vault --account type=string
+FLAG basecamp file vault --agent type=bool
+FLAG basecamp file vault --all type=bool
+FLAG basecamp file vault --cache-dir type=string
+FLAG basecamp file vault --count type=bool
+FLAG basecamp file vault --folder type=string
+FLAG basecamp file vault --help type=bool
+FLAG basecamp file vault --hints type=bool
+FLAG basecamp file vault --ids-only type=bool
+FLAG basecamp file vault --in type=string
+FLAG basecamp file vault --jq type=string
+FLAG basecamp file vault --json type=bool
+FLAG basecamp file vault --limit type=int
+FLAG basecamp file vault --markdown type=bool
+FLAG basecamp file vault --md type=bool
+FLAG basecamp file vault --no-hints type=bool
+FLAG basecamp file vault --no-stats type=bool
+FLAG basecamp file vault --page type=int
+FLAG basecamp file vault --profile type=string
+FLAG basecamp file vault --project type=string
+FLAG basecamp file vault --quiet type=bool
+FLAG basecamp file vault --stats type=bool
+FLAG basecamp file vault --styled type=bool
+FLAG basecamp file vault --todolist type=string
+FLAG basecamp file vault --vault type=string
+FLAG basecamp file vault --verbose type=count
+FLAG basecamp file vault create --account type=string
+FLAG basecamp file vault create --agent type=bool
+FLAG basecamp file vault create --cache-dir type=string
+FLAG basecamp file vault create --count type=bool
+FLAG basecamp file vault create --folder type=string
+FLAG basecamp file vault create --help type=bool
+FLAG basecamp file vault create --hints type=bool
+FLAG basecamp file vault create --ids-only type=bool
+FLAG basecamp file vault create --in type=string
+FLAG basecamp file vault create --jq type=string
+FLAG basecamp file vault create --json type=bool
+FLAG basecamp file vault create --markdown type=bool
+FLAG basecamp file vault create --md type=bool
+FLAG basecamp file vault create --no-hints type=bool
+FLAG basecamp file vault create --no-stats type=bool
+FLAG basecamp file vault create --profile type=string
+FLAG basecamp file vault create --project type=string
+FLAG basecamp file vault create --quiet type=bool
+FLAG basecamp file vault create --stats type=bool
+FLAG basecamp file vault create --styled type=bool
+FLAG basecamp file vault create --todolist type=string
+FLAG basecamp file vault create --vault type=string
+FLAG basecamp file vault create --verbose type=count
+FLAG basecamp file vault list --account type=string
+FLAG basecamp file vault list --agent type=bool
+FLAG basecamp file vault list --all type=bool
+FLAG basecamp file vault list --cache-dir type=string
+FLAG basecamp file vault list --count type=bool
+FLAG basecamp file vault list --folder type=string
+FLAG basecamp file vault list --help type=bool
+FLAG basecamp file vault list --hints type=bool
+FLAG basecamp file vault list --ids-only type=bool
+FLAG basecamp file vault list --in type=string
+FLAG basecamp file vault list --jq type=string
+FLAG basecamp file vault list --json type=bool
+FLAG basecamp file vault list --limit type=int
+FLAG basecamp file vault list --markdown type=bool
+FLAG basecamp file vault list --md type=bool
+FLAG basecamp file vault list --no-hints type=bool
+FLAG basecamp file vault list --no-stats type=bool
+FLAG basecamp file vault list --page type=int
+FLAG basecamp file vault list --profile type=string
+FLAG basecamp file vault list --project type=string
+FLAG basecamp file vault list --quiet type=bool
+FLAG basecamp file vault list --stats type=bool
+FLAG basecamp file vault list --styled type=bool
+FLAG basecamp file vault list --todolist type=string
+FLAG basecamp file vault list --vault type=string
+FLAG basecamp file vault list --verbose type=count
+FLAG basecamp file vaults --account type=string
+FLAG basecamp file vaults --agent type=bool
+FLAG basecamp file vaults --all type=bool
+FLAG basecamp file vaults --cache-dir type=string
+FLAG basecamp file vaults --count type=bool
+FLAG basecamp file vaults --folder type=string
+FLAG basecamp file vaults --help type=bool
+FLAG basecamp file vaults --hints type=bool
+FLAG basecamp file vaults --ids-only type=bool
+FLAG basecamp file vaults --in type=string
+FLAG basecamp file vaults --jq type=string
+FLAG basecamp file vaults --json type=bool
+FLAG basecamp file vaults --limit type=int
+FLAG basecamp file vaults --markdown type=bool
+FLAG basecamp file vaults --md type=bool
+FLAG basecamp file vaults --no-hints type=bool
+FLAG basecamp file vaults --no-stats type=bool
+FLAG basecamp file vaults --page type=int
+FLAG basecamp file vaults --profile type=string
+FLAG basecamp file vaults --project type=string
+FLAG basecamp file vaults --quiet type=bool
+FLAG basecamp file vaults --stats type=bool
+FLAG basecamp file vaults --styled type=bool
+FLAG basecamp file vaults --todolist type=string
+FLAG basecamp file vaults --vault type=string
+FLAG basecamp file vaults --verbose type=count
+FLAG basecamp file vaults create --account type=string
+FLAG basecamp file vaults create --agent type=bool
+FLAG basecamp file vaults create --cache-dir type=string
+FLAG basecamp file vaults create --count type=bool
+FLAG basecamp file vaults create --folder type=string
+FLAG basecamp file vaults create --help type=bool
+FLAG basecamp file vaults create --hints type=bool
+FLAG basecamp file vaults create --ids-only type=bool
+FLAG basecamp file vaults create --in type=string
+FLAG basecamp file vaults create --jq type=string
+FLAG basecamp file vaults create --json type=bool
+FLAG basecamp file vaults create --markdown type=bool
+FLAG basecamp file vaults create --md type=bool
+FLAG basecamp file vaults create --no-hints type=bool
+FLAG basecamp file vaults create --no-stats type=bool
+FLAG basecamp file vaults create --profile type=string
+FLAG basecamp file vaults create --project type=string
+FLAG basecamp file vaults create --quiet type=bool
+FLAG basecamp file vaults create --stats type=bool
+FLAG basecamp file vaults create --styled type=bool
+FLAG basecamp file vaults create --todolist type=string
+FLAG basecamp file vaults create --vault type=string
+FLAG basecamp file vaults create --verbose type=count
+FLAG basecamp file vaults list --account type=string
+FLAG basecamp file vaults list --agent type=bool
+FLAG basecamp file vaults list --all type=bool
+FLAG basecamp file vaults list --cache-dir type=string
+FLAG basecamp file vaults list --count type=bool
+FLAG basecamp file vaults list --folder type=string
+FLAG basecamp file vaults list --help type=bool
+FLAG basecamp file vaults list --hints type=bool
+FLAG basecamp file vaults list --ids-only type=bool
+FLAG basecamp file vaults list --in type=string
+FLAG basecamp file vaults list --jq type=string
+FLAG basecamp file vaults list --json type=bool
+FLAG basecamp file vaults list --limit type=int
+FLAG basecamp file vaults list --markdown type=bool
+FLAG basecamp file vaults list --md type=bool
+FLAG basecamp file vaults list --no-hints type=bool
+FLAG basecamp file vaults list --no-stats type=bool
+FLAG basecamp file vaults list --page type=int
+FLAG basecamp file vaults list --profile type=string
+FLAG basecamp file vaults list --project type=string
+FLAG basecamp file vaults list --quiet type=bool
+FLAG basecamp file vaults list --stats type=bool
+FLAG basecamp file vaults list --styled type=bool
+FLAG basecamp file vaults list --todolist type=string
+FLAG basecamp file vaults list --vault type=string
+FLAG basecamp file vaults list --verbose type=count
 FLAG basecamp files --account type=string
 FLAG basecamp files --agent type=bool
 FLAG basecamp files --cache-dir type=string
 FLAG basecamp files --count type=bool
 FLAG basecamp files --folder type=string
+FLAG basecamp files --help type=bool
 FLAG basecamp files --hints type=bool
 FLAG basecamp files --ids-only type=bool
 FLAG basecamp files --in type=string
@@ -3028,6 +6782,7 @@ FLAG basecamp files archive --agent type=bool
 FLAG basecamp files archive --cache-dir type=string
 FLAG basecamp files archive --count type=bool
 FLAG basecamp files archive --folder type=string
+FLAG basecamp files archive --help type=bool
 FLAG basecamp files archive --hints type=bool
 FLAG basecamp files archive --ids-only type=bool
 FLAG basecamp files archive --in type=string
@@ -3045,12 +6800,171 @@ FLAG basecamp files archive --styled type=bool
 FLAG basecamp files archive --todolist type=string
 FLAG basecamp files archive --vault type=string
 FLAG basecamp files archive --verbose type=count
+FLAG basecamp files doc --account type=string
+FLAG basecamp files doc --agent type=bool
+FLAG basecamp files doc --all type=bool
+FLAG basecamp files doc --cache-dir type=string
+FLAG basecamp files doc --count type=bool
+FLAG basecamp files doc --folder type=string
+FLAG basecamp files doc --help type=bool
+FLAG basecamp files doc --hints type=bool
+FLAG basecamp files doc --ids-only type=bool
+FLAG basecamp files doc --in type=string
+FLAG basecamp files doc --jq type=string
+FLAG basecamp files doc --json type=bool
+FLAG basecamp files doc --limit type=int
+FLAG basecamp files doc --markdown type=bool
+FLAG basecamp files doc --md type=bool
+FLAG basecamp files doc --no-hints type=bool
+FLAG basecamp files doc --no-stats type=bool
+FLAG basecamp files doc --page type=int
+FLAG basecamp files doc --profile type=string
+FLAG basecamp files doc --project type=string
+FLAG basecamp files doc --quiet type=bool
+FLAG basecamp files doc --stats type=bool
+FLAG basecamp files doc --styled type=bool
+FLAG basecamp files doc --todolist type=string
+FLAG basecamp files doc --vault type=string
+FLAG basecamp files doc --verbose type=count
+FLAG basecamp files doc create --account type=string
+FLAG basecamp files doc create --agent type=bool
+FLAG basecamp files doc create --attach type=stringArray
+FLAG basecamp files doc create --cache-dir type=string
+FLAG basecamp files doc create --count type=bool
+FLAG basecamp files doc create --draft type=bool
+FLAG basecamp files doc create --folder type=string
+FLAG basecamp files doc create --help type=bool
+FLAG basecamp files doc create --hints type=bool
+FLAG basecamp files doc create --ids-only type=bool
+FLAG basecamp files doc create --in type=string
+FLAG basecamp files doc create --jq type=string
+FLAG basecamp files doc create --json type=bool
+FLAG basecamp files doc create --markdown type=bool
+FLAG basecamp files doc create --md type=bool
+FLAG basecamp files doc create --no-hints type=bool
+FLAG basecamp files doc create --no-stats type=bool
+FLAG basecamp files doc create --no-subscribe type=bool
+FLAG basecamp files doc create --profile type=string
+FLAG basecamp files doc create --project type=string
+FLAG basecamp files doc create --quiet type=bool
+FLAG basecamp files doc create --stats type=bool
+FLAG basecamp files doc create --styled type=bool
+FLAG basecamp files doc create --subscribe type=string
+FLAG basecamp files doc create --todolist type=string
+FLAG basecamp files doc create --vault type=string
+FLAG basecamp files doc create --verbose type=count
+FLAG basecamp files doc list --account type=string
+FLAG basecamp files doc list --agent type=bool
+FLAG basecamp files doc list --all type=bool
+FLAG basecamp files doc list --cache-dir type=string
+FLAG basecamp files doc list --count type=bool
+FLAG basecamp files doc list --folder type=string
+FLAG basecamp files doc list --help type=bool
+FLAG basecamp files doc list --hints type=bool
+FLAG basecamp files doc list --ids-only type=bool
+FLAG basecamp files doc list --in type=string
+FLAG basecamp files doc list --jq type=string
+FLAG basecamp files doc list --json type=bool
+FLAG basecamp files doc list --limit type=int
+FLAG basecamp files doc list --markdown type=bool
+FLAG basecamp files doc list --md type=bool
+FLAG basecamp files doc list --no-hints type=bool
+FLAG basecamp files doc list --no-stats type=bool
+FLAG basecamp files doc list --page type=int
+FLAG basecamp files doc list --profile type=string
+FLAG basecamp files doc list --project type=string
+FLAG basecamp files doc list --quiet type=bool
+FLAG basecamp files doc list --stats type=bool
+FLAG basecamp files doc list --styled type=bool
+FLAG basecamp files doc list --todolist type=string
+FLAG basecamp files doc list --vault type=string
+FLAG basecamp files doc list --verbose type=count
+FLAG basecamp files document --account type=string
+FLAG basecamp files document --agent type=bool
+FLAG basecamp files document --all type=bool
+FLAG basecamp files document --cache-dir type=string
+FLAG basecamp files document --count type=bool
+FLAG basecamp files document --folder type=string
+FLAG basecamp files document --help type=bool
+FLAG basecamp files document --hints type=bool
+FLAG basecamp files document --ids-only type=bool
+FLAG basecamp files document --in type=string
+FLAG basecamp files document --jq type=string
+FLAG basecamp files document --json type=bool
+FLAG basecamp files document --limit type=int
+FLAG basecamp files document --markdown type=bool
+FLAG basecamp files document --md type=bool
+FLAG basecamp files document --no-hints type=bool
+FLAG basecamp files document --no-stats type=bool
+FLAG basecamp files document --page type=int
+FLAG basecamp files document --profile type=string
+FLAG basecamp files document --project type=string
+FLAG basecamp files document --quiet type=bool
+FLAG basecamp files document --stats type=bool
+FLAG basecamp files document --styled type=bool
+FLAG basecamp files document --todolist type=string
+FLAG basecamp files document --vault type=string
+FLAG basecamp files document --verbose type=count
+FLAG basecamp files document create --account type=string
+FLAG basecamp files document create --agent type=bool
+FLAG basecamp files document create --attach type=stringArray
+FLAG basecamp files document create --cache-dir type=string
+FLAG basecamp files document create --count type=bool
+FLAG basecamp files document create --draft type=bool
+FLAG basecamp files document create --folder type=string
+FLAG basecamp files document create --help type=bool
+FLAG basecamp files document create --hints type=bool
+FLAG basecamp files document create --ids-only type=bool
+FLAG basecamp files document create --in type=string
+FLAG basecamp files document create --jq type=string
+FLAG basecamp files document create --json type=bool
+FLAG basecamp files document create --markdown type=bool
+FLAG basecamp files document create --md type=bool
+FLAG basecamp files document create --no-hints type=bool
+FLAG basecamp files document create --no-stats type=bool
+FLAG basecamp files document create --no-subscribe type=bool
+FLAG basecamp files document create --profile type=string
+FLAG basecamp files document create --project type=string
+FLAG basecamp files document create --quiet type=bool
+FLAG basecamp files document create --stats type=bool
+FLAG basecamp files document create --styled type=bool
+FLAG basecamp files document create --subscribe type=string
+FLAG basecamp files document create --todolist type=string
+FLAG basecamp files document create --vault type=string
+FLAG basecamp files document create --verbose type=count
+FLAG basecamp files document list --account type=string
+FLAG basecamp files document list --agent type=bool
+FLAG basecamp files document list --all type=bool
+FLAG basecamp files document list --cache-dir type=string
+FLAG basecamp files document list --count type=bool
+FLAG basecamp files document list --folder type=string
+FLAG basecamp files document list --help type=bool
+FLAG basecamp files document list --hints type=bool
+FLAG basecamp files document list --ids-only type=bool
+FLAG basecamp files document list --in type=string
+FLAG basecamp files document list --jq type=string
+FLAG basecamp files document list --json type=bool
+FLAG basecamp files document list --limit type=int
+FLAG basecamp files document list --markdown type=bool
+FLAG basecamp files document list --md type=bool
+FLAG basecamp files document list --no-hints type=bool
+FLAG basecamp files document list --no-stats type=bool
+FLAG basecamp files document list --page type=int
+FLAG basecamp files document list --profile type=string
+FLAG basecamp files document list --project type=string
+FLAG basecamp files document list --quiet type=bool
+FLAG basecamp files document list --stats type=bool
+FLAG basecamp files document list --styled type=bool
+FLAG basecamp files document list --todolist type=string
+FLAG basecamp files document list --vault type=string
+FLAG basecamp files document list --verbose type=count
 FLAG basecamp files documents --account type=string
 FLAG basecamp files documents --agent type=bool
 FLAG basecamp files documents --all type=bool
 FLAG basecamp files documents --cache-dir type=string
 FLAG basecamp files documents --count type=bool
 FLAG basecamp files documents --folder type=string
+FLAG basecamp files documents --help type=bool
 FLAG basecamp files documents --hints type=bool
 FLAG basecamp files documents --ids-only type=bool
 FLAG basecamp files documents --in type=string
@@ -3077,6 +6991,7 @@ FLAG basecamp files documents create --cache-dir type=string
 FLAG basecamp files documents create --count type=bool
 FLAG basecamp files documents create --draft type=bool
 FLAG basecamp files documents create --folder type=string
+FLAG basecamp files documents create --help type=bool
 FLAG basecamp files documents create --hints type=bool
 FLAG basecamp files documents create --ids-only type=bool
 FLAG basecamp files documents create --in type=string
@@ -3102,6 +7017,7 @@ FLAG basecamp files documents list --all type=bool
 FLAG basecamp files documents list --cache-dir type=string
 FLAG basecamp files documents list --count type=bool
 FLAG basecamp files documents list --folder type=string
+FLAG basecamp files documents list --help type=bool
 FLAG basecamp files documents list --hints type=bool
 FLAG basecamp files documents list --ids-only type=bool
 FLAG basecamp files documents list --in type=string
@@ -3126,6 +7042,7 @@ FLAG basecamp files download --agent type=bool
 FLAG basecamp files download --cache-dir type=string
 FLAG basecamp files download --count type=bool
 FLAG basecamp files download --folder type=string
+FLAG basecamp files download --help type=bool
 FLAG basecamp files download --hints type=bool
 FLAG basecamp files download --ids-only type=bool
 FLAG basecamp files download --in type=string
@@ -3144,12 +7061,88 @@ FLAG basecamp files download --styled type=bool
 FLAG basecamp files download --todolist type=string
 FLAG basecamp files download --vault type=string
 FLAG basecamp files download --verbose type=count
+FLAG basecamp files folder --account type=string
+FLAG basecamp files folder --agent type=bool
+FLAG basecamp files folder --all type=bool
+FLAG basecamp files folder --cache-dir type=string
+FLAG basecamp files folder --count type=bool
+FLAG basecamp files folder --folder type=string
+FLAG basecamp files folder --help type=bool
+FLAG basecamp files folder --hints type=bool
+FLAG basecamp files folder --ids-only type=bool
+FLAG basecamp files folder --in type=string
+FLAG basecamp files folder --jq type=string
+FLAG basecamp files folder --json type=bool
+FLAG basecamp files folder --limit type=int
+FLAG basecamp files folder --markdown type=bool
+FLAG basecamp files folder --md type=bool
+FLAG basecamp files folder --no-hints type=bool
+FLAG basecamp files folder --no-stats type=bool
+FLAG basecamp files folder --page type=int
+FLAG basecamp files folder --profile type=string
+FLAG basecamp files folder --project type=string
+FLAG basecamp files folder --quiet type=bool
+FLAG basecamp files folder --stats type=bool
+FLAG basecamp files folder --styled type=bool
+FLAG basecamp files folder --todolist type=string
+FLAG basecamp files folder --vault type=string
+FLAG basecamp files folder --verbose type=count
+FLAG basecamp files folder create --account type=string
+FLAG basecamp files folder create --agent type=bool
+FLAG basecamp files folder create --cache-dir type=string
+FLAG basecamp files folder create --count type=bool
+FLAG basecamp files folder create --folder type=string
+FLAG basecamp files folder create --help type=bool
+FLAG basecamp files folder create --hints type=bool
+FLAG basecamp files folder create --ids-only type=bool
+FLAG basecamp files folder create --in type=string
+FLAG basecamp files folder create --jq type=string
+FLAG basecamp files folder create --json type=bool
+FLAG basecamp files folder create --markdown type=bool
+FLAG basecamp files folder create --md type=bool
+FLAG basecamp files folder create --no-hints type=bool
+FLAG basecamp files folder create --no-stats type=bool
+FLAG basecamp files folder create --profile type=string
+FLAG basecamp files folder create --project type=string
+FLAG basecamp files folder create --quiet type=bool
+FLAG basecamp files folder create --stats type=bool
+FLAG basecamp files folder create --styled type=bool
+FLAG basecamp files folder create --todolist type=string
+FLAG basecamp files folder create --vault type=string
+FLAG basecamp files folder create --verbose type=count
+FLAG basecamp files folder list --account type=string
+FLAG basecamp files folder list --agent type=bool
+FLAG basecamp files folder list --all type=bool
+FLAG basecamp files folder list --cache-dir type=string
+FLAG basecamp files folder list --count type=bool
+FLAG basecamp files folder list --folder type=string
+FLAG basecamp files folder list --help type=bool
+FLAG basecamp files folder list --hints type=bool
+FLAG basecamp files folder list --ids-only type=bool
+FLAG basecamp files folder list --in type=string
+FLAG basecamp files folder list --jq type=string
+FLAG basecamp files folder list --json type=bool
+FLAG basecamp files folder list --limit type=int
+FLAG basecamp files folder list --markdown type=bool
+FLAG basecamp files folder list --md type=bool
+FLAG basecamp files folder list --no-hints type=bool
+FLAG basecamp files folder list --no-stats type=bool
+FLAG basecamp files folder list --page type=int
+FLAG basecamp files folder list --profile type=string
+FLAG basecamp files folder list --project type=string
+FLAG basecamp files folder list --quiet type=bool
+FLAG basecamp files folder list --stats type=bool
+FLAG basecamp files folder list --styled type=bool
+FLAG basecamp files folder list --todolist type=string
+FLAG basecamp files folder list --vault type=string
+FLAG basecamp files folder list --verbose type=count
 FLAG basecamp files folders --account type=string
 FLAG basecamp files folders --agent type=bool
 FLAG basecamp files folders --all type=bool
 FLAG basecamp files folders --cache-dir type=string
 FLAG basecamp files folders --count type=bool
 FLAG basecamp files folders --folder type=string
+FLAG basecamp files folders --help type=bool
 FLAG basecamp files folders --hints type=bool
 FLAG basecamp files folders --ids-only type=bool
 FLAG basecamp files folders --in type=string
@@ -3174,6 +7167,7 @@ FLAG basecamp files folders create --agent type=bool
 FLAG basecamp files folders create --cache-dir type=string
 FLAG basecamp files folders create --count type=bool
 FLAG basecamp files folders create --folder type=string
+FLAG basecamp files folders create --help type=bool
 FLAG basecamp files folders create --hints type=bool
 FLAG basecamp files folders create --ids-only type=bool
 FLAG basecamp files folders create --in type=string
@@ -3197,6 +7191,7 @@ FLAG basecamp files folders list --all type=bool
 FLAG basecamp files folders list --cache-dir type=string
 FLAG basecamp files folders list --count type=bool
 FLAG basecamp files folders list --folder type=string
+FLAG basecamp files folders list --help type=bool
 FLAG basecamp files folders list --hints type=bool
 FLAG basecamp files folders list --ids-only type=bool
 FLAG basecamp files folders list --in type=string
@@ -3221,6 +7216,7 @@ FLAG basecamp files list --agent type=bool
 FLAG basecamp files list --cache-dir type=string
 FLAG basecamp files list --count type=bool
 FLAG basecamp files list --folder type=string
+FLAG basecamp files list --help type=bool
 FLAG basecamp files list --hints type=bool
 FLAG basecamp files list --ids-only type=bool
 FLAG basecamp files list --in type=string
@@ -3243,6 +7239,7 @@ FLAG basecamp files restore --agent type=bool
 FLAG basecamp files restore --cache-dir type=string
 FLAG basecamp files restore --count type=bool
 FLAG basecamp files restore --folder type=string
+FLAG basecamp files restore --help type=bool
 FLAG basecamp files restore --hints type=bool
 FLAG basecamp files restore --ids-only type=bool
 FLAG basecamp files restore --in type=string
@@ -3265,6 +7262,7 @@ FLAG basecamp files show --agent type=bool
 FLAG basecamp files show --cache-dir type=string
 FLAG basecamp files show --count type=bool
 FLAG basecamp files show --folder type=string
+FLAG basecamp files show --help type=bool
 FLAG basecamp files show --hints type=bool
 FLAG basecamp files show --ids-only type=bool
 FLAG basecamp files show --in type=string
@@ -3288,6 +7286,7 @@ FLAG basecamp files trash --agent type=bool
 FLAG basecamp files trash --cache-dir type=string
 FLAG basecamp files trash --count type=bool
 FLAG basecamp files trash --folder type=string
+FLAG basecamp files trash --help type=bool
 FLAG basecamp files trash --hints type=bool
 FLAG basecamp files trash --ids-only type=bool
 FLAG basecamp files trash --in type=string
@@ -3311,6 +7310,7 @@ FLAG basecamp files update --cache-dir type=string
 FLAG basecamp files update --content type=string
 FLAG basecamp files update --count type=bool
 FLAG basecamp files update --folder type=string
+FLAG basecamp files update --help type=bool
 FLAG basecamp files update --hints type=bool
 FLAG basecamp files update --ids-only type=bool
 FLAG basecamp files update --in type=string
@@ -3330,12 +7330,89 @@ FLAG basecamp files update --todolist type=string
 FLAG basecamp files update --type type=string
 FLAG basecamp files update --vault type=string
 FLAG basecamp files update --verbose type=count
+FLAG basecamp files upload --account type=string
+FLAG basecamp files upload --agent type=bool
+FLAG basecamp files upload --all type=bool
+FLAG basecamp files upload --cache-dir type=string
+FLAG basecamp files upload --count type=bool
+FLAG basecamp files upload --folder type=string
+FLAG basecamp files upload --help type=bool
+FLAG basecamp files upload --hints type=bool
+FLAG basecamp files upload --ids-only type=bool
+FLAG basecamp files upload --in type=string
+FLAG basecamp files upload --jq type=string
+FLAG basecamp files upload --json type=bool
+FLAG basecamp files upload --limit type=int
+FLAG basecamp files upload --markdown type=bool
+FLAG basecamp files upload --md type=bool
+FLAG basecamp files upload --no-hints type=bool
+FLAG basecamp files upload --no-stats type=bool
+FLAG basecamp files upload --page type=int
+FLAG basecamp files upload --profile type=string
+FLAG basecamp files upload --project type=string
+FLAG basecamp files upload --quiet type=bool
+FLAG basecamp files upload --stats type=bool
+FLAG basecamp files upload --styled type=bool
+FLAG basecamp files upload --todolist type=string
+FLAG basecamp files upload --vault type=string
+FLAG basecamp files upload --verbose type=count
+FLAG basecamp files upload create --account type=string
+FLAG basecamp files upload create --agent type=bool
+FLAG basecamp files upload create --cache-dir type=string
+FLAG basecamp files upload create --count type=bool
+FLAG basecamp files upload create --description type=string
+FLAG basecamp files upload create --folder type=string
+FLAG basecamp files upload create --help type=bool
+FLAG basecamp files upload create --hints type=bool
+FLAG basecamp files upload create --ids-only type=bool
+FLAG basecamp files upload create --in type=string
+FLAG basecamp files upload create --jq type=string
+FLAG basecamp files upload create --json type=bool
+FLAG basecamp files upload create --markdown type=bool
+FLAG basecamp files upload create --md type=bool
+FLAG basecamp files upload create --no-hints type=bool
+FLAG basecamp files upload create --no-stats type=bool
+FLAG basecamp files upload create --profile type=string
+FLAG basecamp files upload create --project type=string
+FLAG basecamp files upload create --quiet type=bool
+FLAG basecamp files upload create --stats type=bool
+FLAG basecamp files upload create --styled type=bool
+FLAG basecamp files upload create --todolist type=string
+FLAG basecamp files upload create --vault type=string
+FLAG basecamp files upload create --verbose type=count
+FLAG basecamp files upload list --account type=string
+FLAG basecamp files upload list --agent type=bool
+FLAG basecamp files upload list --all type=bool
+FLAG basecamp files upload list --cache-dir type=string
+FLAG basecamp files upload list --count type=bool
+FLAG basecamp files upload list --folder type=string
+FLAG basecamp files upload list --help type=bool
+FLAG basecamp files upload list --hints type=bool
+FLAG basecamp files upload list --ids-only type=bool
+FLAG basecamp files upload list --in type=string
+FLAG basecamp files upload list --jq type=string
+FLAG basecamp files upload list --json type=bool
+FLAG basecamp files upload list --limit type=int
+FLAG basecamp files upload list --markdown type=bool
+FLAG basecamp files upload list --md type=bool
+FLAG basecamp files upload list --no-hints type=bool
+FLAG basecamp files upload list --no-stats type=bool
+FLAG basecamp files upload list --page type=int
+FLAG basecamp files upload list --profile type=string
+FLAG basecamp files upload list --project type=string
+FLAG basecamp files upload list --quiet type=bool
+FLAG basecamp files upload list --stats type=bool
+FLAG basecamp files upload list --styled type=bool
+FLAG basecamp files upload list --todolist type=string
+FLAG basecamp files upload list --vault type=string
+FLAG basecamp files upload list --verbose type=count
 FLAG basecamp files uploads --account type=string
 FLAG basecamp files uploads --agent type=bool
 FLAG basecamp files uploads --all type=bool
 FLAG basecamp files uploads --cache-dir type=string
 FLAG basecamp files uploads --count type=bool
 FLAG basecamp files uploads --folder type=string
+FLAG basecamp files uploads --help type=bool
 FLAG basecamp files uploads --hints type=bool
 FLAG basecamp files uploads --ids-only type=bool
 FLAG basecamp files uploads --in type=string
@@ -3361,6 +7438,7 @@ FLAG basecamp files uploads create --cache-dir type=string
 FLAG basecamp files uploads create --count type=bool
 FLAG basecamp files uploads create --description type=string
 FLAG basecamp files uploads create --folder type=string
+FLAG basecamp files uploads create --help type=bool
 FLAG basecamp files uploads create --hints type=bool
 FLAG basecamp files uploads create --ids-only type=bool
 FLAG basecamp files uploads create --in type=string
@@ -3384,6 +7462,7 @@ FLAG basecamp files uploads list --all type=bool
 FLAG basecamp files uploads list --cache-dir type=string
 FLAG basecamp files uploads list --count type=bool
 FLAG basecamp files uploads list --folder type=string
+FLAG basecamp files uploads list --help type=bool
 FLAG basecamp files uploads list --hints type=bool
 FLAG basecamp files uploads list --ids-only type=bool
 FLAG basecamp files uploads list --in type=string
@@ -3403,10 +7482,1039 @@ FLAG basecamp files uploads list --styled type=bool
 FLAG basecamp files uploads list --todolist type=string
 FLAG basecamp files uploads list --vault type=string
 FLAG basecamp files uploads list --verbose type=count
+FLAG basecamp files vault --account type=string
+FLAG basecamp files vault --agent type=bool
+FLAG basecamp files vault --all type=bool
+FLAG basecamp files vault --cache-dir type=string
+FLAG basecamp files vault --count type=bool
+FLAG basecamp files vault --folder type=string
+FLAG basecamp files vault --help type=bool
+FLAG basecamp files vault --hints type=bool
+FLAG basecamp files vault --ids-only type=bool
+FLAG basecamp files vault --in type=string
+FLAG basecamp files vault --jq type=string
+FLAG basecamp files vault --json type=bool
+FLAG basecamp files vault --limit type=int
+FLAG basecamp files vault --markdown type=bool
+FLAG basecamp files vault --md type=bool
+FLAG basecamp files vault --no-hints type=bool
+FLAG basecamp files vault --no-stats type=bool
+FLAG basecamp files vault --page type=int
+FLAG basecamp files vault --profile type=string
+FLAG basecamp files vault --project type=string
+FLAG basecamp files vault --quiet type=bool
+FLAG basecamp files vault --stats type=bool
+FLAG basecamp files vault --styled type=bool
+FLAG basecamp files vault --todolist type=string
+FLAG basecamp files vault --vault type=string
+FLAG basecamp files vault --verbose type=count
+FLAG basecamp files vault create --account type=string
+FLAG basecamp files vault create --agent type=bool
+FLAG basecamp files vault create --cache-dir type=string
+FLAG basecamp files vault create --count type=bool
+FLAG basecamp files vault create --folder type=string
+FLAG basecamp files vault create --help type=bool
+FLAG basecamp files vault create --hints type=bool
+FLAG basecamp files vault create --ids-only type=bool
+FLAG basecamp files vault create --in type=string
+FLAG basecamp files vault create --jq type=string
+FLAG basecamp files vault create --json type=bool
+FLAG basecamp files vault create --markdown type=bool
+FLAG basecamp files vault create --md type=bool
+FLAG basecamp files vault create --no-hints type=bool
+FLAG basecamp files vault create --no-stats type=bool
+FLAG basecamp files vault create --profile type=string
+FLAG basecamp files vault create --project type=string
+FLAG basecamp files vault create --quiet type=bool
+FLAG basecamp files vault create --stats type=bool
+FLAG basecamp files vault create --styled type=bool
+FLAG basecamp files vault create --todolist type=string
+FLAG basecamp files vault create --vault type=string
+FLAG basecamp files vault create --verbose type=count
+FLAG basecamp files vault list --account type=string
+FLAG basecamp files vault list --agent type=bool
+FLAG basecamp files vault list --all type=bool
+FLAG basecamp files vault list --cache-dir type=string
+FLAG basecamp files vault list --count type=bool
+FLAG basecamp files vault list --folder type=string
+FLAG basecamp files vault list --help type=bool
+FLAG basecamp files vault list --hints type=bool
+FLAG basecamp files vault list --ids-only type=bool
+FLAG basecamp files vault list --in type=string
+FLAG basecamp files vault list --jq type=string
+FLAG basecamp files vault list --json type=bool
+FLAG basecamp files vault list --limit type=int
+FLAG basecamp files vault list --markdown type=bool
+FLAG basecamp files vault list --md type=bool
+FLAG basecamp files vault list --no-hints type=bool
+FLAG basecamp files vault list --no-stats type=bool
+FLAG basecamp files vault list --page type=int
+FLAG basecamp files vault list --profile type=string
+FLAG basecamp files vault list --project type=string
+FLAG basecamp files vault list --quiet type=bool
+FLAG basecamp files vault list --stats type=bool
+FLAG basecamp files vault list --styled type=bool
+FLAG basecamp files vault list --todolist type=string
+FLAG basecamp files vault list --vault type=string
+FLAG basecamp files vault list --verbose type=count
+FLAG basecamp files vaults --account type=string
+FLAG basecamp files vaults --agent type=bool
+FLAG basecamp files vaults --all type=bool
+FLAG basecamp files vaults --cache-dir type=string
+FLAG basecamp files vaults --count type=bool
+FLAG basecamp files vaults --folder type=string
+FLAG basecamp files vaults --help type=bool
+FLAG basecamp files vaults --hints type=bool
+FLAG basecamp files vaults --ids-only type=bool
+FLAG basecamp files vaults --in type=string
+FLAG basecamp files vaults --jq type=string
+FLAG basecamp files vaults --json type=bool
+FLAG basecamp files vaults --limit type=int
+FLAG basecamp files vaults --markdown type=bool
+FLAG basecamp files vaults --md type=bool
+FLAG basecamp files vaults --no-hints type=bool
+FLAG basecamp files vaults --no-stats type=bool
+FLAG basecamp files vaults --page type=int
+FLAG basecamp files vaults --profile type=string
+FLAG basecamp files vaults --project type=string
+FLAG basecamp files vaults --quiet type=bool
+FLAG basecamp files vaults --stats type=bool
+FLAG basecamp files vaults --styled type=bool
+FLAG basecamp files vaults --todolist type=string
+FLAG basecamp files vaults --vault type=string
+FLAG basecamp files vaults --verbose type=count
+FLAG basecamp files vaults create --account type=string
+FLAG basecamp files vaults create --agent type=bool
+FLAG basecamp files vaults create --cache-dir type=string
+FLAG basecamp files vaults create --count type=bool
+FLAG basecamp files vaults create --folder type=string
+FLAG basecamp files vaults create --help type=bool
+FLAG basecamp files vaults create --hints type=bool
+FLAG basecamp files vaults create --ids-only type=bool
+FLAG basecamp files vaults create --in type=string
+FLAG basecamp files vaults create --jq type=string
+FLAG basecamp files vaults create --json type=bool
+FLAG basecamp files vaults create --markdown type=bool
+FLAG basecamp files vaults create --md type=bool
+FLAG basecamp files vaults create --no-hints type=bool
+FLAG basecamp files vaults create --no-stats type=bool
+FLAG basecamp files vaults create --profile type=string
+FLAG basecamp files vaults create --project type=string
+FLAG basecamp files vaults create --quiet type=bool
+FLAG basecamp files vaults create --stats type=bool
+FLAG basecamp files vaults create --styled type=bool
+FLAG basecamp files vaults create --todolist type=string
+FLAG basecamp files vaults create --vault type=string
+FLAG basecamp files vaults create --verbose type=count
+FLAG basecamp files vaults list --account type=string
+FLAG basecamp files vaults list --agent type=bool
+FLAG basecamp files vaults list --all type=bool
+FLAG basecamp files vaults list --cache-dir type=string
+FLAG basecamp files vaults list --count type=bool
+FLAG basecamp files vaults list --folder type=string
+FLAG basecamp files vaults list --help type=bool
+FLAG basecamp files vaults list --hints type=bool
+FLAG basecamp files vaults list --ids-only type=bool
+FLAG basecamp files vaults list --in type=string
+FLAG basecamp files vaults list --jq type=string
+FLAG basecamp files vaults list --json type=bool
+FLAG basecamp files vaults list --limit type=int
+FLAG basecamp files vaults list --markdown type=bool
+FLAG basecamp files vaults list --md type=bool
+FLAG basecamp files vaults list --no-hints type=bool
+FLAG basecamp files vaults list --no-stats type=bool
+FLAG basecamp files vaults list --page type=int
+FLAG basecamp files vaults list --profile type=string
+FLAG basecamp files vaults list --project type=string
+FLAG basecamp files vaults list --quiet type=bool
+FLAG basecamp files vaults list --stats type=bool
+FLAG basecamp files vaults list --styled type=bool
+FLAG basecamp files vaults list --todolist type=string
+FLAG basecamp files vaults list --vault type=string
+FLAG basecamp files vaults list --verbose type=count
+FLAG basecamp folders --account type=string
+FLAG basecamp folders --agent type=bool
+FLAG basecamp folders --cache-dir type=string
+FLAG basecamp folders --count type=bool
+FLAG basecamp folders --folder type=string
+FLAG basecamp folders --help type=bool
+FLAG basecamp folders --hints type=bool
+FLAG basecamp folders --ids-only type=bool
+FLAG basecamp folders --in type=string
+FLAG basecamp folders --jq type=string
+FLAG basecamp folders --json type=bool
+FLAG basecamp folders --markdown type=bool
+FLAG basecamp folders --md type=bool
+FLAG basecamp folders --no-hints type=bool
+FLAG basecamp folders --no-stats type=bool
+FLAG basecamp folders --profile type=string
+FLAG basecamp folders --project type=string
+FLAG basecamp folders --quiet type=bool
+FLAG basecamp folders --stats type=bool
+FLAG basecamp folders --styled type=bool
+FLAG basecamp folders --todolist type=string
+FLAG basecamp folders --vault type=string
+FLAG basecamp folders --verbose type=count
+FLAG basecamp folders archive --account type=string
+FLAG basecamp folders archive --agent type=bool
+FLAG basecamp folders archive --cache-dir type=string
+FLAG basecamp folders archive --count type=bool
+FLAG basecamp folders archive --folder type=string
+FLAG basecamp folders archive --help type=bool
+FLAG basecamp folders archive --hints type=bool
+FLAG basecamp folders archive --ids-only type=bool
+FLAG basecamp folders archive --in type=string
+FLAG basecamp folders archive --jq type=string
+FLAG basecamp folders archive --json type=bool
+FLAG basecamp folders archive --markdown type=bool
+FLAG basecamp folders archive --md type=bool
+FLAG basecamp folders archive --no-hints type=bool
+FLAG basecamp folders archive --no-stats type=bool
+FLAG basecamp folders archive --profile type=string
+FLAG basecamp folders archive --project type=string
+FLAG basecamp folders archive --quiet type=bool
+FLAG basecamp folders archive --stats type=bool
+FLAG basecamp folders archive --styled type=bool
+FLAG basecamp folders archive --todolist type=string
+FLAG basecamp folders archive --vault type=string
+FLAG basecamp folders archive --verbose type=count
+FLAG basecamp folders doc --account type=string
+FLAG basecamp folders doc --agent type=bool
+FLAG basecamp folders doc --all type=bool
+FLAG basecamp folders doc --cache-dir type=string
+FLAG basecamp folders doc --count type=bool
+FLAG basecamp folders doc --folder type=string
+FLAG basecamp folders doc --help type=bool
+FLAG basecamp folders doc --hints type=bool
+FLAG basecamp folders doc --ids-only type=bool
+FLAG basecamp folders doc --in type=string
+FLAG basecamp folders doc --jq type=string
+FLAG basecamp folders doc --json type=bool
+FLAG basecamp folders doc --limit type=int
+FLAG basecamp folders doc --markdown type=bool
+FLAG basecamp folders doc --md type=bool
+FLAG basecamp folders doc --no-hints type=bool
+FLAG basecamp folders doc --no-stats type=bool
+FLAG basecamp folders doc --page type=int
+FLAG basecamp folders doc --profile type=string
+FLAG basecamp folders doc --project type=string
+FLAG basecamp folders doc --quiet type=bool
+FLAG basecamp folders doc --stats type=bool
+FLAG basecamp folders doc --styled type=bool
+FLAG basecamp folders doc --todolist type=string
+FLAG basecamp folders doc --vault type=string
+FLAG basecamp folders doc --verbose type=count
+FLAG basecamp folders doc create --account type=string
+FLAG basecamp folders doc create --agent type=bool
+FLAG basecamp folders doc create --attach type=stringArray
+FLAG basecamp folders doc create --cache-dir type=string
+FLAG basecamp folders doc create --count type=bool
+FLAG basecamp folders doc create --draft type=bool
+FLAG basecamp folders doc create --folder type=string
+FLAG basecamp folders doc create --help type=bool
+FLAG basecamp folders doc create --hints type=bool
+FLAG basecamp folders doc create --ids-only type=bool
+FLAG basecamp folders doc create --in type=string
+FLAG basecamp folders doc create --jq type=string
+FLAG basecamp folders doc create --json type=bool
+FLAG basecamp folders doc create --markdown type=bool
+FLAG basecamp folders doc create --md type=bool
+FLAG basecamp folders doc create --no-hints type=bool
+FLAG basecamp folders doc create --no-stats type=bool
+FLAG basecamp folders doc create --no-subscribe type=bool
+FLAG basecamp folders doc create --profile type=string
+FLAG basecamp folders doc create --project type=string
+FLAG basecamp folders doc create --quiet type=bool
+FLAG basecamp folders doc create --stats type=bool
+FLAG basecamp folders doc create --styled type=bool
+FLAG basecamp folders doc create --subscribe type=string
+FLAG basecamp folders doc create --todolist type=string
+FLAG basecamp folders doc create --vault type=string
+FLAG basecamp folders doc create --verbose type=count
+FLAG basecamp folders doc list --account type=string
+FLAG basecamp folders doc list --agent type=bool
+FLAG basecamp folders doc list --all type=bool
+FLAG basecamp folders doc list --cache-dir type=string
+FLAG basecamp folders doc list --count type=bool
+FLAG basecamp folders doc list --folder type=string
+FLAG basecamp folders doc list --help type=bool
+FLAG basecamp folders doc list --hints type=bool
+FLAG basecamp folders doc list --ids-only type=bool
+FLAG basecamp folders doc list --in type=string
+FLAG basecamp folders doc list --jq type=string
+FLAG basecamp folders doc list --json type=bool
+FLAG basecamp folders doc list --limit type=int
+FLAG basecamp folders doc list --markdown type=bool
+FLAG basecamp folders doc list --md type=bool
+FLAG basecamp folders doc list --no-hints type=bool
+FLAG basecamp folders doc list --no-stats type=bool
+FLAG basecamp folders doc list --page type=int
+FLAG basecamp folders doc list --profile type=string
+FLAG basecamp folders doc list --project type=string
+FLAG basecamp folders doc list --quiet type=bool
+FLAG basecamp folders doc list --stats type=bool
+FLAG basecamp folders doc list --styled type=bool
+FLAG basecamp folders doc list --todolist type=string
+FLAG basecamp folders doc list --vault type=string
+FLAG basecamp folders doc list --verbose type=count
+FLAG basecamp folders document --account type=string
+FLAG basecamp folders document --agent type=bool
+FLAG basecamp folders document --all type=bool
+FLAG basecamp folders document --cache-dir type=string
+FLAG basecamp folders document --count type=bool
+FLAG basecamp folders document --folder type=string
+FLAG basecamp folders document --help type=bool
+FLAG basecamp folders document --hints type=bool
+FLAG basecamp folders document --ids-only type=bool
+FLAG basecamp folders document --in type=string
+FLAG basecamp folders document --jq type=string
+FLAG basecamp folders document --json type=bool
+FLAG basecamp folders document --limit type=int
+FLAG basecamp folders document --markdown type=bool
+FLAG basecamp folders document --md type=bool
+FLAG basecamp folders document --no-hints type=bool
+FLAG basecamp folders document --no-stats type=bool
+FLAG basecamp folders document --page type=int
+FLAG basecamp folders document --profile type=string
+FLAG basecamp folders document --project type=string
+FLAG basecamp folders document --quiet type=bool
+FLAG basecamp folders document --stats type=bool
+FLAG basecamp folders document --styled type=bool
+FLAG basecamp folders document --todolist type=string
+FLAG basecamp folders document --vault type=string
+FLAG basecamp folders document --verbose type=count
+FLAG basecamp folders document create --account type=string
+FLAG basecamp folders document create --agent type=bool
+FLAG basecamp folders document create --attach type=stringArray
+FLAG basecamp folders document create --cache-dir type=string
+FLAG basecamp folders document create --count type=bool
+FLAG basecamp folders document create --draft type=bool
+FLAG basecamp folders document create --folder type=string
+FLAG basecamp folders document create --help type=bool
+FLAG basecamp folders document create --hints type=bool
+FLAG basecamp folders document create --ids-only type=bool
+FLAG basecamp folders document create --in type=string
+FLAG basecamp folders document create --jq type=string
+FLAG basecamp folders document create --json type=bool
+FLAG basecamp folders document create --markdown type=bool
+FLAG basecamp folders document create --md type=bool
+FLAG basecamp folders document create --no-hints type=bool
+FLAG basecamp folders document create --no-stats type=bool
+FLAG basecamp folders document create --no-subscribe type=bool
+FLAG basecamp folders document create --profile type=string
+FLAG basecamp folders document create --project type=string
+FLAG basecamp folders document create --quiet type=bool
+FLAG basecamp folders document create --stats type=bool
+FLAG basecamp folders document create --styled type=bool
+FLAG basecamp folders document create --subscribe type=string
+FLAG basecamp folders document create --todolist type=string
+FLAG basecamp folders document create --vault type=string
+FLAG basecamp folders document create --verbose type=count
+FLAG basecamp folders document list --account type=string
+FLAG basecamp folders document list --agent type=bool
+FLAG basecamp folders document list --all type=bool
+FLAG basecamp folders document list --cache-dir type=string
+FLAG basecamp folders document list --count type=bool
+FLAG basecamp folders document list --folder type=string
+FLAG basecamp folders document list --help type=bool
+FLAG basecamp folders document list --hints type=bool
+FLAG basecamp folders document list --ids-only type=bool
+FLAG basecamp folders document list --in type=string
+FLAG basecamp folders document list --jq type=string
+FLAG basecamp folders document list --json type=bool
+FLAG basecamp folders document list --limit type=int
+FLAG basecamp folders document list --markdown type=bool
+FLAG basecamp folders document list --md type=bool
+FLAG basecamp folders document list --no-hints type=bool
+FLAG basecamp folders document list --no-stats type=bool
+FLAG basecamp folders document list --page type=int
+FLAG basecamp folders document list --profile type=string
+FLAG basecamp folders document list --project type=string
+FLAG basecamp folders document list --quiet type=bool
+FLAG basecamp folders document list --stats type=bool
+FLAG basecamp folders document list --styled type=bool
+FLAG basecamp folders document list --todolist type=string
+FLAG basecamp folders document list --vault type=string
+FLAG basecamp folders document list --verbose type=count
+FLAG basecamp folders documents --account type=string
+FLAG basecamp folders documents --agent type=bool
+FLAG basecamp folders documents --all type=bool
+FLAG basecamp folders documents --cache-dir type=string
+FLAG basecamp folders documents --count type=bool
+FLAG basecamp folders documents --folder type=string
+FLAG basecamp folders documents --help type=bool
+FLAG basecamp folders documents --hints type=bool
+FLAG basecamp folders documents --ids-only type=bool
+FLAG basecamp folders documents --in type=string
+FLAG basecamp folders documents --jq type=string
+FLAG basecamp folders documents --json type=bool
+FLAG basecamp folders documents --limit type=int
+FLAG basecamp folders documents --markdown type=bool
+FLAG basecamp folders documents --md type=bool
+FLAG basecamp folders documents --no-hints type=bool
+FLAG basecamp folders documents --no-stats type=bool
+FLAG basecamp folders documents --page type=int
+FLAG basecamp folders documents --profile type=string
+FLAG basecamp folders documents --project type=string
+FLAG basecamp folders documents --quiet type=bool
+FLAG basecamp folders documents --stats type=bool
+FLAG basecamp folders documents --styled type=bool
+FLAG basecamp folders documents --todolist type=string
+FLAG basecamp folders documents --vault type=string
+FLAG basecamp folders documents --verbose type=count
+FLAG basecamp folders documents create --account type=string
+FLAG basecamp folders documents create --agent type=bool
+FLAG basecamp folders documents create --attach type=stringArray
+FLAG basecamp folders documents create --cache-dir type=string
+FLAG basecamp folders documents create --count type=bool
+FLAG basecamp folders documents create --draft type=bool
+FLAG basecamp folders documents create --folder type=string
+FLAG basecamp folders documents create --help type=bool
+FLAG basecamp folders documents create --hints type=bool
+FLAG basecamp folders documents create --ids-only type=bool
+FLAG basecamp folders documents create --in type=string
+FLAG basecamp folders documents create --jq type=string
+FLAG basecamp folders documents create --json type=bool
+FLAG basecamp folders documents create --markdown type=bool
+FLAG basecamp folders documents create --md type=bool
+FLAG basecamp folders documents create --no-hints type=bool
+FLAG basecamp folders documents create --no-stats type=bool
+FLAG basecamp folders documents create --no-subscribe type=bool
+FLAG basecamp folders documents create --profile type=string
+FLAG basecamp folders documents create --project type=string
+FLAG basecamp folders documents create --quiet type=bool
+FLAG basecamp folders documents create --stats type=bool
+FLAG basecamp folders documents create --styled type=bool
+FLAG basecamp folders documents create --subscribe type=string
+FLAG basecamp folders documents create --todolist type=string
+FLAG basecamp folders documents create --vault type=string
+FLAG basecamp folders documents create --verbose type=count
+FLAG basecamp folders documents list --account type=string
+FLAG basecamp folders documents list --agent type=bool
+FLAG basecamp folders documents list --all type=bool
+FLAG basecamp folders documents list --cache-dir type=string
+FLAG basecamp folders documents list --count type=bool
+FLAG basecamp folders documents list --folder type=string
+FLAG basecamp folders documents list --help type=bool
+FLAG basecamp folders documents list --hints type=bool
+FLAG basecamp folders documents list --ids-only type=bool
+FLAG basecamp folders documents list --in type=string
+FLAG basecamp folders documents list --jq type=string
+FLAG basecamp folders documents list --json type=bool
+FLAG basecamp folders documents list --limit type=int
+FLAG basecamp folders documents list --markdown type=bool
+FLAG basecamp folders documents list --md type=bool
+FLAG basecamp folders documents list --no-hints type=bool
+FLAG basecamp folders documents list --no-stats type=bool
+FLAG basecamp folders documents list --page type=int
+FLAG basecamp folders documents list --profile type=string
+FLAG basecamp folders documents list --project type=string
+FLAG basecamp folders documents list --quiet type=bool
+FLAG basecamp folders documents list --stats type=bool
+FLAG basecamp folders documents list --styled type=bool
+FLAG basecamp folders documents list --todolist type=string
+FLAG basecamp folders documents list --vault type=string
+FLAG basecamp folders documents list --verbose type=count
+FLAG basecamp folders download --account type=string
+FLAG basecamp folders download --agent type=bool
+FLAG basecamp folders download --cache-dir type=string
+FLAG basecamp folders download --count type=bool
+FLAG basecamp folders download --folder type=string
+FLAG basecamp folders download --help type=bool
+FLAG basecamp folders download --hints type=bool
+FLAG basecamp folders download --ids-only type=bool
+FLAG basecamp folders download --in type=string
+FLAG basecamp folders download --jq type=string
+FLAG basecamp folders download --json type=bool
+FLAG basecamp folders download --markdown type=bool
+FLAG basecamp folders download --md type=bool
+FLAG basecamp folders download --no-hints type=bool
+FLAG basecamp folders download --no-stats type=bool
+FLAG basecamp folders download --out type=string
+FLAG basecamp folders download --profile type=string
+FLAG basecamp folders download --project type=string
+FLAG basecamp folders download --quiet type=bool
+FLAG basecamp folders download --stats type=bool
+FLAG basecamp folders download --styled type=bool
+FLAG basecamp folders download --todolist type=string
+FLAG basecamp folders download --vault type=string
+FLAG basecamp folders download --verbose type=count
+FLAG basecamp folders folder --account type=string
+FLAG basecamp folders folder --agent type=bool
+FLAG basecamp folders folder --all type=bool
+FLAG basecamp folders folder --cache-dir type=string
+FLAG basecamp folders folder --count type=bool
+FLAG basecamp folders folder --folder type=string
+FLAG basecamp folders folder --help type=bool
+FLAG basecamp folders folder --hints type=bool
+FLAG basecamp folders folder --ids-only type=bool
+FLAG basecamp folders folder --in type=string
+FLAG basecamp folders folder --jq type=string
+FLAG basecamp folders folder --json type=bool
+FLAG basecamp folders folder --limit type=int
+FLAG basecamp folders folder --markdown type=bool
+FLAG basecamp folders folder --md type=bool
+FLAG basecamp folders folder --no-hints type=bool
+FLAG basecamp folders folder --no-stats type=bool
+FLAG basecamp folders folder --page type=int
+FLAG basecamp folders folder --profile type=string
+FLAG basecamp folders folder --project type=string
+FLAG basecamp folders folder --quiet type=bool
+FLAG basecamp folders folder --stats type=bool
+FLAG basecamp folders folder --styled type=bool
+FLAG basecamp folders folder --todolist type=string
+FLAG basecamp folders folder --vault type=string
+FLAG basecamp folders folder --verbose type=count
+FLAG basecamp folders folder create --account type=string
+FLAG basecamp folders folder create --agent type=bool
+FLAG basecamp folders folder create --cache-dir type=string
+FLAG basecamp folders folder create --count type=bool
+FLAG basecamp folders folder create --folder type=string
+FLAG basecamp folders folder create --help type=bool
+FLAG basecamp folders folder create --hints type=bool
+FLAG basecamp folders folder create --ids-only type=bool
+FLAG basecamp folders folder create --in type=string
+FLAG basecamp folders folder create --jq type=string
+FLAG basecamp folders folder create --json type=bool
+FLAG basecamp folders folder create --markdown type=bool
+FLAG basecamp folders folder create --md type=bool
+FLAG basecamp folders folder create --no-hints type=bool
+FLAG basecamp folders folder create --no-stats type=bool
+FLAG basecamp folders folder create --profile type=string
+FLAG basecamp folders folder create --project type=string
+FLAG basecamp folders folder create --quiet type=bool
+FLAG basecamp folders folder create --stats type=bool
+FLAG basecamp folders folder create --styled type=bool
+FLAG basecamp folders folder create --todolist type=string
+FLAG basecamp folders folder create --vault type=string
+FLAG basecamp folders folder create --verbose type=count
+FLAG basecamp folders folder list --account type=string
+FLAG basecamp folders folder list --agent type=bool
+FLAG basecamp folders folder list --all type=bool
+FLAG basecamp folders folder list --cache-dir type=string
+FLAG basecamp folders folder list --count type=bool
+FLAG basecamp folders folder list --folder type=string
+FLAG basecamp folders folder list --help type=bool
+FLAG basecamp folders folder list --hints type=bool
+FLAG basecamp folders folder list --ids-only type=bool
+FLAG basecamp folders folder list --in type=string
+FLAG basecamp folders folder list --jq type=string
+FLAG basecamp folders folder list --json type=bool
+FLAG basecamp folders folder list --limit type=int
+FLAG basecamp folders folder list --markdown type=bool
+FLAG basecamp folders folder list --md type=bool
+FLAG basecamp folders folder list --no-hints type=bool
+FLAG basecamp folders folder list --no-stats type=bool
+FLAG basecamp folders folder list --page type=int
+FLAG basecamp folders folder list --profile type=string
+FLAG basecamp folders folder list --project type=string
+FLAG basecamp folders folder list --quiet type=bool
+FLAG basecamp folders folder list --stats type=bool
+FLAG basecamp folders folder list --styled type=bool
+FLAG basecamp folders folder list --todolist type=string
+FLAG basecamp folders folder list --vault type=string
+FLAG basecamp folders folder list --verbose type=count
+FLAG basecamp folders folders --account type=string
+FLAG basecamp folders folders --agent type=bool
+FLAG basecamp folders folders --all type=bool
+FLAG basecamp folders folders --cache-dir type=string
+FLAG basecamp folders folders --count type=bool
+FLAG basecamp folders folders --folder type=string
+FLAG basecamp folders folders --help type=bool
+FLAG basecamp folders folders --hints type=bool
+FLAG basecamp folders folders --ids-only type=bool
+FLAG basecamp folders folders --in type=string
+FLAG basecamp folders folders --jq type=string
+FLAG basecamp folders folders --json type=bool
+FLAG basecamp folders folders --limit type=int
+FLAG basecamp folders folders --markdown type=bool
+FLAG basecamp folders folders --md type=bool
+FLAG basecamp folders folders --no-hints type=bool
+FLAG basecamp folders folders --no-stats type=bool
+FLAG basecamp folders folders --page type=int
+FLAG basecamp folders folders --profile type=string
+FLAG basecamp folders folders --project type=string
+FLAG basecamp folders folders --quiet type=bool
+FLAG basecamp folders folders --stats type=bool
+FLAG basecamp folders folders --styled type=bool
+FLAG basecamp folders folders --todolist type=string
+FLAG basecamp folders folders --vault type=string
+FLAG basecamp folders folders --verbose type=count
+FLAG basecamp folders folders create --account type=string
+FLAG basecamp folders folders create --agent type=bool
+FLAG basecamp folders folders create --cache-dir type=string
+FLAG basecamp folders folders create --count type=bool
+FLAG basecamp folders folders create --folder type=string
+FLAG basecamp folders folders create --help type=bool
+FLAG basecamp folders folders create --hints type=bool
+FLAG basecamp folders folders create --ids-only type=bool
+FLAG basecamp folders folders create --in type=string
+FLAG basecamp folders folders create --jq type=string
+FLAG basecamp folders folders create --json type=bool
+FLAG basecamp folders folders create --markdown type=bool
+FLAG basecamp folders folders create --md type=bool
+FLAG basecamp folders folders create --no-hints type=bool
+FLAG basecamp folders folders create --no-stats type=bool
+FLAG basecamp folders folders create --profile type=string
+FLAG basecamp folders folders create --project type=string
+FLAG basecamp folders folders create --quiet type=bool
+FLAG basecamp folders folders create --stats type=bool
+FLAG basecamp folders folders create --styled type=bool
+FLAG basecamp folders folders create --todolist type=string
+FLAG basecamp folders folders create --vault type=string
+FLAG basecamp folders folders create --verbose type=count
+FLAG basecamp folders folders list --account type=string
+FLAG basecamp folders folders list --agent type=bool
+FLAG basecamp folders folders list --all type=bool
+FLAG basecamp folders folders list --cache-dir type=string
+FLAG basecamp folders folders list --count type=bool
+FLAG basecamp folders folders list --folder type=string
+FLAG basecamp folders folders list --help type=bool
+FLAG basecamp folders folders list --hints type=bool
+FLAG basecamp folders folders list --ids-only type=bool
+FLAG basecamp folders folders list --in type=string
+FLAG basecamp folders folders list --jq type=string
+FLAG basecamp folders folders list --json type=bool
+FLAG basecamp folders folders list --limit type=int
+FLAG basecamp folders folders list --markdown type=bool
+FLAG basecamp folders folders list --md type=bool
+FLAG basecamp folders folders list --no-hints type=bool
+FLAG basecamp folders folders list --no-stats type=bool
+FLAG basecamp folders folders list --page type=int
+FLAG basecamp folders folders list --profile type=string
+FLAG basecamp folders folders list --project type=string
+FLAG basecamp folders folders list --quiet type=bool
+FLAG basecamp folders folders list --stats type=bool
+FLAG basecamp folders folders list --styled type=bool
+FLAG basecamp folders folders list --todolist type=string
+FLAG basecamp folders folders list --vault type=string
+FLAG basecamp folders folders list --verbose type=count
+FLAG basecamp folders list --account type=string
+FLAG basecamp folders list --agent type=bool
+FLAG basecamp folders list --cache-dir type=string
+FLAG basecamp folders list --count type=bool
+FLAG basecamp folders list --folder type=string
+FLAG basecamp folders list --help type=bool
+FLAG basecamp folders list --hints type=bool
+FLAG basecamp folders list --ids-only type=bool
+FLAG basecamp folders list --in type=string
+FLAG basecamp folders list --jq type=string
+FLAG basecamp folders list --json type=bool
+FLAG basecamp folders list --markdown type=bool
+FLAG basecamp folders list --md type=bool
+FLAG basecamp folders list --no-hints type=bool
+FLAG basecamp folders list --no-stats type=bool
+FLAG basecamp folders list --profile type=string
+FLAG basecamp folders list --project type=string
+FLAG basecamp folders list --quiet type=bool
+FLAG basecamp folders list --stats type=bool
+FLAG basecamp folders list --styled type=bool
+FLAG basecamp folders list --todolist type=string
+FLAG basecamp folders list --vault type=string
+FLAG basecamp folders list --verbose type=count
+FLAG basecamp folders restore --account type=string
+FLAG basecamp folders restore --agent type=bool
+FLAG basecamp folders restore --cache-dir type=string
+FLAG basecamp folders restore --count type=bool
+FLAG basecamp folders restore --folder type=string
+FLAG basecamp folders restore --help type=bool
+FLAG basecamp folders restore --hints type=bool
+FLAG basecamp folders restore --ids-only type=bool
+FLAG basecamp folders restore --in type=string
+FLAG basecamp folders restore --jq type=string
+FLAG basecamp folders restore --json type=bool
+FLAG basecamp folders restore --markdown type=bool
+FLAG basecamp folders restore --md type=bool
+FLAG basecamp folders restore --no-hints type=bool
+FLAG basecamp folders restore --no-stats type=bool
+FLAG basecamp folders restore --profile type=string
+FLAG basecamp folders restore --project type=string
+FLAG basecamp folders restore --quiet type=bool
+FLAG basecamp folders restore --stats type=bool
+FLAG basecamp folders restore --styled type=bool
+FLAG basecamp folders restore --todolist type=string
+FLAG basecamp folders restore --vault type=string
+FLAG basecamp folders restore --verbose type=count
+FLAG basecamp folders show --account type=string
+FLAG basecamp folders show --agent type=bool
+FLAG basecamp folders show --cache-dir type=string
+FLAG basecamp folders show --count type=bool
+FLAG basecamp folders show --folder type=string
+FLAG basecamp folders show --help type=bool
+FLAG basecamp folders show --hints type=bool
+FLAG basecamp folders show --ids-only type=bool
+FLAG basecamp folders show --in type=string
+FLAG basecamp folders show --jq type=string
+FLAG basecamp folders show --json type=bool
+FLAG basecamp folders show --markdown type=bool
+FLAG basecamp folders show --md type=bool
+FLAG basecamp folders show --no-hints type=bool
+FLAG basecamp folders show --no-stats type=bool
+FLAG basecamp folders show --profile type=string
+FLAG basecamp folders show --project type=string
+FLAG basecamp folders show --quiet type=bool
+FLAG basecamp folders show --stats type=bool
+FLAG basecamp folders show --styled type=bool
+FLAG basecamp folders show --todolist type=string
+FLAG basecamp folders show --type type=string
+FLAG basecamp folders show --vault type=string
+FLAG basecamp folders show --verbose type=count
+FLAG basecamp folders trash --account type=string
+FLAG basecamp folders trash --agent type=bool
+FLAG basecamp folders trash --cache-dir type=string
+FLAG basecamp folders trash --count type=bool
+FLAG basecamp folders trash --folder type=string
+FLAG basecamp folders trash --help type=bool
+FLAG basecamp folders trash --hints type=bool
+FLAG basecamp folders trash --ids-only type=bool
+FLAG basecamp folders trash --in type=string
+FLAG basecamp folders trash --jq type=string
+FLAG basecamp folders trash --json type=bool
+FLAG basecamp folders trash --markdown type=bool
+FLAG basecamp folders trash --md type=bool
+FLAG basecamp folders trash --no-hints type=bool
+FLAG basecamp folders trash --no-stats type=bool
+FLAG basecamp folders trash --profile type=string
+FLAG basecamp folders trash --project type=string
+FLAG basecamp folders trash --quiet type=bool
+FLAG basecamp folders trash --stats type=bool
+FLAG basecamp folders trash --styled type=bool
+FLAG basecamp folders trash --todolist type=string
+FLAG basecamp folders trash --vault type=string
+FLAG basecamp folders trash --verbose type=count
+FLAG basecamp folders update --account type=string
+FLAG basecamp folders update --agent type=bool
+FLAG basecamp folders update --cache-dir type=string
+FLAG basecamp folders update --content type=string
+FLAG basecamp folders update --count type=bool
+FLAG basecamp folders update --folder type=string
+FLAG basecamp folders update --help type=bool
+FLAG basecamp folders update --hints type=bool
+FLAG basecamp folders update --ids-only type=bool
+FLAG basecamp folders update --in type=string
+FLAG basecamp folders update --jq type=string
+FLAG basecamp folders update --json type=bool
+FLAG basecamp folders update --markdown type=bool
+FLAG basecamp folders update --md type=bool
+FLAG basecamp folders update --no-hints type=bool
+FLAG basecamp folders update --no-stats type=bool
+FLAG basecamp folders update --profile type=string
+FLAG basecamp folders update --project type=string
+FLAG basecamp folders update --quiet type=bool
+FLAG basecamp folders update --stats type=bool
+FLAG basecamp folders update --styled type=bool
+FLAG basecamp folders update --title type=string
+FLAG basecamp folders update --todolist type=string
+FLAG basecamp folders update --type type=string
+FLAG basecamp folders update --vault type=string
+FLAG basecamp folders update --verbose type=count
+FLAG basecamp folders upload --account type=string
+FLAG basecamp folders upload --agent type=bool
+FLAG basecamp folders upload --all type=bool
+FLAG basecamp folders upload --cache-dir type=string
+FLAG basecamp folders upload --count type=bool
+FLAG basecamp folders upload --folder type=string
+FLAG basecamp folders upload --help type=bool
+FLAG basecamp folders upload --hints type=bool
+FLAG basecamp folders upload --ids-only type=bool
+FLAG basecamp folders upload --in type=string
+FLAG basecamp folders upload --jq type=string
+FLAG basecamp folders upload --json type=bool
+FLAG basecamp folders upload --limit type=int
+FLAG basecamp folders upload --markdown type=bool
+FLAG basecamp folders upload --md type=bool
+FLAG basecamp folders upload --no-hints type=bool
+FLAG basecamp folders upload --no-stats type=bool
+FLAG basecamp folders upload --page type=int
+FLAG basecamp folders upload --profile type=string
+FLAG basecamp folders upload --project type=string
+FLAG basecamp folders upload --quiet type=bool
+FLAG basecamp folders upload --stats type=bool
+FLAG basecamp folders upload --styled type=bool
+FLAG basecamp folders upload --todolist type=string
+FLAG basecamp folders upload --vault type=string
+FLAG basecamp folders upload --verbose type=count
+FLAG basecamp folders upload create --account type=string
+FLAG basecamp folders upload create --agent type=bool
+FLAG basecamp folders upload create --cache-dir type=string
+FLAG basecamp folders upload create --count type=bool
+FLAG basecamp folders upload create --description type=string
+FLAG basecamp folders upload create --folder type=string
+FLAG basecamp folders upload create --help type=bool
+FLAG basecamp folders upload create --hints type=bool
+FLAG basecamp folders upload create --ids-only type=bool
+FLAG basecamp folders upload create --in type=string
+FLAG basecamp folders upload create --jq type=string
+FLAG basecamp folders upload create --json type=bool
+FLAG basecamp folders upload create --markdown type=bool
+FLAG basecamp folders upload create --md type=bool
+FLAG basecamp folders upload create --no-hints type=bool
+FLAG basecamp folders upload create --no-stats type=bool
+FLAG basecamp folders upload create --profile type=string
+FLAG basecamp folders upload create --project type=string
+FLAG basecamp folders upload create --quiet type=bool
+FLAG basecamp folders upload create --stats type=bool
+FLAG basecamp folders upload create --styled type=bool
+FLAG basecamp folders upload create --todolist type=string
+FLAG basecamp folders upload create --vault type=string
+FLAG basecamp folders upload create --verbose type=count
+FLAG basecamp folders upload list --account type=string
+FLAG basecamp folders upload list --agent type=bool
+FLAG basecamp folders upload list --all type=bool
+FLAG basecamp folders upload list --cache-dir type=string
+FLAG basecamp folders upload list --count type=bool
+FLAG basecamp folders upload list --folder type=string
+FLAG basecamp folders upload list --help type=bool
+FLAG basecamp folders upload list --hints type=bool
+FLAG basecamp folders upload list --ids-only type=bool
+FLAG basecamp folders upload list --in type=string
+FLAG basecamp folders upload list --jq type=string
+FLAG basecamp folders upload list --json type=bool
+FLAG basecamp folders upload list --limit type=int
+FLAG basecamp folders upload list --markdown type=bool
+FLAG basecamp folders upload list --md type=bool
+FLAG basecamp folders upload list --no-hints type=bool
+FLAG basecamp folders upload list --no-stats type=bool
+FLAG basecamp folders upload list --page type=int
+FLAG basecamp folders upload list --profile type=string
+FLAG basecamp folders upload list --project type=string
+FLAG basecamp folders upload list --quiet type=bool
+FLAG basecamp folders upload list --stats type=bool
+FLAG basecamp folders upload list --styled type=bool
+FLAG basecamp folders upload list --todolist type=string
+FLAG basecamp folders upload list --vault type=string
+FLAG basecamp folders upload list --verbose type=count
+FLAG basecamp folders uploads --account type=string
+FLAG basecamp folders uploads --agent type=bool
+FLAG basecamp folders uploads --all type=bool
+FLAG basecamp folders uploads --cache-dir type=string
+FLAG basecamp folders uploads --count type=bool
+FLAG basecamp folders uploads --folder type=string
+FLAG basecamp folders uploads --help type=bool
+FLAG basecamp folders uploads --hints type=bool
+FLAG basecamp folders uploads --ids-only type=bool
+FLAG basecamp folders uploads --in type=string
+FLAG basecamp folders uploads --jq type=string
+FLAG basecamp folders uploads --json type=bool
+FLAG basecamp folders uploads --limit type=int
+FLAG basecamp folders uploads --markdown type=bool
+FLAG basecamp folders uploads --md type=bool
+FLAG basecamp folders uploads --no-hints type=bool
+FLAG basecamp folders uploads --no-stats type=bool
+FLAG basecamp folders uploads --page type=int
+FLAG basecamp folders uploads --profile type=string
+FLAG basecamp folders uploads --project type=string
+FLAG basecamp folders uploads --quiet type=bool
+FLAG basecamp folders uploads --stats type=bool
+FLAG basecamp folders uploads --styled type=bool
+FLAG basecamp folders uploads --todolist type=string
+FLAG basecamp folders uploads --vault type=string
+FLAG basecamp folders uploads --verbose type=count
+FLAG basecamp folders uploads create --account type=string
+FLAG basecamp folders uploads create --agent type=bool
+FLAG basecamp folders uploads create --cache-dir type=string
+FLAG basecamp folders uploads create --count type=bool
+FLAG basecamp folders uploads create --description type=string
+FLAG basecamp folders uploads create --folder type=string
+FLAG basecamp folders uploads create --help type=bool
+FLAG basecamp folders uploads create --hints type=bool
+FLAG basecamp folders uploads create --ids-only type=bool
+FLAG basecamp folders uploads create --in type=string
+FLAG basecamp folders uploads create --jq type=string
+FLAG basecamp folders uploads create --json type=bool
+FLAG basecamp folders uploads create --markdown type=bool
+FLAG basecamp folders uploads create --md type=bool
+FLAG basecamp folders uploads create --no-hints type=bool
+FLAG basecamp folders uploads create --no-stats type=bool
+FLAG basecamp folders uploads create --profile type=string
+FLAG basecamp folders uploads create --project type=string
+FLAG basecamp folders uploads create --quiet type=bool
+FLAG basecamp folders uploads create --stats type=bool
+FLAG basecamp folders uploads create --styled type=bool
+FLAG basecamp folders uploads create --todolist type=string
+FLAG basecamp folders uploads create --vault type=string
+FLAG basecamp folders uploads create --verbose type=count
+FLAG basecamp folders uploads list --account type=string
+FLAG basecamp folders uploads list --agent type=bool
+FLAG basecamp folders uploads list --all type=bool
+FLAG basecamp folders uploads list --cache-dir type=string
+FLAG basecamp folders uploads list --count type=bool
+FLAG basecamp folders uploads list --folder type=string
+FLAG basecamp folders uploads list --help type=bool
+FLAG basecamp folders uploads list --hints type=bool
+FLAG basecamp folders uploads list --ids-only type=bool
+FLAG basecamp folders uploads list --in type=string
+FLAG basecamp folders uploads list --jq type=string
+FLAG basecamp folders uploads list --json type=bool
+FLAG basecamp folders uploads list --limit type=int
+FLAG basecamp folders uploads list --markdown type=bool
+FLAG basecamp folders uploads list --md type=bool
+FLAG basecamp folders uploads list --no-hints type=bool
+FLAG basecamp folders uploads list --no-stats type=bool
+FLAG basecamp folders uploads list --page type=int
+FLAG basecamp folders uploads list --profile type=string
+FLAG basecamp folders uploads list --project type=string
+FLAG basecamp folders uploads list --quiet type=bool
+FLAG basecamp folders uploads list --stats type=bool
+FLAG basecamp folders uploads list --styled type=bool
+FLAG basecamp folders uploads list --todolist type=string
+FLAG basecamp folders uploads list --vault type=string
+FLAG basecamp folders uploads list --verbose type=count
+FLAG basecamp folders vault --account type=string
+FLAG basecamp folders vault --agent type=bool
+FLAG basecamp folders vault --all type=bool
+FLAG basecamp folders vault --cache-dir type=string
+FLAG basecamp folders vault --count type=bool
+FLAG basecamp folders vault --folder type=string
+FLAG basecamp folders vault --help type=bool
+FLAG basecamp folders vault --hints type=bool
+FLAG basecamp folders vault --ids-only type=bool
+FLAG basecamp folders vault --in type=string
+FLAG basecamp folders vault --jq type=string
+FLAG basecamp folders vault --json type=bool
+FLAG basecamp folders vault --limit type=int
+FLAG basecamp folders vault --markdown type=bool
+FLAG basecamp folders vault --md type=bool
+FLAG basecamp folders vault --no-hints type=bool
+FLAG basecamp folders vault --no-stats type=bool
+FLAG basecamp folders vault --page type=int
+FLAG basecamp folders vault --profile type=string
+FLAG basecamp folders vault --project type=string
+FLAG basecamp folders vault --quiet type=bool
+FLAG basecamp folders vault --stats type=bool
+FLAG basecamp folders vault --styled type=bool
+FLAG basecamp folders vault --todolist type=string
+FLAG basecamp folders vault --vault type=string
+FLAG basecamp folders vault --verbose type=count
+FLAG basecamp folders vault create --account type=string
+FLAG basecamp folders vault create --agent type=bool
+FLAG basecamp folders vault create --cache-dir type=string
+FLAG basecamp folders vault create --count type=bool
+FLAG basecamp folders vault create --folder type=string
+FLAG basecamp folders vault create --help type=bool
+FLAG basecamp folders vault create --hints type=bool
+FLAG basecamp folders vault create --ids-only type=bool
+FLAG basecamp folders vault create --in type=string
+FLAG basecamp folders vault create --jq type=string
+FLAG basecamp folders vault create --json type=bool
+FLAG basecamp folders vault create --markdown type=bool
+FLAG basecamp folders vault create --md type=bool
+FLAG basecamp folders vault create --no-hints type=bool
+FLAG basecamp folders vault create --no-stats type=bool
+FLAG basecamp folders vault create --profile type=string
+FLAG basecamp folders vault create --project type=string
+FLAG basecamp folders vault create --quiet type=bool
+FLAG basecamp folders vault create --stats type=bool
+FLAG basecamp folders vault create --styled type=bool
+FLAG basecamp folders vault create --todolist type=string
+FLAG basecamp folders vault create --vault type=string
+FLAG basecamp folders vault create --verbose type=count
+FLAG basecamp folders vault list --account type=string
+FLAG basecamp folders vault list --agent type=bool
+FLAG basecamp folders vault list --all type=bool
+FLAG basecamp folders vault list --cache-dir type=string
+FLAG basecamp folders vault list --count type=bool
+FLAG basecamp folders vault list --folder type=string
+FLAG basecamp folders vault list --help type=bool
+FLAG basecamp folders vault list --hints type=bool
+FLAG basecamp folders vault list --ids-only type=bool
+FLAG basecamp folders vault list --in type=string
+FLAG basecamp folders vault list --jq type=string
+FLAG basecamp folders vault list --json type=bool
+FLAG basecamp folders vault list --limit type=int
+FLAG basecamp folders vault list --markdown type=bool
+FLAG basecamp folders vault list --md type=bool
+FLAG basecamp folders vault list --no-hints type=bool
+FLAG basecamp folders vault list --no-stats type=bool
+FLAG basecamp folders vault list --page type=int
+FLAG basecamp folders vault list --profile type=string
+FLAG basecamp folders vault list --project type=string
+FLAG basecamp folders vault list --quiet type=bool
+FLAG basecamp folders vault list --stats type=bool
+FLAG basecamp folders vault list --styled type=bool
+FLAG basecamp folders vault list --todolist type=string
+FLAG basecamp folders vault list --vault type=string
+FLAG basecamp folders vault list --verbose type=count
+FLAG basecamp folders vaults --account type=string
+FLAG basecamp folders vaults --agent type=bool
+FLAG basecamp folders vaults --all type=bool
+FLAG basecamp folders vaults --cache-dir type=string
+FLAG basecamp folders vaults --count type=bool
+FLAG basecamp folders vaults --folder type=string
+FLAG basecamp folders vaults --help type=bool
+FLAG basecamp folders vaults --hints type=bool
+FLAG basecamp folders vaults --ids-only type=bool
+FLAG basecamp folders vaults --in type=string
+FLAG basecamp folders vaults --jq type=string
+FLAG basecamp folders vaults --json type=bool
+FLAG basecamp folders vaults --limit type=int
+FLAG basecamp folders vaults --markdown type=bool
+FLAG basecamp folders vaults --md type=bool
+FLAG basecamp folders vaults --no-hints type=bool
+FLAG basecamp folders vaults --no-stats type=bool
+FLAG basecamp folders vaults --page type=int
+FLAG basecamp folders vaults --profile type=string
+FLAG basecamp folders vaults --project type=string
+FLAG basecamp folders vaults --quiet type=bool
+FLAG basecamp folders vaults --stats type=bool
+FLAG basecamp folders vaults --styled type=bool
+FLAG basecamp folders vaults --todolist type=string
+FLAG basecamp folders vaults --vault type=string
+FLAG basecamp folders vaults --verbose type=count
+FLAG basecamp folders vaults create --account type=string
+FLAG basecamp folders vaults create --agent type=bool
+FLAG basecamp folders vaults create --cache-dir type=string
+FLAG basecamp folders vaults create --count type=bool
+FLAG basecamp folders vaults create --folder type=string
+FLAG basecamp folders vaults create --help type=bool
+FLAG basecamp folders vaults create --hints type=bool
+FLAG basecamp folders vaults create --ids-only type=bool
+FLAG basecamp folders vaults create --in type=string
+FLAG basecamp folders vaults create --jq type=string
+FLAG basecamp folders vaults create --json type=bool
+FLAG basecamp folders vaults create --markdown type=bool
+FLAG basecamp folders vaults create --md type=bool
+FLAG basecamp folders vaults create --no-hints type=bool
+FLAG basecamp folders vaults create --no-stats type=bool
+FLAG basecamp folders vaults create --profile type=string
+FLAG basecamp folders vaults create --project type=string
+FLAG basecamp folders vaults create --quiet type=bool
+FLAG basecamp folders vaults create --stats type=bool
+FLAG basecamp folders vaults create --styled type=bool
+FLAG basecamp folders vaults create --todolist type=string
+FLAG basecamp folders vaults create --vault type=string
+FLAG basecamp folders vaults create --verbose type=count
+FLAG basecamp folders vaults list --account type=string
+FLAG basecamp folders vaults list --agent type=bool
+FLAG basecamp folders vaults list --all type=bool
+FLAG basecamp folders vaults list --cache-dir type=string
+FLAG basecamp folders vaults list --count type=bool
+FLAG basecamp folders vaults list --folder type=string
+FLAG basecamp folders vaults list --help type=bool
+FLAG basecamp folders vaults list --hints type=bool
+FLAG basecamp folders vaults list --ids-only type=bool
+FLAG basecamp folders vaults list --in type=string
+FLAG basecamp folders vaults list --jq type=string
+FLAG basecamp folders vaults list --json type=bool
+FLAG basecamp folders vaults list --limit type=int
+FLAG basecamp folders vaults list --markdown type=bool
+FLAG basecamp folders vaults list --md type=bool
+FLAG basecamp folders vaults list --no-hints type=bool
+FLAG basecamp folders vaults list --no-stats type=bool
+FLAG basecamp folders vaults list --page type=int
+FLAG basecamp folders vaults list --profile type=string
+FLAG basecamp folders vaults list --project type=string
+FLAG basecamp folders vaults list --quiet type=bool
+FLAG basecamp folders vaults list --stats type=bool
+FLAG basecamp folders vaults list --styled type=bool
+FLAG basecamp folders vaults list --todolist type=string
+FLAG basecamp folders vaults list --vault type=string
+FLAG basecamp folders vaults list --verbose type=count
 FLAG basecamp forwards --account type=string
 FLAG basecamp forwards --agent type=bool
 FLAG basecamp forwards --cache-dir type=string
 FLAG basecamp forwards --count type=bool
+FLAG basecamp forwards --help type=bool
 FLAG basecamp forwards --hints type=bool
 FLAG basecamp forwards --ids-only type=bool
 FLAG basecamp forwards --in type=string
@@ -3428,6 +8536,7 @@ FLAG basecamp forwards inbox --account type=string
 FLAG basecamp forwards inbox --agent type=bool
 FLAG basecamp forwards inbox --cache-dir type=string
 FLAG basecamp forwards inbox --count type=bool
+FLAG basecamp forwards inbox --help type=bool
 FLAG basecamp forwards inbox --hints type=bool
 FLAG basecamp forwards inbox --ids-only type=bool
 FLAG basecamp forwards inbox --in type=string
@@ -3450,6 +8559,7 @@ FLAG basecamp forwards list --agent type=bool
 FLAG basecamp forwards list --all type=bool
 FLAG basecamp forwards list --cache-dir type=string
 FLAG basecamp forwards list --count type=bool
+FLAG basecamp forwards list --help type=bool
 FLAG basecamp forwards list --hints type=bool
 FLAG basecamp forwards list --ids-only type=bool
 FLAG basecamp forwards list --in type=string
@@ -3474,6 +8584,7 @@ FLAG basecamp forwards replies --agent type=bool
 FLAG basecamp forwards replies --all type=bool
 FLAG basecamp forwards replies --cache-dir type=string
 FLAG basecamp forwards replies --count type=bool
+FLAG basecamp forwards replies --help type=bool
 FLAG basecamp forwards replies --hints type=bool
 FLAG basecamp forwards replies --ids-only type=bool
 FLAG basecamp forwards replies --in type=string
@@ -3497,6 +8608,7 @@ FLAG basecamp forwards reply --account type=string
 FLAG basecamp forwards reply --agent type=bool
 FLAG basecamp forwards reply --cache-dir type=string
 FLAG basecamp forwards reply --count type=bool
+FLAG basecamp forwards reply --help type=bool
 FLAG basecamp forwards reply --hints type=bool
 FLAG basecamp forwards reply --ids-only type=bool
 FLAG basecamp forwards reply --in type=string
@@ -3518,6 +8630,7 @@ FLAG basecamp forwards show --account type=string
 FLAG basecamp forwards show --agent type=bool
 FLAG basecamp forwards show --cache-dir type=string
 FLAG basecamp forwards show --count type=bool
+FLAG basecamp forwards show --help type=bool
 FLAG basecamp forwards show --hints type=bool
 FLAG basecamp forwards show --ids-only type=bool
 FLAG basecamp forwards show --in type=string
@@ -3539,6 +8652,7 @@ FLAG basecamp help --account type=string
 FLAG basecamp help --agent type=bool
 FLAG basecamp help --cache-dir type=string
 FLAG basecamp help --count type=bool
+FLAG basecamp help --help type=bool
 FLAG basecamp help --hints type=bool
 FLAG basecamp help --ids-only type=bool
 FLAG basecamp help --in type=string
@@ -3559,6 +8673,7 @@ FLAG basecamp hillcharts --account type=string
 FLAG basecamp hillcharts --agent type=bool
 FLAG basecamp hillcharts --cache-dir type=string
 FLAG basecamp hillcharts --count type=bool
+FLAG basecamp hillcharts --help type=bool
 FLAG basecamp hillcharts --hints type=bool
 FLAG basecamp hillcharts --ids-only type=bool
 FLAG basecamp hillcharts --in type=string
@@ -3579,6 +8694,7 @@ FLAG basecamp hillcharts show --account type=string
 FLAG basecamp hillcharts show --agent type=bool
 FLAG basecamp hillcharts show --cache-dir type=string
 FLAG basecamp hillcharts show --count type=bool
+FLAG basecamp hillcharts show --help type=bool
 FLAG basecamp hillcharts show --hints type=bool
 FLAG basecamp hillcharts show --ids-only type=bool
 FLAG basecamp hillcharts show --in type=string
@@ -3600,6 +8716,7 @@ FLAG basecamp hillcharts track --account type=string
 FLAG basecamp hillcharts track --agent type=bool
 FLAG basecamp hillcharts track --cache-dir type=string
 FLAG basecamp hillcharts track --count type=bool
+FLAG basecamp hillcharts track --help type=bool
 FLAG basecamp hillcharts track --hints type=bool
 FLAG basecamp hillcharts track --ids-only type=bool
 FLAG basecamp hillcharts track --in type=string
@@ -3621,6 +8738,7 @@ FLAG basecamp hillcharts untrack --account type=string
 FLAG basecamp hillcharts untrack --agent type=bool
 FLAG basecamp hillcharts untrack --cache-dir type=string
 FLAG basecamp hillcharts untrack --count type=bool
+FLAG basecamp hillcharts untrack --help type=bool
 FLAG basecamp hillcharts untrack --hints type=bool
 FLAG basecamp hillcharts untrack --ids-only type=bool
 FLAG basecamp hillcharts untrack --in type=string
@@ -3642,6 +8760,7 @@ FLAG basecamp lineup --account type=string
 FLAG basecamp lineup --agent type=bool
 FLAG basecamp lineup --cache-dir type=string
 FLAG basecamp lineup --count type=bool
+FLAG basecamp lineup --help type=bool
 FLAG basecamp lineup --hints type=bool
 FLAG basecamp lineup --ids-only type=bool
 FLAG basecamp lineup --in type=string
@@ -3662,6 +8781,7 @@ FLAG basecamp lineup create --account type=string
 FLAG basecamp lineup create --agent type=bool
 FLAG basecamp lineup create --cache-dir type=string
 FLAG basecamp lineup create --count type=bool
+FLAG basecamp lineup create --help type=bool
 FLAG basecamp lineup create --hints type=bool
 FLAG basecamp lineup create --ids-only type=bool
 FLAG basecamp lineup create --in type=string
@@ -3682,6 +8802,7 @@ FLAG basecamp lineup delete --account type=string
 FLAG basecamp lineup delete --agent type=bool
 FLAG basecamp lineup delete --cache-dir type=string
 FLAG basecamp lineup delete --count type=bool
+FLAG basecamp lineup delete --help type=bool
 FLAG basecamp lineup delete --hints type=bool
 FLAG basecamp lineup delete --ids-only type=bool
 FLAG basecamp lineup delete --in type=string
@@ -3702,6 +8823,7 @@ FLAG basecamp lineup list --account type=string
 FLAG basecamp lineup list --agent type=bool
 FLAG basecamp lineup list --cache-dir type=string
 FLAG basecamp lineup list --count type=bool
+FLAG basecamp lineup list --help type=bool
 FLAG basecamp lineup list --hints type=bool
 FLAG basecamp lineup list --ids-only type=bool
 FLAG basecamp lineup list --in type=string
@@ -3722,6 +8844,7 @@ FLAG basecamp lineup update --account type=string
 FLAG basecamp lineup update --agent type=bool
 FLAG basecamp lineup update --cache-dir type=string
 FLAG basecamp lineup update --count type=bool
+FLAG basecamp lineup update --help type=bool
 FLAG basecamp lineup update --hints type=bool
 FLAG basecamp lineup update --ids-only type=bool
 FLAG basecamp lineup update --in type=string
@@ -3743,6 +8866,7 @@ FLAG basecamp login --agent type=bool
 FLAG basecamp login --cache-dir type=string
 FLAG basecamp login --count type=bool
 FLAG basecamp login --device-code type=bool
+FLAG basecamp login --help type=bool
 FLAG basecamp login --hints type=bool
 FLAG basecamp login --ids-only type=bool
 FLAG basecamp login --in type=string
@@ -3767,6 +8891,7 @@ FLAG basecamp logout --account type=string
 FLAG basecamp logout --agent type=bool
 FLAG basecamp logout --cache-dir type=string
 FLAG basecamp logout --count type=bool
+FLAG basecamp logout --help type=bool
 FLAG basecamp logout --hints type=bool
 FLAG basecamp logout --ids-only type=bool
 FLAG basecamp logout --in type=string
@@ -3787,6 +8912,7 @@ FLAG basecamp me --account type=string
 FLAG basecamp me --agent type=bool
 FLAG basecamp me --cache-dir type=string
 FLAG basecamp me --count type=bool
+FLAG basecamp me --help type=bool
 FLAG basecamp me --hints type=bool
 FLAG basecamp me --ids-only type=bool
 FLAG basecamp me --in type=string
@@ -3810,6 +8936,7 @@ FLAG basecamp message --cache-dir type=string
 FLAG basecamp message --count type=bool
 FLAG basecamp message --draft type=bool
 FLAG basecamp message --edit type=bool
+FLAG basecamp message --help type=bool
 FLAG basecamp message --hints type=bool
 FLAG basecamp message --ids-only type=bool
 FLAG basecamp message --in type=string
@@ -3834,6 +8961,7 @@ FLAG basecamp messageboards --agent type=bool
 FLAG basecamp messageboards --board type=string
 FLAG basecamp messageboards --cache-dir type=string
 FLAG basecamp messageboards --count type=bool
+FLAG basecamp messageboards --help type=bool
 FLAG basecamp messageboards --hints type=bool
 FLAG basecamp messageboards --ids-only type=bool
 FLAG basecamp messageboards --in type=string
@@ -3855,6 +8983,7 @@ FLAG basecamp messageboards show --agent type=bool
 FLAG basecamp messageboards show --board type=string
 FLAG basecamp messageboards show --cache-dir type=string
 FLAG basecamp messageboards show --count type=bool
+FLAG basecamp messageboards show --help type=bool
 FLAG basecamp messageboards show --hints type=bool
 FLAG basecamp messageboards show --ids-only type=bool
 FLAG basecamp messageboards show --in type=string
@@ -3875,6 +9004,7 @@ FLAG basecamp messages --account type=string
 FLAG basecamp messages --agent type=bool
 FLAG basecamp messages --cache-dir type=string
 FLAG basecamp messages --count type=bool
+FLAG basecamp messages --help type=bool
 FLAG basecamp messages --hints type=bool
 FLAG basecamp messages --ids-only type=bool
 FLAG basecamp messages --in type=string
@@ -3896,6 +9026,7 @@ FLAG basecamp messages archive --account type=string
 FLAG basecamp messages archive --agent type=bool
 FLAG basecamp messages archive --cache-dir type=string
 FLAG basecamp messages archive --count type=bool
+FLAG basecamp messages archive --help type=bool
 FLAG basecamp messages archive --hints type=bool
 FLAG basecamp messages archive --ids-only type=bool
 FLAG basecamp messages archive --in type=string
@@ -3920,6 +9051,7 @@ FLAG basecamp messages create --cache-dir type=string
 FLAG basecamp messages create --count type=bool
 FLAG basecamp messages create --draft type=bool
 FLAG basecamp messages create --edit type=bool
+FLAG basecamp messages create --help type=bool
 FLAG basecamp messages create --hints type=bool
 FLAG basecamp messages create --ids-only type=bool
 FLAG basecamp messages create --in type=string
@@ -3944,6 +9076,7 @@ FLAG basecamp messages list --agent type=bool
 FLAG basecamp messages list --all type=bool
 FLAG basecamp messages list --cache-dir type=string
 FLAG basecamp messages list --count type=bool
+FLAG basecamp messages list --help type=bool
 FLAG basecamp messages list --hints type=bool
 FLAG basecamp messages list --ids-only type=bool
 FLAG basecamp messages list --in type=string
@@ -3969,6 +9102,7 @@ FLAG basecamp messages pin --account type=string
 FLAG basecamp messages pin --agent type=bool
 FLAG basecamp messages pin --cache-dir type=string
 FLAG basecamp messages pin --count type=bool
+FLAG basecamp messages pin --help type=bool
 FLAG basecamp messages pin --hints type=bool
 FLAG basecamp messages pin --ids-only type=bool
 FLAG basecamp messages pin --in type=string
@@ -3990,6 +9124,7 @@ FLAG basecamp messages publish --account type=string
 FLAG basecamp messages publish --agent type=bool
 FLAG basecamp messages publish --cache-dir type=string
 FLAG basecamp messages publish --count type=bool
+FLAG basecamp messages publish --help type=bool
 FLAG basecamp messages publish --hints type=bool
 FLAG basecamp messages publish --ids-only type=bool
 FLAG basecamp messages publish --in type=string
@@ -4011,6 +9146,7 @@ FLAG basecamp messages restore --account type=string
 FLAG basecamp messages restore --agent type=bool
 FLAG basecamp messages restore --cache-dir type=string
 FLAG basecamp messages restore --count type=bool
+FLAG basecamp messages restore --help type=bool
 FLAG basecamp messages restore --hints type=bool
 FLAG basecamp messages restore --ids-only type=bool
 FLAG basecamp messages restore --in type=string
@@ -4032,6 +9168,7 @@ FLAG basecamp messages show --account type=string
 FLAG basecamp messages show --agent type=bool
 FLAG basecamp messages show --cache-dir type=string
 FLAG basecamp messages show --count type=bool
+FLAG basecamp messages show --help type=bool
 FLAG basecamp messages show --hints type=bool
 FLAG basecamp messages show --ids-only type=bool
 FLAG basecamp messages show --in type=string
@@ -4053,6 +9190,7 @@ FLAG basecamp messages trash --account type=string
 FLAG basecamp messages trash --agent type=bool
 FLAG basecamp messages trash --cache-dir type=string
 FLAG basecamp messages trash --count type=bool
+FLAG basecamp messages trash --help type=bool
 FLAG basecamp messages trash --hints type=bool
 FLAG basecamp messages trash --ids-only type=bool
 FLAG basecamp messages trash --in type=string
@@ -4074,6 +9212,7 @@ FLAG basecamp messages unpin --account type=string
 FLAG basecamp messages unpin --agent type=bool
 FLAG basecamp messages unpin --cache-dir type=string
 FLAG basecamp messages unpin --count type=bool
+FLAG basecamp messages unpin --help type=bool
 FLAG basecamp messages unpin --hints type=bool
 FLAG basecamp messages unpin --ids-only type=bool
 FLAG basecamp messages unpin --in type=string
@@ -4096,6 +9235,7 @@ FLAG basecamp messages update --agent type=bool
 FLAG basecamp messages update --body type=string
 FLAG basecamp messages update --cache-dir type=string
 FLAG basecamp messages update --count type=bool
+FLAG basecamp messages update --help type=bool
 FLAG basecamp messages update --hints type=bool
 FLAG basecamp messages update --ids-only type=bool
 FLAG basecamp messages update --in type=string
@@ -4118,6 +9258,7 @@ FLAG basecamp messagetypes --account type=string
 FLAG basecamp messagetypes --agent type=bool
 FLAG basecamp messagetypes --cache-dir type=string
 FLAG basecamp messagetypes --count type=bool
+FLAG basecamp messagetypes --help type=bool
 FLAG basecamp messagetypes --hints type=bool
 FLAG basecamp messagetypes --ids-only type=bool
 FLAG basecamp messagetypes --in type=string
@@ -4138,6 +9279,7 @@ FLAG basecamp messagetypes create --account type=string
 FLAG basecamp messagetypes create --agent type=bool
 FLAG basecamp messagetypes create --cache-dir type=string
 FLAG basecamp messagetypes create --count type=bool
+FLAG basecamp messagetypes create --help type=bool
 FLAG basecamp messagetypes create --hints type=bool
 FLAG basecamp messagetypes create --icon type=string
 FLAG basecamp messagetypes create --ids-only type=bool
@@ -4160,6 +9302,7 @@ FLAG basecamp messagetypes delete --account type=string
 FLAG basecamp messagetypes delete --agent type=bool
 FLAG basecamp messagetypes delete --cache-dir type=string
 FLAG basecamp messagetypes delete --count type=bool
+FLAG basecamp messagetypes delete --help type=bool
 FLAG basecamp messagetypes delete --hints type=bool
 FLAG basecamp messagetypes delete --ids-only type=bool
 FLAG basecamp messagetypes delete --in type=string
@@ -4180,6 +9323,7 @@ FLAG basecamp messagetypes list --account type=string
 FLAG basecamp messagetypes list --agent type=bool
 FLAG basecamp messagetypes list --cache-dir type=string
 FLAG basecamp messagetypes list --count type=bool
+FLAG basecamp messagetypes list --help type=bool
 FLAG basecamp messagetypes list --hints type=bool
 FLAG basecamp messagetypes list --ids-only type=bool
 FLAG basecamp messagetypes list --in type=string
@@ -4200,6 +9344,7 @@ FLAG basecamp messagetypes show --account type=string
 FLAG basecamp messagetypes show --agent type=bool
 FLAG basecamp messagetypes show --cache-dir type=string
 FLAG basecamp messagetypes show --count type=bool
+FLAG basecamp messagetypes show --help type=bool
 FLAG basecamp messagetypes show --hints type=bool
 FLAG basecamp messagetypes show --ids-only type=bool
 FLAG basecamp messagetypes show --in type=string
@@ -4220,6 +9365,7 @@ FLAG basecamp messagetypes update --account type=string
 FLAG basecamp messagetypes update --agent type=bool
 FLAG basecamp messagetypes update --cache-dir type=string
 FLAG basecamp messagetypes update --count type=bool
+FLAG basecamp messagetypes update --help type=bool
 FLAG basecamp messagetypes update --hints type=bool
 FLAG basecamp messagetypes update --icon type=string
 FLAG basecamp messagetypes update --ids-only type=bool
@@ -4243,6 +9389,7 @@ FLAG basecamp migrate --agent type=bool
 FLAG basecamp migrate --cache-dir type=string
 FLAG basecamp migrate --count type=bool
 FLAG basecamp migrate --force type=bool
+FLAG basecamp migrate --help type=bool
 FLAG basecamp migrate --hints type=bool
 FLAG basecamp migrate --ids-only type=bool
 FLAG basecamp migrate --in type=string
@@ -4259,10 +9406,265 @@ FLAG basecamp migrate --stats type=bool
 FLAG basecamp migrate --styled type=bool
 FLAG basecamp migrate --todolist type=string
 FLAG basecamp migrate --verbose type=count
+FLAG basecamp msgs --account type=string
+FLAG basecamp msgs --agent type=bool
+FLAG basecamp msgs --cache-dir type=string
+FLAG basecamp msgs --count type=bool
+FLAG basecamp msgs --help type=bool
+FLAG basecamp msgs --hints type=bool
+FLAG basecamp msgs --ids-only type=bool
+FLAG basecamp msgs --in type=string
+FLAG basecamp msgs --jq type=string
+FLAG basecamp msgs --json type=bool
+FLAG basecamp msgs --markdown type=bool
+FLAG basecamp msgs --md type=bool
+FLAG basecamp msgs --message-board type=string
+FLAG basecamp msgs --no-hints type=bool
+FLAG basecamp msgs --no-stats type=bool
+FLAG basecamp msgs --profile type=string
+FLAG basecamp msgs --project type=string
+FLAG basecamp msgs --quiet type=bool
+FLAG basecamp msgs --stats type=bool
+FLAG basecamp msgs --styled type=bool
+FLAG basecamp msgs --todolist type=string
+FLAG basecamp msgs --verbose type=count
+FLAG basecamp msgs archive --account type=string
+FLAG basecamp msgs archive --agent type=bool
+FLAG basecamp msgs archive --cache-dir type=string
+FLAG basecamp msgs archive --count type=bool
+FLAG basecamp msgs archive --help type=bool
+FLAG basecamp msgs archive --hints type=bool
+FLAG basecamp msgs archive --ids-only type=bool
+FLAG basecamp msgs archive --in type=string
+FLAG basecamp msgs archive --jq type=string
+FLAG basecamp msgs archive --json type=bool
+FLAG basecamp msgs archive --markdown type=bool
+FLAG basecamp msgs archive --md type=bool
+FLAG basecamp msgs archive --message-board type=string
+FLAG basecamp msgs archive --no-hints type=bool
+FLAG basecamp msgs archive --no-stats type=bool
+FLAG basecamp msgs archive --profile type=string
+FLAG basecamp msgs archive --project type=string
+FLAG basecamp msgs archive --quiet type=bool
+FLAG basecamp msgs archive --stats type=bool
+FLAG basecamp msgs archive --styled type=bool
+FLAG basecamp msgs archive --todolist type=string
+FLAG basecamp msgs archive --verbose type=count
+FLAG basecamp msgs create --account type=string
+FLAG basecamp msgs create --agent type=bool
+FLAG basecamp msgs create --attach type=stringArray
+FLAG basecamp msgs create --cache-dir type=string
+FLAG basecamp msgs create --count type=bool
+FLAG basecamp msgs create --draft type=bool
+FLAG basecamp msgs create --edit type=bool
+FLAG basecamp msgs create --help type=bool
+FLAG basecamp msgs create --hints type=bool
+FLAG basecamp msgs create --ids-only type=bool
+FLAG basecamp msgs create --in type=string
+FLAG basecamp msgs create --jq type=string
+FLAG basecamp msgs create --json type=bool
+FLAG basecamp msgs create --markdown type=bool
+FLAG basecamp msgs create --md type=bool
+FLAG basecamp msgs create --message-board type=string
+FLAG basecamp msgs create --no-hints type=bool
+FLAG basecamp msgs create --no-stats type=bool
+FLAG basecamp msgs create --no-subscribe type=bool
+FLAG basecamp msgs create --profile type=string
+FLAG basecamp msgs create --project type=string
+FLAG basecamp msgs create --quiet type=bool
+FLAG basecamp msgs create --stats type=bool
+FLAG basecamp msgs create --styled type=bool
+FLAG basecamp msgs create --subscribe type=string
+FLAG basecamp msgs create --todolist type=string
+FLAG basecamp msgs create --verbose type=count
+FLAG basecamp msgs list --account type=string
+FLAG basecamp msgs list --agent type=bool
+FLAG basecamp msgs list --all type=bool
+FLAG basecamp msgs list --cache-dir type=string
+FLAG basecamp msgs list --count type=bool
+FLAG basecamp msgs list --help type=bool
+FLAG basecamp msgs list --hints type=bool
+FLAG basecamp msgs list --ids-only type=bool
+FLAG basecamp msgs list --in type=string
+FLAG basecamp msgs list --jq type=string
+FLAG basecamp msgs list --json type=bool
+FLAG basecamp msgs list --limit type=int
+FLAG basecamp msgs list --markdown type=bool
+FLAG basecamp msgs list --md type=bool
+FLAG basecamp msgs list --message-board type=string
+FLAG basecamp msgs list --no-hints type=bool
+FLAG basecamp msgs list --no-stats type=bool
+FLAG basecamp msgs list --page type=int
+FLAG basecamp msgs list --profile type=string
+FLAG basecamp msgs list --project type=string
+FLAG basecamp msgs list --quiet type=bool
+FLAG basecamp msgs list --reverse type=bool
+FLAG basecamp msgs list --sort type=string
+FLAG basecamp msgs list --stats type=bool
+FLAG basecamp msgs list --styled type=bool
+FLAG basecamp msgs list --todolist type=string
+FLAG basecamp msgs list --verbose type=count
+FLAG basecamp msgs pin --account type=string
+FLAG basecamp msgs pin --agent type=bool
+FLAG basecamp msgs pin --cache-dir type=string
+FLAG basecamp msgs pin --count type=bool
+FLAG basecamp msgs pin --help type=bool
+FLAG basecamp msgs pin --hints type=bool
+FLAG basecamp msgs pin --ids-only type=bool
+FLAG basecamp msgs pin --in type=string
+FLAG basecamp msgs pin --jq type=string
+FLAG basecamp msgs pin --json type=bool
+FLAG basecamp msgs pin --markdown type=bool
+FLAG basecamp msgs pin --md type=bool
+FLAG basecamp msgs pin --message-board type=string
+FLAG basecamp msgs pin --no-hints type=bool
+FLAG basecamp msgs pin --no-stats type=bool
+FLAG basecamp msgs pin --profile type=string
+FLAG basecamp msgs pin --project type=string
+FLAG basecamp msgs pin --quiet type=bool
+FLAG basecamp msgs pin --stats type=bool
+FLAG basecamp msgs pin --styled type=bool
+FLAG basecamp msgs pin --todolist type=string
+FLAG basecamp msgs pin --verbose type=count
+FLAG basecamp msgs publish --account type=string
+FLAG basecamp msgs publish --agent type=bool
+FLAG basecamp msgs publish --cache-dir type=string
+FLAG basecamp msgs publish --count type=bool
+FLAG basecamp msgs publish --help type=bool
+FLAG basecamp msgs publish --hints type=bool
+FLAG basecamp msgs publish --ids-only type=bool
+FLAG basecamp msgs publish --in type=string
+FLAG basecamp msgs publish --jq type=string
+FLAG basecamp msgs publish --json type=bool
+FLAG basecamp msgs publish --markdown type=bool
+FLAG basecamp msgs publish --md type=bool
+FLAG basecamp msgs publish --message-board type=string
+FLAG basecamp msgs publish --no-hints type=bool
+FLAG basecamp msgs publish --no-stats type=bool
+FLAG basecamp msgs publish --profile type=string
+FLAG basecamp msgs publish --project type=string
+FLAG basecamp msgs publish --quiet type=bool
+FLAG basecamp msgs publish --stats type=bool
+FLAG basecamp msgs publish --styled type=bool
+FLAG basecamp msgs publish --todolist type=string
+FLAG basecamp msgs publish --verbose type=count
+FLAG basecamp msgs restore --account type=string
+FLAG basecamp msgs restore --agent type=bool
+FLAG basecamp msgs restore --cache-dir type=string
+FLAG basecamp msgs restore --count type=bool
+FLAG basecamp msgs restore --help type=bool
+FLAG basecamp msgs restore --hints type=bool
+FLAG basecamp msgs restore --ids-only type=bool
+FLAG basecamp msgs restore --in type=string
+FLAG basecamp msgs restore --jq type=string
+FLAG basecamp msgs restore --json type=bool
+FLAG basecamp msgs restore --markdown type=bool
+FLAG basecamp msgs restore --md type=bool
+FLAG basecamp msgs restore --message-board type=string
+FLAG basecamp msgs restore --no-hints type=bool
+FLAG basecamp msgs restore --no-stats type=bool
+FLAG basecamp msgs restore --profile type=string
+FLAG basecamp msgs restore --project type=string
+FLAG basecamp msgs restore --quiet type=bool
+FLAG basecamp msgs restore --stats type=bool
+FLAG basecamp msgs restore --styled type=bool
+FLAG basecamp msgs restore --todolist type=string
+FLAG basecamp msgs restore --verbose type=count
+FLAG basecamp msgs show --account type=string
+FLAG basecamp msgs show --agent type=bool
+FLAG basecamp msgs show --cache-dir type=string
+FLAG basecamp msgs show --count type=bool
+FLAG basecamp msgs show --help type=bool
+FLAG basecamp msgs show --hints type=bool
+FLAG basecamp msgs show --ids-only type=bool
+FLAG basecamp msgs show --in type=string
+FLAG basecamp msgs show --jq type=string
+FLAG basecamp msgs show --json type=bool
+FLAG basecamp msgs show --markdown type=bool
+FLAG basecamp msgs show --md type=bool
+FLAG basecamp msgs show --message-board type=string
+FLAG basecamp msgs show --no-hints type=bool
+FLAG basecamp msgs show --no-stats type=bool
+FLAG basecamp msgs show --profile type=string
+FLAG basecamp msgs show --project type=string
+FLAG basecamp msgs show --quiet type=bool
+FLAG basecamp msgs show --stats type=bool
+FLAG basecamp msgs show --styled type=bool
+FLAG basecamp msgs show --todolist type=string
+FLAG basecamp msgs show --verbose type=count
+FLAG basecamp msgs trash --account type=string
+FLAG basecamp msgs trash --agent type=bool
+FLAG basecamp msgs trash --cache-dir type=string
+FLAG basecamp msgs trash --count type=bool
+FLAG basecamp msgs trash --help type=bool
+FLAG basecamp msgs trash --hints type=bool
+FLAG basecamp msgs trash --ids-only type=bool
+FLAG basecamp msgs trash --in type=string
+FLAG basecamp msgs trash --jq type=string
+FLAG basecamp msgs trash --json type=bool
+FLAG basecamp msgs trash --markdown type=bool
+FLAG basecamp msgs trash --md type=bool
+FLAG basecamp msgs trash --message-board type=string
+FLAG basecamp msgs trash --no-hints type=bool
+FLAG basecamp msgs trash --no-stats type=bool
+FLAG basecamp msgs trash --profile type=string
+FLAG basecamp msgs trash --project type=string
+FLAG basecamp msgs trash --quiet type=bool
+FLAG basecamp msgs trash --stats type=bool
+FLAG basecamp msgs trash --styled type=bool
+FLAG basecamp msgs trash --todolist type=string
+FLAG basecamp msgs trash --verbose type=count
+FLAG basecamp msgs unpin --account type=string
+FLAG basecamp msgs unpin --agent type=bool
+FLAG basecamp msgs unpin --cache-dir type=string
+FLAG basecamp msgs unpin --count type=bool
+FLAG basecamp msgs unpin --help type=bool
+FLAG basecamp msgs unpin --hints type=bool
+FLAG basecamp msgs unpin --ids-only type=bool
+FLAG basecamp msgs unpin --in type=string
+FLAG basecamp msgs unpin --jq type=string
+FLAG basecamp msgs unpin --json type=bool
+FLAG basecamp msgs unpin --markdown type=bool
+FLAG basecamp msgs unpin --md type=bool
+FLAG basecamp msgs unpin --message-board type=string
+FLAG basecamp msgs unpin --no-hints type=bool
+FLAG basecamp msgs unpin --no-stats type=bool
+FLAG basecamp msgs unpin --profile type=string
+FLAG basecamp msgs unpin --project type=string
+FLAG basecamp msgs unpin --quiet type=bool
+FLAG basecamp msgs unpin --stats type=bool
+FLAG basecamp msgs unpin --styled type=bool
+FLAG basecamp msgs unpin --todolist type=string
+FLAG basecamp msgs unpin --verbose type=count
+FLAG basecamp msgs update --account type=string
+FLAG basecamp msgs update --agent type=bool
+FLAG basecamp msgs update --body type=string
+FLAG basecamp msgs update --cache-dir type=string
+FLAG basecamp msgs update --count type=bool
+FLAG basecamp msgs update --help type=bool
+FLAG basecamp msgs update --hints type=bool
+FLAG basecamp msgs update --ids-only type=bool
+FLAG basecamp msgs update --in type=string
+FLAG basecamp msgs update --jq type=string
+FLAG basecamp msgs update --json type=bool
+FLAG basecamp msgs update --markdown type=bool
+FLAG basecamp msgs update --md type=bool
+FLAG basecamp msgs update --message-board type=string
+FLAG basecamp msgs update --no-hints type=bool
+FLAG basecamp msgs update --no-stats type=bool
+FLAG basecamp msgs update --profile type=string
+FLAG basecamp msgs update --project type=string
+FLAG basecamp msgs update --quiet type=bool
+FLAG basecamp msgs update --stats type=bool
+FLAG basecamp msgs update --styled type=bool
+FLAG basecamp msgs update --title type=string
+FLAG basecamp msgs update --todolist type=string
+FLAG basecamp msgs update --verbose type=count
 FLAG basecamp people --account type=string
 FLAG basecamp people --agent type=bool
 FLAG basecamp people --cache-dir type=string
 FLAG basecamp people --count type=bool
+FLAG basecamp people --help type=bool
 FLAG basecamp people --hints type=bool
 FLAG basecamp people --ids-only type=bool
 FLAG basecamp people --in type=string
@@ -4283,6 +9685,7 @@ FLAG basecamp people add --account type=string
 FLAG basecamp people add --agent type=bool
 FLAG basecamp people add --cache-dir type=string
 FLAG basecamp people add --count type=bool
+FLAG basecamp people add --help type=bool
 FLAG basecamp people add --hints type=bool
 FLAG basecamp people add --ids-only type=bool
 FLAG basecamp people add --in type=string
@@ -4304,6 +9707,7 @@ FLAG basecamp people list --agent type=bool
 FLAG basecamp people list --all type=bool
 FLAG basecamp people list --cache-dir type=string
 FLAG basecamp people list --count type=bool
+FLAG basecamp people list --help type=bool
 FLAG basecamp people list --hints type=bool
 FLAG basecamp people list --ids-only type=bool
 FLAG basecamp people list --in type=string
@@ -4328,6 +9732,7 @@ FLAG basecamp people pingable --account type=string
 FLAG basecamp people pingable --agent type=bool
 FLAG basecamp people pingable --cache-dir type=string
 FLAG basecamp people pingable --count type=bool
+FLAG basecamp people pingable --help type=bool
 FLAG basecamp people pingable --hints type=bool
 FLAG basecamp people pingable --ids-only type=bool
 FLAG basecamp people pingable --in type=string
@@ -4348,6 +9753,7 @@ FLAG basecamp people remove --account type=string
 FLAG basecamp people remove --agent type=bool
 FLAG basecamp people remove --cache-dir type=string
 FLAG basecamp people remove --count type=bool
+FLAG basecamp people remove --help type=bool
 FLAG basecamp people remove --hints type=bool
 FLAG basecamp people remove --ids-only type=bool
 FLAG basecamp people remove --in type=string
@@ -4368,6 +9774,7 @@ FLAG basecamp people show --account type=string
 FLAG basecamp people show --agent type=bool
 FLAG basecamp people show --cache-dir type=string
 FLAG basecamp people show --count type=bool
+FLAG basecamp people show --help type=bool
 FLAG basecamp people show --hints type=bool
 FLAG basecamp people show --ids-only type=bool
 FLAG basecamp people show --in type=string
@@ -4388,6 +9795,7 @@ FLAG basecamp profile --account type=string
 FLAG basecamp profile --agent type=bool
 FLAG basecamp profile --cache-dir type=string
 FLAG basecamp profile --count type=bool
+FLAG basecamp profile --help type=bool
 FLAG basecamp profile --hints type=bool
 FLAG basecamp profile --ids-only type=bool
 FLAG basecamp profile --in type=string
@@ -4410,6 +9818,7 @@ FLAG basecamp profile create --base-url type=string
 FLAG basecamp profile create --cache-dir type=string
 FLAG basecamp profile create --count type=bool
 FLAG basecamp profile create --device-code type=bool
+FLAG basecamp profile create --help type=bool
 FLAG basecamp profile create --hints type=bool
 FLAG basecamp profile create --ids-only type=bool
 FLAG basecamp profile create --in type=string
@@ -4434,6 +9843,7 @@ FLAG basecamp profile delete --account type=string
 FLAG basecamp profile delete --agent type=bool
 FLAG basecamp profile delete --cache-dir type=string
 FLAG basecamp profile delete --count type=bool
+FLAG basecamp profile delete --help type=bool
 FLAG basecamp profile delete --hints type=bool
 FLAG basecamp profile delete --ids-only type=bool
 FLAG basecamp profile delete --in type=string
@@ -4454,6 +9864,7 @@ FLAG basecamp profile list --account type=string
 FLAG basecamp profile list --agent type=bool
 FLAG basecamp profile list --cache-dir type=string
 FLAG basecamp profile list --count type=bool
+FLAG basecamp profile list --help type=bool
 FLAG basecamp profile list --hints type=bool
 FLAG basecamp profile list --ids-only type=bool
 FLAG basecamp profile list --in type=string
@@ -4474,6 +9885,7 @@ FLAG basecamp profile set-default --account type=string
 FLAG basecamp profile set-default --agent type=bool
 FLAG basecamp profile set-default --cache-dir type=string
 FLAG basecamp profile set-default --count type=bool
+FLAG basecamp profile set-default --help type=bool
 FLAG basecamp profile set-default --hints type=bool
 FLAG basecamp profile set-default --ids-only type=bool
 FLAG basecamp profile set-default --in type=string
@@ -4494,6 +9906,7 @@ FLAG basecamp profile show --account type=string
 FLAG basecamp profile show --agent type=bool
 FLAG basecamp profile show --cache-dir type=string
 FLAG basecamp profile show --count type=bool
+FLAG basecamp profile show --help type=bool
 FLAG basecamp profile show --hints type=bool
 FLAG basecamp profile show --ids-only type=bool
 FLAG basecamp profile show --in type=string
@@ -4510,10 +9923,168 @@ FLAG basecamp profile show --stats type=bool
 FLAG basecamp profile show --styled type=bool
 FLAG basecamp profile show --todolist type=string
 FLAG basecamp profile show --verbose type=count
+FLAG basecamp project --account type=string
+FLAG basecamp project --agent type=bool
+FLAG basecamp project --cache-dir type=string
+FLAG basecamp project --count type=bool
+FLAG basecamp project --help type=bool
+FLAG basecamp project --hints type=bool
+FLAG basecamp project --ids-only type=bool
+FLAG basecamp project --in type=string
+FLAG basecamp project --jq type=string
+FLAG basecamp project --json type=bool
+FLAG basecamp project --markdown type=bool
+FLAG basecamp project --md type=bool
+FLAG basecamp project --no-hints type=bool
+FLAG basecamp project --no-stats type=bool
+FLAG basecamp project --profile type=string
+FLAG basecamp project --project type=string
+FLAG basecamp project --quiet type=bool
+FLAG basecamp project --stats type=bool
+FLAG basecamp project --styled type=bool
+FLAG basecamp project --todolist type=string
+FLAG basecamp project --verbose type=count
+FLAG basecamp project create --account type=string
+FLAG basecamp project create --agent type=bool
+FLAG basecamp project create --cache-dir type=string
+FLAG basecamp project create --count type=bool
+FLAG basecamp project create --description type=string
+FLAG basecamp project create --help type=bool
+FLAG basecamp project create --hints type=bool
+FLAG basecamp project create --ids-only type=bool
+FLAG basecamp project create --in type=string
+FLAG basecamp project create --jq type=string
+FLAG basecamp project create --json type=bool
+FLAG basecamp project create --markdown type=bool
+FLAG basecamp project create --md type=bool
+FLAG basecamp project create --no-hints type=bool
+FLAG basecamp project create --no-stats type=bool
+FLAG basecamp project create --profile type=string
+FLAG basecamp project create --project type=string
+FLAG basecamp project create --quiet type=bool
+FLAG basecamp project create --stats type=bool
+FLAG basecamp project create --styled type=bool
+FLAG basecamp project create --todolist type=string
+FLAG basecamp project create --verbose type=count
+FLAG basecamp project delete --account type=string
+FLAG basecamp project delete --agent type=bool
+FLAG basecamp project delete --cache-dir type=string
+FLAG basecamp project delete --count type=bool
+FLAG basecamp project delete --help type=bool
+FLAG basecamp project delete --hints type=bool
+FLAG basecamp project delete --ids-only type=bool
+FLAG basecamp project delete --in type=string
+FLAG basecamp project delete --jq type=string
+FLAG basecamp project delete --json type=bool
+FLAG basecamp project delete --markdown type=bool
+FLAG basecamp project delete --md type=bool
+FLAG basecamp project delete --no-hints type=bool
+FLAG basecamp project delete --no-stats type=bool
+FLAG basecamp project delete --profile type=string
+FLAG basecamp project delete --project type=string
+FLAG basecamp project delete --quiet type=bool
+FLAG basecamp project delete --stats type=bool
+FLAG basecamp project delete --styled type=bool
+FLAG basecamp project delete --todolist type=string
+FLAG basecamp project delete --verbose type=count
+FLAG basecamp project list --account type=string
+FLAG basecamp project list --agent type=bool
+FLAG basecamp project list --all type=bool
+FLAG basecamp project list --cache-dir type=string
+FLAG basecamp project list --count type=bool
+FLAG basecamp project list --help type=bool
+FLAG basecamp project list --hints type=bool
+FLAG basecamp project list --ids-only type=bool
+FLAG basecamp project list --in type=string
+FLAG basecamp project list --jq type=string
+FLAG basecamp project list --json type=bool
+FLAG basecamp project list --limit type=int
+FLAG basecamp project list --markdown type=bool
+FLAG basecamp project list --md type=bool
+FLAG basecamp project list --no-hints type=bool
+FLAG basecamp project list --no-stats type=bool
+FLAG basecamp project list --page type=int
+FLAG basecamp project list --profile type=string
+FLAG basecamp project list --project type=string
+FLAG basecamp project list --quiet type=bool
+FLAG basecamp project list --reverse type=bool
+FLAG basecamp project list --sort type=string
+FLAG basecamp project list --stats type=bool
+FLAG basecamp project list --status type=string
+FLAG basecamp project list --styled type=bool
+FLAG basecamp project list --todolist type=string
+FLAG basecamp project list --verbose type=count
+FLAG basecamp project show --account type=string
+FLAG basecamp project show --agent type=bool
+FLAG basecamp project show --all type=bool
+FLAG basecamp project show --cache-dir type=string
+FLAG basecamp project show --count type=bool
+FLAG basecamp project show --help type=bool
+FLAG basecamp project show --hints type=bool
+FLAG basecamp project show --ids-only type=bool
+FLAG basecamp project show --in type=string
+FLAG basecamp project show --jq type=string
+FLAG basecamp project show --json type=bool
+FLAG basecamp project show --markdown type=bool
+FLAG basecamp project show --md type=bool
+FLAG basecamp project show --no-hints type=bool
+FLAG basecamp project show --no-stats type=bool
+FLAG basecamp project show --profile type=string
+FLAG basecamp project show --project type=string
+FLAG basecamp project show --quiet type=bool
+FLAG basecamp project show --stats type=bool
+FLAG basecamp project show --styled type=bool
+FLAG basecamp project show --todolist type=string
+FLAG basecamp project show --verbose type=count
+FLAG basecamp project trash --account type=string
+FLAG basecamp project trash --agent type=bool
+FLAG basecamp project trash --cache-dir type=string
+FLAG basecamp project trash --count type=bool
+FLAG basecamp project trash --help type=bool
+FLAG basecamp project trash --hints type=bool
+FLAG basecamp project trash --ids-only type=bool
+FLAG basecamp project trash --in type=string
+FLAG basecamp project trash --jq type=string
+FLAG basecamp project trash --json type=bool
+FLAG basecamp project trash --markdown type=bool
+FLAG basecamp project trash --md type=bool
+FLAG basecamp project trash --no-hints type=bool
+FLAG basecamp project trash --no-stats type=bool
+FLAG basecamp project trash --profile type=string
+FLAG basecamp project trash --project type=string
+FLAG basecamp project trash --quiet type=bool
+FLAG basecamp project trash --stats type=bool
+FLAG basecamp project trash --styled type=bool
+FLAG basecamp project trash --todolist type=string
+FLAG basecamp project trash --verbose type=count
+FLAG basecamp project update --account type=string
+FLAG basecamp project update --agent type=bool
+FLAG basecamp project update --cache-dir type=string
+FLAG basecamp project update --count type=bool
+FLAG basecamp project update --description type=string
+FLAG basecamp project update --help type=bool
+FLAG basecamp project update --hints type=bool
+FLAG basecamp project update --ids-only type=bool
+FLAG basecamp project update --in type=string
+FLAG basecamp project update --jq type=string
+FLAG basecamp project update --json type=bool
+FLAG basecamp project update --markdown type=bool
+FLAG basecamp project update --md type=bool
+FLAG basecamp project update --name type=string
+FLAG basecamp project update --no-hints type=bool
+FLAG basecamp project update --no-stats type=bool
+FLAG basecamp project update --profile type=string
+FLAG basecamp project update --project type=string
+FLAG basecamp project update --quiet type=bool
+FLAG basecamp project update --stats type=bool
+FLAG basecamp project update --styled type=bool
+FLAG basecamp project update --todolist type=string
+FLAG basecamp project update --verbose type=count
 FLAG basecamp projects --account type=string
 FLAG basecamp projects --agent type=bool
 FLAG basecamp projects --cache-dir type=string
 FLAG basecamp projects --count type=bool
+FLAG basecamp projects --help type=bool
 FLAG basecamp projects --hints type=bool
 FLAG basecamp projects --ids-only type=bool
 FLAG basecamp projects --in type=string
@@ -4535,6 +10106,7 @@ FLAG basecamp projects create --agent type=bool
 FLAG basecamp projects create --cache-dir type=string
 FLAG basecamp projects create --count type=bool
 FLAG basecamp projects create --description type=string
+FLAG basecamp projects create --help type=bool
 FLAG basecamp projects create --hints type=bool
 FLAG basecamp projects create --ids-only type=bool
 FLAG basecamp projects create --in type=string
@@ -4555,6 +10127,7 @@ FLAG basecamp projects delete --account type=string
 FLAG basecamp projects delete --agent type=bool
 FLAG basecamp projects delete --cache-dir type=string
 FLAG basecamp projects delete --count type=bool
+FLAG basecamp projects delete --help type=bool
 FLAG basecamp projects delete --hints type=bool
 FLAG basecamp projects delete --ids-only type=bool
 FLAG basecamp projects delete --in type=string
@@ -4576,6 +10149,7 @@ FLAG basecamp projects list --agent type=bool
 FLAG basecamp projects list --all type=bool
 FLAG basecamp projects list --cache-dir type=string
 FLAG basecamp projects list --count type=bool
+FLAG basecamp projects list --help type=bool
 FLAG basecamp projects list --hints type=bool
 FLAG basecamp projects list --ids-only type=bool
 FLAG basecamp projects list --in type=string
@@ -4602,6 +10176,7 @@ FLAG basecamp projects show --agent type=bool
 FLAG basecamp projects show --all type=bool
 FLAG basecamp projects show --cache-dir type=string
 FLAG basecamp projects show --count type=bool
+FLAG basecamp projects show --help type=bool
 FLAG basecamp projects show --hints type=bool
 FLAG basecamp projects show --ids-only type=bool
 FLAG basecamp projects show --in type=string
@@ -4618,11 +10193,33 @@ FLAG basecamp projects show --stats type=bool
 FLAG basecamp projects show --styled type=bool
 FLAG basecamp projects show --todolist type=string
 FLAG basecamp projects show --verbose type=count
+FLAG basecamp projects trash --account type=string
+FLAG basecamp projects trash --agent type=bool
+FLAG basecamp projects trash --cache-dir type=string
+FLAG basecamp projects trash --count type=bool
+FLAG basecamp projects trash --help type=bool
+FLAG basecamp projects trash --hints type=bool
+FLAG basecamp projects trash --ids-only type=bool
+FLAG basecamp projects trash --in type=string
+FLAG basecamp projects trash --jq type=string
+FLAG basecamp projects trash --json type=bool
+FLAG basecamp projects trash --markdown type=bool
+FLAG basecamp projects trash --md type=bool
+FLAG basecamp projects trash --no-hints type=bool
+FLAG basecamp projects trash --no-stats type=bool
+FLAG basecamp projects trash --profile type=string
+FLAG basecamp projects trash --project type=string
+FLAG basecamp projects trash --quiet type=bool
+FLAG basecamp projects trash --stats type=bool
+FLAG basecamp projects trash --styled type=bool
+FLAG basecamp projects trash --todolist type=string
+FLAG basecamp projects trash --verbose type=count
 FLAG basecamp projects update --account type=string
 FLAG basecamp projects update --agent type=bool
 FLAG basecamp projects update --cache-dir type=string
 FLAG basecamp projects update --count type=bool
 FLAG basecamp projects update --description type=string
+FLAG basecamp projects update --help type=bool
 FLAG basecamp projects update --hints type=bool
 FLAG basecamp projects update --ids-only type=bool
 FLAG basecamp projects update --in type=string
@@ -4645,6 +10242,7 @@ FLAG basecamp react --agent type=bool
 FLAG basecamp react --cache-dir type=string
 FLAG basecamp react --count type=bool
 FLAG basecamp react --event type=string
+FLAG basecamp react --help type=bool
 FLAG basecamp react --hints type=bool
 FLAG basecamp react --ids-only type=bool
 FLAG basecamp react --in type=string
@@ -4669,6 +10267,7 @@ FLAG basecamp recordings --all type=bool
 FLAG basecamp recordings --cache-dir type=string
 FLAG basecamp recordings --count type=bool
 FLAG basecamp recordings --direction type=string
+FLAG basecamp recordings --help type=bool
 FLAG basecamp recordings --hints type=bool
 FLAG basecamp recordings --ids-only type=bool
 FLAG basecamp recordings --in type=string
@@ -4690,10 +10289,32 @@ FLAG basecamp recordings --styled type=bool
 FLAG basecamp recordings --todolist type=string
 FLAG basecamp recordings --type type=string
 FLAG basecamp recordings --verbose type=count
+FLAG basecamp recordings active --account type=string
+FLAG basecamp recordings active --agent type=bool
+FLAG basecamp recordings active --cache-dir type=string
+FLAG basecamp recordings active --count type=bool
+FLAG basecamp recordings active --help type=bool
+FLAG basecamp recordings active --hints type=bool
+FLAG basecamp recordings active --ids-only type=bool
+FLAG basecamp recordings active --in type=string
+FLAG basecamp recordings active --jq type=string
+FLAG basecamp recordings active --json type=bool
+FLAG basecamp recordings active --markdown type=bool
+FLAG basecamp recordings active --md type=bool
+FLAG basecamp recordings active --no-hints type=bool
+FLAG basecamp recordings active --no-stats type=bool
+FLAG basecamp recordings active --profile type=string
+FLAG basecamp recordings active --project type=string
+FLAG basecamp recordings active --quiet type=bool
+FLAG basecamp recordings active --stats type=bool
+FLAG basecamp recordings active --styled type=bool
+FLAG basecamp recordings active --todolist type=string
+FLAG basecamp recordings active --verbose type=count
 FLAG basecamp recordings archive --account type=string
 FLAG basecamp recordings archive --agent type=bool
 FLAG basecamp recordings archive --cache-dir type=string
 FLAG basecamp recordings archive --count type=bool
+FLAG basecamp recordings archive --help type=bool
 FLAG basecamp recordings archive --hints type=bool
 FLAG basecamp recordings archive --ids-only type=bool
 FLAG basecamp recordings archive --in type=string
@@ -4710,12 +10331,59 @@ FLAG basecamp recordings archive --stats type=bool
 FLAG basecamp recordings archive --styled type=bool
 FLAG basecamp recordings archive --todolist type=string
 FLAG basecamp recordings archive --verbose type=count
+FLAG basecamp recordings archived --account type=string
+FLAG basecamp recordings archived --agent type=bool
+FLAG basecamp recordings archived --cache-dir type=string
+FLAG basecamp recordings archived --count type=bool
+FLAG basecamp recordings archived --help type=bool
+FLAG basecamp recordings archived --hints type=bool
+FLAG basecamp recordings archived --ids-only type=bool
+FLAG basecamp recordings archived --in type=string
+FLAG basecamp recordings archived --jq type=string
+FLAG basecamp recordings archived --json type=bool
+FLAG basecamp recordings archived --markdown type=bool
+FLAG basecamp recordings archived --md type=bool
+FLAG basecamp recordings archived --no-hints type=bool
+FLAG basecamp recordings archived --no-stats type=bool
+FLAG basecamp recordings archived --profile type=string
+FLAG basecamp recordings archived --project type=string
+FLAG basecamp recordings archived --quiet type=bool
+FLAG basecamp recordings archived --stats type=bool
+FLAG basecamp recordings archived --styled type=bool
+FLAG basecamp recordings archived --todolist type=string
+FLAG basecamp recordings archived --verbose type=count
+FLAG basecamp recordings client-visibility --account type=string
+FLAG basecamp recordings client-visibility --agent type=bool
+FLAG basecamp recordings client-visibility --cache-dir type=string
+FLAG basecamp recordings client-visibility --count type=bool
+FLAG basecamp recordings client-visibility --help type=bool
+FLAG basecamp recordings client-visibility --hidden type=bool
+FLAG basecamp recordings client-visibility --hide type=bool
+FLAG basecamp recordings client-visibility --hints type=bool
+FLAG basecamp recordings client-visibility --ids-only type=bool
+FLAG basecamp recordings client-visibility --in type=string
+FLAG basecamp recordings client-visibility --jq type=string
+FLAG basecamp recordings client-visibility --json type=bool
+FLAG basecamp recordings client-visibility --markdown type=bool
+FLAG basecamp recordings client-visibility --md type=bool
+FLAG basecamp recordings client-visibility --no-hints type=bool
+FLAG basecamp recordings client-visibility --no-stats type=bool
+FLAG basecamp recordings client-visibility --profile type=string
+FLAG basecamp recordings client-visibility --project type=string
+FLAG basecamp recordings client-visibility --quiet type=bool
+FLAG basecamp recordings client-visibility --show type=bool
+FLAG basecamp recordings client-visibility --stats type=bool
+FLAG basecamp recordings client-visibility --styled type=bool
+FLAG basecamp recordings client-visibility --todolist type=string
+FLAG basecamp recordings client-visibility --verbose type=count
+FLAG basecamp recordings client-visibility --visible type=bool
 FLAG basecamp recordings list --account type=string
 FLAG basecamp recordings list --agent type=bool
 FLAG basecamp recordings list --all type=bool
 FLAG basecamp recordings list --cache-dir type=string
 FLAG basecamp recordings list --count type=bool
 FLAG basecamp recordings list --direction type=string
+FLAG basecamp recordings list --help type=bool
 FLAG basecamp recordings list --hints type=bool
 FLAG basecamp recordings list --ids-only type=bool
 FLAG basecamp recordings list --in type=string
@@ -4741,6 +10409,7 @@ FLAG basecamp recordings restore --account type=string
 FLAG basecamp recordings restore --agent type=bool
 FLAG basecamp recordings restore --cache-dir type=string
 FLAG basecamp recordings restore --count type=bool
+FLAG basecamp recordings restore --help type=bool
 FLAG basecamp recordings restore --hints type=bool
 FLAG basecamp recordings restore --ids-only type=bool
 FLAG basecamp recordings restore --in type=string
@@ -4761,6 +10430,7 @@ FLAG basecamp recordings trash --account type=string
 FLAG basecamp recordings trash --agent type=bool
 FLAG basecamp recordings trash --cache-dir type=string
 FLAG basecamp recordings trash --count type=bool
+FLAG basecamp recordings trash --help type=bool
 FLAG basecamp recordings trash --hints type=bool
 FLAG basecamp recordings trash --ids-only type=bool
 FLAG basecamp recordings trash --in type=string
@@ -4777,10 +10447,32 @@ FLAG basecamp recordings trash --stats type=bool
 FLAG basecamp recordings trash --styled type=bool
 FLAG basecamp recordings trash --todolist type=string
 FLAG basecamp recordings trash --verbose type=count
+FLAG basecamp recordings trashed --account type=string
+FLAG basecamp recordings trashed --agent type=bool
+FLAG basecamp recordings trashed --cache-dir type=string
+FLAG basecamp recordings trashed --count type=bool
+FLAG basecamp recordings trashed --help type=bool
+FLAG basecamp recordings trashed --hints type=bool
+FLAG basecamp recordings trashed --ids-only type=bool
+FLAG basecamp recordings trashed --in type=string
+FLAG basecamp recordings trashed --jq type=string
+FLAG basecamp recordings trashed --json type=bool
+FLAG basecamp recordings trashed --markdown type=bool
+FLAG basecamp recordings trashed --md type=bool
+FLAG basecamp recordings trashed --no-hints type=bool
+FLAG basecamp recordings trashed --no-stats type=bool
+FLAG basecamp recordings trashed --profile type=string
+FLAG basecamp recordings trashed --project type=string
+FLAG basecamp recordings trashed --quiet type=bool
+FLAG basecamp recordings trashed --stats type=bool
+FLAG basecamp recordings trashed --styled type=bool
+FLAG basecamp recordings trashed --todolist type=string
+FLAG basecamp recordings trashed --verbose type=count
 FLAG basecamp recordings visibility --account type=string
 FLAG basecamp recordings visibility --agent type=bool
 FLAG basecamp recordings visibility --cache-dir type=string
 FLAG basecamp recordings visibility --count type=bool
+FLAG basecamp recordings visibility --help type=bool
 FLAG basecamp recordings visibility --hidden type=bool
 FLAG basecamp recordings visibility --hide type=bool
 FLAG basecamp recordings visibility --hints type=bool
@@ -4805,6 +10497,7 @@ FLAG basecamp reopen --account type=string
 FLAG basecamp reopen --agent type=bool
 FLAG basecamp reopen --cache-dir type=string
 FLAG basecamp reopen --count type=bool
+FLAG basecamp reopen --help type=bool
 FLAG basecamp reopen --hints type=bool
 FLAG basecamp reopen --ids-only type=bool
 FLAG basecamp reopen --in type=string
@@ -4825,6 +10518,7 @@ FLAG basecamp reports --account type=string
 FLAG basecamp reports --agent type=bool
 FLAG basecamp reports --cache-dir type=string
 FLAG basecamp reports --count type=bool
+FLAG basecamp reports --help type=bool
 FLAG basecamp reports --hints type=bool
 FLAG basecamp reports --ids-only type=bool
 FLAG basecamp reports --in type=string
@@ -4845,6 +10539,7 @@ FLAG basecamp reports assignable --account type=string
 FLAG basecamp reports assignable --agent type=bool
 FLAG basecamp reports assignable --cache-dir type=string
 FLAG basecamp reports assignable --count type=bool
+FLAG basecamp reports assignable --help type=bool
 FLAG basecamp reports assignable --hints type=bool
 FLAG basecamp reports assignable --ids-only type=bool
 FLAG basecamp reports assignable --in type=string
@@ -4866,6 +10561,7 @@ FLAG basecamp reports assigned --agent type=bool
 FLAG basecamp reports assigned --cache-dir type=string
 FLAG basecamp reports assigned --count type=bool
 FLAG basecamp reports assigned --group-by type=string
+FLAG basecamp reports assigned --help type=bool
 FLAG basecamp reports assigned --hints type=bool
 FLAG basecamp reports assigned --ids-only type=bool
 FLAG basecamp reports assigned --in type=string
@@ -4886,6 +10582,7 @@ FLAG basecamp reports overdue --account type=string
 FLAG basecamp reports overdue --agent type=bool
 FLAG basecamp reports overdue --cache-dir type=string
 FLAG basecamp reports overdue --count type=bool
+FLAG basecamp reports overdue --help type=bool
 FLAG basecamp reports overdue --hints type=bool
 FLAG basecamp reports overdue --ids-only type=bool
 FLAG basecamp reports overdue --in type=string
@@ -4907,6 +10604,7 @@ FLAG basecamp reports schedule --agent type=bool
 FLAG basecamp reports schedule --cache-dir type=string
 FLAG basecamp reports schedule --count type=bool
 FLAG basecamp reports schedule --end type=string
+FLAG basecamp reports schedule --help type=bool
 FLAG basecamp reports schedule --hints type=bool
 FLAG basecamp reports schedule --ids-only type=bool
 FLAG basecamp reports schedule --in type=string
@@ -4928,6 +10626,7 @@ FLAG basecamp schedule --account type=string
 FLAG basecamp schedule --agent type=bool
 FLAG basecamp schedule --cache-dir type=string
 FLAG basecamp schedule --count type=bool
+FLAG basecamp schedule --help type=bool
 FLAG basecamp schedule --hints type=bool
 FLAG basecamp schedule --ids-only type=bool
 FLAG basecamp schedule --in type=string
@@ -4955,6 +10654,7 @@ FLAG basecamp schedule create --desc type=string
 FLAG basecamp schedule create --description type=string
 FLAG basecamp schedule create --end type=string
 FLAG basecamp schedule create --ends-at type=string
+FLAG basecamp schedule create --help type=bool
 FLAG basecamp schedule create --hints type=bool
 FLAG basecamp schedule create --ids-only type=bool
 FLAG basecamp schedule create --in type=string
@@ -4986,6 +10686,7 @@ FLAG basecamp schedule entries --agent type=bool
 FLAG basecamp schedule entries --all type=bool
 FLAG basecamp schedule entries --cache-dir type=string
 FLAG basecamp schedule entries --count type=bool
+FLAG basecamp schedule entries --help type=bool
 FLAG basecamp schedule entries --hints type=bool
 FLAG basecamp schedule entries --ids-only type=bool
 FLAG basecamp schedule entries --in type=string
@@ -5012,6 +10713,7 @@ FLAG basecamp schedule info --account type=string
 FLAG basecamp schedule info --agent type=bool
 FLAG basecamp schedule info --cache-dir type=string
 FLAG basecamp schedule info --count type=bool
+FLAG basecamp schedule info --help type=bool
 FLAG basecamp schedule info --hints type=bool
 FLAG basecamp schedule info --ids-only type=bool
 FLAG basecamp schedule info --in type=string
@@ -5033,6 +10735,7 @@ FLAG basecamp schedule settings --account type=string
 FLAG basecamp schedule settings --agent type=bool
 FLAG basecamp schedule settings --cache-dir type=string
 FLAG basecamp schedule settings --count type=bool
+FLAG basecamp schedule settings --help type=bool
 FLAG basecamp schedule settings --hints type=bool
 FLAG basecamp schedule settings --ids-only type=bool
 FLAG basecamp schedule settings --in type=string
@@ -5057,6 +10760,7 @@ FLAG basecamp schedule show --agent type=bool
 FLAG basecamp schedule show --cache-dir type=string
 FLAG basecamp schedule show --count type=bool
 FLAG basecamp schedule show --date type=string
+FLAG basecamp schedule show --help type=bool
 FLAG basecamp schedule show --hints type=bool
 FLAG basecamp schedule show --ids-only type=bool
 FLAG basecamp schedule show --in type=string
@@ -5085,6 +10789,7 @@ FLAG basecamp schedule update --desc type=string
 FLAG basecamp schedule update --description type=string
 FLAG basecamp schedule update --end type=string
 FLAG basecamp schedule update --ends-at type=string
+FLAG basecamp schedule update --help type=bool
 FLAG basecamp schedule update --hints type=bool
 FLAG basecamp schedule update --ids-only type=bool
 FLAG basecamp schedule update --in type=string
@@ -5114,6 +10819,7 @@ FLAG basecamp search --agent type=bool
 FLAG basecamp search --all type=bool
 FLAG basecamp search --cache-dir type=string
 FLAG basecamp search --count type=bool
+FLAG basecamp search --help type=bool
 FLAG basecamp search --hints type=bool
 FLAG basecamp search --ids-only type=bool
 FLAG basecamp search --in type=string
@@ -5136,6 +10842,7 @@ FLAG basecamp search metadata --account type=string
 FLAG basecamp search metadata --agent type=bool
 FLAG basecamp search metadata --cache-dir type=string
 FLAG basecamp search metadata --count type=bool
+FLAG basecamp search metadata --help type=bool
 FLAG basecamp search metadata --hints type=bool
 FLAG basecamp search metadata --ids-only type=bool
 FLAG basecamp search metadata --in type=string
@@ -5152,10 +10859,32 @@ FLAG basecamp search metadata --stats type=bool
 FLAG basecamp search metadata --styled type=bool
 FLAG basecamp search metadata --todolist type=string
 FLAG basecamp search metadata --verbose type=count
+FLAG basecamp search types --account type=string
+FLAG basecamp search types --agent type=bool
+FLAG basecamp search types --cache-dir type=string
+FLAG basecamp search types --count type=bool
+FLAG basecamp search types --help type=bool
+FLAG basecamp search types --hints type=bool
+FLAG basecamp search types --ids-only type=bool
+FLAG basecamp search types --in type=string
+FLAG basecamp search types --jq type=string
+FLAG basecamp search types --json type=bool
+FLAG basecamp search types --markdown type=bool
+FLAG basecamp search types --md type=bool
+FLAG basecamp search types --no-hints type=bool
+FLAG basecamp search types --no-stats type=bool
+FLAG basecamp search types --profile type=string
+FLAG basecamp search types --project type=string
+FLAG basecamp search types --quiet type=bool
+FLAG basecamp search types --stats type=bool
+FLAG basecamp search types --styled type=bool
+FLAG basecamp search types --todolist type=string
+FLAG basecamp search types --verbose type=count
 FLAG basecamp setup --account type=string
 FLAG basecamp setup --agent type=bool
 FLAG basecamp setup --cache-dir type=string
 FLAG basecamp setup --count type=bool
+FLAG basecamp setup --help type=bool
 FLAG basecamp setup --hints type=bool
 FLAG basecamp setup --ids-only type=bool
 FLAG basecamp setup --in type=string
@@ -5176,6 +10905,7 @@ FLAG basecamp setup claude --account type=string
 FLAG basecamp setup claude --agent type=bool
 FLAG basecamp setup claude --cache-dir type=string
 FLAG basecamp setup claude --count type=bool
+FLAG basecamp setup claude --help type=bool
 FLAG basecamp setup claude --hints type=bool
 FLAG basecamp setup claude --ids-only type=bool
 FLAG basecamp setup claude --in type=string
@@ -5196,6 +10926,7 @@ FLAG basecamp show --account type=string
 FLAG basecamp show --agent type=bool
 FLAG basecamp show --cache-dir type=string
 FLAG basecamp show --count type=bool
+FLAG basecamp show --help type=bool
 FLAG basecamp show --hints type=bool
 FLAG basecamp show --ids-only type=bool
 FLAG basecamp show --in type=string
@@ -5217,6 +10948,7 @@ FLAG basecamp skill --account type=string
 FLAG basecamp skill --agent type=bool
 FLAG basecamp skill --cache-dir type=string
 FLAG basecamp skill --count type=bool
+FLAG basecamp skill --help type=bool
 FLAG basecamp skill --hints type=bool
 FLAG basecamp skill --ids-only type=bool
 FLAG basecamp skill --in type=string
@@ -5237,6 +10969,7 @@ FLAG basecamp skill install --account type=string
 FLAG basecamp skill install --agent type=bool
 FLAG basecamp skill install --cache-dir type=string
 FLAG basecamp skill install --count type=bool
+FLAG basecamp skill install --help type=bool
 FLAG basecamp skill install --hints type=bool
 FLAG basecamp skill install --ids-only type=bool
 FLAG basecamp skill install --in type=string
@@ -5257,6 +10990,7 @@ FLAG basecamp subscriptions --account type=string
 FLAG basecamp subscriptions --agent type=bool
 FLAG basecamp subscriptions --cache-dir type=string
 FLAG basecamp subscriptions --count type=bool
+FLAG basecamp subscriptions --help type=bool
 FLAG basecamp subscriptions --hints type=bool
 FLAG basecamp subscriptions --ids-only type=bool
 FLAG basecamp subscriptions --in type=string
@@ -5277,6 +11011,7 @@ FLAG basecamp subscriptions add --account type=string
 FLAG basecamp subscriptions add --agent type=bool
 FLAG basecamp subscriptions add --cache-dir type=string
 FLAG basecamp subscriptions add --count type=bool
+FLAG basecamp subscriptions add --help type=bool
 FLAG basecamp subscriptions add --hints type=bool
 FLAG basecamp subscriptions add --ids-only type=bool
 FLAG basecamp subscriptions add --in type=string
@@ -5298,6 +11033,7 @@ FLAG basecamp subscriptions remove --account type=string
 FLAG basecamp subscriptions remove --agent type=bool
 FLAG basecamp subscriptions remove --cache-dir type=string
 FLAG basecamp subscriptions remove --count type=bool
+FLAG basecamp subscriptions remove --help type=bool
 FLAG basecamp subscriptions remove --hints type=bool
 FLAG basecamp subscriptions remove --ids-only type=bool
 FLAG basecamp subscriptions remove --in type=string
@@ -5319,6 +11055,7 @@ FLAG basecamp subscriptions show --account type=string
 FLAG basecamp subscriptions show --agent type=bool
 FLAG basecamp subscriptions show --cache-dir type=string
 FLAG basecamp subscriptions show --count type=bool
+FLAG basecamp subscriptions show --help type=bool
 FLAG basecamp subscriptions show --hints type=bool
 FLAG basecamp subscriptions show --ids-only type=bool
 FLAG basecamp subscriptions show --in type=string
@@ -5339,6 +11076,7 @@ FLAG basecamp subscriptions subscribe --account type=string
 FLAG basecamp subscriptions subscribe --agent type=bool
 FLAG basecamp subscriptions subscribe --cache-dir type=string
 FLAG basecamp subscriptions subscribe --count type=bool
+FLAG basecamp subscriptions subscribe --help type=bool
 FLAG basecamp subscriptions subscribe --hints type=bool
 FLAG basecamp subscriptions subscribe --ids-only type=bool
 FLAG basecamp subscriptions subscribe --in type=string
@@ -5359,6 +11097,7 @@ FLAG basecamp subscriptions unsubscribe --account type=string
 FLAG basecamp subscriptions unsubscribe --agent type=bool
 FLAG basecamp subscriptions unsubscribe --cache-dir type=string
 FLAG basecamp subscriptions unsubscribe --count type=bool
+FLAG basecamp subscriptions unsubscribe --help type=bool
 FLAG basecamp subscriptions unsubscribe --hints type=bool
 FLAG basecamp subscriptions unsubscribe --ids-only type=bool
 FLAG basecamp subscriptions unsubscribe --in type=string
@@ -5379,6 +11118,7 @@ FLAG basecamp templates --account type=string
 FLAG basecamp templates --agent type=bool
 FLAG basecamp templates --cache-dir type=string
 FLAG basecamp templates --count type=bool
+FLAG basecamp templates --help type=bool
 FLAG basecamp templates --hints type=bool
 FLAG basecamp templates --ids-only type=bool
 FLAG basecamp templates --in type=string
@@ -5402,6 +11142,7 @@ FLAG basecamp templates construct --cache-dir type=string
 FLAG basecamp templates construct --count type=bool
 FLAG basecamp templates construct --desc type=string
 FLAG basecamp templates construct --description type=string
+FLAG basecamp templates construct --help type=bool
 FLAG basecamp templates construct --hints type=bool
 FLAG basecamp templates construct --ids-only type=bool
 FLAG basecamp templates construct --in type=string
@@ -5424,6 +11165,7 @@ FLAG basecamp templates construction --account type=string
 FLAG basecamp templates construction --agent type=bool
 FLAG basecamp templates construction --cache-dir type=string
 FLAG basecamp templates construction --count type=bool
+FLAG basecamp templates construction --help type=bool
 FLAG basecamp templates construction --hints type=bool
 FLAG basecamp templates construction --ids-only type=bool
 FLAG basecamp templates construction --in type=string
@@ -5447,6 +11189,7 @@ FLAG basecamp templates create --cache-dir type=string
 FLAG basecamp templates create --count type=bool
 FLAG basecamp templates create --desc type=string
 FLAG basecamp templates create --description type=string
+FLAG basecamp templates create --help type=bool
 FLAG basecamp templates create --hints type=bool
 FLAG basecamp templates create --ids-only type=bool
 FLAG basecamp templates create --in type=string
@@ -5469,6 +11212,7 @@ FLAG basecamp templates delete --account type=string
 FLAG basecamp templates delete --agent type=bool
 FLAG basecamp templates delete --cache-dir type=string
 FLAG basecamp templates delete --count type=bool
+FLAG basecamp templates delete --help type=bool
 FLAG basecamp templates delete --hints type=bool
 FLAG basecamp templates delete --ids-only type=bool
 FLAG basecamp templates delete --in type=string
@@ -5490,6 +11234,7 @@ FLAG basecamp templates list --account type=string
 FLAG basecamp templates list --agent type=bool
 FLAG basecamp templates list --cache-dir type=string
 FLAG basecamp templates list --count type=bool
+FLAG basecamp templates list --help type=bool
 FLAG basecamp templates list --hints type=bool
 FLAG basecamp templates list --ids-only type=bool
 FLAG basecamp templates list --in type=string
@@ -5511,6 +11256,7 @@ FLAG basecamp templates show --account type=string
 FLAG basecamp templates show --agent type=bool
 FLAG basecamp templates show --cache-dir type=string
 FLAG basecamp templates show --count type=bool
+FLAG basecamp templates show --help type=bool
 FLAG basecamp templates show --hints type=bool
 FLAG basecamp templates show --ids-only type=bool
 FLAG basecamp templates show --in type=string
@@ -5534,6 +11280,7 @@ FLAG basecamp templates update --cache-dir type=string
 FLAG basecamp templates update --count type=bool
 FLAG basecamp templates update --desc type=string
 FLAG basecamp templates update --description type=string
+FLAG basecamp templates update --help type=bool
 FLAG basecamp templates update --hints type=bool
 FLAG basecamp templates update --ids-only type=bool
 FLAG basecamp templates update --in type=string
@@ -5557,6 +11304,7 @@ FLAG basecamp timeline --agent type=bool
 FLAG basecamp timeline --all type=bool
 FLAG basecamp timeline --cache-dir type=string
 FLAG basecamp timeline --count type=bool
+FLAG basecamp timeline --help type=bool
 FLAG basecamp timeline --hints type=bool
 FLAG basecamp timeline --ids-only type=bool
 FLAG basecamp timeline --in type=string
@@ -5584,6 +11332,7 @@ FLAG basecamp timesheet --cache-dir type=string
 FLAG basecamp timesheet --count type=bool
 FLAG basecamp timesheet --end type=string
 FLAG basecamp timesheet --from type=string
+FLAG basecamp timesheet --help type=bool
 FLAG basecamp timesheet --hints type=bool
 FLAG basecamp timesheet --ids-only type=bool
 FLAG basecamp timesheet --in type=string
@@ -5609,6 +11358,7 @@ FLAG basecamp timesheet item --cache-dir type=string
 FLAG basecamp timesheet item --count type=bool
 FLAG basecamp timesheet item --end type=string
 FLAG basecamp timesheet item --from type=string
+FLAG basecamp timesheet item --help type=bool
 FLAG basecamp timesheet item --hints type=bool
 FLAG basecamp timesheet item --ids-only type=bool
 FLAG basecamp timesheet item --in type=string
@@ -5634,6 +11384,7 @@ FLAG basecamp timesheet project --cache-dir type=string
 FLAG basecamp timesheet project --count type=bool
 FLAG basecamp timesheet project --end type=string
 FLAG basecamp timesheet project --from type=string
+FLAG basecamp timesheet project --help type=bool
 FLAG basecamp timesheet project --hints type=bool
 FLAG basecamp timesheet project --ids-only type=bool
 FLAG basecamp timesheet project --in type=string
@@ -5653,12 +11404,39 @@ FLAG basecamp timesheet project --styled type=bool
 FLAG basecamp timesheet project --to type=string
 FLAG basecamp timesheet project --todolist type=string
 FLAG basecamp timesheet project --verbose type=count
+FLAG basecamp timesheet recording --account type=string
+FLAG basecamp timesheet recording --agent type=bool
+FLAG basecamp timesheet recording --cache-dir type=string
+FLAG basecamp timesheet recording --count type=bool
+FLAG basecamp timesheet recording --end type=string
+FLAG basecamp timesheet recording --from type=string
+FLAG basecamp timesheet recording --help type=bool
+FLAG basecamp timesheet recording --hints type=bool
+FLAG basecamp timesheet recording --ids-only type=bool
+FLAG basecamp timesheet recording --in type=string
+FLAG basecamp timesheet recording --jq type=string
+FLAG basecamp timesheet recording --json type=bool
+FLAG basecamp timesheet recording --markdown type=bool
+FLAG basecamp timesheet recording --md type=bool
+FLAG basecamp timesheet recording --no-hints type=bool
+FLAG basecamp timesheet recording --no-stats type=bool
+FLAG basecamp timesheet recording --person type=string
+FLAG basecamp timesheet recording --profile type=string
+FLAG basecamp timesheet recording --project type=string
+FLAG basecamp timesheet recording --quiet type=bool
+FLAG basecamp timesheet recording --start type=string
+FLAG basecamp timesheet recording --stats type=bool
+FLAG basecamp timesheet recording --styled type=bool
+FLAG basecamp timesheet recording --to type=string
+FLAG basecamp timesheet recording --todolist type=string
+FLAG basecamp timesheet recording --verbose type=count
 FLAG basecamp timesheet report --account type=string
 FLAG basecamp timesheet report --agent type=bool
 FLAG basecamp timesheet report --cache-dir type=string
 FLAG basecamp timesheet report --count type=bool
 FLAG basecamp timesheet report --end type=string
 FLAG basecamp timesheet report --from type=string
+FLAG basecamp timesheet report --help type=bool
 FLAG basecamp timesheet report --hints type=bool
 FLAG basecamp timesheet report --ids-only type=bool
 FLAG basecamp timesheet report --in type=string
@@ -5678,6 +11456,366 @@ FLAG basecamp timesheet report --styled type=bool
 FLAG basecamp timesheet report --to type=string
 FLAG basecamp timesheet report --todolist type=string
 FLAG basecamp timesheet report --verbose type=count
+FLAG basecamp tlgroup --account type=string
+FLAG basecamp tlgroup --agent type=bool
+FLAG basecamp tlgroup --cache-dir type=string
+FLAG basecamp tlgroup --count type=bool
+FLAG basecamp tlgroup --help type=bool
+FLAG basecamp tlgroup --hints type=bool
+FLAG basecamp tlgroup --ids-only type=bool
+FLAG basecamp tlgroup --in type=string
+FLAG basecamp tlgroup --jq type=string
+FLAG basecamp tlgroup --json type=bool
+FLAG basecamp tlgroup --list type=string
+FLAG basecamp tlgroup --markdown type=bool
+FLAG basecamp tlgroup --md type=bool
+FLAG basecamp tlgroup --no-hints type=bool
+FLAG basecamp tlgroup --no-stats type=bool
+FLAG basecamp tlgroup --profile type=string
+FLAG basecamp tlgroup --project type=string
+FLAG basecamp tlgroup --quiet type=bool
+FLAG basecamp tlgroup --stats type=bool
+FLAG basecamp tlgroup --styled type=bool
+FLAG basecamp tlgroup --todolist type=string
+FLAG basecamp tlgroup --verbose type=count
+FLAG basecamp tlgroup create --account type=string
+FLAG basecamp tlgroup create --agent type=bool
+FLAG basecamp tlgroup create --cache-dir type=string
+FLAG basecamp tlgroup create --count type=bool
+FLAG basecamp tlgroup create --help type=bool
+FLAG basecamp tlgroup create --hints type=bool
+FLAG basecamp tlgroup create --ids-only type=bool
+FLAG basecamp tlgroup create --in type=string
+FLAG basecamp tlgroup create --jq type=string
+FLAG basecamp tlgroup create --json type=bool
+FLAG basecamp tlgroup create --list type=string
+FLAG basecamp tlgroup create --markdown type=bool
+FLAG basecamp tlgroup create --md type=bool
+FLAG basecamp tlgroup create --no-hints type=bool
+FLAG basecamp tlgroup create --no-stats type=bool
+FLAG basecamp tlgroup create --profile type=string
+FLAG basecamp tlgroup create --project type=string
+FLAG basecamp tlgroup create --quiet type=bool
+FLAG basecamp tlgroup create --stats type=bool
+FLAG basecamp tlgroup create --styled type=bool
+FLAG basecamp tlgroup create --todolist type=string
+FLAG basecamp tlgroup create --verbose type=count
+FLAG basecamp tlgroup list --account type=string
+FLAG basecamp tlgroup list --agent type=bool
+FLAG basecamp tlgroup list --cache-dir type=string
+FLAG basecamp tlgroup list --count type=bool
+FLAG basecamp tlgroup list --help type=bool
+FLAG basecamp tlgroup list --hints type=bool
+FLAG basecamp tlgroup list --ids-only type=bool
+FLAG basecamp tlgroup list --in type=string
+FLAG basecamp tlgroup list --jq type=string
+FLAG basecamp tlgroup list --json type=bool
+FLAG basecamp tlgroup list --list type=string
+FLAG basecamp tlgroup list --markdown type=bool
+FLAG basecamp tlgroup list --md type=bool
+FLAG basecamp tlgroup list --no-hints type=bool
+FLAG basecamp tlgroup list --no-stats type=bool
+FLAG basecamp tlgroup list --profile type=string
+FLAG basecamp tlgroup list --project type=string
+FLAG basecamp tlgroup list --quiet type=bool
+FLAG basecamp tlgroup list --stats type=bool
+FLAG basecamp tlgroup list --styled type=bool
+FLAG basecamp tlgroup list --todolist type=string
+FLAG basecamp tlgroup list --verbose type=count
+FLAG basecamp tlgroup move --account type=string
+FLAG basecamp tlgroup move --agent type=bool
+FLAG basecamp tlgroup move --cache-dir type=string
+FLAG basecamp tlgroup move --count type=bool
+FLAG basecamp tlgroup move --help type=bool
+FLAG basecamp tlgroup move --hints type=bool
+FLAG basecamp tlgroup move --ids-only type=bool
+FLAG basecamp tlgroup move --in type=string
+FLAG basecamp tlgroup move --jq type=string
+FLAG basecamp tlgroup move --json type=bool
+FLAG basecamp tlgroup move --list type=string
+FLAG basecamp tlgroup move --markdown type=bool
+FLAG basecamp tlgroup move --md type=bool
+FLAG basecamp tlgroup move --no-hints type=bool
+FLAG basecamp tlgroup move --no-stats type=bool
+FLAG basecamp tlgroup move --pos type=int
+FLAG basecamp tlgroup move --position type=int
+FLAG basecamp tlgroup move --profile type=string
+FLAG basecamp tlgroup move --project type=string
+FLAG basecamp tlgroup move --quiet type=bool
+FLAG basecamp tlgroup move --stats type=bool
+FLAG basecamp tlgroup move --styled type=bool
+FLAG basecamp tlgroup move --todolist type=string
+FLAG basecamp tlgroup move --verbose type=count
+FLAG basecamp tlgroup position --account type=string
+FLAG basecamp tlgroup position --agent type=bool
+FLAG basecamp tlgroup position --cache-dir type=string
+FLAG basecamp tlgroup position --count type=bool
+FLAG basecamp tlgroup position --help type=bool
+FLAG basecamp tlgroup position --hints type=bool
+FLAG basecamp tlgroup position --ids-only type=bool
+FLAG basecamp tlgroup position --in type=string
+FLAG basecamp tlgroup position --jq type=string
+FLAG basecamp tlgroup position --json type=bool
+FLAG basecamp tlgroup position --list type=string
+FLAG basecamp tlgroup position --markdown type=bool
+FLAG basecamp tlgroup position --md type=bool
+FLAG basecamp tlgroup position --no-hints type=bool
+FLAG basecamp tlgroup position --no-stats type=bool
+FLAG basecamp tlgroup position --pos type=int
+FLAG basecamp tlgroup position --position type=int
+FLAG basecamp tlgroup position --profile type=string
+FLAG basecamp tlgroup position --project type=string
+FLAG basecamp tlgroup position --quiet type=bool
+FLAG basecamp tlgroup position --stats type=bool
+FLAG basecamp tlgroup position --styled type=bool
+FLAG basecamp tlgroup position --todolist type=string
+FLAG basecamp tlgroup position --verbose type=count
+FLAG basecamp tlgroup rename --account type=string
+FLAG basecamp tlgroup rename --agent type=bool
+FLAG basecamp tlgroup rename --cache-dir type=string
+FLAG basecamp tlgroup rename --count type=bool
+FLAG basecamp tlgroup rename --help type=bool
+FLAG basecamp tlgroup rename --hints type=bool
+FLAG basecamp tlgroup rename --ids-only type=bool
+FLAG basecamp tlgroup rename --in type=string
+FLAG basecamp tlgroup rename --jq type=string
+FLAG basecamp tlgroup rename --json type=bool
+FLAG basecamp tlgroup rename --list type=string
+FLAG basecamp tlgroup rename --markdown type=bool
+FLAG basecamp tlgroup rename --md type=bool
+FLAG basecamp tlgroup rename --no-hints type=bool
+FLAG basecamp tlgroup rename --no-stats type=bool
+FLAG basecamp tlgroup rename --profile type=string
+FLAG basecamp tlgroup rename --project type=string
+FLAG basecamp tlgroup rename --quiet type=bool
+FLAG basecamp tlgroup rename --stats type=bool
+FLAG basecamp tlgroup rename --styled type=bool
+FLAG basecamp tlgroup rename --todolist type=string
+FLAG basecamp tlgroup rename --verbose type=count
+FLAG basecamp tlgroup show --account type=string
+FLAG basecamp tlgroup show --agent type=bool
+FLAG basecamp tlgroup show --cache-dir type=string
+FLAG basecamp tlgroup show --count type=bool
+FLAG basecamp tlgroup show --help type=bool
+FLAG basecamp tlgroup show --hints type=bool
+FLAG basecamp tlgroup show --ids-only type=bool
+FLAG basecamp tlgroup show --in type=string
+FLAG basecamp tlgroup show --jq type=string
+FLAG basecamp tlgroup show --json type=bool
+FLAG basecamp tlgroup show --list type=string
+FLAG basecamp tlgroup show --markdown type=bool
+FLAG basecamp tlgroup show --md type=bool
+FLAG basecamp tlgroup show --no-hints type=bool
+FLAG basecamp tlgroup show --no-stats type=bool
+FLAG basecamp tlgroup show --profile type=string
+FLAG basecamp tlgroup show --project type=string
+FLAG basecamp tlgroup show --quiet type=bool
+FLAG basecamp tlgroup show --stats type=bool
+FLAG basecamp tlgroup show --styled type=bool
+FLAG basecamp tlgroup show --todolist type=string
+FLAG basecamp tlgroup show --verbose type=count
+FLAG basecamp tlgroup update --account type=string
+FLAG basecamp tlgroup update --agent type=bool
+FLAG basecamp tlgroup update --cache-dir type=string
+FLAG basecamp tlgroup update --count type=bool
+FLAG basecamp tlgroup update --help type=bool
+FLAG basecamp tlgroup update --hints type=bool
+FLAG basecamp tlgroup update --ids-only type=bool
+FLAG basecamp tlgroup update --in type=string
+FLAG basecamp tlgroup update --jq type=string
+FLAG basecamp tlgroup update --json type=bool
+FLAG basecamp tlgroup update --list type=string
+FLAG basecamp tlgroup update --markdown type=bool
+FLAG basecamp tlgroup update --md type=bool
+FLAG basecamp tlgroup update --no-hints type=bool
+FLAG basecamp tlgroup update --no-stats type=bool
+FLAG basecamp tlgroup update --profile type=string
+FLAG basecamp tlgroup update --project type=string
+FLAG basecamp tlgroup update --quiet type=bool
+FLAG basecamp tlgroup update --stats type=bool
+FLAG basecamp tlgroup update --styled type=bool
+FLAG basecamp tlgroup update --todolist type=string
+FLAG basecamp tlgroup update --verbose type=count
+FLAG basecamp tlgroups --account type=string
+FLAG basecamp tlgroups --agent type=bool
+FLAG basecamp tlgroups --cache-dir type=string
+FLAG basecamp tlgroups --count type=bool
+FLAG basecamp tlgroups --help type=bool
+FLAG basecamp tlgroups --hints type=bool
+FLAG basecamp tlgroups --ids-only type=bool
+FLAG basecamp tlgroups --in type=string
+FLAG basecamp tlgroups --jq type=string
+FLAG basecamp tlgroups --json type=bool
+FLAG basecamp tlgroups --list type=string
+FLAG basecamp tlgroups --markdown type=bool
+FLAG basecamp tlgroups --md type=bool
+FLAG basecamp tlgroups --no-hints type=bool
+FLAG basecamp tlgroups --no-stats type=bool
+FLAG basecamp tlgroups --profile type=string
+FLAG basecamp tlgroups --project type=string
+FLAG basecamp tlgroups --quiet type=bool
+FLAG basecamp tlgroups --stats type=bool
+FLAG basecamp tlgroups --styled type=bool
+FLAG basecamp tlgroups --todolist type=string
+FLAG basecamp tlgroups --verbose type=count
+FLAG basecamp tlgroups create --account type=string
+FLAG basecamp tlgroups create --agent type=bool
+FLAG basecamp tlgroups create --cache-dir type=string
+FLAG basecamp tlgroups create --count type=bool
+FLAG basecamp tlgroups create --help type=bool
+FLAG basecamp tlgroups create --hints type=bool
+FLAG basecamp tlgroups create --ids-only type=bool
+FLAG basecamp tlgroups create --in type=string
+FLAG basecamp tlgroups create --jq type=string
+FLAG basecamp tlgroups create --json type=bool
+FLAG basecamp tlgroups create --list type=string
+FLAG basecamp tlgroups create --markdown type=bool
+FLAG basecamp tlgroups create --md type=bool
+FLAG basecamp tlgroups create --no-hints type=bool
+FLAG basecamp tlgroups create --no-stats type=bool
+FLAG basecamp tlgroups create --profile type=string
+FLAG basecamp tlgroups create --project type=string
+FLAG basecamp tlgroups create --quiet type=bool
+FLAG basecamp tlgroups create --stats type=bool
+FLAG basecamp tlgroups create --styled type=bool
+FLAG basecamp tlgroups create --todolist type=string
+FLAG basecamp tlgroups create --verbose type=count
+FLAG basecamp tlgroups list --account type=string
+FLAG basecamp tlgroups list --agent type=bool
+FLAG basecamp tlgroups list --cache-dir type=string
+FLAG basecamp tlgroups list --count type=bool
+FLAG basecamp tlgroups list --help type=bool
+FLAG basecamp tlgroups list --hints type=bool
+FLAG basecamp tlgroups list --ids-only type=bool
+FLAG basecamp tlgroups list --in type=string
+FLAG basecamp tlgroups list --jq type=string
+FLAG basecamp tlgroups list --json type=bool
+FLAG basecamp tlgroups list --list type=string
+FLAG basecamp tlgroups list --markdown type=bool
+FLAG basecamp tlgroups list --md type=bool
+FLAG basecamp tlgroups list --no-hints type=bool
+FLAG basecamp tlgroups list --no-stats type=bool
+FLAG basecamp tlgroups list --profile type=string
+FLAG basecamp tlgroups list --project type=string
+FLAG basecamp tlgroups list --quiet type=bool
+FLAG basecamp tlgroups list --stats type=bool
+FLAG basecamp tlgroups list --styled type=bool
+FLAG basecamp tlgroups list --todolist type=string
+FLAG basecamp tlgroups list --verbose type=count
+FLAG basecamp tlgroups move --account type=string
+FLAG basecamp tlgroups move --agent type=bool
+FLAG basecamp tlgroups move --cache-dir type=string
+FLAG basecamp tlgroups move --count type=bool
+FLAG basecamp tlgroups move --help type=bool
+FLAG basecamp tlgroups move --hints type=bool
+FLAG basecamp tlgroups move --ids-only type=bool
+FLAG basecamp tlgroups move --in type=string
+FLAG basecamp tlgroups move --jq type=string
+FLAG basecamp tlgroups move --json type=bool
+FLAG basecamp tlgroups move --list type=string
+FLAG basecamp tlgroups move --markdown type=bool
+FLAG basecamp tlgroups move --md type=bool
+FLAG basecamp tlgroups move --no-hints type=bool
+FLAG basecamp tlgroups move --no-stats type=bool
+FLAG basecamp tlgroups move --pos type=int
+FLAG basecamp tlgroups move --position type=int
+FLAG basecamp tlgroups move --profile type=string
+FLAG basecamp tlgroups move --project type=string
+FLAG basecamp tlgroups move --quiet type=bool
+FLAG basecamp tlgroups move --stats type=bool
+FLAG basecamp tlgroups move --styled type=bool
+FLAG basecamp tlgroups move --todolist type=string
+FLAG basecamp tlgroups move --verbose type=count
+FLAG basecamp tlgroups position --account type=string
+FLAG basecamp tlgroups position --agent type=bool
+FLAG basecamp tlgroups position --cache-dir type=string
+FLAG basecamp tlgroups position --count type=bool
+FLAG basecamp tlgroups position --help type=bool
+FLAG basecamp tlgroups position --hints type=bool
+FLAG basecamp tlgroups position --ids-only type=bool
+FLAG basecamp tlgroups position --in type=string
+FLAG basecamp tlgroups position --jq type=string
+FLAG basecamp tlgroups position --json type=bool
+FLAG basecamp tlgroups position --list type=string
+FLAG basecamp tlgroups position --markdown type=bool
+FLAG basecamp tlgroups position --md type=bool
+FLAG basecamp tlgroups position --no-hints type=bool
+FLAG basecamp tlgroups position --no-stats type=bool
+FLAG basecamp tlgroups position --pos type=int
+FLAG basecamp tlgroups position --position type=int
+FLAG basecamp tlgroups position --profile type=string
+FLAG basecamp tlgroups position --project type=string
+FLAG basecamp tlgroups position --quiet type=bool
+FLAG basecamp tlgroups position --stats type=bool
+FLAG basecamp tlgroups position --styled type=bool
+FLAG basecamp tlgroups position --todolist type=string
+FLAG basecamp tlgroups position --verbose type=count
+FLAG basecamp tlgroups rename --account type=string
+FLAG basecamp tlgroups rename --agent type=bool
+FLAG basecamp tlgroups rename --cache-dir type=string
+FLAG basecamp tlgroups rename --count type=bool
+FLAG basecamp tlgroups rename --help type=bool
+FLAG basecamp tlgroups rename --hints type=bool
+FLAG basecamp tlgroups rename --ids-only type=bool
+FLAG basecamp tlgroups rename --in type=string
+FLAG basecamp tlgroups rename --jq type=string
+FLAG basecamp tlgroups rename --json type=bool
+FLAG basecamp tlgroups rename --list type=string
+FLAG basecamp tlgroups rename --markdown type=bool
+FLAG basecamp tlgroups rename --md type=bool
+FLAG basecamp tlgroups rename --no-hints type=bool
+FLAG basecamp tlgroups rename --no-stats type=bool
+FLAG basecamp tlgroups rename --profile type=string
+FLAG basecamp tlgroups rename --project type=string
+FLAG basecamp tlgroups rename --quiet type=bool
+FLAG basecamp tlgroups rename --stats type=bool
+FLAG basecamp tlgroups rename --styled type=bool
+FLAG basecamp tlgroups rename --todolist type=string
+FLAG basecamp tlgroups rename --verbose type=count
+FLAG basecamp tlgroups show --account type=string
+FLAG basecamp tlgroups show --agent type=bool
+FLAG basecamp tlgroups show --cache-dir type=string
+FLAG basecamp tlgroups show --count type=bool
+FLAG basecamp tlgroups show --help type=bool
+FLAG basecamp tlgroups show --hints type=bool
+FLAG basecamp tlgroups show --ids-only type=bool
+FLAG basecamp tlgroups show --in type=string
+FLAG basecamp tlgroups show --jq type=string
+FLAG basecamp tlgroups show --json type=bool
+FLAG basecamp tlgroups show --list type=string
+FLAG basecamp tlgroups show --markdown type=bool
+FLAG basecamp tlgroups show --md type=bool
+FLAG basecamp tlgroups show --no-hints type=bool
+FLAG basecamp tlgroups show --no-stats type=bool
+FLAG basecamp tlgroups show --profile type=string
+FLAG basecamp tlgroups show --project type=string
+FLAG basecamp tlgroups show --quiet type=bool
+FLAG basecamp tlgroups show --stats type=bool
+FLAG basecamp tlgroups show --styled type=bool
+FLAG basecamp tlgroups show --todolist type=string
+FLAG basecamp tlgroups show --verbose type=count
+FLAG basecamp tlgroups update --account type=string
+FLAG basecamp tlgroups update --agent type=bool
+FLAG basecamp tlgroups update --cache-dir type=string
+FLAG basecamp tlgroups update --count type=bool
+FLAG basecamp tlgroups update --help type=bool
+FLAG basecamp tlgroups update --hints type=bool
+FLAG basecamp tlgroups update --ids-only type=bool
+FLAG basecamp tlgroups update --in type=string
+FLAG basecamp tlgroups update --jq type=string
+FLAG basecamp tlgroups update --json type=bool
+FLAG basecamp tlgroups update --list type=string
+FLAG basecamp tlgroups update --markdown type=bool
+FLAG basecamp tlgroups update --md type=bool
+FLAG basecamp tlgroups update --no-hints type=bool
+FLAG basecamp tlgroups update --no-stats type=bool
+FLAG basecamp tlgroups update --profile type=string
+FLAG basecamp tlgroups update --project type=string
+FLAG basecamp tlgroups update --quiet type=bool
+FLAG basecamp tlgroups update --stats type=bool
+FLAG basecamp tlgroups update --styled type=bool
+FLAG basecamp tlgroups update --todolist type=string
+FLAG basecamp tlgroups update --verbose type=count
 FLAG basecamp todo --account type=string
 FLAG basecamp todo --agent type=bool
 FLAG basecamp todo --assignee type=string
@@ -5686,6 +11824,7 @@ FLAG basecamp todo --cache-dir type=string
 FLAG basecamp todo --count type=bool
 FLAG basecamp todo --description type=string
 FLAG basecamp todo --due type=string
+FLAG basecamp todo --help type=bool
 FLAG basecamp todo --hints type=bool
 FLAG basecamp todo --ids-only type=bool
 FLAG basecamp todo --in type=string
@@ -5705,10 +11844,370 @@ FLAG basecamp todo --to type=string
 FLAG basecamp todo --todolist type=string
 FLAG basecamp todo --todoset type=string
 FLAG basecamp todo --verbose type=count
+FLAG basecamp todolist --account type=string
+FLAG basecamp todolist --agent type=bool
+FLAG basecamp todolist --cache-dir type=string
+FLAG basecamp todolist --count type=bool
+FLAG basecamp todolist --help type=bool
+FLAG basecamp todolist --hints type=bool
+FLAG basecamp todolist --ids-only type=bool
+FLAG basecamp todolist --in type=string
+FLAG basecamp todolist --jq type=string
+FLAG basecamp todolist --json type=bool
+FLAG basecamp todolist --markdown type=bool
+FLAG basecamp todolist --md type=bool
+FLAG basecamp todolist --no-hints type=bool
+FLAG basecamp todolist --no-stats type=bool
+FLAG basecamp todolist --profile type=string
+FLAG basecamp todolist --project type=string
+FLAG basecamp todolist --quiet type=bool
+FLAG basecamp todolist --stats type=bool
+FLAG basecamp todolist --styled type=bool
+FLAG basecamp todolist --todolist type=string
+FLAG basecamp todolist --verbose type=count
+FLAG basecamp todolist archive --account type=string
+FLAG basecamp todolist archive --agent type=bool
+FLAG basecamp todolist archive --cache-dir type=string
+FLAG basecamp todolist archive --count type=bool
+FLAG basecamp todolist archive --help type=bool
+FLAG basecamp todolist archive --hints type=bool
+FLAG basecamp todolist archive --ids-only type=bool
+FLAG basecamp todolist archive --in type=string
+FLAG basecamp todolist archive --jq type=string
+FLAG basecamp todolist archive --json type=bool
+FLAG basecamp todolist archive --markdown type=bool
+FLAG basecamp todolist archive --md type=bool
+FLAG basecamp todolist archive --no-hints type=bool
+FLAG basecamp todolist archive --no-stats type=bool
+FLAG basecamp todolist archive --profile type=string
+FLAG basecamp todolist archive --project type=string
+FLAG basecamp todolist archive --quiet type=bool
+FLAG basecamp todolist archive --stats type=bool
+FLAG basecamp todolist archive --styled type=bool
+FLAG basecamp todolist archive --todolist type=string
+FLAG basecamp todolist archive --verbose type=count
+FLAG basecamp todolist create --account type=string
+FLAG basecamp todolist create --agent type=bool
+FLAG basecamp todolist create --cache-dir type=string
+FLAG basecamp todolist create --count type=bool
+FLAG basecamp todolist create --description type=string
+FLAG basecamp todolist create --help type=bool
+FLAG basecamp todolist create --hints type=bool
+FLAG basecamp todolist create --ids-only type=bool
+FLAG basecamp todolist create --in type=string
+FLAG basecamp todolist create --jq type=string
+FLAG basecamp todolist create --json type=bool
+FLAG basecamp todolist create --markdown type=bool
+FLAG basecamp todolist create --md type=bool
+FLAG basecamp todolist create --no-hints type=bool
+FLAG basecamp todolist create --no-stats type=bool
+FLAG basecamp todolist create --profile type=string
+FLAG basecamp todolist create --project type=string
+FLAG basecamp todolist create --quiet type=bool
+FLAG basecamp todolist create --stats type=bool
+FLAG basecamp todolist create --styled type=bool
+FLAG basecamp todolist create --todolist type=string
+FLAG basecamp todolist create --todoset type=string
+FLAG basecamp todolist create --verbose type=count
+FLAG basecamp todolist list --account type=string
+FLAG basecamp todolist list --agent type=bool
+FLAG basecamp todolist list --all type=bool
+FLAG basecamp todolist list --archived type=bool
+FLAG basecamp todolist list --cache-dir type=string
+FLAG basecamp todolist list --count type=bool
+FLAG basecamp todolist list --help type=bool
+FLAG basecamp todolist list --hints type=bool
+FLAG basecamp todolist list --ids-only type=bool
+FLAG basecamp todolist list --in type=string
+FLAG basecamp todolist list --jq type=string
+FLAG basecamp todolist list --json type=bool
+FLAG basecamp todolist list --limit type=int
+FLAG basecamp todolist list --markdown type=bool
+FLAG basecamp todolist list --md type=bool
+FLAG basecamp todolist list --no-hints type=bool
+FLAG basecamp todolist list --no-stats type=bool
+FLAG basecamp todolist list --page type=int
+FLAG basecamp todolist list --profile type=string
+FLAG basecamp todolist list --project type=string
+FLAG basecamp todolist list --quiet type=bool
+FLAG basecamp todolist list --reverse type=bool
+FLAG basecamp todolist list --sort type=string
+FLAG basecamp todolist list --stats type=bool
+FLAG basecamp todolist list --styled type=bool
+FLAG basecamp todolist list --todolist type=string
+FLAG basecamp todolist list --todoset type=string
+FLAG basecamp todolist list --verbose type=count
+FLAG basecamp todolist restore --account type=string
+FLAG basecamp todolist restore --agent type=bool
+FLAG basecamp todolist restore --cache-dir type=string
+FLAG basecamp todolist restore --count type=bool
+FLAG basecamp todolist restore --help type=bool
+FLAG basecamp todolist restore --hints type=bool
+FLAG basecamp todolist restore --ids-only type=bool
+FLAG basecamp todolist restore --in type=string
+FLAG basecamp todolist restore --jq type=string
+FLAG basecamp todolist restore --json type=bool
+FLAG basecamp todolist restore --markdown type=bool
+FLAG basecamp todolist restore --md type=bool
+FLAG basecamp todolist restore --no-hints type=bool
+FLAG basecamp todolist restore --no-stats type=bool
+FLAG basecamp todolist restore --profile type=string
+FLAG basecamp todolist restore --project type=string
+FLAG basecamp todolist restore --quiet type=bool
+FLAG basecamp todolist restore --stats type=bool
+FLAG basecamp todolist restore --styled type=bool
+FLAG basecamp todolist restore --todolist type=string
+FLAG basecamp todolist restore --verbose type=count
+FLAG basecamp todolist show --account type=string
+FLAG basecamp todolist show --agent type=bool
+FLAG basecamp todolist show --cache-dir type=string
+FLAG basecamp todolist show --count type=bool
+FLAG basecamp todolist show --help type=bool
+FLAG basecamp todolist show --hints type=bool
+FLAG basecamp todolist show --ids-only type=bool
+FLAG basecamp todolist show --in type=string
+FLAG basecamp todolist show --jq type=string
+FLAG basecamp todolist show --json type=bool
+FLAG basecamp todolist show --markdown type=bool
+FLAG basecamp todolist show --md type=bool
+FLAG basecamp todolist show --no-hints type=bool
+FLAG basecamp todolist show --no-stats type=bool
+FLAG basecamp todolist show --profile type=string
+FLAG basecamp todolist show --project type=string
+FLAG basecamp todolist show --quiet type=bool
+FLAG basecamp todolist show --stats type=bool
+FLAG basecamp todolist show --styled type=bool
+FLAG basecamp todolist show --todolist type=string
+FLAG basecamp todolist show --verbose type=count
+FLAG basecamp todolist trash --account type=string
+FLAG basecamp todolist trash --agent type=bool
+FLAG basecamp todolist trash --cache-dir type=string
+FLAG basecamp todolist trash --count type=bool
+FLAG basecamp todolist trash --help type=bool
+FLAG basecamp todolist trash --hints type=bool
+FLAG basecamp todolist trash --ids-only type=bool
+FLAG basecamp todolist trash --in type=string
+FLAG basecamp todolist trash --jq type=string
+FLAG basecamp todolist trash --json type=bool
+FLAG basecamp todolist trash --markdown type=bool
+FLAG basecamp todolist trash --md type=bool
+FLAG basecamp todolist trash --no-hints type=bool
+FLAG basecamp todolist trash --no-stats type=bool
+FLAG basecamp todolist trash --profile type=string
+FLAG basecamp todolist trash --project type=string
+FLAG basecamp todolist trash --quiet type=bool
+FLAG basecamp todolist trash --stats type=bool
+FLAG basecamp todolist trash --styled type=bool
+FLAG basecamp todolist trash --todolist type=string
+FLAG basecamp todolist trash --verbose type=count
+FLAG basecamp todolist update --account type=string
+FLAG basecamp todolist update --agent type=bool
+FLAG basecamp todolist update --cache-dir type=string
+FLAG basecamp todolist update --count type=bool
+FLAG basecamp todolist update --description type=string
+FLAG basecamp todolist update --help type=bool
+FLAG basecamp todolist update --hints type=bool
+FLAG basecamp todolist update --ids-only type=bool
+FLAG basecamp todolist update --in type=string
+FLAG basecamp todolist update --jq type=string
+FLAG basecamp todolist update --json type=bool
+FLAG basecamp todolist update --markdown type=bool
+FLAG basecamp todolist update --md type=bool
+FLAG basecamp todolist update --name type=string
+FLAG basecamp todolist update --no-hints type=bool
+FLAG basecamp todolist update --no-stats type=bool
+FLAG basecamp todolist update --profile type=string
+FLAG basecamp todolist update --project type=string
+FLAG basecamp todolist update --quiet type=bool
+FLAG basecamp todolist update --stats type=bool
+FLAG basecamp todolist update --styled type=bool
+FLAG basecamp todolist update --todolist type=string
+FLAG basecamp todolist update --verbose type=count
+FLAG basecamp todolistgroup --account type=string
+FLAG basecamp todolistgroup --agent type=bool
+FLAG basecamp todolistgroup --cache-dir type=string
+FLAG basecamp todolistgroup --count type=bool
+FLAG basecamp todolistgroup --help type=bool
+FLAG basecamp todolistgroup --hints type=bool
+FLAG basecamp todolistgroup --ids-only type=bool
+FLAG basecamp todolistgroup --in type=string
+FLAG basecamp todolistgroup --jq type=string
+FLAG basecamp todolistgroup --json type=bool
+FLAG basecamp todolistgroup --list type=string
+FLAG basecamp todolistgroup --markdown type=bool
+FLAG basecamp todolistgroup --md type=bool
+FLAG basecamp todolistgroup --no-hints type=bool
+FLAG basecamp todolistgroup --no-stats type=bool
+FLAG basecamp todolistgroup --profile type=string
+FLAG basecamp todolistgroup --project type=string
+FLAG basecamp todolistgroup --quiet type=bool
+FLAG basecamp todolistgroup --stats type=bool
+FLAG basecamp todolistgroup --styled type=bool
+FLAG basecamp todolistgroup --todolist type=string
+FLAG basecamp todolistgroup --verbose type=count
+FLAG basecamp todolistgroup create --account type=string
+FLAG basecamp todolistgroup create --agent type=bool
+FLAG basecamp todolistgroup create --cache-dir type=string
+FLAG basecamp todolistgroup create --count type=bool
+FLAG basecamp todolistgroup create --help type=bool
+FLAG basecamp todolistgroup create --hints type=bool
+FLAG basecamp todolistgroup create --ids-only type=bool
+FLAG basecamp todolistgroup create --in type=string
+FLAG basecamp todolistgroup create --jq type=string
+FLAG basecamp todolistgroup create --json type=bool
+FLAG basecamp todolistgroup create --list type=string
+FLAG basecamp todolistgroup create --markdown type=bool
+FLAG basecamp todolistgroup create --md type=bool
+FLAG basecamp todolistgroup create --no-hints type=bool
+FLAG basecamp todolistgroup create --no-stats type=bool
+FLAG basecamp todolistgroup create --profile type=string
+FLAG basecamp todolistgroup create --project type=string
+FLAG basecamp todolistgroup create --quiet type=bool
+FLAG basecamp todolistgroup create --stats type=bool
+FLAG basecamp todolistgroup create --styled type=bool
+FLAG basecamp todolistgroup create --todolist type=string
+FLAG basecamp todolistgroup create --verbose type=count
+FLAG basecamp todolistgroup list --account type=string
+FLAG basecamp todolistgroup list --agent type=bool
+FLAG basecamp todolistgroup list --cache-dir type=string
+FLAG basecamp todolistgroup list --count type=bool
+FLAG basecamp todolistgroup list --help type=bool
+FLAG basecamp todolistgroup list --hints type=bool
+FLAG basecamp todolistgroup list --ids-only type=bool
+FLAG basecamp todolistgroup list --in type=string
+FLAG basecamp todolistgroup list --jq type=string
+FLAG basecamp todolistgroup list --json type=bool
+FLAG basecamp todolistgroup list --list type=string
+FLAG basecamp todolistgroup list --markdown type=bool
+FLAG basecamp todolistgroup list --md type=bool
+FLAG basecamp todolistgroup list --no-hints type=bool
+FLAG basecamp todolistgroup list --no-stats type=bool
+FLAG basecamp todolistgroup list --profile type=string
+FLAG basecamp todolistgroup list --project type=string
+FLAG basecamp todolistgroup list --quiet type=bool
+FLAG basecamp todolistgroup list --stats type=bool
+FLAG basecamp todolistgroup list --styled type=bool
+FLAG basecamp todolistgroup list --todolist type=string
+FLAG basecamp todolistgroup list --verbose type=count
+FLAG basecamp todolistgroup move --account type=string
+FLAG basecamp todolistgroup move --agent type=bool
+FLAG basecamp todolistgroup move --cache-dir type=string
+FLAG basecamp todolistgroup move --count type=bool
+FLAG basecamp todolistgroup move --help type=bool
+FLAG basecamp todolistgroup move --hints type=bool
+FLAG basecamp todolistgroup move --ids-only type=bool
+FLAG basecamp todolistgroup move --in type=string
+FLAG basecamp todolistgroup move --jq type=string
+FLAG basecamp todolistgroup move --json type=bool
+FLAG basecamp todolistgroup move --list type=string
+FLAG basecamp todolistgroup move --markdown type=bool
+FLAG basecamp todolistgroup move --md type=bool
+FLAG basecamp todolistgroup move --no-hints type=bool
+FLAG basecamp todolistgroup move --no-stats type=bool
+FLAG basecamp todolistgroup move --pos type=int
+FLAG basecamp todolistgroup move --position type=int
+FLAG basecamp todolistgroup move --profile type=string
+FLAG basecamp todolistgroup move --project type=string
+FLAG basecamp todolistgroup move --quiet type=bool
+FLAG basecamp todolistgroup move --stats type=bool
+FLAG basecamp todolistgroup move --styled type=bool
+FLAG basecamp todolistgroup move --todolist type=string
+FLAG basecamp todolistgroup move --verbose type=count
+FLAG basecamp todolistgroup position --account type=string
+FLAG basecamp todolistgroup position --agent type=bool
+FLAG basecamp todolistgroup position --cache-dir type=string
+FLAG basecamp todolistgroup position --count type=bool
+FLAG basecamp todolistgroup position --help type=bool
+FLAG basecamp todolistgroup position --hints type=bool
+FLAG basecamp todolistgroup position --ids-only type=bool
+FLAG basecamp todolistgroup position --in type=string
+FLAG basecamp todolistgroup position --jq type=string
+FLAG basecamp todolistgroup position --json type=bool
+FLAG basecamp todolistgroup position --list type=string
+FLAG basecamp todolistgroup position --markdown type=bool
+FLAG basecamp todolistgroup position --md type=bool
+FLAG basecamp todolistgroup position --no-hints type=bool
+FLAG basecamp todolistgroup position --no-stats type=bool
+FLAG basecamp todolistgroup position --pos type=int
+FLAG basecamp todolistgroup position --position type=int
+FLAG basecamp todolistgroup position --profile type=string
+FLAG basecamp todolistgroup position --project type=string
+FLAG basecamp todolistgroup position --quiet type=bool
+FLAG basecamp todolistgroup position --stats type=bool
+FLAG basecamp todolistgroup position --styled type=bool
+FLAG basecamp todolistgroup position --todolist type=string
+FLAG basecamp todolistgroup position --verbose type=count
+FLAG basecamp todolistgroup rename --account type=string
+FLAG basecamp todolistgroup rename --agent type=bool
+FLAG basecamp todolistgroup rename --cache-dir type=string
+FLAG basecamp todolistgroup rename --count type=bool
+FLAG basecamp todolistgroup rename --help type=bool
+FLAG basecamp todolistgroup rename --hints type=bool
+FLAG basecamp todolistgroup rename --ids-only type=bool
+FLAG basecamp todolistgroup rename --in type=string
+FLAG basecamp todolistgroup rename --jq type=string
+FLAG basecamp todolistgroup rename --json type=bool
+FLAG basecamp todolistgroup rename --list type=string
+FLAG basecamp todolistgroup rename --markdown type=bool
+FLAG basecamp todolistgroup rename --md type=bool
+FLAG basecamp todolistgroup rename --no-hints type=bool
+FLAG basecamp todolistgroup rename --no-stats type=bool
+FLAG basecamp todolistgroup rename --profile type=string
+FLAG basecamp todolistgroup rename --project type=string
+FLAG basecamp todolistgroup rename --quiet type=bool
+FLAG basecamp todolistgroup rename --stats type=bool
+FLAG basecamp todolistgroup rename --styled type=bool
+FLAG basecamp todolistgroup rename --todolist type=string
+FLAG basecamp todolistgroup rename --verbose type=count
+FLAG basecamp todolistgroup show --account type=string
+FLAG basecamp todolistgroup show --agent type=bool
+FLAG basecamp todolistgroup show --cache-dir type=string
+FLAG basecamp todolistgroup show --count type=bool
+FLAG basecamp todolistgroup show --help type=bool
+FLAG basecamp todolistgroup show --hints type=bool
+FLAG basecamp todolistgroup show --ids-only type=bool
+FLAG basecamp todolistgroup show --in type=string
+FLAG basecamp todolistgroup show --jq type=string
+FLAG basecamp todolistgroup show --json type=bool
+FLAG basecamp todolistgroup show --list type=string
+FLAG basecamp todolistgroup show --markdown type=bool
+FLAG basecamp todolistgroup show --md type=bool
+FLAG basecamp todolistgroup show --no-hints type=bool
+FLAG basecamp todolistgroup show --no-stats type=bool
+FLAG basecamp todolistgroup show --profile type=string
+FLAG basecamp todolistgroup show --project type=string
+FLAG basecamp todolistgroup show --quiet type=bool
+FLAG basecamp todolistgroup show --stats type=bool
+FLAG basecamp todolistgroup show --styled type=bool
+FLAG basecamp todolistgroup show --todolist type=string
+FLAG basecamp todolistgroup show --verbose type=count
+FLAG basecamp todolistgroup update --account type=string
+FLAG basecamp todolistgroup update --agent type=bool
+FLAG basecamp todolistgroup update --cache-dir type=string
+FLAG basecamp todolistgroup update --count type=bool
+FLAG basecamp todolistgroup update --help type=bool
+FLAG basecamp todolistgroup update --hints type=bool
+FLAG basecamp todolistgroup update --ids-only type=bool
+FLAG basecamp todolistgroup update --in type=string
+FLAG basecamp todolistgroup update --jq type=string
+FLAG basecamp todolistgroup update --json type=bool
+FLAG basecamp todolistgroup update --list type=string
+FLAG basecamp todolistgroup update --markdown type=bool
+FLAG basecamp todolistgroup update --md type=bool
+FLAG basecamp todolistgroup update --no-hints type=bool
+FLAG basecamp todolistgroup update --no-stats type=bool
+FLAG basecamp todolistgroup update --profile type=string
+FLAG basecamp todolistgroup update --project type=string
+FLAG basecamp todolistgroup update --quiet type=bool
+FLAG basecamp todolistgroup update --stats type=bool
+FLAG basecamp todolistgroup update --styled type=bool
+FLAG basecamp todolistgroup update --todolist type=string
+FLAG basecamp todolistgroup update --verbose type=count
 FLAG basecamp todolistgroups --account type=string
 FLAG basecamp todolistgroups --agent type=bool
 FLAG basecamp todolistgroups --cache-dir type=string
 FLAG basecamp todolistgroups --count type=bool
+FLAG basecamp todolistgroups --help type=bool
 FLAG basecamp todolistgroups --hints type=bool
 FLAG basecamp todolistgroups --ids-only type=bool
 FLAG basecamp todolistgroups --in type=string
@@ -5730,6 +12229,7 @@ FLAG basecamp todolistgroups create --account type=string
 FLAG basecamp todolistgroups create --agent type=bool
 FLAG basecamp todolistgroups create --cache-dir type=string
 FLAG basecamp todolistgroups create --count type=bool
+FLAG basecamp todolistgroups create --help type=bool
 FLAG basecamp todolistgroups create --hints type=bool
 FLAG basecamp todolistgroups create --ids-only type=bool
 FLAG basecamp todolistgroups create --in type=string
@@ -5751,6 +12251,7 @@ FLAG basecamp todolistgroups list --account type=string
 FLAG basecamp todolistgroups list --agent type=bool
 FLAG basecamp todolistgroups list --cache-dir type=string
 FLAG basecamp todolistgroups list --count type=bool
+FLAG basecamp todolistgroups list --help type=bool
 FLAG basecamp todolistgroups list --hints type=bool
 FLAG basecamp todolistgroups list --ids-only type=bool
 FLAG basecamp todolistgroups list --in type=string
@@ -5768,10 +12269,35 @@ FLAG basecamp todolistgroups list --stats type=bool
 FLAG basecamp todolistgroups list --styled type=bool
 FLAG basecamp todolistgroups list --todolist type=string
 FLAG basecamp todolistgroups list --verbose type=count
+FLAG basecamp todolistgroups move --account type=string
+FLAG basecamp todolistgroups move --agent type=bool
+FLAG basecamp todolistgroups move --cache-dir type=string
+FLAG basecamp todolistgroups move --count type=bool
+FLAG basecamp todolistgroups move --help type=bool
+FLAG basecamp todolistgroups move --hints type=bool
+FLAG basecamp todolistgroups move --ids-only type=bool
+FLAG basecamp todolistgroups move --in type=string
+FLAG basecamp todolistgroups move --jq type=string
+FLAG basecamp todolistgroups move --json type=bool
+FLAG basecamp todolistgroups move --list type=string
+FLAG basecamp todolistgroups move --markdown type=bool
+FLAG basecamp todolistgroups move --md type=bool
+FLAG basecamp todolistgroups move --no-hints type=bool
+FLAG basecamp todolistgroups move --no-stats type=bool
+FLAG basecamp todolistgroups move --pos type=int
+FLAG basecamp todolistgroups move --position type=int
+FLAG basecamp todolistgroups move --profile type=string
+FLAG basecamp todolistgroups move --project type=string
+FLAG basecamp todolistgroups move --quiet type=bool
+FLAG basecamp todolistgroups move --stats type=bool
+FLAG basecamp todolistgroups move --styled type=bool
+FLAG basecamp todolistgroups move --todolist type=string
+FLAG basecamp todolistgroups move --verbose type=count
 FLAG basecamp todolistgroups position --account type=string
 FLAG basecamp todolistgroups position --agent type=bool
 FLAG basecamp todolistgroups position --cache-dir type=string
 FLAG basecamp todolistgroups position --count type=bool
+FLAG basecamp todolistgroups position --help type=bool
 FLAG basecamp todolistgroups position --hints type=bool
 FLAG basecamp todolistgroups position --ids-only type=bool
 FLAG basecamp todolistgroups position --in type=string
@@ -5791,10 +12317,33 @@ FLAG basecamp todolistgroups position --stats type=bool
 FLAG basecamp todolistgroups position --styled type=bool
 FLAG basecamp todolistgroups position --todolist type=string
 FLAG basecamp todolistgroups position --verbose type=count
+FLAG basecamp todolistgroups rename --account type=string
+FLAG basecamp todolistgroups rename --agent type=bool
+FLAG basecamp todolistgroups rename --cache-dir type=string
+FLAG basecamp todolistgroups rename --count type=bool
+FLAG basecamp todolistgroups rename --help type=bool
+FLAG basecamp todolistgroups rename --hints type=bool
+FLAG basecamp todolistgroups rename --ids-only type=bool
+FLAG basecamp todolistgroups rename --in type=string
+FLAG basecamp todolistgroups rename --jq type=string
+FLAG basecamp todolistgroups rename --json type=bool
+FLAG basecamp todolistgroups rename --list type=string
+FLAG basecamp todolistgroups rename --markdown type=bool
+FLAG basecamp todolistgroups rename --md type=bool
+FLAG basecamp todolistgroups rename --no-hints type=bool
+FLAG basecamp todolistgroups rename --no-stats type=bool
+FLAG basecamp todolistgroups rename --profile type=string
+FLAG basecamp todolistgroups rename --project type=string
+FLAG basecamp todolistgroups rename --quiet type=bool
+FLAG basecamp todolistgroups rename --stats type=bool
+FLAG basecamp todolistgroups rename --styled type=bool
+FLAG basecamp todolistgroups rename --todolist type=string
+FLAG basecamp todolistgroups rename --verbose type=count
 FLAG basecamp todolistgroups show --account type=string
 FLAG basecamp todolistgroups show --agent type=bool
 FLAG basecamp todolistgroups show --cache-dir type=string
 FLAG basecamp todolistgroups show --count type=bool
+FLAG basecamp todolistgroups show --help type=bool
 FLAG basecamp todolistgroups show --hints type=bool
 FLAG basecamp todolistgroups show --ids-only type=bool
 FLAG basecamp todolistgroups show --in type=string
@@ -5816,6 +12365,7 @@ FLAG basecamp todolistgroups update --account type=string
 FLAG basecamp todolistgroups update --agent type=bool
 FLAG basecamp todolistgroups update --cache-dir type=string
 FLAG basecamp todolistgroups update --count type=bool
+FLAG basecamp todolistgroups update --help type=bool
 FLAG basecamp todolistgroups update --hints type=bool
 FLAG basecamp todolistgroups update --ids-only type=bool
 FLAG basecamp todolistgroups update --in type=string
@@ -5837,6 +12387,7 @@ FLAG basecamp todolists --account type=string
 FLAG basecamp todolists --agent type=bool
 FLAG basecamp todolists --cache-dir type=string
 FLAG basecamp todolists --count type=bool
+FLAG basecamp todolists --help type=bool
 FLAG basecamp todolists --hints type=bool
 FLAG basecamp todolists --ids-only type=bool
 FLAG basecamp todolists --in type=string
@@ -5857,6 +12408,7 @@ FLAG basecamp todolists archive --account type=string
 FLAG basecamp todolists archive --agent type=bool
 FLAG basecamp todolists archive --cache-dir type=string
 FLAG basecamp todolists archive --count type=bool
+FLAG basecamp todolists archive --help type=bool
 FLAG basecamp todolists archive --hints type=bool
 FLAG basecamp todolists archive --ids-only type=bool
 FLAG basecamp todolists archive --in type=string
@@ -5878,6 +12430,7 @@ FLAG basecamp todolists create --agent type=bool
 FLAG basecamp todolists create --cache-dir type=string
 FLAG basecamp todolists create --count type=bool
 FLAG basecamp todolists create --description type=string
+FLAG basecamp todolists create --help type=bool
 FLAG basecamp todolists create --hints type=bool
 FLAG basecamp todolists create --ids-only type=bool
 FLAG basecamp todolists create --in type=string
@@ -5901,6 +12454,7 @@ FLAG basecamp todolists list --all type=bool
 FLAG basecamp todolists list --archived type=bool
 FLAG basecamp todolists list --cache-dir type=string
 FLAG basecamp todolists list --count type=bool
+FLAG basecamp todolists list --help type=bool
 FLAG basecamp todolists list --hints type=bool
 FLAG basecamp todolists list --ids-only type=bool
 FLAG basecamp todolists list --in type=string
@@ -5926,6 +12480,7 @@ FLAG basecamp todolists restore --account type=string
 FLAG basecamp todolists restore --agent type=bool
 FLAG basecamp todolists restore --cache-dir type=string
 FLAG basecamp todolists restore --count type=bool
+FLAG basecamp todolists restore --help type=bool
 FLAG basecamp todolists restore --hints type=bool
 FLAG basecamp todolists restore --ids-only type=bool
 FLAG basecamp todolists restore --in type=string
@@ -5946,6 +12501,7 @@ FLAG basecamp todolists show --account type=string
 FLAG basecamp todolists show --agent type=bool
 FLAG basecamp todolists show --cache-dir type=string
 FLAG basecamp todolists show --count type=bool
+FLAG basecamp todolists show --help type=bool
 FLAG basecamp todolists show --hints type=bool
 FLAG basecamp todolists show --ids-only type=bool
 FLAG basecamp todolists show --in type=string
@@ -5966,6 +12522,7 @@ FLAG basecamp todolists trash --account type=string
 FLAG basecamp todolists trash --agent type=bool
 FLAG basecamp todolists trash --cache-dir type=string
 FLAG basecamp todolists trash --count type=bool
+FLAG basecamp todolists trash --help type=bool
 FLAG basecamp todolists trash --hints type=bool
 FLAG basecamp todolists trash --ids-only type=bool
 FLAG basecamp todolists trash --in type=string
@@ -5987,6 +12544,7 @@ FLAG basecamp todolists update --agent type=bool
 FLAG basecamp todolists update --cache-dir type=string
 FLAG basecamp todolists update --count type=bool
 FLAG basecamp todolists update --description type=string
+FLAG basecamp todolists update --help type=bool
 FLAG basecamp todolists update --hints type=bool
 FLAG basecamp todolists update --ids-only type=bool
 FLAG basecamp todolists update --in type=string
@@ -6008,6 +12566,7 @@ FLAG basecamp todos --account type=string
 FLAG basecamp todos --agent type=bool
 FLAG basecamp todos --cache-dir type=string
 FLAG basecamp todos --count type=bool
+FLAG basecamp todos --help type=bool
 FLAG basecamp todos --hints type=bool
 FLAG basecamp todos --ids-only type=bool
 FLAG basecamp todos --in type=string
@@ -6028,6 +12587,7 @@ FLAG basecamp todos archive --account type=string
 FLAG basecamp todos archive --agent type=bool
 FLAG basecamp todos archive --cache-dir type=string
 FLAG basecamp todos archive --count type=bool
+FLAG basecamp todos archive --help type=bool
 FLAG basecamp todos archive --hints type=bool
 FLAG basecamp todos archive --ids-only type=bool
 FLAG basecamp todos archive --in type=string
@@ -6048,6 +12608,7 @@ FLAG basecamp todos complete --account type=string
 FLAG basecamp todos complete --agent type=bool
 FLAG basecamp todos complete --cache-dir type=string
 FLAG basecamp todos complete --count type=bool
+FLAG basecamp todos complete --help type=bool
 FLAG basecamp todos complete --hints type=bool
 FLAG basecamp todos complete --ids-only type=bool
 FLAG basecamp todos complete --in type=string
@@ -6072,6 +12633,7 @@ FLAG basecamp todos create --cache-dir type=string
 FLAG basecamp todos create --count type=bool
 FLAG basecamp todos create --description type=string
 FLAG basecamp todos create --due type=string
+FLAG basecamp todos create --help type=bool
 FLAG basecamp todos create --hints type=bool
 FLAG basecamp todos create --ids-only type=bool
 FLAG basecamp todos create --in type=string
@@ -6098,6 +12660,7 @@ FLAG basecamp todos list --assignee type=string
 FLAG basecamp todos list --cache-dir type=string
 FLAG basecamp todos list --completed type=bool
 FLAG basecamp todos list --count type=bool
+FLAG basecamp todos list --help type=bool
 FLAG basecamp todos list --hints type=bool
 FLAG basecamp todos list --ids-only type=bool
 FLAG basecamp todos list --in type=string
@@ -6122,10 +12685,34 @@ FLAG basecamp todos list --styled type=bool
 FLAG basecamp todos list --todolist type=string
 FLAG basecamp todos list --todoset type=string
 FLAG basecamp todos list --verbose type=count
+FLAG basecamp todos move --account type=string
+FLAG basecamp todos move --agent type=bool
+FLAG basecamp todos move --cache-dir type=string
+FLAG basecamp todos move --count type=bool
+FLAG basecamp todos move --help type=bool
+FLAG basecamp todos move --hints type=bool
+FLAG basecamp todos move --ids-only type=bool
+FLAG basecamp todos move --in type=string
+FLAG basecamp todos move --jq type=string
+FLAG basecamp todos move --json type=bool
+FLAG basecamp todos move --markdown type=bool
+FLAG basecamp todos move --md type=bool
+FLAG basecamp todos move --no-hints type=bool
+FLAG basecamp todos move --no-stats type=bool
+FLAG basecamp todos move --position type=int
+FLAG basecamp todos move --profile type=string
+FLAG basecamp todos move --project type=string
+FLAG basecamp todos move --quiet type=bool
+FLAG basecamp todos move --stats type=bool
+FLAG basecamp todos move --styled type=bool
+FLAG basecamp todos move --to type=int
+FLAG basecamp todos move --todolist type=string
+FLAG basecamp todos move --verbose type=count
 FLAG basecamp todos position --account type=string
 FLAG basecamp todos position --agent type=bool
 FLAG basecamp todos position --cache-dir type=string
 FLAG basecamp todos position --count type=bool
+FLAG basecamp todos position --help type=bool
 FLAG basecamp todos position --hints type=bool
 FLAG basecamp todos position --ids-only type=bool
 FLAG basecamp todos position --in type=string
@@ -6144,10 +12731,55 @@ FLAG basecamp todos position --styled type=bool
 FLAG basecamp todos position --to type=int
 FLAG basecamp todos position --todolist type=string
 FLAG basecamp todos position --verbose type=count
+FLAG basecamp todos reopen --account type=string
+FLAG basecamp todos reopen --agent type=bool
+FLAG basecamp todos reopen --cache-dir type=string
+FLAG basecamp todos reopen --count type=bool
+FLAG basecamp todos reopen --help type=bool
+FLAG basecamp todos reopen --hints type=bool
+FLAG basecamp todos reopen --ids-only type=bool
+FLAG basecamp todos reopen --in type=string
+FLAG basecamp todos reopen --jq type=string
+FLAG basecamp todos reopen --json type=bool
+FLAG basecamp todos reopen --markdown type=bool
+FLAG basecamp todos reopen --md type=bool
+FLAG basecamp todos reopen --no-hints type=bool
+FLAG basecamp todos reopen --no-stats type=bool
+FLAG basecamp todos reopen --profile type=string
+FLAG basecamp todos reopen --project type=string
+FLAG basecamp todos reopen --quiet type=bool
+FLAG basecamp todos reopen --stats type=bool
+FLAG basecamp todos reopen --styled type=bool
+FLAG basecamp todos reopen --todolist type=string
+FLAG basecamp todos reopen --verbose type=count
+FLAG basecamp todos reorder --account type=string
+FLAG basecamp todos reorder --agent type=bool
+FLAG basecamp todos reorder --cache-dir type=string
+FLAG basecamp todos reorder --count type=bool
+FLAG basecamp todos reorder --help type=bool
+FLAG basecamp todos reorder --hints type=bool
+FLAG basecamp todos reorder --ids-only type=bool
+FLAG basecamp todos reorder --in type=string
+FLAG basecamp todos reorder --jq type=string
+FLAG basecamp todos reorder --json type=bool
+FLAG basecamp todos reorder --markdown type=bool
+FLAG basecamp todos reorder --md type=bool
+FLAG basecamp todos reorder --no-hints type=bool
+FLAG basecamp todos reorder --no-stats type=bool
+FLAG basecamp todos reorder --position type=int
+FLAG basecamp todos reorder --profile type=string
+FLAG basecamp todos reorder --project type=string
+FLAG basecamp todos reorder --quiet type=bool
+FLAG basecamp todos reorder --stats type=bool
+FLAG basecamp todos reorder --styled type=bool
+FLAG basecamp todos reorder --to type=int
+FLAG basecamp todos reorder --todolist type=string
+FLAG basecamp todos reorder --verbose type=count
 FLAG basecamp todos restore --account type=string
 FLAG basecamp todos restore --agent type=bool
 FLAG basecamp todos restore --cache-dir type=string
 FLAG basecamp todos restore --count type=bool
+FLAG basecamp todos restore --help type=bool
 FLAG basecamp todos restore --hints type=bool
 FLAG basecamp todos restore --ids-only type=bool
 FLAG basecamp todos restore --in type=string
@@ -6168,6 +12800,7 @@ FLAG basecamp todos show --account type=string
 FLAG basecamp todos show --agent type=bool
 FLAG basecamp todos show --cache-dir type=string
 FLAG basecamp todos show --count type=bool
+FLAG basecamp todos show --help type=bool
 FLAG basecamp todos show --hints type=bool
 FLAG basecamp todos show --ids-only type=bool
 FLAG basecamp todos show --in type=string
@@ -6193,6 +12826,7 @@ FLAG basecamp todos sweep --complete type=bool
 FLAG basecamp todos sweep --count type=bool
 FLAG basecamp todos sweep --done type=bool
 FLAG basecamp todos sweep --dry-run type=bool
+FLAG basecamp todos sweep --help type=bool
 FLAG basecamp todos sweep --hints type=bool
 FLAG basecamp todos sweep --ids-only type=bool
 FLAG basecamp todos sweep --in type=string
@@ -6215,6 +12849,7 @@ FLAG basecamp todos trash --account type=string
 FLAG basecamp todos trash --agent type=bool
 FLAG basecamp todos trash --cache-dir type=string
 FLAG basecamp todos trash --count type=bool
+FLAG basecamp todos trash --help type=bool
 FLAG basecamp todos trash --hints type=bool
 FLAG basecamp todos trash --ids-only type=bool
 FLAG basecamp todos trash --in type=string
@@ -6235,6 +12870,7 @@ FLAG basecamp todos uncomplete --account type=string
 FLAG basecamp todos uncomplete --agent type=bool
 FLAG basecamp todos uncomplete --cache-dir type=string
 FLAG basecamp todos uncomplete --count type=bool
+FLAG basecamp todos uncomplete --help type=bool
 FLAG basecamp todos uncomplete --hints type=bool
 FLAG basecamp todos uncomplete --ids-only type=bool
 FLAG basecamp todos uncomplete --in type=string
@@ -6258,6 +12894,7 @@ FLAG basecamp todos update --cache-dir type=string
 FLAG basecamp todos update --count type=bool
 FLAG basecamp todos update --description type=string
 FLAG basecamp todos update --due type=string
+FLAG basecamp todos update --help type=bool
 FLAG basecamp todos update --hints type=bool
 FLAG basecamp todos update --ids-only type=bool
 FLAG basecamp todos update --in type=string
@@ -6282,6 +12919,7 @@ FLAG basecamp todosets --account type=string
 FLAG basecamp todosets --agent type=bool
 FLAG basecamp todosets --cache-dir type=string
 FLAG basecamp todosets --count type=bool
+FLAG basecamp todosets --help type=bool
 FLAG basecamp todosets --hints type=bool
 FLAG basecamp todosets --ids-only type=bool
 FLAG basecamp todosets --in type=string
@@ -6302,6 +12940,7 @@ FLAG basecamp todosets list --account type=string
 FLAG basecamp todosets list --agent type=bool
 FLAG basecamp todosets list --cache-dir type=string
 FLAG basecamp todosets list --count type=bool
+FLAG basecamp todosets list --help type=bool
 FLAG basecamp todosets list --hints type=bool
 FLAG basecamp todosets list --ids-only type=bool
 FLAG basecamp todosets list --in type=string
@@ -6322,6 +12961,7 @@ FLAG basecamp todosets show --account type=string
 FLAG basecamp todosets show --agent type=bool
 FLAG basecamp todosets show --cache-dir type=string
 FLAG basecamp todosets show --count type=bool
+FLAG basecamp todosets show --help type=bool
 FLAG basecamp todosets show --hints type=bool
 FLAG basecamp todosets show --ids-only type=bool
 FLAG basecamp todosets show --in type=string
@@ -6343,6 +12983,7 @@ FLAG basecamp tools --account type=string
 FLAG basecamp tools --agent type=bool
 FLAG basecamp tools --cache-dir type=string
 FLAG basecamp tools --count type=bool
+FLAG basecamp tools --help type=bool
 FLAG basecamp tools --hints type=bool
 FLAG basecamp tools --ids-only type=bool
 FLAG basecamp tools --in type=string
@@ -6364,6 +13005,7 @@ FLAG basecamp tools create --agent type=bool
 FLAG basecamp tools create --cache-dir type=string
 FLAG basecamp tools create --clone type=string
 FLAG basecamp tools create --count type=bool
+FLAG basecamp tools create --help type=bool
 FLAG basecamp tools create --hints type=bool
 FLAG basecamp tools create --ids-only type=bool
 FLAG basecamp tools create --in type=string
@@ -6381,10 +13023,32 @@ FLAG basecamp tools create --stats type=bool
 FLAG basecamp tools create --styled type=bool
 FLAG basecamp tools create --todolist type=string
 FLAG basecamp tools create --verbose type=count
+FLAG basecamp tools delete --account type=string
+FLAG basecamp tools delete --agent type=bool
+FLAG basecamp tools delete --cache-dir type=string
+FLAG basecamp tools delete --count type=bool
+FLAG basecamp tools delete --help type=bool
+FLAG basecamp tools delete --hints type=bool
+FLAG basecamp tools delete --ids-only type=bool
+FLAG basecamp tools delete --in type=string
+FLAG basecamp tools delete --jq type=string
+FLAG basecamp tools delete --json type=bool
+FLAG basecamp tools delete --markdown type=bool
+FLAG basecamp tools delete --md type=bool
+FLAG basecamp tools delete --no-hints type=bool
+FLAG basecamp tools delete --no-stats type=bool
+FLAG basecamp tools delete --profile type=string
+FLAG basecamp tools delete --project type=string
+FLAG basecamp tools delete --quiet type=bool
+FLAG basecamp tools delete --stats type=bool
+FLAG basecamp tools delete --styled type=bool
+FLAG basecamp tools delete --todolist type=string
+FLAG basecamp tools delete --verbose type=count
 FLAG basecamp tools disable --account type=string
 FLAG basecamp tools disable --agent type=bool
 FLAG basecamp tools disable --cache-dir type=string
 FLAG basecamp tools disable --count type=bool
+FLAG basecamp tools disable --help type=bool
 FLAG basecamp tools disable --hints type=bool
 FLAG basecamp tools disable --ids-only type=bool
 FLAG basecamp tools disable --in type=string
@@ -6405,6 +13069,7 @@ FLAG basecamp tools enable --account type=string
 FLAG basecamp tools enable --agent type=bool
 FLAG basecamp tools enable --cache-dir type=string
 FLAG basecamp tools enable --count type=bool
+FLAG basecamp tools enable --help type=bool
 FLAG basecamp tools enable --hints type=bool
 FLAG basecamp tools enable --ids-only type=bool
 FLAG basecamp tools enable --in type=string
@@ -6421,10 +13086,55 @@ FLAG basecamp tools enable --stats type=bool
 FLAG basecamp tools enable --styled type=bool
 FLAG basecamp tools enable --todolist type=string
 FLAG basecamp tools enable --verbose type=count
+FLAG basecamp tools move --account type=string
+FLAG basecamp tools move --agent type=bool
+FLAG basecamp tools move --cache-dir type=string
+FLAG basecamp tools move --count type=bool
+FLAG basecamp tools move --help type=bool
+FLAG basecamp tools move --hints type=bool
+FLAG basecamp tools move --ids-only type=bool
+FLAG basecamp tools move --in type=string
+FLAG basecamp tools move --jq type=string
+FLAG basecamp tools move --json type=bool
+FLAG basecamp tools move --markdown type=bool
+FLAG basecamp tools move --md type=bool
+FLAG basecamp tools move --no-hints type=bool
+FLAG basecamp tools move --no-stats type=bool
+FLAG basecamp tools move --pos type=int
+FLAG basecamp tools move --position type=int
+FLAG basecamp tools move --profile type=string
+FLAG basecamp tools move --project type=string
+FLAG basecamp tools move --quiet type=bool
+FLAG basecamp tools move --stats type=bool
+FLAG basecamp tools move --styled type=bool
+FLAG basecamp tools move --todolist type=string
+FLAG basecamp tools move --verbose type=count
+FLAG basecamp tools rename --account type=string
+FLAG basecamp tools rename --agent type=bool
+FLAG basecamp tools rename --cache-dir type=string
+FLAG basecamp tools rename --count type=bool
+FLAG basecamp tools rename --help type=bool
+FLAG basecamp tools rename --hints type=bool
+FLAG basecamp tools rename --ids-only type=bool
+FLAG basecamp tools rename --in type=string
+FLAG basecamp tools rename --jq type=string
+FLAG basecamp tools rename --json type=bool
+FLAG basecamp tools rename --markdown type=bool
+FLAG basecamp tools rename --md type=bool
+FLAG basecamp tools rename --no-hints type=bool
+FLAG basecamp tools rename --no-stats type=bool
+FLAG basecamp tools rename --profile type=string
+FLAG basecamp tools rename --project type=string
+FLAG basecamp tools rename --quiet type=bool
+FLAG basecamp tools rename --stats type=bool
+FLAG basecamp tools rename --styled type=bool
+FLAG basecamp tools rename --todolist type=string
+FLAG basecamp tools rename --verbose type=count
 FLAG basecamp tools reposition --account type=string
 FLAG basecamp tools reposition --agent type=bool
 FLAG basecamp tools reposition --cache-dir type=string
 FLAG basecamp tools reposition --count type=bool
+FLAG basecamp tools reposition --help type=bool
 FLAG basecamp tools reposition --hints type=bool
 FLAG basecamp tools reposition --ids-only type=bool
 FLAG basecamp tools reposition --in type=string
@@ -6447,6 +13157,7 @@ FLAG basecamp tools show --account type=string
 FLAG basecamp tools show --agent type=bool
 FLAG basecamp tools show --cache-dir type=string
 FLAG basecamp tools show --count type=bool
+FLAG basecamp tools show --help type=bool
 FLAG basecamp tools show --hints type=bool
 FLAG basecamp tools show --ids-only type=bool
 FLAG basecamp tools show --in type=string
@@ -6467,6 +13178,7 @@ FLAG basecamp tools trash --account type=string
 FLAG basecamp tools trash --agent type=bool
 FLAG basecamp tools trash --cache-dir type=string
 FLAG basecamp tools trash --count type=bool
+FLAG basecamp tools trash --help type=bool
 FLAG basecamp tools trash --hints type=bool
 FLAG basecamp tools trash --ids-only type=bool
 FLAG basecamp tools trash --in type=string
@@ -6487,6 +13199,7 @@ FLAG basecamp tools update --account type=string
 FLAG basecamp tools update --agent type=bool
 FLAG basecamp tools update --cache-dir type=string
 FLAG basecamp tools update --count type=bool
+FLAG basecamp tools update --help type=bool
 FLAG basecamp tools update --hints type=bool
 FLAG basecamp tools update --ids-only type=bool
 FLAG basecamp tools update --in type=string
@@ -6507,6 +13220,7 @@ FLAG basecamp tui --account type=string
 FLAG basecamp tui --agent type=bool
 FLAG basecamp tui --cache-dir type=string
 FLAG basecamp tui --count type=bool
+FLAG basecamp tui --help type=bool
 FLAG basecamp tui --hints type=bool
 FLAG basecamp tui --ids-only type=bool
 FLAG basecamp tui --in type=string
@@ -6530,6 +13244,7 @@ FLAG basecamp unassign --cache-dir type=string
 FLAG basecamp unassign --card type=bool
 FLAG basecamp unassign --count type=bool
 FLAG basecamp unassign --from type=string
+FLAG basecamp unassign --help type=bool
 FLAG basecamp unassign --hints type=bool
 FLAG basecamp unassign --ids-only type=bool
 FLAG basecamp unassign --in type=string
@@ -6551,6 +13266,7 @@ FLAG basecamp upgrade --account type=string
 FLAG basecamp upgrade --agent type=bool
 FLAG basecamp upgrade --cache-dir type=string
 FLAG basecamp upgrade --count type=bool
+FLAG basecamp upgrade --help type=bool
 FLAG basecamp upgrade --hints type=bool
 FLAG basecamp upgrade --ids-only type=bool
 FLAG basecamp upgrade --in type=string
@@ -6573,6 +13289,7 @@ FLAG basecamp upload --cache-dir type=string
 FLAG basecamp upload --count type=bool
 FLAG basecamp upload --description type=string
 FLAG basecamp upload --folder type=string
+FLAG basecamp upload --help type=bool
 FLAG basecamp upload --hints type=bool
 FLAG basecamp upload --ids-only type=bool
 FLAG basecamp upload --in type=string
@@ -6595,6 +13312,7 @@ FLAG basecamp uploads --agent type=bool
 FLAG basecamp uploads --cache-dir type=string
 FLAG basecamp uploads --count type=bool
 FLAG basecamp uploads --folder type=string
+FLAG basecamp uploads --help type=bool
 FLAG basecamp uploads --hints type=bool
 FLAG basecamp uploads --ids-only type=bool
 FLAG basecamp uploads --in type=string
@@ -6618,6 +13336,7 @@ FLAG basecamp uploads create --cache-dir type=string
 FLAG basecamp uploads create --count type=bool
 FLAG basecamp uploads create --description type=string
 FLAG basecamp uploads create --folder type=string
+FLAG basecamp uploads create --help type=bool
 FLAG basecamp uploads create --hints type=bool
 FLAG basecamp uploads create --ids-only type=bool
 FLAG basecamp uploads create --in type=string
@@ -6641,6 +13360,7 @@ FLAG basecamp uploads list --all type=bool
 FLAG basecamp uploads list --cache-dir type=string
 FLAG basecamp uploads list --count type=bool
 FLAG basecamp uploads list --folder type=string
+FLAG basecamp uploads list --help type=bool
 FLAG basecamp uploads list --hints type=bool
 FLAG basecamp uploads list --ids-only type=bool
 FLAG basecamp uploads list --in type=string
@@ -6665,6 +13385,7 @@ FLAG basecamp uploads show --agent type=bool
 FLAG basecamp uploads show --cache-dir type=string
 FLAG basecamp uploads show --count type=bool
 FLAG basecamp uploads show --folder type=string
+FLAG basecamp uploads show --help type=bool
 FLAG basecamp uploads show --hints type=bool
 FLAG basecamp uploads show --ids-only type=bool
 FLAG basecamp uploads show --in type=string
@@ -6687,6 +13408,7 @@ FLAG basecamp url --account type=string
 FLAG basecamp url --agent type=bool
 FLAG basecamp url --cache-dir type=string
 FLAG basecamp url --count type=bool
+FLAG basecamp url --help type=bool
 FLAG basecamp url --hints type=bool
 FLAG basecamp url --ids-only type=bool
 FLAG basecamp url --in type=string
@@ -6707,6 +13429,7 @@ FLAG basecamp url parse --account type=string
 FLAG basecamp url parse --agent type=bool
 FLAG basecamp url parse --cache-dir type=string
 FLAG basecamp url parse --count type=bool
+FLAG basecamp url parse --help type=bool
 FLAG basecamp url parse --hints type=bool
 FLAG basecamp url parse --ids-only type=bool
 FLAG basecamp url parse --in type=string
@@ -6723,11 +13446,890 @@ FLAG basecamp url parse --stats type=bool
 FLAG basecamp url parse --styled type=bool
 FLAG basecamp url parse --todolist type=string
 FLAG basecamp url parse --verbose type=count
+FLAG basecamp vault --account type=string
+FLAG basecamp vault --agent type=bool
+FLAG basecamp vault --cache-dir type=string
+FLAG basecamp vault --count type=bool
+FLAG basecamp vault --folder type=string
+FLAG basecamp vault --help type=bool
+FLAG basecamp vault --hints type=bool
+FLAG basecamp vault --ids-only type=bool
+FLAG basecamp vault --in type=string
+FLAG basecamp vault --jq type=string
+FLAG basecamp vault --json type=bool
+FLAG basecamp vault --markdown type=bool
+FLAG basecamp vault --md type=bool
+FLAG basecamp vault --no-hints type=bool
+FLAG basecamp vault --no-stats type=bool
+FLAG basecamp vault --profile type=string
+FLAG basecamp vault --project type=string
+FLAG basecamp vault --quiet type=bool
+FLAG basecamp vault --stats type=bool
+FLAG basecamp vault --styled type=bool
+FLAG basecamp vault --todolist type=string
+FLAG basecamp vault --vault type=string
+FLAG basecamp vault --verbose type=count
+FLAG basecamp vault archive --account type=string
+FLAG basecamp vault archive --agent type=bool
+FLAG basecamp vault archive --cache-dir type=string
+FLAG basecamp vault archive --count type=bool
+FLAG basecamp vault archive --folder type=string
+FLAG basecamp vault archive --help type=bool
+FLAG basecamp vault archive --hints type=bool
+FLAG basecamp vault archive --ids-only type=bool
+FLAG basecamp vault archive --in type=string
+FLAG basecamp vault archive --jq type=string
+FLAG basecamp vault archive --json type=bool
+FLAG basecamp vault archive --markdown type=bool
+FLAG basecamp vault archive --md type=bool
+FLAG basecamp vault archive --no-hints type=bool
+FLAG basecamp vault archive --no-stats type=bool
+FLAG basecamp vault archive --profile type=string
+FLAG basecamp vault archive --project type=string
+FLAG basecamp vault archive --quiet type=bool
+FLAG basecamp vault archive --stats type=bool
+FLAG basecamp vault archive --styled type=bool
+FLAG basecamp vault archive --todolist type=string
+FLAG basecamp vault archive --vault type=string
+FLAG basecamp vault archive --verbose type=count
+FLAG basecamp vault doc --account type=string
+FLAG basecamp vault doc --agent type=bool
+FLAG basecamp vault doc --all type=bool
+FLAG basecamp vault doc --cache-dir type=string
+FLAG basecamp vault doc --count type=bool
+FLAG basecamp vault doc --folder type=string
+FLAG basecamp vault doc --help type=bool
+FLAG basecamp vault doc --hints type=bool
+FLAG basecamp vault doc --ids-only type=bool
+FLAG basecamp vault doc --in type=string
+FLAG basecamp vault doc --jq type=string
+FLAG basecamp vault doc --json type=bool
+FLAG basecamp vault doc --limit type=int
+FLAG basecamp vault doc --markdown type=bool
+FLAG basecamp vault doc --md type=bool
+FLAG basecamp vault doc --no-hints type=bool
+FLAG basecamp vault doc --no-stats type=bool
+FLAG basecamp vault doc --page type=int
+FLAG basecamp vault doc --profile type=string
+FLAG basecamp vault doc --project type=string
+FLAG basecamp vault doc --quiet type=bool
+FLAG basecamp vault doc --stats type=bool
+FLAG basecamp vault doc --styled type=bool
+FLAG basecamp vault doc --todolist type=string
+FLAG basecamp vault doc --vault type=string
+FLAG basecamp vault doc --verbose type=count
+FLAG basecamp vault doc create --account type=string
+FLAG basecamp vault doc create --agent type=bool
+FLAG basecamp vault doc create --attach type=stringArray
+FLAG basecamp vault doc create --cache-dir type=string
+FLAG basecamp vault doc create --count type=bool
+FLAG basecamp vault doc create --draft type=bool
+FLAG basecamp vault doc create --folder type=string
+FLAG basecamp vault doc create --help type=bool
+FLAG basecamp vault doc create --hints type=bool
+FLAG basecamp vault doc create --ids-only type=bool
+FLAG basecamp vault doc create --in type=string
+FLAG basecamp vault doc create --jq type=string
+FLAG basecamp vault doc create --json type=bool
+FLAG basecamp vault doc create --markdown type=bool
+FLAG basecamp vault doc create --md type=bool
+FLAG basecamp vault doc create --no-hints type=bool
+FLAG basecamp vault doc create --no-stats type=bool
+FLAG basecamp vault doc create --no-subscribe type=bool
+FLAG basecamp vault doc create --profile type=string
+FLAG basecamp vault doc create --project type=string
+FLAG basecamp vault doc create --quiet type=bool
+FLAG basecamp vault doc create --stats type=bool
+FLAG basecamp vault doc create --styled type=bool
+FLAG basecamp vault doc create --subscribe type=string
+FLAG basecamp vault doc create --todolist type=string
+FLAG basecamp vault doc create --vault type=string
+FLAG basecamp vault doc create --verbose type=count
+FLAG basecamp vault doc list --account type=string
+FLAG basecamp vault doc list --agent type=bool
+FLAG basecamp vault doc list --all type=bool
+FLAG basecamp vault doc list --cache-dir type=string
+FLAG basecamp vault doc list --count type=bool
+FLAG basecamp vault doc list --folder type=string
+FLAG basecamp vault doc list --help type=bool
+FLAG basecamp vault doc list --hints type=bool
+FLAG basecamp vault doc list --ids-only type=bool
+FLAG basecamp vault doc list --in type=string
+FLAG basecamp vault doc list --jq type=string
+FLAG basecamp vault doc list --json type=bool
+FLAG basecamp vault doc list --limit type=int
+FLAG basecamp vault doc list --markdown type=bool
+FLAG basecamp vault doc list --md type=bool
+FLAG basecamp vault doc list --no-hints type=bool
+FLAG basecamp vault doc list --no-stats type=bool
+FLAG basecamp vault doc list --page type=int
+FLAG basecamp vault doc list --profile type=string
+FLAG basecamp vault doc list --project type=string
+FLAG basecamp vault doc list --quiet type=bool
+FLAG basecamp vault doc list --stats type=bool
+FLAG basecamp vault doc list --styled type=bool
+FLAG basecamp vault doc list --todolist type=string
+FLAG basecamp vault doc list --vault type=string
+FLAG basecamp vault doc list --verbose type=count
+FLAG basecamp vault document --account type=string
+FLAG basecamp vault document --agent type=bool
+FLAG basecamp vault document --all type=bool
+FLAG basecamp vault document --cache-dir type=string
+FLAG basecamp vault document --count type=bool
+FLAG basecamp vault document --folder type=string
+FLAG basecamp vault document --help type=bool
+FLAG basecamp vault document --hints type=bool
+FLAG basecamp vault document --ids-only type=bool
+FLAG basecamp vault document --in type=string
+FLAG basecamp vault document --jq type=string
+FLAG basecamp vault document --json type=bool
+FLAG basecamp vault document --limit type=int
+FLAG basecamp vault document --markdown type=bool
+FLAG basecamp vault document --md type=bool
+FLAG basecamp vault document --no-hints type=bool
+FLAG basecamp vault document --no-stats type=bool
+FLAG basecamp vault document --page type=int
+FLAG basecamp vault document --profile type=string
+FLAG basecamp vault document --project type=string
+FLAG basecamp vault document --quiet type=bool
+FLAG basecamp vault document --stats type=bool
+FLAG basecamp vault document --styled type=bool
+FLAG basecamp vault document --todolist type=string
+FLAG basecamp vault document --vault type=string
+FLAG basecamp vault document --verbose type=count
+FLAG basecamp vault document create --account type=string
+FLAG basecamp vault document create --agent type=bool
+FLAG basecamp vault document create --attach type=stringArray
+FLAG basecamp vault document create --cache-dir type=string
+FLAG basecamp vault document create --count type=bool
+FLAG basecamp vault document create --draft type=bool
+FLAG basecamp vault document create --folder type=string
+FLAG basecamp vault document create --help type=bool
+FLAG basecamp vault document create --hints type=bool
+FLAG basecamp vault document create --ids-only type=bool
+FLAG basecamp vault document create --in type=string
+FLAG basecamp vault document create --jq type=string
+FLAG basecamp vault document create --json type=bool
+FLAG basecamp vault document create --markdown type=bool
+FLAG basecamp vault document create --md type=bool
+FLAG basecamp vault document create --no-hints type=bool
+FLAG basecamp vault document create --no-stats type=bool
+FLAG basecamp vault document create --no-subscribe type=bool
+FLAG basecamp vault document create --profile type=string
+FLAG basecamp vault document create --project type=string
+FLAG basecamp vault document create --quiet type=bool
+FLAG basecamp vault document create --stats type=bool
+FLAG basecamp vault document create --styled type=bool
+FLAG basecamp vault document create --subscribe type=string
+FLAG basecamp vault document create --todolist type=string
+FLAG basecamp vault document create --vault type=string
+FLAG basecamp vault document create --verbose type=count
+FLAG basecamp vault document list --account type=string
+FLAG basecamp vault document list --agent type=bool
+FLAG basecamp vault document list --all type=bool
+FLAG basecamp vault document list --cache-dir type=string
+FLAG basecamp vault document list --count type=bool
+FLAG basecamp vault document list --folder type=string
+FLAG basecamp vault document list --help type=bool
+FLAG basecamp vault document list --hints type=bool
+FLAG basecamp vault document list --ids-only type=bool
+FLAG basecamp vault document list --in type=string
+FLAG basecamp vault document list --jq type=string
+FLAG basecamp vault document list --json type=bool
+FLAG basecamp vault document list --limit type=int
+FLAG basecamp vault document list --markdown type=bool
+FLAG basecamp vault document list --md type=bool
+FLAG basecamp vault document list --no-hints type=bool
+FLAG basecamp vault document list --no-stats type=bool
+FLAG basecamp vault document list --page type=int
+FLAG basecamp vault document list --profile type=string
+FLAG basecamp vault document list --project type=string
+FLAG basecamp vault document list --quiet type=bool
+FLAG basecamp vault document list --stats type=bool
+FLAG basecamp vault document list --styled type=bool
+FLAG basecamp vault document list --todolist type=string
+FLAG basecamp vault document list --vault type=string
+FLAG basecamp vault document list --verbose type=count
+FLAG basecamp vault documents --account type=string
+FLAG basecamp vault documents --agent type=bool
+FLAG basecamp vault documents --all type=bool
+FLAG basecamp vault documents --cache-dir type=string
+FLAG basecamp vault documents --count type=bool
+FLAG basecamp vault documents --folder type=string
+FLAG basecamp vault documents --help type=bool
+FLAG basecamp vault documents --hints type=bool
+FLAG basecamp vault documents --ids-only type=bool
+FLAG basecamp vault documents --in type=string
+FLAG basecamp vault documents --jq type=string
+FLAG basecamp vault documents --json type=bool
+FLAG basecamp vault documents --limit type=int
+FLAG basecamp vault documents --markdown type=bool
+FLAG basecamp vault documents --md type=bool
+FLAG basecamp vault documents --no-hints type=bool
+FLAG basecamp vault documents --no-stats type=bool
+FLAG basecamp vault documents --page type=int
+FLAG basecamp vault documents --profile type=string
+FLAG basecamp vault documents --project type=string
+FLAG basecamp vault documents --quiet type=bool
+FLAG basecamp vault documents --stats type=bool
+FLAG basecamp vault documents --styled type=bool
+FLAG basecamp vault documents --todolist type=string
+FLAG basecamp vault documents --vault type=string
+FLAG basecamp vault documents --verbose type=count
+FLAG basecamp vault documents create --account type=string
+FLAG basecamp vault documents create --agent type=bool
+FLAG basecamp vault documents create --attach type=stringArray
+FLAG basecamp vault documents create --cache-dir type=string
+FLAG basecamp vault documents create --count type=bool
+FLAG basecamp vault documents create --draft type=bool
+FLAG basecamp vault documents create --folder type=string
+FLAG basecamp vault documents create --help type=bool
+FLAG basecamp vault documents create --hints type=bool
+FLAG basecamp vault documents create --ids-only type=bool
+FLAG basecamp vault documents create --in type=string
+FLAG basecamp vault documents create --jq type=string
+FLAG basecamp vault documents create --json type=bool
+FLAG basecamp vault documents create --markdown type=bool
+FLAG basecamp vault documents create --md type=bool
+FLAG basecamp vault documents create --no-hints type=bool
+FLAG basecamp vault documents create --no-stats type=bool
+FLAG basecamp vault documents create --no-subscribe type=bool
+FLAG basecamp vault documents create --profile type=string
+FLAG basecamp vault documents create --project type=string
+FLAG basecamp vault documents create --quiet type=bool
+FLAG basecamp vault documents create --stats type=bool
+FLAG basecamp vault documents create --styled type=bool
+FLAG basecamp vault documents create --subscribe type=string
+FLAG basecamp vault documents create --todolist type=string
+FLAG basecamp vault documents create --vault type=string
+FLAG basecamp vault documents create --verbose type=count
+FLAG basecamp vault documents list --account type=string
+FLAG basecamp vault documents list --agent type=bool
+FLAG basecamp vault documents list --all type=bool
+FLAG basecamp vault documents list --cache-dir type=string
+FLAG basecamp vault documents list --count type=bool
+FLAG basecamp vault documents list --folder type=string
+FLAG basecamp vault documents list --help type=bool
+FLAG basecamp vault documents list --hints type=bool
+FLAG basecamp vault documents list --ids-only type=bool
+FLAG basecamp vault documents list --in type=string
+FLAG basecamp vault documents list --jq type=string
+FLAG basecamp vault documents list --json type=bool
+FLAG basecamp vault documents list --limit type=int
+FLAG basecamp vault documents list --markdown type=bool
+FLAG basecamp vault documents list --md type=bool
+FLAG basecamp vault documents list --no-hints type=bool
+FLAG basecamp vault documents list --no-stats type=bool
+FLAG basecamp vault documents list --page type=int
+FLAG basecamp vault documents list --profile type=string
+FLAG basecamp vault documents list --project type=string
+FLAG basecamp vault documents list --quiet type=bool
+FLAG basecamp vault documents list --stats type=bool
+FLAG basecamp vault documents list --styled type=bool
+FLAG basecamp vault documents list --todolist type=string
+FLAG basecamp vault documents list --vault type=string
+FLAG basecamp vault documents list --verbose type=count
+FLAG basecamp vault download --account type=string
+FLAG basecamp vault download --agent type=bool
+FLAG basecamp vault download --cache-dir type=string
+FLAG basecamp vault download --count type=bool
+FLAG basecamp vault download --folder type=string
+FLAG basecamp vault download --help type=bool
+FLAG basecamp vault download --hints type=bool
+FLAG basecamp vault download --ids-only type=bool
+FLAG basecamp vault download --in type=string
+FLAG basecamp vault download --jq type=string
+FLAG basecamp vault download --json type=bool
+FLAG basecamp vault download --markdown type=bool
+FLAG basecamp vault download --md type=bool
+FLAG basecamp vault download --no-hints type=bool
+FLAG basecamp vault download --no-stats type=bool
+FLAG basecamp vault download --out type=string
+FLAG basecamp vault download --profile type=string
+FLAG basecamp vault download --project type=string
+FLAG basecamp vault download --quiet type=bool
+FLAG basecamp vault download --stats type=bool
+FLAG basecamp vault download --styled type=bool
+FLAG basecamp vault download --todolist type=string
+FLAG basecamp vault download --vault type=string
+FLAG basecamp vault download --verbose type=count
+FLAG basecamp vault folder --account type=string
+FLAG basecamp vault folder --agent type=bool
+FLAG basecamp vault folder --all type=bool
+FLAG basecamp vault folder --cache-dir type=string
+FLAG basecamp vault folder --count type=bool
+FLAG basecamp vault folder --folder type=string
+FLAG basecamp vault folder --help type=bool
+FLAG basecamp vault folder --hints type=bool
+FLAG basecamp vault folder --ids-only type=bool
+FLAG basecamp vault folder --in type=string
+FLAG basecamp vault folder --jq type=string
+FLAG basecamp vault folder --json type=bool
+FLAG basecamp vault folder --limit type=int
+FLAG basecamp vault folder --markdown type=bool
+FLAG basecamp vault folder --md type=bool
+FLAG basecamp vault folder --no-hints type=bool
+FLAG basecamp vault folder --no-stats type=bool
+FLAG basecamp vault folder --page type=int
+FLAG basecamp vault folder --profile type=string
+FLAG basecamp vault folder --project type=string
+FLAG basecamp vault folder --quiet type=bool
+FLAG basecamp vault folder --stats type=bool
+FLAG basecamp vault folder --styled type=bool
+FLAG basecamp vault folder --todolist type=string
+FLAG basecamp vault folder --vault type=string
+FLAG basecamp vault folder --verbose type=count
+FLAG basecamp vault folder create --account type=string
+FLAG basecamp vault folder create --agent type=bool
+FLAG basecamp vault folder create --cache-dir type=string
+FLAG basecamp vault folder create --count type=bool
+FLAG basecamp vault folder create --folder type=string
+FLAG basecamp vault folder create --help type=bool
+FLAG basecamp vault folder create --hints type=bool
+FLAG basecamp vault folder create --ids-only type=bool
+FLAG basecamp vault folder create --in type=string
+FLAG basecamp vault folder create --jq type=string
+FLAG basecamp vault folder create --json type=bool
+FLAG basecamp vault folder create --markdown type=bool
+FLAG basecamp vault folder create --md type=bool
+FLAG basecamp vault folder create --no-hints type=bool
+FLAG basecamp vault folder create --no-stats type=bool
+FLAG basecamp vault folder create --profile type=string
+FLAG basecamp vault folder create --project type=string
+FLAG basecamp vault folder create --quiet type=bool
+FLAG basecamp vault folder create --stats type=bool
+FLAG basecamp vault folder create --styled type=bool
+FLAG basecamp vault folder create --todolist type=string
+FLAG basecamp vault folder create --vault type=string
+FLAG basecamp vault folder create --verbose type=count
+FLAG basecamp vault folder list --account type=string
+FLAG basecamp vault folder list --agent type=bool
+FLAG basecamp vault folder list --all type=bool
+FLAG basecamp vault folder list --cache-dir type=string
+FLAG basecamp vault folder list --count type=bool
+FLAG basecamp vault folder list --folder type=string
+FLAG basecamp vault folder list --help type=bool
+FLAG basecamp vault folder list --hints type=bool
+FLAG basecamp vault folder list --ids-only type=bool
+FLAG basecamp vault folder list --in type=string
+FLAG basecamp vault folder list --jq type=string
+FLAG basecamp vault folder list --json type=bool
+FLAG basecamp vault folder list --limit type=int
+FLAG basecamp vault folder list --markdown type=bool
+FLAG basecamp vault folder list --md type=bool
+FLAG basecamp vault folder list --no-hints type=bool
+FLAG basecamp vault folder list --no-stats type=bool
+FLAG basecamp vault folder list --page type=int
+FLAG basecamp vault folder list --profile type=string
+FLAG basecamp vault folder list --project type=string
+FLAG basecamp vault folder list --quiet type=bool
+FLAG basecamp vault folder list --stats type=bool
+FLAG basecamp vault folder list --styled type=bool
+FLAG basecamp vault folder list --todolist type=string
+FLAG basecamp vault folder list --vault type=string
+FLAG basecamp vault folder list --verbose type=count
+FLAG basecamp vault folders --account type=string
+FLAG basecamp vault folders --agent type=bool
+FLAG basecamp vault folders --all type=bool
+FLAG basecamp vault folders --cache-dir type=string
+FLAG basecamp vault folders --count type=bool
+FLAG basecamp vault folders --folder type=string
+FLAG basecamp vault folders --help type=bool
+FLAG basecamp vault folders --hints type=bool
+FLAG basecamp vault folders --ids-only type=bool
+FLAG basecamp vault folders --in type=string
+FLAG basecamp vault folders --jq type=string
+FLAG basecamp vault folders --json type=bool
+FLAG basecamp vault folders --limit type=int
+FLAG basecamp vault folders --markdown type=bool
+FLAG basecamp vault folders --md type=bool
+FLAG basecamp vault folders --no-hints type=bool
+FLAG basecamp vault folders --no-stats type=bool
+FLAG basecamp vault folders --page type=int
+FLAG basecamp vault folders --profile type=string
+FLAG basecamp vault folders --project type=string
+FLAG basecamp vault folders --quiet type=bool
+FLAG basecamp vault folders --stats type=bool
+FLAG basecamp vault folders --styled type=bool
+FLAG basecamp vault folders --todolist type=string
+FLAG basecamp vault folders --vault type=string
+FLAG basecamp vault folders --verbose type=count
+FLAG basecamp vault folders create --account type=string
+FLAG basecamp vault folders create --agent type=bool
+FLAG basecamp vault folders create --cache-dir type=string
+FLAG basecamp vault folders create --count type=bool
+FLAG basecamp vault folders create --folder type=string
+FLAG basecamp vault folders create --help type=bool
+FLAG basecamp vault folders create --hints type=bool
+FLAG basecamp vault folders create --ids-only type=bool
+FLAG basecamp vault folders create --in type=string
+FLAG basecamp vault folders create --jq type=string
+FLAG basecamp vault folders create --json type=bool
+FLAG basecamp vault folders create --markdown type=bool
+FLAG basecamp vault folders create --md type=bool
+FLAG basecamp vault folders create --no-hints type=bool
+FLAG basecamp vault folders create --no-stats type=bool
+FLAG basecamp vault folders create --profile type=string
+FLAG basecamp vault folders create --project type=string
+FLAG basecamp vault folders create --quiet type=bool
+FLAG basecamp vault folders create --stats type=bool
+FLAG basecamp vault folders create --styled type=bool
+FLAG basecamp vault folders create --todolist type=string
+FLAG basecamp vault folders create --vault type=string
+FLAG basecamp vault folders create --verbose type=count
+FLAG basecamp vault folders list --account type=string
+FLAG basecamp vault folders list --agent type=bool
+FLAG basecamp vault folders list --all type=bool
+FLAG basecamp vault folders list --cache-dir type=string
+FLAG basecamp vault folders list --count type=bool
+FLAG basecamp vault folders list --folder type=string
+FLAG basecamp vault folders list --help type=bool
+FLAG basecamp vault folders list --hints type=bool
+FLAG basecamp vault folders list --ids-only type=bool
+FLAG basecamp vault folders list --in type=string
+FLAG basecamp vault folders list --jq type=string
+FLAG basecamp vault folders list --json type=bool
+FLAG basecamp vault folders list --limit type=int
+FLAG basecamp vault folders list --markdown type=bool
+FLAG basecamp vault folders list --md type=bool
+FLAG basecamp vault folders list --no-hints type=bool
+FLAG basecamp vault folders list --no-stats type=bool
+FLAG basecamp vault folders list --page type=int
+FLAG basecamp vault folders list --profile type=string
+FLAG basecamp vault folders list --project type=string
+FLAG basecamp vault folders list --quiet type=bool
+FLAG basecamp vault folders list --stats type=bool
+FLAG basecamp vault folders list --styled type=bool
+FLAG basecamp vault folders list --todolist type=string
+FLAG basecamp vault folders list --vault type=string
+FLAG basecamp vault folders list --verbose type=count
+FLAG basecamp vault list --account type=string
+FLAG basecamp vault list --agent type=bool
+FLAG basecamp vault list --cache-dir type=string
+FLAG basecamp vault list --count type=bool
+FLAG basecamp vault list --folder type=string
+FLAG basecamp vault list --help type=bool
+FLAG basecamp vault list --hints type=bool
+FLAG basecamp vault list --ids-only type=bool
+FLAG basecamp vault list --in type=string
+FLAG basecamp vault list --jq type=string
+FLAG basecamp vault list --json type=bool
+FLAG basecamp vault list --markdown type=bool
+FLAG basecamp vault list --md type=bool
+FLAG basecamp vault list --no-hints type=bool
+FLAG basecamp vault list --no-stats type=bool
+FLAG basecamp vault list --profile type=string
+FLAG basecamp vault list --project type=string
+FLAG basecamp vault list --quiet type=bool
+FLAG basecamp vault list --stats type=bool
+FLAG basecamp vault list --styled type=bool
+FLAG basecamp vault list --todolist type=string
+FLAG basecamp vault list --vault type=string
+FLAG basecamp vault list --verbose type=count
+FLAG basecamp vault restore --account type=string
+FLAG basecamp vault restore --agent type=bool
+FLAG basecamp vault restore --cache-dir type=string
+FLAG basecamp vault restore --count type=bool
+FLAG basecamp vault restore --folder type=string
+FLAG basecamp vault restore --help type=bool
+FLAG basecamp vault restore --hints type=bool
+FLAG basecamp vault restore --ids-only type=bool
+FLAG basecamp vault restore --in type=string
+FLAG basecamp vault restore --jq type=string
+FLAG basecamp vault restore --json type=bool
+FLAG basecamp vault restore --markdown type=bool
+FLAG basecamp vault restore --md type=bool
+FLAG basecamp vault restore --no-hints type=bool
+FLAG basecamp vault restore --no-stats type=bool
+FLAG basecamp vault restore --profile type=string
+FLAG basecamp vault restore --project type=string
+FLAG basecamp vault restore --quiet type=bool
+FLAG basecamp vault restore --stats type=bool
+FLAG basecamp vault restore --styled type=bool
+FLAG basecamp vault restore --todolist type=string
+FLAG basecamp vault restore --vault type=string
+FLAG basecamp vault restore --verbose type=count
+FLAG basecamp vault show --account type=string
+FLAG basecamp vault show --agent type=bool
+FLAG basecamp vault show --cache-dir type=string
+FLAG basecamp vault show --count type=bool
+FLAG basecamp vault show --folder type=string
+FLAG basecamp vault show --help type=bool
+FLAG basecamp vault show --hints type=bool
+FLAG basecamp vault show --ids-only type=bool
+FLAG basecamp vault show --in type=string
+FLAG basecamp vault show --jq type=string
+FLAG basecamp vault show --json type=bool
+FLAG basecamp vault show --markdown type=bool
+FLAG basecamp vault show --md type=bool
+FLAG basecamp vault show --no-hints type=bool
+FLAG basecamp vault show --no-stats type=bool
+FLAG basecamp vault show --profile type=string
+FLAG basecamp vault show --project type=string
+FLAG basecamp vault show --quiet type=bool
+FLAG basecamp vault show --stats type=bool
+FLAG basecamp vault show --styled type=bool
+FLAG basecamp vault show --todolist type=string
+FLAG basecamp vault show --type type=string
+FLAG basecamp vault show --vault type=string
+FLAG basecamp vault show --verbose type=count
+FLAG basecamp vault trash --account type=string
+FLAG basecamp vault trash --agent type=bool
+FLAG basecamp vault trash --cache-dir type=string
+FLAG basecamp vault trash --count type=bool
+FLAG basecamp vault trash --folder type=string
+FLAG basecamp vault trash --help type=bool
+FLAG basecamp vault trash --hints type=bool
+FLAG basecamp vault trash --ids-only type=bool
+FLAG basecamp vault trash --in type=string
+FLAG basecamp vault trash --jq type=string
+FLAG basecamp vault trash --json type=bool
+FLAG basecamp vault trash --markdown type=bool
+FLAG basecamp vault trash --md type=bool
+FLAG basecamp vault trash --no-hints type=bool
+FLAG basecamp vault trash --no-stats type=bool
+FLAG basecamp vault trash --profile type=string
+FLAG basecamp vault trash --project type=string
+FLAG basecamp vault trash --quiet type=bool
+FLAG basecamp vault trash --stats type=bool
+FLAG basecamp vault trash --styled type=bool
+FLAG basecamp vault trash --todolist type=string
+FLAG basecamp vault trash --vault type=string
+FLAG basecamp vault trash --verbose type=count
+FLAG basecamp vault update --account type=string
+FLAG basecamp vault update --agent type=bool
+FLAG basecamp vault update --cache-dir type=string
+FLAG basecamp vault update --content type=string
+FLAG basecamp vault update --count type=bool
+FLAG basecamp vault update --folder type=string
+FLAG basecamp vault update --help type=bool
+FLAG basecamp vault update --hints type=bool
+FLAG basecamp vault update --ids-only type=bool
+FLAG basecamp vault update --in type=string
+FLAG basecamp vault update --jq type=string
+FLAG basecamp vault update --json type=bool
+FLAG basecamp vault update --markdown type=bool
+FLAG basecamp vault update --md type=bool
+FLAG basecamp vault update --no-hints type=bool
+FLAG basecamp vault update --no-stats type=bool
+FLAG basecamp vault update --profile type=string
+FLAG basecamp vault update --project type=string
+FLAG basecamp vault update --quiet type=bool
+FLAG basecamp vault update --stats type=bool
+FLAG basecamp vault update --styled type=bool
+FLAG basecamp vault update --title type=string
+FLAG basecamp vault update --todolist type=string
+FLAG basecamp vault update --type type=string
+FLAG basecamp vault update --vault type=string
+FLAG basecamp vault update --verbose type=count
+FLAG basecamp vault upload --account type=string
+FLAG basecamp vault upload --agent type=bool
+FLAG basecamp vault upload --all type=bool
+FLAG basecamp vault upload --cache-dir type=string
+FLAG basecamp vault upload --count type=bool
+FLAG basecamp vault upload --folder type=string
+FLAG basecamp vault upload --help type=bool
+FLAG basecamp vault upload --hints type=bool
+FLAG basecamp vault upload --ids-only type=bool
+FLAG basecamp vault upload --in type=string
+FLAG basecamp vault upload --jq type=string
+FLAG basecamp vault upload --json type=bool
+FLAG basecamp vault upload --limit type=int
+FLAG basecamp vault upload --markdown type=bool
+FLAG basecamp vault upload --md type=bool
+FLAG basecamp vault upload --no-hints type=bool
+FLAG basecamp vault upload --no-stats type=bool
+FLAG basecamp vault upload --page type=int
+FLAG basecamp vault upload --profile type=string
+FLAG basecamp vault upload --project type=string
+FLAG basecamp vault upload --quiet type=bool
+FLAG basecamp vault upload --stats type=bool
+FLAG basecamp vault upload --styled type=bool
+FLAG basecamp vault upload --todolist type=string
+FLAG basecamp vault upload --vault type=string
+FLAG basecamp vault upload --verbose type=count
+FLAG basecamp vault upload create --account type=string
+FLAG basecamp vault upload create --agent type=bool
+FLAG basecamp vault upload create --cache-dir type=string
+FLAG basecamp vault upload create --count type=bool
+FLAG basecamp vault upload create --description type=string
+FLAG basecamp vault upload create --folder type=string
+FLAG basecamp vault upload create --help type=bool
+FLAG basecamp vault upload create --hints type=bool
+FLAG basecamp vault upload create --ids-only type=bool
+FLAG basecamp vault upload create --in type=string
+FLAG basecamp vault upload create --jq type=string
+FLAG basecamp vault upload create --json type=bool
+FLAG basecamp vault upload create --markdown type=bool
+FLAG basecamp vault upload create --md type=bool
+FLAG basecamp vault upload create --no-hints type=bool
+FLAG basecamp vault upload create --no-stats type=bool
+FLAG basecamp vault upload create --profile type=string
+FLAG basecamp vault upload create --project type=string
+FLAG basecamp vault upload create --quiet type=bool
+FLAG basecamp vault upload create --stats type=bool
+FLAG basecamp vault upload create --styled type=bool
+FLAG basecamp vault upload create --todolist type=string
+FLAG basecamp vault upload create --vault type=string
+FLAG basecamp vault upload create --verbose type=count
+FLAG basecamp vault upload list --account type=string
+FLAG basecamp vault upload list --agent type=bool
+FLAG basecamp vault upload list --all type=bool
+FLAG basecamp vault upload list --cache-dir type=string
+FLAG basecamp vault upload list --count type=bool
+FLAG basecamp vault upload list --folder type=string
+FLAG basecamp vault upload list --help type=bool
+FLAG basecamp vault upload list --hints type=bool
+FLAG basecamp vault upload list --ids-only type=bool
+FLAG basecamp vault upload list --in type=string
+FLAG basecamp vault upload list --jq type=string
+FLAG basecamp vault upload list --json type=bool
+FLAG basecamp vault upload list --limit type=int
+FLAG basecamp vault upload list --markdown type=bool
+FLAG basecamp vault upload list --md type=bool
+FLAG basecamp vault upload list --no-hints type=bool
+FLAG basecamp vault upload list --no-stats type=bool
+FLAG basecamp vault upload list --page type=int
+FLAG basecamp vault upload list --profile type=string
+FLAG basecamp vault upload list --project type=string
+FLAG basecamp vault upload list --quiet type=bool
+FLAG basecamp vault upload list --stats type=bool
+FLAG basecamp vault upload list --styled type=bool
+FLAG basecamp vault upload list --todolist type=string
+FLAG basecamp vault upload list --vault type=string
+FLAG basecamp vault upload list --verbose type=count
+FLAG basecamp vault uploads --account type=string
+FLAG basecamp vault uploads --agent type=bool
+FLAG basecamp vault uploads --all type=bool
+FLAG basecamp vault uploads --cache-dir type=string
+FLAG basecamp vault uploads --count type=bool
+FLAG basecamp vault uploads --folder type=string
+FLAG basecamp vault uploads --help type=bool
+FLAG basecamp vault uploads --hints type=bool
+FLAG basecamp vault uploads --ids-only type=bool
+FLAG basecamp vault uploads --in type=string
+FLAG basecamp vault uploads --jq type=string
+FLAG basecamp vault uploads --json type=bool
+FLAG basecamp vault uploads --limit type=int
+FLAG basecamp vault uploads --markdown type=bool
+FLAG basecamp vault uploads --md type=bool
+FLAG basecamp vault uploads --no-hints type=bool
+FLAG basecamp vault uploads --no-stats type=bool
+FLAG basecamp vault uploads --page type=int
+FLAG basecamp vault uploads --profile type=string
+FLAG basecamp vault uploads --project type=string
+FLAG basecamp vault uploads --quiet type=bool
+FLAG basecamp vault uploads --stats type=bool
+FLAG basecamp vault uploads --styled type=bool
+FLAG basecamp vault uploads --todolist type=string
+FLAG basecamp vault uploads --vault type=string
+FLAG basecamp vault uploads --verbose type=count
+FLAG basecamp vault uploads create --account type=string
+FLAG basecamp vault uploads create --agent type=bool
+FLAG basecamp vault uploads create --cache-dir type=string
+FLAG basecamp vault uploads create --count type=bool
+FLAG basecamp vault uploads create --description type=string
+FLAG basecamp vault uploads create --folder type=string
+FLAG basecamp vault uploads create --help type=bool
+FLAG basecamp vault uploads create --hints type=bool
+FLAG basecamp vault uploads create --ids-only type=bool
+FLAG basecamp vault uploads create --in type=string
+FLAG basecamp vault uploads create --jq type=string
+FLAG basecamp vault uploads create --json type=bool
+FLAG basecamp vault uploads create --markdown type=bool
+FLAG basecamp vault uploads create --md type=bool
+FLAG basecamp vault uploads create --no-hints type=bool
+FLAG basecamp vault uploads create --no-stats type=bool
+FLAG basecamp vault uploads create --profile type=string
+FLAG basecamp vault uploads create --project type=string
+FLAG basecamp vault uploads create --quiet type=bool
+FLAG basecamp vault uploads create --stats type=bool
+FLAG basecamp vault uploads create --styled type=bool
+FLAG basecamp vault uploads create --todolist type=string
+FLAG basecamp vault uploads create --vault type=string
+FLAG basecamp vault uploads create --verbose type=count
+FLAG basecamp vault uploads list --account type=string
+FLAG basecamp vault uploads list --agent type=bool
+FLAG basecamp vault uploads list --all type=bool
+FLAG basecamp vault uploads list --cache-dir type=string
+FLAG basecamp vault uploads list --count type=bool
+FLAG basecamp vault uploads list --folder type=string
+FLAG basecamp vault uploads list --help type=bool
+FLAG basecamp vault uploads list --hints type=bool
+FLAG basecamp vault uploads list --ids-only type=bool
+FLAG basecamp vault uploads list --in type=string
+FLAG basecamp vault uploads list --jq type=string
+FLAG basecamp vault uploads list --json type=bool
+FLAG basecamp vault uploads list --limit type=int
+FLAG basecamp vault uploads list --markdown type=bool
+FLAG basecamp vault uploads list --md type=bool
+FLAG basecamp vault uploads list --no-hints type=bool
+FLAG basecamp vault uploads list --no-stats type=bool
+FLAG basecamp vault uploads list --page type=int
+FLAG basecamp vault uploads list --profile type=string
+FLAG basecamp vault uploads list --project type=string
+FLAG basecamp vault uploads list --quiet type=bool
+FLAG basecamp vault uploads list --stats type=bool
+FLAG basecamp vault uploads list --styled type=bool
+FLAG basecamp vault uploads list --todolist type=string
+FLAG basecamp vault uploads list --vault type=string
+FLAG basecamp vault uploads list --verbose type=count
+FLAG basecamp vault vault --account type=string
+FLAG basecamp vault vault --agent type=bool
+FLAG basecamp vault vault --all type=bool
+FLAG basecamp vault vault --cache-dir type=string
+FLAG basecamp vault vault --count type=bool
+FLAG basecamp vault vault --folder type=string
+FLAG basecamp vault vault --help type=bool
+FLAG basecamp vault vault --hints type=bool
+FLAG basecamp vault vault --ids-only type=bool
+FLAG basecamp vault vault --in type=string
+FLAG basecamp vault vault --jq type=string
+FLAG basecamp vault vault --json type=bool
+FLAG basecamp vault vault --limit type=int
+FLAG basecamp vault vault --markdown type=bool
+FLAG basecamp vault vault --md type=bool
+FLAG basecamp vault vault --no-hints type=bool
+FLAG basecamp vault vault --no-stats type=bool
+FLAG basecamp vault vault --page type=int
+FLAG basecamp vault vault --profile type=string
+FLAG basecamp vault vault --project type=string
+FLAG basecamp vault vault --quiet type=bool
+FLAG basecamp vault vault --stats type=bool
+FLAG basecamp vault vault --styled type=bool
+FLAG basecamp vault vault --todolist type=string
+FLAG basecamp vault vault --vault type=string
+FLAG basecamp vault vault --verbose type=count
+FLAG basecamp vault vault create --account type=string
+FLAG basecamp vault vault create --agent type=bool
+FLAG basecamp vault vault create --cache-dir type=string
+FLAG basecamp vault vault create --count type=bool
+FLAG basecamp vault vault create --folder type=string
+FLAG basecamp vault vault create --help type=bool
+FLAG basecamp vault vault create --hints type=bool
+FLAG basecamp vault vault create --ids-only type=bool
+FLAG basecamp vault vault create --in type=string
+FLAG basecamp vault vault create --jq type=string
+FLAG basecamp vault vault create --json type=bool
+FLAG basecamp vault vault create --markdown type=bool
+FLAG basecamp vault vault create --md type=bool
+FLAG basecamp vault vault create --no-hints type=bool
+FLAG basecamp vault vault create --no-stats type=bool
+FLAG basecamp vault vault create --profile type=string
+FLAG basecamp vault vault create --project type=string
+FLAG basecamp vault vault create --quiet type=bool
+FLAG basecamp vault vault create --stats type=bool
+FLAG basecamp vault vault create --styled type=bool
+FLAG basecamp vault vault create --todolist type=string
+FLAG basecamp vault vault create --vault type=string
+FLAG basecamp vault vault create --verbose type=count
+FLAG basecamp vault vault list --account type=string
+FLAG basecamp vault vault list --agent type=bool
+FLAG basecamp vault vault list --all type=bool
+FLAG basecamp vault vault list --cache-dir type=string
+FLAG basecamp vault vault list --count type=bool
+FLAG basecamp vault vault list --folder type=string
+FLAG basecamp vault vault list --help type=bool
+FLAG basecamp vault vault list --hints type=bool
+FLAG basecamp vault vault list --ids-only type=bool
+FLAG basecamp vault vault list --in type=string
+FLAG basecamp vault vault list --jq type=string
+FLAG basecamp vault vault list --json type=bool
+FLAG basecamp vault vault list --limit type=int
+FLAG basecamp vault vault list --markdown type=bool
+FLAG basecamp vault vault list --md type=bool
+FLAG basecamp vault vault list --no-hints type=bool
+FLAG basecamp vault vault list --no-stats type=bool
+FLAG basecamp vault vault list --page type=int
+FLAG basecamp vault vault list --profile type=string
+FLAG basecamp vault vault list --project type=string
+FLAG basecamp vault vault list --quiet type=bool
+FLAG basecamp vault vault list --stats type=bool
+FLAG basecamp vault vault list --styled type=bool
+FLAG basecamp vault vault list --todolist type=string
+FLAG basecamp vault vault list --vault type=string
+FLAG basecamp vault vault list --verbose type=count
+FLAG basecamp vault vaults --account type=string
+FLAG basecamp vault vaults --agent type=bool
+FLAG basecamp vault vaults --all type=bool
+FLAG basecamp vault vaults --cache-dir type=string
+FLAG basecamp vault vaults --count type=bool
+FLAG basecamp vault vaults --folder type=string
+FLAG basecamp vault vaults --help type=bool
+FLAG basecamp vault vaults --hints type=bool
+FLAG basecamp vault vaults --ids-only type=bool
+FLAG basecamp vault vaults --in type=string
+FLAG basecamp vault vaults --jq type=string
+FLAG basecamp vault vaults --json type=bool
+FLAG basecamp vault vaults --limit type=int
+FLAG basecamp vault vaults --markdown type=bool
+FLAG basecamp vault vaults --md type=bool
+FLAG basecamp vault vaults --no-hints type=bool
+FLAG basecamp vault vaults --no-stats type=bool
+FLAG basecamp vault vaults --page type=int
+FLAG basecamp vault vaults --profile type=string
+FLAG basecamp vault vaults --project type=string
+FLAG basecamp vault vaults --quiet type=bool
+FLAG basecamp vault vaults --stats type=bool
+FLAG basecamp vault vaults --styled type=bool
+FLAG basecamp vault vaults --todolist type=string
+FLAG basecamp vault vaults --vault type=string
+FLAG basecamp vault vaults --verbose type=count
+FLAG basecamp vault vaults create --account type=string
+FLAG basecamp vault vaults create --agent type=bool
+FLAG basecamp vault vaults create --cache-dir type=string
+FLAG basecamp vault vaults create --count type=bool
+FLAG basecamp vault vaults create --folder type=string
+FLAG basecamp vault vaults create --help type=bool
+FLAG basecamp vault vaults create --hints type=bool
+FLAG basecamp vault vaults create --ids-only type=bool
+FLAG basecamp vault vaults create --in type=string
+FLAG basecamp vault vaults create --jq type=string
+FLAG basecamp vault vaults create --json type=bool
+FLAG basecamp vault vaults create --markdown type=bool
+FLAG basecamp vault vaults create --md type=bool
+FLAG basecamp vault vaults create --no-hints type=bool
+FLAG basecamp vault vaults create --no-stats type=bool
+FLAG basecamp vault vaults create --profile type=string
+FLAG basecamp vault vaults create --project type=string
+FLAG basecamp vault vaults create --quiet type=bool
+FLAG basecamp vault vaults create --stats type=bool
+FLAG basecamp vault vaults create --styled type=bool
+FLAG basecamp vault vaults create --todolist type=string
+FLAG basecamp vault vaults create --vault type=string
+FLAG basecamp vault vaults create --verbose type=count
+FLAG basecamp vault vaults list --account type=string
+FLAG basecamp vault vaults list --agent type=bool
+FLAG basecamp vault vaults list --all type=bool
+FLAG basecamp vault vaults list --cache-dir type=string
+FLAG basecamp vault vaults list --count type=bool
+FLAG basecamp vault vaults list --folder type=string
+FLAG basecamp vault vaults list --help type=bool
+FLAG basecamp vault vaults list --hints type=bool
+FLAG basecamp vault vaults list --ids-only type=bool
+FLAG basecamp vault vaults list --in type=string
+FLAG basecamp vault vaults list --jq type=string
+FLAG basecamp vault vaults list --json type=bool
+FLAG basecamp vault vaults list --limit type=int
+FLAG basecamp vault vaults list --markdown type=bool
+FLAG basecamp vault vaults list --md type=bool
+FLAG basecamp vault vaults list --no-hints type=bool
+FLAG basecamp vault vaults list --no-stats type=bool
+FLAG basecamp vault vaults list --page type=int
+FLAG basecamp vault vaults list --profile type=string
+FLAG basecamp vault vaults list --project type=string
+FLAG basecamp vault vaults list --quiet type=bool
+FLAG basecamp vault vaults list --stats type=bool
+FLAG basecamp vault vaults list --styled type=bool
+FLAG basecamp vault vaults list --todolist type=string
+FLAG basecamp vault vaults list --vault type=string
+FLAG basecamp vault vaults list --verbose type=count
 FLAG basecamp vaults --account type=string
 FLAG basecamp vaults --agent type=bool
 FLAG basecamp vaults --cache-dir type=string
 FLAG basecamp vaults --count type=bool
 FLAG basecamp vaults --folder type=string
+FLAG basecamp vaults --help type=bool
 FLAG basecamp vaults --hints type=bool
 FLAG basecamp vaults --ids-only type=bool
 FLAG basecamp vaults --in type=string
@@ -6750,6 +14352,7 @@ FLAG basecamp vaults archive --agent type=bool
 FLAG basecamp vaults archive --cache-dir type=string
 FLAG basecamp vaults archive --count type=bool
 FLAG basecamp vaults archive --folder type=string
+FLAG basecamp vaults archive --help type=bool
 FLAG basecamp vaults archive --hints type=bool
 FLAG basecamp vaults archive --ids-only type=bool
 FLAG basecamp vaults archive --in type=string
@@ -6767,12 +14370,171 @@ FLAG basecamp vaults archive --styled type=bool
 FLAG basecamp vaults archive --todolist type=string
 FLAG basecamp vaults archive --vault type=string
 FLAG basecamp vaults archive --verbose type=count
+FLAG basecamp vaults doc --account type=string
+FLAG basecamp vaults doc --agent type=bool
+FLAG basecamp vaults doc --all type=bool
+FLAG basecamp vaults doc --cache-dir type=string
+FLAG basecamp vaults doc --count type=bool
+FLAG basecamp vaults doc --folder type=string
+FLAG basecamp vaults doc --help type=bool
+FLAG basecamp vaults doc --hints type=bool
+FLAG basecamp vaults doc --ids-only type=bool
+FLAG basecamp vaults doc --in type=string
+FLAG basecamp vaults doc --jq type=string
+FLAG basecamp vaults doc --json type=bool
+FLAG basecamp vaults doc --limit type=int
+FLAG basecamp vaults doc --markdown type=bool
+FLAG basecamp vaults doc --md type=bool
+FLAG basecamp vaults doc --no-hints type=bool
+FLAG basecamp vaults doc --no-stats type=bool
+FLAG basecamp vaults doc --page type=int
+FLAG basecamp vaults doc --profile type=string
+FLAG basecamp vaults doc --project type=string
+FLAG basecamp vaults doc --quiet type=bool
+FLAG basecamp vaults doc --stats type=bool
+FLAG basecamp vaults doc --styled type=bool
+FLAG basecamp vaults doc --todolist type=string
+FLAG basecamp vaults doc --vault type=string
+FLAG basecamp vaults doc --verbose type=count
+FLAG basecamp vaults doc create --account type=string
+FLAG basecamp vaults doc create --agent type=bool
+FLAG basecamp vaults doc create --attach type=stringArray
+FLAG basecamp vaults doc create --cache-dir type=string
+FLAG basecamp vaults doc create --count type=bool
+FLAG basecamp vaults doc create --draft type=bool
+FLAG basecamp vaults doc create --folder type=string
+FLAG basecamp vaults doc create --help type=bool
+FLAG basecamp vaults doc create --hints type=bool
+FLAG basecamp vaults doc create --ids-only type=bool
+FLAG basecamp vaults doc create --in type=string
+FLAG basecamp vaults doc create --jq type=string
+FLAG basecamp vaults doc create --json type=bool
+FLAG basecamp vaults doc create --markdown type=bool
+FLAG basecamp vaults doc create --md type=bool
+FLAG basecamp vaults doc create --no-hints type=bool
+FLAG basecamp vaults doc create --no-stats type=bool
+FLAG basecamp vaults doc create --no-subscribe type=bool
+FLAG basecamp vaults doc create --profile type=string
+FLAG basecamp vaults doc create --project type=string
+FLAG basecamp vaults doc create --quiet type=bool
+FLAG basecamp vaults doc create --stats type=bool
+FLAG basecamp vaults doc create --styled type=bool
+FLAG basecamp vaults doc create --subscribe type=string
+FLAG basecamp vaults doc create --todolist type=string
+FLAG basecamp vaults doc create --vault type=string
+FLAG basecamp vaults doc create --verbose type=count
+FLAG basecamp vaults doc list --account type=string
+FLAG basecamp vaults doc list --agent type=bool
+FLAG basecamp vaults doc list --all type=bool
+FLAG basecamp vaults doc list --cache-dir type=string
+FLAG basecamp vaults doc list --count type=bool
+FLAG basecamp vaults doc list --folder type=string
+FLAG basecamp vaults doc list --help type=bool
+FLAG basecamp vaults doc list --hints type=bool
+FLAG basecamp vaults doc list --ids-only type=bool
+FLAG basecamp vaults doc list --in type=string
+FLAG basecamp vaults doc list --jq type=string
+FLAG basecamp vaults doc list --json type=bool
+FLAG basecamp vaults doc list --limit type=int
+FLAG basecamp vaults doc list --markdown type=bool
+FLAG basecamp vaults doc list --md type=bool
+FLAG basecamp vaults doc list --no-hints type=bool
+FLAG basecamp vaults doc list --no-stats type=bool
+FLAG basecamp vaults doc list --page type=int
+FLAG basecamp vaults doc list --profile type=string
+FLAG basecamp vaults doc list --project type=string
+FLAG basecamp vaults doc list --quiet type=bool
+FLAG basecamp vaults doc list --stats type=bool
+FLAG basecamp vaults doc list --styled type=bool
+FLAG basecamp vaults doc list --todolist type=string
+FLAG basecamp vaults doc list --vault type=string
+FLAG basecamp vaults doc list --verbose type=count
+FLAG basecamp vaults document --account type=string
+FLAG basecamp vaults document --agent type=bool
+FLAG basecamp vaults document --all type=bool
+FLAG basecamp vaults document --cache-dir type=string
+FLAG basecamp vaults document --count type=bool
+FLAG basecamp vaults document --folder type=string
+FLAG basecamp vaults document --help type=bool
+FLAG basecamp vaults document --hints type=bool
+FLAG basecamp vaults document --ids-only type=bool
+FLAG basecamp vaults document --in type=string
+FLAG basecamp vaults document --jq type=string
+FLAG basecamp vaults document --json type=bool
+FLAG basecamp vaults document --limit type=int
+FLAG basecamp vaults document --markdown type=bool
+FLAG basecamp vaults document --md type=bool
+FLAG basecamp vaults document --no-hints type=bool
+FLAG basecamp vaults document --no-stats type=bool
+FLAG basecamp vaults document --page type=int
+FLAG basecamp vaults document --profile type=string
+FLAG basecamp vaults document --project type=string
+FLAG basecamp vaults document --quiet type=bool
+FLAG basecamp vaults document --stats type=bool
+FLAG basecamp vaults document --styled type=bool
+FLAG basecamp vaults document --todolist type=string
+FLAG basecamp vaults document --vault type=string
+FLAG basecamp vaults document --verbose type=count
+FLAG basecamp vaults document create --account type=string
+FLAG basecamp vaults document create --agent type=bool
+FLAG basecamp vaults document create --attach type=stringArray
+FLAG basecamp vaults document create --cache-dir type=string
+FLAG basecamp vaults document create --count type=bool
+FLAG basecamp vaults document create --draft type=bool
+FLAG basecamp vaults document create --folder type=string
+FLAG basecamp vaults document create --help type=bool
+FLAG basecamp vaults document create --hints type=bool
+FLAG basecamp vaults document create --ids-only type=bool
+FLAG basecamp vaults document create --in type=string
+FLAG basecamp vaults document create --jq type=string
+FLAG basecamp vaults document create --json type=bool
+FLAG basecamp vaults document create --markdown type=bool
+FLAG basecamp vaults document create --md type=bool
+FLAG basecamp vaults document create --no-hints type=bool
+FLAG basecamp vaults document create --no-stats type=bool
+FLAG basecamp vaults document create --no-subscribe type=bool
+FLAG basecamp vaults document create --profile type=string
+FLAG basecamp vaults document create --project type=string
+FLAG basecamp vaults document create --quiet type=bool
+FLAG basecamp vaults document create --stats type=bool
+FLAG basecamp vaults document create --styled type=bool
+FLAG basecamp vaults document create --subscribe type=string
+FLAG basecamp vaults document create --todolist type=string
+FLAG basecamp vaults document create --vault type=string
+FLAG basecamp vaults document create --verbose type=count
+FLAG basecamp vaults document list --account type=string
+FLAG basecamp vaults document list --agent type=bool
+FLAG basecamp vaults document list --all type=bool
+FLAG basecamp vaults document list --cache-dir type=string
+FLAG basecamp vaults document list --count type=bool
+FLAG basecamp vaults document list --folder type=string
+FLAG basecamp vaults document list --help type=bool
+FLAG basecamp vaults document list --hints type=bool
+FLAG basecamp vaults document list --ids-only type=bool
+FLAG basecamp vaults document list --in type=string
+FLAG basecamp vaults document list --jq type=string
+FLAG basecamp vaults document list --json type=bool
+FLAG basecamp vaults document list --limit type=int
+FLAG basecamp vaults document list --markdown type=bool
+FLAG basecamp vaults document list --md type=bool
+FLAG basecamp vaults document list --no-hints type=bool
+FLAG basecamp vaults document list --no-stats type=bool
+FLAG basecamp vaults document list --page type=int
+FLAG basecamp vaults document list --profile type=string
+FLAG basecamp vaults document list --project type=string
+FLAG basecamp vaults document list --quiet type=bool
+FLAG basecamp vaults document list --stats type=bool
+FLAG basecamp vaults document list --styled type=bool
+FLAG basecamp vaults document list --todolist type=string
+FLAG basecamp vaults document list --vault type=string
+FLAG basecamp vaults document list --verbose type=count
 FLAG basecamp vaults documents --account type=string
 FLAG basecamp vaults documents --agent type=bool
 FLAG basecamp vaults documents --all type=bool
 FLAG basecamp vaults documents --cache-dir type=string
 FLAG basecamp vaults documents --count type=bool
 FLAG basecamp vaults documents --folder type=string
+FLAG basecamp vaults documents --help type=bool
 FLAG basecamp vaults documents --hints type=bool
 FLAG basecamp vaults documents --ids-only type=bool
 FLAG basecamp vaults documents --in type=string
@@ -6799,6 +14561,7 @@ FLAG basecamp vaults documents create --cache-dir type=string
 FLAG basecamp vaults documents create --count type=bool
 FLAG basecamp vaults documents create --draft type=bool
 FLAG basecamp vaults documents create --folder type=string
+FLAG basecamp vaults documents create --help type=bool
 FLAG basecamp vaults documents create --hints type=bool
 FLAG basecamp vaults documents create --ids-only type=bool
 FLAG basecamp vaults documents create --in type=string
@@ -6824,6 +14587,7 @@ FLAG basecamp vaults documents list --all type=bool
 FLAG basecamp vaults documents list --cache-dir type=string
 FLAG basecamp vaults documents list --count type=bool
 FLAG basecamp vaults documents list --folder type=string
+FLAG basecamp vaults documents list --help type=bool
 FLAG basecamp vaults documents list --hints type=bool
 FLAG basecamp vaults documents list --ids-only type=bool
 FLAG basecamp vaults documents list --in type=string
@@ -6848,6 +14612,7 @@ FLAG basecamp vaults download --agent type=bool
 FLAG basecamp vaults download --cache-dir type=string
 FLAG basecamp vaults download --count type=bool
 FLAG basecamp vaults download --folder type=string
+FLAG basecamp vaults download --help type=bool
 FLAG basecamp vaults download --hints type=bool
 FLAG basecamp vaults download --ids-only type=bool
 FLAG basecamp vaults download --in type=string
@@ -6866,12 +14631,88 @@ FLAG basecamp vaults download --styled type=bool
 FLAG basecamp vaults download --todolist type=string
 FLAG basecamp vaults download --vault type=string
 FLAG basecamp vaults download --verbose type=count
+FLAG basecamp vaults folder --account type=string
+FLAG basecamp vaults folder --agent type=bool
+FLAG basecamp vaults folder --all type=bool
+FLAG basecamp vaults folder --cache-dir type=string
+FLAG basecamp vaults folder --count type=bool
+FLAG basecamp vaults folder --folder type=string
+FLAG basecamp vaults folder --help type=bool
+FLAG basecamp vaults folder --hints type=bool
+FLAG basecamp vaults folder --ids-only type=bool
+FLAG basecamp vaults folder --in type=string
+FLAG basecamp vaults folder --jq type=string
+FLAG basecamp vaults folder --json type=bool
+FLAG basecamp vaults folder --limit type=int
+FLAG basecamp vaults folder --markdown type=bool
+FLAG basecamp vaults folder --md type=bool
+FLAG basecamp vaults folder --no-hints type=bool
+FLAG basecamp vaults folder --no-stats type=bool
+FLAG basecamp vaults folder --page type=int
+FLAG basecamp vaults folder --profile type=string
+FLAG basecamp vaults folder --project type=string
+FLAG basecamp vaults folder --quiet type=bool
+FLAG basecamp vaults folder --stats type=bool
+FLAG basecamp vaults folder --styled type=bool
+FLAG basecamp vaults folder --todolist type=string
+FLAG basecamp vaults folder --vault type=string
+FLAG basecamp vaults folder --verbose type=count
+FLAG basecamp vaults folder create --account type=string
+FLAG basecamp vaults folder create --agent type=bool
+FLAG basecamp vaults folder create --cache-dir type=string
+FLAG basecamp vaults folder create --count type=bool
+FLAG basecamp vaults folder create --folder type=string
+FLAG basecamp vaults folder create --help type=bool
+FLAG basecamp vaults folder create --hints type=bool
+FLAG basecamp vaults folder create --ids-only type=bool
+FLAG basecamp vaults folder create --in type=string
+FLAG basecamp vaults folder create --jq type=string
+FLAG basecamp vaults folder create --json type=bool
+FLAG basecamp vaults folder create --markdown type=bool
+FLAG basecamp vaults folder create --md type=bool
+FLAG basecamp vaults folder create --no-hints type=bool
+FLAG basecamp vaults folder create --no-stats type=bool
+FLAG basecamp vaults folder create --profile type=string
+FLAG basecamp vaults folder create --project type=string
+FLAG basecamp vaults folder create --quiet type=bool
+FLAG basecamp vaults folder create --stats type=bool
+FLAG basecamp vaults folder create --styled type=bool
+FLAG basecamp vaults folder create --todolist type=string
+FLAG basecamp vaults folder create --vault type=string
+FLAG basecamp vaults folder create --verbose type=count
+FLAG basecamp vaults folder list --account type=string
+FLAG basecamp vaults folder list --agent type=bool
+FLAG basecamp vaults folder list --all type=bool
+FLAG basecamp vaults folder list --cache-dir type=string
+FLAG basecamp vaults folder list --count type=bool
+FLAG basecamp vaults folder list --folder type=string
+FLAG basecamp vaults folder list --help type=bool
+FLAG basecamp vaults folder list --hints type=bool
+FLAG basecamp vaults folder list --ids-only type=bool
+FLAG basecamp vaults folder list --in type=string
+FLAG basecamp vaults folder list --jq type=string
+FLAG basecamp vaults folder list --json type=bool
+FLAG basecamp vaults folder list --limit type=int
+FLAG basecamp vaults folder list --markdown type=bool
+FLAG basecamp vaults folder list --md type=bool
+FLAG basecamp vaults folder list --no-hints type=bool
+FLAG basecamp vaults folder list --no-stats type=bool
+FLAG basecamp vaults folder list --page type=int
+FLAG basecamp vaults folder list --profile type=string
+FLAG basecamp vaults folder list --project type=string
+FLAG basecamp vaults folder list --quiet type=bool
+FLAG basecamp vaults folder list --stats type=bool
+FLAG basecamp vaults folder list --styled type=bool
+FLAG basecamp vaults folder list --todolist type=string
+FLAG basecamp vaults folder list --vault type=string
+FLAG basecamp vaults folder list --verbose type=count
 FLAG basecamp vaults folders --account type=string
 FLAG basecamp vaults folders --agent type=bool
 FLAG basecamp vaults folders --all type=bool
 FLAG basecamp vaults folders --cache-dir type=string
 FLAG basecamp vaults folders --count type=bool
 FLAG basecamp vaults folders --folder type=string
+FLAG basecamp vaults folders --help type=bool
 FLAG basecamp vaults folders --hints type=bool
 FLAG basecamp vaults folders --ids-only type=bool
 FLAG basecamp vaults folders --in type=string
@@ -6896,6 +14737,7 @@ FLAG basecamp vaults folders create --agent type=bool
 FLAG basecamp vaults folders create --cache-dir type=string
 FLAG basecamp vaults folders create --count type=bool
 FLAG basecamp vaults folders create --folder type=string
+FLAG basecamp vaults folders create --help type=bool
 FLAG basecamp vaults folders create --hints type=bool
 FLAG basecamp vaults folders create --ids-only type=bool
 FLAG basecamp vaults folders create --in type=string
@@ -6919,6 +14761,7 @@ FLAG basecamp vaults folders list --all type=bool
 FLAG basecamp vaults folders list --cache-dir type=string
 FLAG basecamp vaults folders list --count type=bool
 FLAG basecamp vaults folders list --folder type=string
+FLAG basecamp vaults folders list --help type=bool
 FLAG basecamp vaults folders list --hints type=bool
 FLAG basecamp vaults folders list --ids-only type=bool
 FLAG basecamp vaults folders list --in type=string
@@ -6943,6 +14786,7 @@ FLAG basecamp vaults list --agent type=bool
 FLAG basecamp vaults list --cache-dir type=string
 FLAG basecamp vaults list --count type=bool
 FLAG basecamp vaults list --folder type=string
+FLAG basecamp vaults list --help type=bool
 FLAG basecamp vaults list --hints type=bool
 FLAG basecamp vaults list --ids-only type=bool
 FLAG basecamp vaults list --in type=string
@@ -6965,6 +14809,7 @@ FLAG basecamp vaults restore --agent type=bool
 FLAG basecamp vaults restore --cache-dir type=string
 FLAG basecamp vaults restore --count type=bool
 FLAG basecamp vaults restore --folder type=string
+FLAG basecamp vaults restore --help type=bool
 FLAG basecamp vaults restore --hints type=bool
 FLAG basecamp vaults restore --ids-only type=bool
 FLAG basecamp vaults restore --in type=string
@@ -6987,6 +14832,7 @@ FLAG basecamp vaults show --agent type=bool
 FLAG basecamp vaults show --cache-dir type=string
 FLAG basecamp vaults show --count type=bool
 FLAG basecamp vaults show --folder type=string
+FLAG basecamp vaults show --help type=bool
 FLAG basecamp vaults show --hints type=bool
 FLAG basecamp vaults show --ids-only type=bool
 FLAG basecamp vaults show --in type=string
@@ -7010,6 +14856,7 @@ FLAG basecamp vaults trash --agent type=bool
 FLAG basecamp vaults trash --cache-dir type=string
 FLAG basecamp vaults trash --count type=bool
 FLAG basecamp vaults trash --folder type=string
+FLAG basecamp vaults trash --help type=bool
 FLAG basecamp vaults trash --hints type=bool
 FLAG basecamp vaults trash --ids-only type=bool
 FLAG basecamp vaults trash --in type=string
@@ -7033,6 +14880,7 @@ FLAG basecamp vaults update --cache-dir type=string
 FLAG basecamp vaults update --content type=string
 FLAG basecamp vaults update --count type=bool
 FLAG basecamp vaults update --folder type=string
+FLAG basecamp vaults update --help type=bool
 FLAG basecamp vaults update --hints type=bool
 FLAG basecamp vaults update --ids-only type=bool
 FLAG basecamp vaults update --in type=string
@@ -7052,12 +14900,89 @@ FLAG basecamp vaults update --todolist type=string
 FLAG basecamp vaults update --type type=string
 FLAG basecamp vaults update --vault type=string
 FLAG basecamp vaults update --verbose type=count
+FLAG basecamp vaults upload --account type=string
+FLAG basecamp vaults upload --agent type=bool
+FLAG basecamp vaults upload --all type=bool
+FLAG basecamp vaults upload --cache-dir type=string
+FLAG basecamp vaults upload --count type=bool
+FLAG basecamp vaults upload --folder type=string
+FLAG basecamp vaults upload --help type=bool
+FLAG basecamp vaults upload --hints type=bool
+FLAG basecamp vaults upload --ids-only type=bool
+FLAG basecamp vaults upload --in type=string
+FLAG basecamp vaults upload --jq type=string
+FLAG basecamp vaults upload --json type=bool
+FLAG basecamp vaults upload --limit type=int
+FLAG basecamp vaults upload --markdown type=bool
+FLAG basecamp vaults upload --md type=bool
+FLAG basecamp vaults upload --no-hints type=bool
+FLAG basecamp vaults upload --no-stats type=bool
+FLAG basecamp vaults upload --page type=int
+FLAG basecamp vaults upload --profile type=string
+FLAG basecamp vaults upload --project type=string
+FLAG basecamp vaults upload --quiet type=bool
+FLAG basecamp vaults upload --stats type=bool
+FLAG basecamp vaults upload --styled type=bool
+FLAG basecamp vaults upload --todolist type=string
+FLAG basecamp vaults upload --vault type=string
+FLAG basecamp vaults upload --verbose type=count
+FLAG basecamp vaults upload create --account type=string
+FLAG basecamp vaults upload create --agent type=bool
+FLAG basecamp vaults upload create --cache-dir type=string
+FLAG basecamp vaults upload create --count type=bool
+FLAG basecamp vaults upload create --description type=string
+FLAG basecamp vaults upload create --folder type=string
+FLAG basecamp vaults upload create --help type=bool
+FLAG basecamp vaults upload create --hints type=bool
+FLAG basecamp vaults upload create --ids-only type=bool
+FLAG basecamp vaults upload create --in type=string
+FLAG basecamp vaults upload create --jq type=string
+FLAG basecamp vaults upload create --json type=bool
+FLAG basecamp vaults upload create --markdown type=bool
+FLAG basecamp vaults upload create --md type=bool
+FLAG basecamp vaults upload create --no-hints type=bool
+FLAG basecamp vaults upload create --no-stats type=bool
+FLAG basecamp vaults upload create --profile type=string
+FLAG basecamp vaults upload create --project type=string
+FLAG basecamp vaults upload create --quiet type=bool
+FLAG basecamp vaults upload create --stats type=bool
+FLAG basecamp vaults upload create --styled type=bool
+FLAG basecamp vaults upload create --todolist type=string
+FLAG basecamp vaults upload create --vault type=string
+FLAG basecamp vaults upload create --verbose type=count
+FLAG basecamp vaults upload list --account type=string
+FLAG basecamp vaults upload list --agent type=bool
+FLAG basecamp vaults upload list --all type=bool
+FLAG basecamp vaults upload list --cache-dir type=string
+FLAG basecamp vaults upload list --count type=bool
+FLAG basecamp vaults upload list --folder type=string
+FLAG basecamp vaults upload list --help type=bool
+FLAG basecamp vaults upload list --hints type=bool
+FLAG basecamp vaults upload list --ids-only type=bool
+FLAG basecamp vaults upload list --in type=string
+FLAG basecamp vaults upload list --jq type=string
+FLAG basecamp vaults upload list --json type=bool
+FLAG basecamp vaults upload list --limit type=int
+FLAG basecamp vaults upload list --markdown type=bool
+FLAG basecamp vaults upload list --md type=bool
+FLAG basecamp vaults upload list --no-hints type=bool
+FLAG basecamp vaults upload list --no-stats type=bool
+FLAG basecamp vaults upload list --page type=int
+FLAG basecamp vaults upload list --profile type=string
+FLAG basecamp vaults upload list --project type=string
+FLAG basecamp vaults upload list --quiet type=bool
+FLAG basecamp vaults upload list --stats type=bool
+FLAG basecamp vaults upload list --styled type=bool
+FLAG basecamp vaults upload list --todolist type=string
+FLAG basecamp vaults upload list --vault type=string
+FLAG basecamp vaults upload list --verbose type=count
 FLAG basecamp vaults uploads --account type=string
 FLAG basecamp vaults uploads --agent type=bool
 FLAG basecamp vaults uploads --all type=bool
 FLAG basecamp vaults uploads --cache-dir type=string
 FLAG basecamp vaults uploads --count type=bool
 FLAG basecamp vaults uploads --folder type=string
+FLAG basecamp vaults uploads --help type=bool
 FLAG basecamp vaults uploads --hints type=bool
 FLAG basecamp vaults uploads --ids-only type=bool
 FLAG basecamp vaults uploads --in type=string
@@ -7083,6 +15008,7 @@ FLAG basecamp vaults uploads create --cache-dir type=string
 FLAG basecamp vaults uploads create --count type=bool
 FLAG basecamp vaults uploads create --description type=string
 FLAG basecamp vaults uploads create --folder type=string
+FLAG basecamp vaults uploads create --help type=bool
 FLAG basecamp vaults uploads create --hints type=bool
 FLAG basecamp vaults uploads create --ids-only type=bool
 FLAG basecamp vaults uploads create --in type=string
@@ -7106,6 +15032,7 @@ FLAG basecamp vaults uploads list --all type=bool
 FLAG basecamp vaults uploads list --cache-dir type=string
 FLAG basecamp vaults uploads list --count type=bool
 FLAG basecamp vaults uploads list --folder type=string
+FLAG basecamp vaults uploads list --help type=bool
 FLAG basecamp vaults uploads list --hints type=bool
 FLAG basecamp vaults uploads list --ids-only type=bool
 FLAG basecamp vaults uploads list --in type=string
@@ -7125,10 +15052,161 @@ FLAG basecamp vaults uploads list --styled type=bool
 FLAG basecamp vaults uploads list --todolist type=string
 FLAG basecamp vaults uploads list --vault type=string
 FLAG basecamp vaults uploads list --verbose type=count
+FLAG basecamp vaults vault --account type=string
+FLAG basecamp vaults vault --agent type=bool
+FLAG basecamp vaults vault --all type=bool
+FLAG basecamp vaults vault --cache-dir type=string
+FLAG basecamp vaults vault --count type=bool
+FLAG basecamp vaults vault --folder type=string
+FLAG basecamp vaults vault --help type=bool
+FLAG basecamp vaults vault --hints type=bool
+FLAG basecamp vaults vault --ids-only type=bool
+FLAG basecamp vaults vault --in type=string
+FLAG basecamp vaults vault --jq type=string
+FLAG basecamp vaults vault --json type=bool
+FLAG basecamp vaults vault --limit type=int
+FLAG basecamp vaults vault --markdown type=bool
+FLAG basecamp vaults vault --md type=bool
+FLAG basecamp vaults vault --no-hints type=bool
+FLAG basecamp vaults vault --no-stats type=bool
+FLAG basecamp vaults vault --page type=int
+FLAG basecamp vaults vault --profile type=string
+FLAG basecamp vaults vault --project type=string
+FLAG basecamp vaults vault --quiet type=bool
+FLAG basecamp vaults vault --stats type=bool
+FLAG basecamp vaults vault --styled type=bool
+FLAG basecamp vaults vault --todolist type=string
+FLAG basecamp vaults vault --vault type=string
+FLAG basecamp vaults vault --verbose type=count
+FLAG basecamp vaults vault create --account type=string
+FLAG basecamp vaults vault create --agent type=bool
+FLAG basecamp vaults vault create --cache-dir type=string
+FLAG basecamp vaults vault create --count type=bool
+FLAG basecamp vaults vault create --folder type=string
+FLAG basecamp vaults vault create --help type=bool
+FLAG basecamp vaults vault create --hints type=bool
+FLAG basecamp vaults vault create --ids-only type=bool
+FLAG basecamp vaults vault create --in type=string
+FLAG basecamp vaults vault create --jq type=string
+FLAG basecamp vaults vault create --json type=bool
+FLAG basecamp vaults vault create --markdown type=bool
+FLAG basecamp vaults vault create --md type=bool
+FLAG basecamp vaults vault create --no-hints type=bool
+FLAG basecamp vaults vault create --no-stats type=bool
+FLAG basecamp vaults vault create --profile type=string
+FLAG basecamp vaults vault create --project type=string
+FLAG basecamp vaults vault create --quiet type=bool
+FLAG basecamp vaults vault create --stats type=bool
+FLAG basecamp vaults vault create --styled type=bool
+FLAG basecamp vaults vault create --todolist type=string
+FLAG basecamp vaults vault create --vault type=string
+FLAG basecamp vaults vault create --verbose type=count
+FLAG basecamp vaults vault list --account type=string
+FLAG basecamp vaults vault list --agent type=bool
+FLAG basecamp vaults vault list --all type=bool
+FLAG basecamp vaults vault list --cache-dir type=string
+FLAG basecamp vaults vault list --count type=bool
+FLAG basecamp vaults vault list --folder type=string
+FLAG basecamp vaults vault list --help type=bool
+FLAG basecamp vaults vault list --hints type=bool
+FLAG basecamp vaults vault list --ids-only type=bool
+FLAG basecamp vaults vault list --in type=string
+FLAG basecamp vaults vault list --jq type=string
+FLAG basecamp vaults vault list --json type=bool
+FLAG basecamp vaults vault list --limit type=int
+FLAG basecamp vaults vault list --markdown type=bool
+FLAG basecamp vaults vault list --md type=bool
+FLAG basecamp vaults vault list --no-hints type=bool
+FLAG basecamp vaults vault list --no-stats type=bool
+FLAG basecamp vaults vault list --page type=int
+FLAG basecamp vaults vault list --profile type=string
+FLAG basecamp vaults vault list --project type=string
+FLAG basecamp vaults vault list --quiet type=bool
+FLAG basecamp vaults vault list --stats type=bool
+FLAG basecamp vaults vault list --styled type=bool
+FLAG basecamp vaults vault list --todolist type=string
+FLAG basecamp vaults vault list --vault type=string
+FLAG basecamp vaults vault list --verbose type=count
+FLAG basecamp vaults vaults --account type=string
+FLAG basecamp vaults vaults --agent type=bool
+FLAG basecamp vaults vaults --all type=bool
+FLAG basecamp vaults vaults --cache-dir type=string
+FLAG basecamp vaults vaults --count type=bool
+FLAG basecamp vaults vaults --folder type=string
+FLAG basecamp vaults vaults --help type=bool
+FLAG basecamp vaults vaults --hints type=bool
+FLAG basecamp vaults vaults --ids-only type=bool
+FLAG basecamp vaults vaults --in type=string
+FLAG basecamp vaults vaults --jq type=string
+FLAG basecamp vaults vaults --json type=bool
+FLAG basecamp vaults vaults --limit type=int
+FLAG basecamp vaults vaults --markdown type=bool
+FLAG basecamp vaults vaults --md type=bool
+FLAG basecamp vaults vaults --no-hints type=bool
+FLAG basecamp vaults vaults --no-stats type=bool
+FLAG basecamp vaults vaults --page type=int
+FLAG basecamp vaults vaults --profile type=string
+FLAG basecamp vaults vaults --project type=string
+FLAG basecamp vaults vaults --quiet type=bool
+FLAG basecamp vaults vaults --stats type=bool
+FLAG basecamp vaults vaults --styled type=bool
+FLAG basecamp vaults vaults --todolist type=string
+FLAG basecamp vaults vaults --vault type=string
+FLAG basecamp vaults vaults --verbose type=count
+FLAG basecamp vaults vaults create --account type=string
+FLAG basecamp vaults vaults create --agent type=bool
+FLAG basecamp vaults vaults create --cache-dir type=string
+FLAG basecamp vaults vaults create --count type=bool
+FLAG basecamp vaults vaults create --folder type=string
+FLAG basecamp vaults vaults create --help type=bool
+FLAG basecamp vaults vaults create --hints type=bool
+FLAG basecamp vaults vaults create --ids-only type=bool
+FLAG basecamp vaults vaults create --in type=string
+FLAG basecamp vaults vaults create --jq type=string
+FLAG basecamp vaults vaults create --json type=bool
+FLAG basecamp vaults vaults create --markdown type=bool
+FLAG basecamp vaults vaults create --md type=bool
+FLAG basecamp vaults vaults create --no-hints type=bool
+FLAG basecamp vaults vaults create --no-stats type=bool
+FLAG basecamp vaults vaults create --profile type=string
+FLAG basecamp vaults vaults create --project type=string
+FLAG basecamp vaults vaults create --quiet type=bool
+FLAG basecamp vaults vaults create --stats type=bool
+FLAG basecamp vaults vaults create --styled type=bool
+FLAG basecamp vaults vaults create --todolist type=string
+FLAG basecamp vaults vaults create --vault type=string
+FLAG basecamp vaults vaults create --verbose type=count
+FLAG basecamp vaults vaults list --account type=string
+FLAG basecamp vaults vaults list --agent type=bool
+FLAG basecamp vaults vaults list --all type=bool
+FLAG basecamp vaults vaults list --cache-dir type=string
+FLAG basecamp vaults vaults list --count type=bool
+FLAG basecamp vaults vaults list --folder type=string
+FLAG basecamp vaults vaults list --help type=bool
+FLAG basecamp vaults vaults list --hints type=bool
+FLAG basecamp vaults vaults list --ids-only type=bool
+FLAG basecamp vaults vaults list --in type=string
+FLAG basecamp vaults vaults list --jq type=string
+FLAG basecamp vaults vaults list --json type=bool
+FLAG basecamp vaults vaults list --limit type=int
+FLAG basecamp vaults vaults list --markdown type=bool
+FLAG basecamp vaults vaults list --md type=bool
+FLAG basecamp vaults vaults list --no-hints type=bool
+FLAG basecamp vaults vaults list --no-stats type=bool
+FLAG basecamp vaults vaults list --page type=int
+FLAG basecamp vaults vaults list --profile type=string
+FLAG basecamp vaults vaults list --project type=string
+FLAG basecamp vaults vaults list --quiet type=bool
+FLAG basecamp vaults vaults list --stats type=bool
+FLAG basecamp vaults vaults list --styled type=bool
+FLAG basecamp vaults vaults list --todolist type=string
+FLAG basecamp vaults vaults list --vault type=string
+FLAG basecamp vaults vaults list --verbose type=count
 FLAG basecamp version --account type=string
 FLAG basecamp version --agent type=bool
 FLAG basecamp version --cache-dir type=string
 FLAG basecamp version --count type=bool
+FLAG basecamp version --help type=bool
 FLAG basecamp version --hints type=bool
 FLAG basecamp version --ids-only type=bool
 FLAG basecamp version --in type=string
@@ -7145,10 +15223,142 @@ FLAG basecamp version --stats type=bool
 FLAG basecamp version --styled type=bool
 FLAG basecamp version --todolist type=string
 FLAG basecamp version --verbose type=count
+FLAG basecamp webhook --account type=string
+FLAG basecamp webhook --agent type=bool
+FLAG basecamp webhook --cache-dir type=string
+FLAG basecamp webhook --count type=bool
+FLAG basecamp webhook --help type=bool
+FLAG basecamp webhook --hints type=bool
+FLAG basecamp webhook --ids-only type=bool
+FLAG basecamp webhook --in type=string
+FLAG basecamp webhook --jq type=string
+FLAG basecamp webhook --json type=bool
+FLAG basecamp webhook --markdown type=bool
+FLAG basecamp webhook --md type=bool
+FLAG basecamp webhook --no-hints type=bool
+FLAG basecamp webhook --no-stats type=bool
+FLAG basecamp webhook --profile type=string
+FLAG basecamp webhook --project type=string
+FLAG basecamp webhook --quiet type=bool
+FLAG basecamp webhook --stats type=bool
+FLAG basecamp webhook --styled type=bool
+FLAG basecamp webhook --todolist type=string
+FLAG basecamp webhook --verbose type=count
+FLAG basecamp webhook create --account type=string
+FLAG basecamp webhook create --agent type=bool
+FLAG basecamp webhook create --cache-dir type=string
+FLAG basecamp webhook create --count type=bool
+FLAG basecamp webhook create --help type=bool
+FLAG basecamp webhook create --hints type=bool
+FLAG basecamp webhook create --ids-only type=bool
+FLAG basecamp webhook create --in type=string
+FLAG basecamp webhook create --jq type=string
+FLAG basecamp webhook create --json type=bool
+FLAG basecamp webhook create --markdown type=bool
+FLAG basecamp webhook create --md type=bool
+FLAG basecamp webhook create --no-hints type=bool
+FLAG basecamp webhook create --no-stats type=bool
+FLAG basecamp webhook create --profile type=string
+FLAG basecamp webhook create --project type=string
+FLAG basecamp webhook create --quiet type=bool
+FLAG basecamp webhook create --stats type=bool
+FLAG basecamp webhook create --styled type=bool
+FLAG basecamp webhook create --todolist type=string
+FLAG basecamp webhook create --types type=string
+FLAG basecamp webhook create --verbose type=count
+FLAG basecamp webhook delete --account type=string
+FLAG basecamp webhook delete --agent type=bool
+FLAG basecamp webhook delete --cache-dir type=string
+FLAG basecamp webhook delete --count type=bool
+FLAG basecamp webhook delete --help type=bool
+FLAG basecamp webhook delete --hints type=bool
+FLAG basecamp webhook delete --ids-only type=bool
+FLAG basecamp webhook delete --in type=string
+FLAG basecamp webhook delete --jq type=string
+FLAG basecamp webhook delete --json type=bool
+FLAG basecamp webhook delete --markdown type=bool
+FLAG basecamp webhook delete --md type=bool
+FLAG basecamp webhook delete --no-hints type=bool
+FLAG basecamp webhook delete --no-stats type=bool
+FLAG basecamp webhook delete --profile type=string
+FLAG basecamp webhook delete --project type=string
+FLAG basecamp webhook delete --quiet type=bool
+FLAG basecamp webhook delete --stats type=bool
+FLAG basecamp webhook delete --styled type=bool
+FLAG basecamp webhook delete --todolist type=string
+FLAG basecamp webhook delete --verbose type=count
+FLAG basecamp webhook list --account type=string
+FLAG basecamp webhook list --agent type=bool
+FLAG basecamp webhook list --cache-dir type=string
+FLAG basecamp webhook list --count type=bool
+FLAG basecamp webhook list --help type=bool
+FLAG basecamp webhook list --hints type=bool
+FLAG basecamp webhook list --ids-only type=bool
+FLAG basecamp webhook list --in type=string
+FLAG basecamp webhook list --jq type=string
+FLAG basecamp webhook list --json type=bool
+FLAG basecamp webhook list --markdown type=bool
+FLAG basecamp webhook list --md type=bool
+FLAG basecamp webhook list --no-hints type=bool
+FLAG basecamp webhook list --no-stats type=bool
+FLAG basecamp webhook list --profile type=string
+FLAG basecamp webhook list --project type=string
+FLAG basecamp webhook list --quiet type=bool
+FLAG basecamp webhook list --stats type=bool
+FLAG basecamp webhook list --styled type=bool
+FLAG basecamp webhook list --todolist type=string
+FLAG basecamp webhook list --verbose type=count
+FLAG basecamp webhook show --account type=string
+FLAG basecamp webhook show --agent type=bool
+FLAG basecamp webhook show --cache-dir type=string
+FLAG basecamp webhook show --count type=bool
+FLAG basecamp webhook show --help type=bool
+FLAG basecamp webhook show --hints type=bool
+FLAG basecamp webhook show --ids-only type=bool
+FLAG basecamp webhook show --in type=string
+FLAG basecamp webhook show --jq type=string
+FLAG basecamp webhook show --json type=bool
+FLAG basecamp webhook show --markdown type=bool
+FLAG basecamp webhook show --md type=bool
+FLAG basecamp webhook show --no-hints type=bool
+FLAG basecamp webhook show --no-stats type=bool
+FLAG basecamp webhook show --profile type=string
+FLAG basecamp webhook show --project type=string
+FLAG basecamp webhook show --quiet type=bool
+FLAG basecamp webhook show --stats type=bool
+FLAG basecamp webhook show --styled type=bool
+FLAG basecamp webhook show --todolist type=string
+FLAG basecamp webhook show --verbose type=count
+FLAG basecamp webhook update --account type=string
+FLAG basecamp webhook update --active type=bool
+FLAG basecamp webhook update --agent type=bool
+FLAG basecamp webhook update --cache-dir type=string
+FLAG basecamp webhook update --count type=bool
+FLAG basecamp webhook update --help type=bool
+FLAG basecamp webhook update --hints type=bool
+FLAG basecamp webhook update --ids-only type=bool
+FLAG basecamp webhook update --in type=string
+FLAG basecamp webhook update --inactive type=bool
+FLAG basecamp webhook update --jq type=string
+FLAG basecamp webhook update --json type=bool
+FLAG basecamp webhook update --markdown type=bool
+FLAG basecamp webhook update --md type=bool
+FLAG basecamp webhook update --no-hints type=bool
+FLAG basecamp webhook update --no-stats type=bool
+FLAG basecamp webhook update --profile type=string
+FLAG basecamp webhook update --project type=string
+FLAG basecamp webhook update --quiet type=bool
+FLAG basecamp webhook update --stats type=bool
+FLAG basecamp webhook update --styled type=bool
+FLAG basecamp webhook update --todolist type=string
+FLAG basecamp webhook update --types type=string
+FLAG basecamp webhook update --url type=string
+FLAG basecamp webhook update --verbose type=count
 FLAG basecamp webhooks --account type=string
 FLAG basecamp webhooks --agent type=bool
 FLAG basecamp webhooks --cache-dir type=string
 FLAG basecamp webhooks --count type=bool
+FLAG basecamp webhooks --help type=bool
 FLAG basecamp webhooks --hints type=bool
 FLAG basecamp webhooks --ids-only type=bool
 FLAG basecamp webhooks --in type=string
@@ -7169,6 +15379,7 @@ FLAG basecamp webhooks create --account type=string
 FLAG basecamp webhooks create --agent type=bool
 FLAG basecamp webhooks create --cache-dir type=string
 FLAG basecamp webhooks create --count type=bool
+FLAG basecamp webhooks create --help type=bool
 FLAG basecamp webhooks create --hints type=bool
 FLAG basecamp webhooks create --ids-only type=bool
 FLAG basecamp webhooks create --in type=string
@@ -7190,6 +15401,7 @@ FLAG basecamp webhooks delete --account type=string
 FLAG basecamp webhooks delete --agent type=bool
 FLAG basecamp webhooks delete --cache-dir type=string
 FLAG basecamp webhooks delete --count type=bool
+FLAG basecamp webhooks delete --help type=bool
 FLAG basecamp webhooks delete --hints type=bool
 FLAG basecamp webhooks delete --ids-only type=bool
 FLAG basecamp webhooks delete --in type=string
@@ -7210,6 +15422,7 @@ FLAG basecamp webhooks list --account type=string
 FLAG basecamp webhooks list --agent type=bool
 FLAG basecamp webhooks list --cache-dir type=string
 FLAG basecamp webhooks list --count type=bool
+FLAG basecamp webhooks list --help type=bool
 FLAG basecamp webhooks list --hints type=bool
 FLAG basecamp webhooks list --ids-only type=bool
 FLAG basecamp webhooks list --in type=string
@@ -7230,6 +15443,7 @@ FLAG basecamp webhooks show --account type=string
 FLAG basecamp webhooks show --agent type=bool
 FLAG basecamp webhooks show --cache-dir type=string
 FLAG basecamp webhooks show --count type=bool
+FLAG basecamp webhooks show --help type=bool
 FLAG basecamp webhooks show --hints type=bool
 FLAG basecamp webhooks show --ids-only type=bool
 FLAG basecamp webhooks show --in type=string
@@ -7251,6 +15465,7 @@ FLAG basecamp webhooks update --active type=bool
 FLAG basecamp webhooks update --agent type=bool
 FLAG basecamp webhooks update --cache-dir type=string
 FLAG basecamp webhooks update --count type=bool
+FLAG basecamp webhooks update --help type=bool
 FLAG basecamp webhooks update --hints type=bool
 FLAG basecamp webhooks update --ids-only type=bool
 FLAG basecamp webhooks update --in type=string
@@ -7270,6 +15485,9 @@ FLAG basecamp webhooks update --todolist type=string
 FLAG basecamp webhooks update --types type=string
 FLAG basecamp webhooks update --url type=string
 FLAG basecamp webhooks update --verbose type=count
+SUB basecamp account
+SUB basecamp account list
+SUB basecamp account use
 SUB basecamp accounts
 SUB basecamp accounts list
 SUB basecamp accounts use
@@ -7299,8 +15517,22 @@ SUB basecamp boost create
 SUB basecamp boost delete
 SUB basecamp boost list
 SUB basecamp boost show
+SUB basecamp boosts
+SUB basecamp boosts create
+SUB basecamp boosts delete
+SUB basecamp boosts list
+SUB basecamp boosts show
+SUB basecamp campfire
+SUB basecamp campfire delete
+SUB basecamp campfire line
+SUB basecamp campfire list
+SUB basecamp campfire messages
+SUB basecamp campfire post
+SUB basecamp campfire show
+SUB basecamp campfire upload
 SUB basecamp card
 SUB basecamp card move
+SUB basecamp card mv
 SUB basecamp card update
 SUB basecamp cards
 SUB basecamp cards archive
@@ -7318,6 +15550,7 @@ SUB basecamp cards columns
 SUB basecamp cards create
 SUB basecamp cards list
 SUB basecamp cards move
+SUB basecamp cards mv
 SUB basecamp cards restore
 SUB basecamp cards show
 SUB basecamp cards step
@@ -7336,7 +15569,19 @@ SUB basecamp chat line
 SUB basecamp chat list
 SUB basecamp chat messages
 SUB basecamp chat post
+SUB basecamp chat show
 SUB basecamp chat upload
+SUB basecamp checkin
+SUB basecamp checkin answer
+SUB basecamp checkin answer create
+SUB basecamp checkin answer show
+SUB basecamp checkin answer update
+SUB basecamp checkin answers
+SUB basecamp checkin question
+SUB basecamp checkin question create
+SUB basecamp checkin question show
+SUB basecamp checkin question update
+SUB basecamp checkin questions
 SUB basecamp checkins
 SUB basecamp checkins answer
 SUB basecamp checkins answer create
@@ -7348,6 +15593,7 @@ SUB basecamp checkins question create
 SUB basecamp checkins question show
 SUB basecamp checkins question update
 SUB basecamp checkins questions
+SUB basecamp cmds
 SUB basecamp commands
 SUB basecamp comment
 SUB basecamp comments
@@ -7375,10 +15621,19 @@ SUB basecamp config unset
 SUB basecamp config untrust
 SUB basecamp docs
 SUB basecamp docs archive
+SUB basecamp docs doc
+SUB basecamp docs doc create
+SUB basecamp docs doc list
+SUB basecamp docs document
+SUB basecamp docs document create
+SUB basecamp docs document list
 SUB basecamp docs documents
 SUB basecamp docs documents create
 SUB basecamp docs documents list
 SUB basecamp docs download
+SUB basecamp docs folder
+SUB basecamp docs folder create
+SUB basecamp docs folder list
 SUB basecamp docs folders
 SUB basecamp docs folders create
 SUB basecamp docs folders list
@@ -7387,18 +15642,106 @@ SUB basecamp docs restore
 SUB basecamp docs show
 SUB basecamp docs trash
 SUB basecamp docs update
+SUB basecamp docs upload
+SUB basecamp docs upload create
+SUB basecamp docs upload list
 SUB basecamp docs uploads
 SUB basecamp docs uploads create
 SUB basecamp docs uploads list
+SUB basecamp docs vault
+SUB basecamp docs vault create
+SUB basecamp docs vault list
+SUB basecamp docs vaults
+SUB basecamp docs vaults create
+SUB basecamp docs vaults list
 SUB basecamp doctor
+SUB basecamp documents
+SUB basecamp documents archive
+SUB basecamp documents doc
+SUB basecamp documents doc create
+SUB basecamp documents doc list
+SUB basecamp documents document
+SUB basecamp documents document create
+SUB basecamp documents document list
+SUB basecamp documents documents
+SUB basecamp documents documents create
+SUB basecamp documents documents list
+SUB basecamp documents download
+SUB basecamp documents folder
+SUB basecamp documents folder create
+SUB basecamp documents folder list
+SUB basecamp documents folders
+SUB basecamp documents folders create
+SUB basecamp documents folders list
+SUB basecamp documents list
+SUB basecamp documents restore
+SUB basecamp documents show
+SUB basecamp documents trash
+SUB basecamp documents update
+SUB basecamp documents upload
+SUB basecamp documents upload create
+SUB basecamp documents upload list
+SUB basecamp documents uploads
+SUB basecamp documents uploads create
+SUB basecamp documents uploads list
+SUB basecamp documents vault
+SUB basecamp documents vault create
+SUB basecamp documents vault list
+SUB basecamp documents vaults
+SUB basecamp documents vaults create
+SUB basecamp documents vaults list
 SUB basecamp done
 SUB basecamp events
+SUB basecamp file
+SUB basecamp file archive
+SUB basecamp file doc
+SUB basecamp file doc create
+SUB basecamp file doc list
+SUB basecamp file document
+SUB basecamp file document create
+SUB basecamp file document list
+SUB basecamp file documents
+SUB basecamp file documents create
+SUB basecamp file documents list
+SUB basecamp file download
+SUB basecamp file folder
+SUB basecamp file folder create
+SUB basecamp file folder list
+SUB basecamp file folders
+SUB basecamp file folders create
+SUB basecamp file folders list
+SUB basecamp file list
+SUB basecamp file restore
+SUB basecamp file show
+SUB basecamp file trash
+SUB basecamp file update
+SUB basecamp file upload
+SUB basecamp file upload create
+SUB basecamp file upload list
+SUB basecamp file uploads
+SUB basecamp file uploads create
+SUB basecamp file uploads list
+SUB basecamp file vault
+SUB basecamp file vault create
+SUB basecamp file vault list
+SUB basecamp file vaults
+SUB basecamp file vaults create
+SUB basecamp file vaults list
 SUB basecamp files
 SUB basecamp files archive
+SUB basecamp files doc
+SUB basecamp files doc create
+SUB basecamp files doc list
+SUB basecamp files document
+SUB basecamp files document create
+SUB basecamp files document list
 SUB basecamp files documents
 SUB basecamp files documents create
 SUB basecamp files documents list
 SUB basecamp files download
+SUB basecamp files folder
+SUB basecamp files folder create
+SUB basecamp files folder list
 SUB basecamp files folders
 SUB basecamp files folders create
 SUB basecamp files folders list
@@ -7407,9 +15750,53 @@ SUB basecamp files restore
 SUB basecamp files show
 SUB basecamp files trash
 SUB basecamp files update
+SUB basecamp files upload
+SUB basecamp files upload create
+SUB basecamp files upload list
 SUB basecamp files uploads
 SUB basecamp files uploads create
 SUB basecamp files uploads list
+SUB basecamp files vault
+SUB basecamp files vault create
+SUB basecamp files vault list
+SUB basecamp files vaults
+SUB basecamp files vaults create
+SUB basecamp files vaults list
+SUB basecamp folders
+SUB basecamp folders archive
+SUB basecamp folders doc
+SUB basecamp folders doc create
+SUB basecamp folders doc list
+SUB basecamp folders document
+SUB basecamp folders document create
+SUB basecamp folders document list
+SUB basecamp folders documents
+SUB basecamp folders documents create
+SUB basecamp folders documents list
+SUB basecamp folders download
+SUB basecamp folders folder
+SUB basecamp folders folder create
+SUB basecamp folders folder list
+SUB basecamp folders folders
+SUB basecamp folders folders create
+SUB basecamp folders folders list
+SUB basecamp folders list
+SUB basecamp folders restore
+SUB basecamp folders show
+SUB basecamp folders trash
+SUB basecamp folders update
+SUB basecamp folders upload
+SUB basecamp folders upload create
+SUB basecamp folders upload list
+SUB basecamp folders uploads
+SUB basecamp folders uploads create
+SUB basecamp folders uploads list
+SUB basecamp folders vault
+SUB basecamp folders vault create
+SUB basecamp folders vault list
+SUB basecamp folders vaults
+SUB basecamp folders vaults create
+SUB basecamp folders vaults list
 SUB basecamp forwards
 SUB basecamp forwards inbox
 SUB basecamp forwards list
@@ -7450,6 +15837,17 @@ SUB basecamp messagetypes list
 SUB basecamp messagetypes show
 SUB basecamp messagetypes update
 SUB basecamp migrate
+SUB basecamp msgs
+SUB basecamp msgs archive
+SUB basecamp msgs create
+SUB basecamp msgs list
+SUB basecamp msgs pin
+SUB basecamp msgs publish
+SUB basecamp msgs restore
+SUB basecamp msgs show
+SUB basecamp msgs trash
+SUB basecamp msgs unpin
+SUB basecamp msgs update
 SUB basecamp people
 SUB basecamp people add
 SUB basecamp people list
@@ -7462,18 +15860,30 @@ SUB basecamp profile delete
 SUB basecamp profile list
 SUB basecamp profile set-default
 SUB basecamp profile show
+SUB basecamp project
+SUB basecamp project create
+SUB basecamp project delete
+SUB basecamp project list
+SUB basecamp project show
+SUB basecamp project trash
+SUB basecamp project update
 SUB basecamp projects
 SUB basecamp projects create
 SUB basecamp projects delete
 SUB basecamp projects list
 SUB basecamp projects show
+SUB basecamp projects trash
 SUB basecamp projects update
 SUB basecamp react
 SUB basecamp recordings
+SUB basecamp recordings active
 SUB basecamp recordings archive
+SUB basecamp recordings archived
+SUB basecamp recordings client-visibility
 SUB basecamp recordings list
 SUB basecamp recordings restore
 SUB basecamp recordings trash
+SUB basecamp recordings trashed
 SUB basecamp recordings visibility
 SUB basecamp reopen
 SUB basecamp reports
@@ -7490,6 +15900,7 @@ SUB basecamp schedule show
 SUB basecamp schedule update
 SUB basecamp search
 SUB basecamp search metadata
+SUB basecamp search types
 SUB basecamp setup
 SUB basecamp setup claude
 SUB basecamp show
@@ -7513,12 +15924,47 @@ SUB basecamp timeline
 SUB basecamp timesheet
 SUB basecamp timesheet item
 SUB basecamp timesheet project
+SUB basecamp timesheet recording
 SUB basecamp timesheet report
+SUB basecamp tlgroup
+SUB basecamp tlgroup create
+SUB basecamp tlgroup list
+SUB basecamp tlgroup move
+SUB basecamp tlgroup position
+SUB basecamp tlgroup rename
+SUB basecamp tlgroup show
+SUB basecamp tlgroup update
+SUB basecamp tlgroups
+SUB basecamp tlgroups create
+SUB basecamp tlgroups list
+SUB basecamp tlgroups move
+SUB basecamp tlgroups position
+SUB basecamp tlgroups rename
+SUB basecamp tlgroups show
+SUB basecamp tlgroups update
 SUB basecamp todo
+SUB basecamp todolist
+SUB basecamp todolist archive
+SUB basecamp todolist create
+SUB basecamp todolist list
+SUB basecamp todolist restore
+SUB basecamp todolist show
+SUB basecamp todolist trash
+SUB basecamp todolist update
+SUB basecamp todolistgroup
+SUB basecamp todolistgroup create
+SUB basecamp todolistgroup list
+SUB basecamp todolistgroup move
+SUB basecamp todolistgroup position
+SUB basecamp todolistgroup rename
+SUB basecamp todolistgroup show
+SUB basecamp todolistgroup update
 SUB basecamp todolistgroups
 SUB basecamp todolistgroups create
 SUB basecamp todolistgroups list
+SUB basecamp todolistgroups move
 SUB basecamp todolistgroups position
+SUB basecamp todolistgroups rename
 SUB basecamp todolistgroups show
 SUB basecamp todolistgroups update
 SUB basecamp todolists
@@ -7534,7 +15980,10 @@ SUB basecamp todos archive
 SUB basecamp todos complete
 SUB basecamp todos create
 SUB basecamp todos list
+SUB basecamp todos move
 SUB basecamp todos position
+SUB basecamp todos reopen
+SUB basecamp todos reorder
 SUB basecamp todos restore
 SUB basecamp todos show
 SUB basecamp todos sweep
@@ -7546,8 +15995,11 @@ SUB basecamp todosets list
 SUB basecamp todosets show
 SUB basecamp tools
 SUB basecamp tools create
+SUB basecamp tools delete
 SUB basecamp tools disable
 SUB basecamp tools enable
+SUB basecamp tools move
+SUB basecamp tools rename
 SUB basecamp tools reposition
 SUB basecamp tools show
 SUB basecamp tools trash
@@ -7562,12 +16014,56 @@ SUB basecamp uploads list
 SUB basecamp uploads show
 SUB basecamp url
 SUB basecamp url parse
+SUB basecamp vault
+SUB basecamp vault archive
+SUB basecamp vault doc
+SUB basecamp vault doc create
+SUB basecamp vault doc list
+SUB basecamp vault document
+SUB basecamp vault document create
+SUB basecamp vault document list
+SUB basecamp vault documents
+SUB basecamp vault documents create
+SUB basecamp vault documents list
+SUB basecamp vault download
+SUB basecamp vault folder
+SUB basecamp vault folder create
+SUB basecamp vault folder list
+SUB basecamp vault folders
+SUB basecamp vault folders create
+SUB basecamp vault folders list
+SUB basecamp vault list
+SUB basecamp vault restore
+SUB basecamp vault show
+SUB basecamp vault trash
+SUB basecamp vault update
+SUB basecamp vault upload
+SUB basecamp vault upload create
+SUB basecamp vault upload list
+SUB basecamp vault uploads
+SUB basecamp vault uploads create
+SUB basecamp vault uploads list
+SUB basecamp vault vault
+SUB basecamp vault vault create
+SUB basecamp vault vault list
+SUB basecamp vault vaults
+SUB basecamp vault vaults create
+SUB basecamp vault vaults list
 SUB basecamp vaults
 SUB basecamp vaults archive
+SUB basecamp vaults doc
+SUB basecamp vaults doc create
+SUB basecamp vaults doc list
+SUB basecamp vaults document
+SUB basecamp vaults document create
+SUB basecamp vaults document list
 SUB basecamp vaults documents
 SUB basecamp vaults documents create
 SUB basecamp vaults documents list
 SUB basecamp vaults download
+SUB basecamp vaults folder
+SUB basecamp vaults folder create
+SUB basecamp vaults folder list
 SUB basecamp vaults folders
 SUB basecamp vaults folders create
 SUB basecamp vaults folders list
@@ -7576,10 +16072,25 @@ SUB basecamp vaults restore
 SUB basecamp vaults show
 SUB basecamp vaults trash
 SUB basecamp vaults update
+SUB basecamp vaults upload
+SUB basecamp vaults upload create
+SUB basecamp vaults upload list
 SUB basecamp vaults uploads
 SUB basecamp vaults uploads create
 SUB basecamp vaults uploads list
+SUB basecamp vaults vault
+SUB basecamp vaults vault create
+SUB basecamp vaults vault list
+SUB basecamp vaults vaults
+SUB basecamp vaults vaults create
+SUB basecamp vaults vaults list
 SUB basecamp version
+SUB basecamp webhook
+SUB basecamp webhook create
+SUB basecamp webhook delete
+SUB basecamp webhook list
+SUB basecamp webhook show
+SUB basecamp webhook update
 SUB basecamp webhooks
 SUB basecamp webhooks create
 SUB basecamp webhooks delete

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320
-	github.com/basecamp/cli v0.1.1
+	github.com/basecamp/cli v0.2.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320 h1:xHbqMcj57XgSb69wsy+dhTzZ+p3IYb/BnjisI9NF5c4=
 github.com/basecamp/basecamp-sdk/go v0.6.1-0.20260320103941-fe6154c8b320/go.mod h1:g05DM58QkUm4/mvBAvRiugPw+F4trliuGkRGg8y+Th4=
-github.com/basecamp/cli v0.1.1 h1:FAF3M09xo1m7gJJXf38glCkT50ZUuvz+31f+c3R3zcc=
-github.com/basecamp/cli v0.1.1/go.mod h1:NTHe+keCTGI2qM5sMXdkUN0QgU3zGbwnBxcmg8vD5QU=
+github.com/basecamp/cli v0.2.1 h1:8GyehPVtsTXla0oOPu4QgXRjwwzJ99prlByvyi+0HRQ=
+github.com/basecamp/cli v0.2.1/go.mod h1:p8tt/DatJ2LAzWO6N6tNfV8x3gF5T3IxDTo+U8FfWPo=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=


### PR DESCRIPTION
## Summary
- Bumps `github.com/basecamp/cli` to v0.2.1, which extends the `surface` package to emit `ARG` entries (positional arguments parsed from `cmd.Use`) and walk alias command paths alongside primary names
- Regenerates `.surface` from the Go walker — now the authoritative source for `TestSurfaceSnapshot` — with full ARG + alias coverage
- Net -615 lines vs main: removes 612 `--version` flags and 2 hidden `--assignee` flags (see details below)

## What's preserved
- 413 ARG entries (positional argument contract)
- 296 alias CMD paths (e.g., `basecamp account`, `basecamp campfire`)
- All CMD/FLAG/SUB entries

## What's removed (-615 lines)
- **612 `--version` flags on subcommands**: The shell script (`check-cli-surface.sh:45`) merges root flags into every subcommand via `$ROOT_FLAGS`, but Cobra adds `--version` as a root-local flag (not persistent). The Go walker correctly omits it from subcommands. Exact parity with the shell script except for this known over-propagation bug; no other diff remained.
- **2 `--assignee` flags on recordings**: These were hidden flags (`MarkHidden`) present in main's `.surface` baseline (from the shell-script regeneration). The Go walker correctly excludes hidden flags. These do not appear in the current shell-script output either — they were artifacts of an earlier generation.

## Test plan
- [x] `TestSurfaceSnapshot` passes without `-update-surface`
- [x] Diff against shell-script output verified: only the 612 `--version` entries differ (shell script has them, Go walker correctly omits them)
- [x] `make test` — all pass
- [x] `scripts/check-skill-drift.sh` — passes