### PR TITLE
fix: fall back to summary when title is empty in formatCell

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -870,6 +870,30 @@ func TestFormatCellWithMapArray(t *testing.T) {
 	}
 	result = formatCell(attachments)
 	assert.Equal(t, "100, 200", result)
+
+	// Test maps with summary fallback (schedule entries: the reports/upcoming API
+	// uses the calendar partial which emits summary but not title, so title arrives
+	// as an empty string from the SDK zero-value; summary must win).
+	entries := []any{
+		map[string]any{"id": float64(1), "title": "", "summary": "Team standup"},
+		map[string]any{"id": float64(2), "title": "", "summary": "Paul G OUT (Sabbatical)"},
+	}
+	result = formatCell(entries)
+	assert.Equal(t, "Team standup, Paul G OUT (Sabbatical)", result)
+
+	// Test that a non-empty title still wins over summary.
+	withBoth := []any{
+		map[string]any{"id": float64(1), "title": "Explicit title", "summary": "Summary text"},
+	}
+	result = formatCell(withBoth)
+	assert.Equal(t, "Explicit title", result)
+
+	// Test that an empty name does not shadow a valid title (empty-string guard).
+	emptyName := []any{
+		map[string]any{"id": float64(1), "name": "", "title": "A task"},
+	}
+	result = formatCell(emptyName)
+	assert.Equal(t, "A task", result)
 }
 
 // =============================================================================

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -763,11 +763,16 @@ func formatCell(val any) string {
 			case int, int64:
 				items = append(items, fmt.Sprintf("%d", elem))
 			case map[string]any:
-				// Try name, then title, then id, then fallback
-				if name, ok := elem["name"].(string); ok {
+				// Try name → title → summary → id.
+				// summary is checked after title because schedule entries omit title
+				// from the calendar/reports API response and use summary as their
+				// display name (Schedule::Entry#title delegates to summary in bc3).
+				if name, ok := elem["name"].(string); ok && name != "" {
 					items = append(items, ansi.Strip(name))
-				} else if title, ok := elem["title"].(string); ok {
+				} else if title, ok := elem["title"].(string); ok && title != "" {
 					items = append(items, ansi.Strip(title))
+				} else if summary, ok := elem["summary"].(string); ok && summary != "" {
+					items = append(items, ansi.Strip(summary))
 				} else if id, ok := elem["id"]; ok {
 					items = append(items, fmt.Sprintf("%v", id))
 				}


### PR DESCRIPTION
## Problem

`basecamp reports schedule --md` shows blank names for every schedule entry:

```
## 82 upcoming items (43 entries, 31 recurring, 8 assignables)

- **Schedule Entries:** , , , , , , , ...
```

Ref: https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9717714333

## Root cause

The bc3 reports/upcoming API uses the calendar partial (`schedules/calendar/_entry.json.jbuilder`) which emits `summary` but **not** `title` for schedule entries. The SDK deserialises the missing field to Go's zero value `""`.

The generic `formatCell` renderer, when displaying an array of maps (as `schedule_entries` is rendered inside the `UpcomingScheduleResponse` object), walks `name → title → id` to find a display label. Since `title` is present but empty, the type assertion succeeds with `ok=true`, an empty string is appended for each entry, and the join produces `, , , , ...`.

Note: `Schedule::Entry#title` in bc3 delegates directly to `summary`, so the two fields are semantically identical — `summary` is just what the calendar API path exposes.

## Fix

Add `summary` as a fallback between `title` and `id` in the `map[string]any` arm of `formatCell`. Also add empty-string guards on `name` and `title` so an empty field can't silently win over a non-empty one lower in the chain.

This is a generic renderer fix — any future resource that uses `summary` as its display name benefits automatically.

## Testing

Extended `TestFormatCellWithMapArray` with three new cases:
- Schedule-entry shape (empty `title`, `summary` wins)
- Non-empty `title` still beats `summary`
- Empty `name` does not shadow a valid `title`

`bin/ci` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank schedule entry names in `basecamp reports schedule --md`. `formatCell` now falls back to `summary` when `title` is empty and skips empty `name`/`title` values.

- **Bug Fixes**
  - Added `summary` fallback between `title` and `id` in `formatCell`, and ignore empty `name`/`title`.
  - Expanded tests to cover schedule entries and label precedence.

<sup>Written for commit b78b5d1e92d32c203f55eb76da91feaf03ef280e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

