### PR TITLE
Fix Windows/scoop installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Arm64: substitute `arm64` for `amd64` in the filename. Verify the SHA-256 checks
 **Scoop (Windows):**
 ```bash
 scoop bucket add basecamp https://github.com/basecamp/homebrew-tap
-scoop install basecamp-cli
+scoop install basecamp
 ```
 
 **Shell script:**


### PR DESCRIPTION
## What
Fix Windows/scoop installation command

## Why
The scoop app is called `basecamp`, not `basecamp-cli`.

## Testing
Works on my machine 👍🏼


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Windows `scoop` install command in the README to use the correct app name. Change `scoop install basecamp-cli` to `scoop install basecamp`.

<sup>Written for commit ad8f56d7d2789ed0a09dc86c188d031d0dbafe71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

