### PR TITLE
Rewrite release summary prompt for scannable output

### DIFF
--- a/.github/prompts/summarize-changelog.prompt.yml
+++ b/.github/prompts/summarize-changelog.prompt.yml
@@ -6,10 +6,10 @@ messages:
       (the detailed per-PR list is generated separately below your summary).
 
       Format:
-      - Start with one short sentence setting the tone (e.g. "Big one!" or "Patch release with two fixes.").
-      - If there are breaking changes, lead with a ⚠️ line before anything else.
-      - Then a bullet list of highlights. Each bullet leads with the command or
-        feature name in backticks, then a plain-English description.
+      - If there are breaking changes, start with a ⚠️ line describing what broke.
+      - Then one short sentence setting the tone (e.g. "Big one!" or "Patch release with two fixes.").
+      - Then a bullet list of highlights. Lead with the command or feature name
+        in backticks when there is one; otherwise just describe the change directly.
       - 1–3 bullets for small releases (1–5 commits). 4–10 for larger ones.
       - Do NOT pad small releases with filler bullets. Fewer is better.
 
@@ -25,7 +25,6 @@ messages:
 
       Big one! 100+ PRs spanning new commands, quality-of-life polish, and bugfixes.
 
-      Highlights:
       - `basecamp show <url>`: paste in any Basecamp URL to display it.
       - Inline images and attachments. Reference local file paths in Markdown to upload and create native Basecamp attachments.
       - `--sort` and `--reverse`: ubiquitous flags on list commands to sort by name, date, position, etc.


### PR DESCRIPTION
## Summary

- Rewrite the AI changelog prompt to produce a short intro sentence + bullet list of highlights instead of bloated prose paragraphs
- Add few-shot examples modeled on the hand-written v0.7.0 release notes
- Cut `maxCompletionTokens` from 1500 → 600 and `temperature` from 0.2 → 0 to force conciseness and eliminate truncation

## Problem

Every AI-generated release summary was truncated mid-sentence (v0.7.1 ends with "Multi", v0.4.0 ends with "visual improvements", v0.3.0 ends with "OSC 8 clickable") and read like corporate filler before it cut off. The hand-written v0.7.0 notes showed the right format: punchy, scannable, useful.

## Test plan

- [x] YAML validated locally with `python3 -c "import yaml; yaml.safe_load(open(...))"` 
- [ ] Next release verifies the output in practice