### PR TITLE
Fix todo update dropping untouched fields

### DIFF
--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -1164,7 +1164,29 @@ Clear a field by passing its --no- flag or an empty value:
 					return convertSDKError(err)
 				}
 			} else {
-				req := &basecamp.UpdateTodoRequest{}
+				// Fetch existing todo so we can preserve fields the user
+				// didn't change. The BC3 API clears fields by omission,
+				// so a partial PUT would wipe untouched fields.
+				existingTodo, err := app.Account().Todos().Get(cmd.Context(), todoID)
+				if err != nil {
+					return convertSDKError(err)
+				}
+
+				req := &basecamp.UpdateTodoRequest{
+					Content:     existingTodo.Content,
+					Description: existingTodo.Description,
+					DueOn:       existingTodo.DueOn,
+					StartsOn:    existingTodo.StartsOn,
+				}
+				if len(existingTodo.Assignees) > 0 {
+					ids := make([]int64, len(existingTodo.Assignees))
+					for i, a := range existingTodo.Assignees {
+						ids[i] = a.ID
+					}
+					req.AssigneeIDs = ids
+				}
+
+				// Override with user-provided values.
 				if effectiveTitle != "" {
 					req.Content = effectiveTitle
 				}

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -1182,7 +1182,29 @@ Clear a field by passing its --no- flag or an empty value:
 					return convertSDKError(err)
 				}
 			} else {
-				req := &basecamp.UpdateTodoRequest{}
+				// Fetch existing todo so we can preserve fields the user
+				// didn't change. The BC3 API clears fields by omission,
+				// so a partial PUT would wipe untouched fields.
+				existingTodo, err := app.Account().Todos().Get(cmd.Context(), todoID)
+				if err != nil {
+					return convertSDKError(err)
+				}
+
+				req := &basecamp.UpdateTodoRequest{
+					Content:     existingTodo.Content,
+					Description: existingTodo.Description,
+					DueOn:       existingTodo.DueOn,
+					StartsOn:    existingTodo.StartsOn,
+				}
+				if len(existingTodo.Assignees) > 0 {
+					ids := make([]int64, len(existingTodo.Assignees))
+					for i, a := range existingTodo.Assignees {
+						ids[i] = a.ID
+					}
+					req.AssigneeIDs = ids
+				}
+
+				// Override with user-provided values.
 				if effectiveTitle != "" {
 					req.Content = effectiveTitle
 				}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -1947,6 +1947,53 @@ func TestTodosUpdateClearPreservesAssignees(t *testing.T) {
 	assert.Equal(t, float64(42), ids[0])
 }
 
+func TestTodosUpdateDueDatePreservesExistingFields(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "--due", "2026-04-12")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody, "expected PUT body but got none")
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	// The new due date is applied.
+	assert.Equal(t, "2026-04-12", body["due_on"])
+
+	// BC3 API clears fields by omission, so untouched fields from the
+	// existing todo must be preserved in the request body.
+	assert.Equal(t, "Test todo", body["content"])
+	assert.Equal(t, "Existing desc", body["description"])
+	assert.Equal(t, "2026-03-25", body["starts_on"])
+
+	ids, ok := body["assignee_ids"].([]any)
+	require.True(t, ok, "assignee_ids must be preserved")
+	require.Len(t, ids, 1)
+	assert.Equal(t, float64(42), ids[0])
+}
+
+func TestTodosUpdateTitlePreservesExistingFields(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "New title")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "New title", body["content"])
+	assert.Equal(t, "Existing desc", body["description"])
+	assert.Equal(t, "2026-04-01", body["due_on"])
+	assert.Equal(t, "2026-03-25", body["starts_on"])
+}
+
 // =============================================================================
 // --assignee filtering tests (single-list path)
 // =============================================================================

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -1810,6 +1810,53 @@ func TestTodosUpdateClearPreservesAssignees(t *testing.T) {
 	assert.Equal(t, float64(42), ids[0])
 }
 
+func TestTodosUpdateDueDatePreservesExistingFields(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "--due", "2026-04-12")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody, "expected PUT body but got none")
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	// The new due date is applied.
+	assert.Equal(t, "2026-04-12", body["due_on"])
+
+	// BC3 API clears fields by omission, so untouched fields from the
+	// existing todo must be preserved in the request body.
+	assert.Equal(t, "Test todo", body["content"])
+	assert.Equal(t, "Existing desc", body["description"])
+	assert.Equal(t, "2026-03-25", body["starts_on"])
+
+	ids, ok := body["assignee_ids"].([]any)
+	require.True(t, ok, "assignee_ids must be preserved")
+	require.Len(t, ids, 1)
+	assert.Equal(t, float64(42), ids[0])
+}
+
+func TestTodosUpdateTitlePreservesExistingFields(t *testing.T) {
+	transport := &mockTodoUpdateTransport{}
+	app := setupTodoUpdateApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "update", "999", "New title")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "New title", body["content"])
+	assert.Equal(t, "Existing desc", body["description"])
+	assert.Equal(t, "2026-04-01", body["due_on"])
+	assert.Equal(t, "2026-03-25", body["starts_on"])
+}
+
 // =============================================================================
 // --assignee filtering tests (single-list path)
 // =============================================================================


### PR DESCRIPTION
## Summary

- Fixes #412 — `todos update --due` (and other partial updates) silently wiped
  untouched fields because the BC3 API clears fields by omission.
- Fixes #458 — title-only `todos update` preserved the new title but cleared the
  existing description and due date.
- Fixes #485 — `--due` now persists on the update path; create-with-due is also
  verified against the current branch.
- The non-clear update path now fetches the existing todo first and seeds the
  request with current values before applying user overrides, matching what the
  clear path (`--no-due`, `--no-description`) already did.
- Adds tests verifying that `--due`-only and title-only updates preserve
  content, description, dates, and assignees.

## Live verification

Tested against the Rob Zolkos account in the Verdant Coffee Roasters project,
Fusilli todolist, using a locally built rebased branch.

- #412 / #485: Created a temporary todo, ran `basecamp todos update <id> --due
  2027-01-15`, and confirmed `todos show` returned `due_on: "2027-01-15"`
  while preserving title and description.
- #458: Ran `basecamp todos update <id> --title ...` and confirmed `todos show`
  preserved the existing description and due date.
- #485: Created the temporary todo with `--due 2026-12-31` and confirmed the
  created todo returned `due_on: "2026-12-31"`.

Fixes #412
Fixes #458
Fixes #485

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes partial `todos update` wiping untouched fields. The command now fetches the existing todo and seeds the PUT body so content, description, due/start dates, and assignees are preserved.

- **Bug Fixes**
  - Preload the update request with existing values before applying overrides to prevent BC3’s clear-by-omission behavior; matches clear-flag behavior.
  - Added tests for `--due`-only and title-only updates to confirm content, description, due_on, starts_on, and assignee_ids are retained.

<sup>Written for commit 49cdc819df6066c36fb8b802ec05ec2d86218e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

