### PR TITLE
Add stdin support for comment content

### DIFF
--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -298,6 +298,9 @@ Comma-separated IDs add the same comment to multiple items:
   basecamp comment 789,012,345 "Looks good!"
   basecamp comment https://3.basecamp.com/123/buckets/456/todos/789 "Looks good!"
 
+Content can also be piped from stdin:
+  printf 'Looks good!' | basecamp comment 789
+
 Content supports Markdown and @mentions (@Name or @First.Last):
   basecamp comment 789 "Hey @Jane.Smith, **please review**"`,
 		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments"},
@@ -331,16 +334,26 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 				}
 			}
 
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			if !edit && strings.TrimSpace(content) == "" {
+				stdinContent, hasPipedStdin, err := readPipedStdin()
+				if err != nil {
+					return err
+				}
+				if hasPipedStdin {
+					content = stdinContent
+				}
+			}
+
 			// Show help when invoked with no content; keep error if editor was opened
 			if strings.TrimSpace(content) == "" {
 				if edit {
 					return output.ErrUsage("Comment content required")
 				}
 				return missingArg(cmd, "<content>")
-			}
-
-			if err := ensureAccount(cmd, app); err != nil {
-				return err
 			}
 
 			// Expand comma-separated IDs and extract from URLs

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -334,15 +334,8 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 				}
 			}
 
-			if err := ensureAccount(cmd, app); err != nil {
-				return err
-			}
-
 			if !edit && strings.TrimSpace(content) == "" {
-				stdinContent, hasPipedStdin, err := readPipedStdin()
-				if err != nil {
-					return err
-				}
+				stdinContent, hasPipedStdin := readPipedStdin()
 				if hasPipedStdin {
 					content = stdinContent
 				}
@@ -354,6 +347,10 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 					return output.ErrUsage("Comment content required")
 				}
 				return missingArg(cmd, "<content>")
+			}
+
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
 			}
 
 			// Expand comma-separated IDs and extract from URLs

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -177,9 +177,9 @@ func TestCommentCreateMissingContentReturnsUsageBeforeAccountResolution(t *testi
 	app.Config.AccountID = ""
 	app.Flags.JSON = true
 
-	devNull, err := os.Open("/dev/null")
+	devNull, err := os.Open(os.DevNull)
 	if err != nil {
-		t.Skip("/dev/null not available")
+		t.Skip("dev null not available")
 	}
 
 	origStdin := os.Stdin

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -171,3 +171,44 @@ func TestCommentsCreateReadsContentFromStdin(t *testing.T) {
 	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
 	assert.Equal(t, "<p>hello from stdin</p>", body["content"])
 }
+
+func TestCommentCreateMissingContentReturnsUsageBeforeAccountResolution(t *testing.T) {
+	app, _ := setupTestApp(t)
+	app.Config.AccountID = ""
+	app.Flags.JSON = true
+
+	devNull, err := os.Open("/dev/null")
+	if err != nil {
+		t.Skip("/dev/null not available")
+	}
+
+	origStdin := os.Stdin
+	os.Stdin = devNull
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		devNull.Close()
+	})
+
+	cmd := NewCommentCmd()
+	err = executeCommand(cmd, app, "123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "<content> required")
+	assert.NotContains(t, err.Error(), "account")
+}
+
+func TestReadPipedStdinIgnoresUnreadableStdin(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.NoError(t, w.Close())
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+	})
+
+	content, hasPipedStdin := readPipedStdin()
+	assert.Empty(t, content)
+	assert.False(t, hasPipedStdin)
+}

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -1,6 +1,12 @@
 package commands
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +61,113 @@ func TestCommentsGroupAcceptsInFlag(t *testing.T) {
 	require.NotNil(t, err)
 	assert.NotContains(t, err.Error(), "unknown flag")
 	assert.NotContains(t, err.Error(), "unknown shorthand")
+}
+
+type mockCommentCreateTransport struct {
+	capturedBody []byte
+}
+
+func (t *mockCommentCreateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	if req.Method != http.MethodPost {
+		return nil, errors.New("unexpected request")
+	}
+	if !strings.HasSuffix(req.URL.Path, "/comments.json") {
+		return nil, errors.New("unexpected path: " + req.URL.Path)
+	}
+
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		t.capturedBody = body
+		req.Body.Close()
+	}
+
+	return &http.Response{
+		StatusCode: 201,
+		Body:       io.NopCloser(strings.NewReader(`{"id": 999, "content": "<p>hello from stdin</p>", "status": "active"}`)),
+		Header:     header,
+	}, nil
+}
+
+func TestCommentCreateReadsContentFromStdin(t *testing.T) {
+	transport := &mockCommentCreateTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = io.WriteString(w, "hello from stdin")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		r.Close()
+	})
+
+	cmd := NewCommentCmd()
+	err = executeCommand(cmd, app, "123")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	assert.Equal(t, "<p>hello from stdin</p>", body["content"])
+}
+
+func TestCommentCreatePrefersPositionalContentOverStdin(t *testing.T) {
+	transport := &mockCommentCreateTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = io.WriteString(w, "ignored stdin")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		r.Close()
+	})
+
+	cmd := NewCommentCmd()
+	err = executeCommand(cmd, app, "123", "hello from args")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	assert.Equal(t, "<p>hello from args</p>", body["content"])
+}
+
+func TestCommentsCreateReadsContentFromStdin(t *testing.T) {
+	transport := &mockCommentCreateTransport{}
+	app, _ := newTestAppWithTransport(t, transport)
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = io.WriteString(w, "hello from stdin")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		r.Close()
+	})
+
+	cmd := NewCommentsCmd()
+	err = executeCommand(cmd, app, "create", "123")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	assert.Equal(t, "<p>hello from stdin</p>", body["content"])
 }

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -80,20 +80,20 @@ func isMachineOutput(cmd *cobra.Command) bool {
 	return false
 }
 
-func readPipedStdin() (string, bool, error) {
+func readPipedStdin() (string, bool) {
 	fi, err := os.Stdin.Stat()
 	if err != nil {
-		return "", false, fmt.Errorf("failed to inspect stdin: %w", err)
+		return "", false
 	}
 	if (fi.Mode() & os.ModeCharDevice) != 0 {
-		return "", false, nil
+		return "", false
 	}
 
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		return "", true, fmt.Errorf("failed to read stdin: %w", err)
+		return "", false
 	}
-	return string(data), true, nil
+	return string(data), true
 }
 
 // DockTool represents a tool in a project's dock.

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -77,6 +78,22 @@ func isMachineOutput(cmd *cobra.Command) bool {
 		}
 	}
 	return false
+}
+
+func readPipedStdin() (string, bool, error) {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to inspect stdin: %w", err)
+	}
+	if (fi.Mode() & os.ModeCharDevice) != 0 {
+		return "", false, nil
+	}
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to read stdin: %w", err)
+	}
+	return string(data), true, nil
 }
 
 // DockTool represents a tool in a project's dock.


### PR DESCRIPTION
## Summary

This adds support for supplying comment content via piped stdin for `basecamp comment` and `basecamp comments create`.

That makes the CLI easier to use in scripts and shell pipelines, especially for multiline Markdown or generated text, without requiring awkward shell quoting.

Closes #410

## Changes

- Read comment content from stdin when positional content is omitted
- Preserve existing behavior when positional content is provided
- Keep `--edit` behavior unchanged
- Add tests covering stdin input for both `comment` and `comments create`

## Live verification

Tested against the Rob Zolkos account in the Verdant Coffee Roasters project,
Fusilli todolist, using a locally built rebased branch.

- `printf ... | basecamp comment <todo_id>` created a comment with the piped content.
- `printf ... | basecamp comments create <todo_id>` created a comment with the piped content.
- `printf ignored | basecamp comment <todo_id> "positional content"` used the positional content and ignored stdin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stdin support for comment content in `basecamp comment` and `basecamp comments create` when no positional content is provided, and returns a clear usage error early when content is empty (Linear 410). This simplifies scripts and avoids unnecessary account lookups.

- **New Features**
  - Read comment content from piped stdin when content is omitted; help now shows a piping example.
  - Positional content takes precedence over stdin.
  - Return "<content> required" before account resolution when no content or stdin is provided.
  - `--edit` behavior unchanged.

<sup>Written for commit 9cca9fa92740a70dbbabed52791901961daa8b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

