### PR TITLE
Use Trix-compatible HTML for proper paragraph spacing

### DIFF
--- a/internal/commands/checkins_test.go
+++ b/internal/commands/checkins_test.go
@@ -84,7 +84,7 @@ func TestCheckinsAnswerCreateDefaultsDateToToday(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, transport.recordedBody)
 	assert.Equal(t, "/99999/questions/456/answers.json", transport.recordedPath)
-	assert.Equal(t, "<p>hello world</p>", transport.recordedBody["content"])
+	assert.Equal(t, "<div>hello world</div>", transport.recordedBody["content"])
 	assert.Equal(t, "2026-03-25", transport.recordedBody["group_on"])
 }
 

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -47,8 +47,15 @@ var (
 	// prefix (e.g. <p> vs <pre>, <b> vs <br>, <em> vs <embed>, <i> vs <img>,
 	// <s> vs <script>, <del> vs <details>, <a> vs <abbr>).
 	reP  = regexp.MustCompile(`(?is)<p(?:\s[^>]*)?>(.*?)</p>`)
-	reBR = regexp.MustCompile(`(?i)<br\s*/?\s*>`)
 	reHR = regexp.MustCompile(`(?i)<hr\s*/?\s*>`)
+
+	// Trix-native block shapes. Trix (the editor behind Basecamp) stores
+	// paragraphs as <div>...</div> and blank-line separators as
+	// <div><br></div>. HTMLToMarkdown needs to unwrap both so content
+	// typed in Basecamp round-trips cleanly, and so the CLI's own output
+	// (which MarkdownToHTML emits in the same shape) can be re-parsed.
+	reDivEmpty = regexp.MustCompile(`(?i)<div(?:\s[^>]*)?>\s*<br\s*/?\s*>\s*</div>`)
+	reDiv      = regexp.MustCompile(`(?is)<div(?:\s[^>]*)?>(.*?)</div>`)
 )
 
 // Pre-compiled regexes for HTMLToMarkdown inline elements
@@ -167,6 +174,16 @@ func (p *escapedAtParser) Parse(_ ast.Node, block text.Reader, _ parser.Context)
 type trixTransformer struct{}
 
 func (t *trixTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
+	// Phase 0: Convert soft line breaks to hard across the entire document.
+	// In Markdown `"Line 1\nLine 2"` (no blank line) is authored as a single
+	// paragraph with an intentional visible line break. goldmark's default
+	// renders the soft break as a literal newline, which browsers collapse
+	// to whitespace. Trix (the editor behind Basecamp) represents the same
+	// "single Enter" as <br> inside the paragraph's <div>, so emit <br>.
+	// convertSoftBreaksToHard is idempotent, so later per-list / per-blockquote
+	// re-invocations stay a no-op.
+	convertSoftBreaksToHard(node)
+
 	// Phase 1: Force tight lists, convert soft breaks to hard in list items,
 	// and unwrap blockquote paragraphs
 	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -244,12 +261,29 @@ func insertBreaksBetweenTextBlocks(parent ast.Node) {
 type trixRenderer struct{}
 
 func (r *trixRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindParagraph, r.renderParagraph)
 	reg.Register(ast.KindRawHTML, r.renderRawHTML)
 	reg.Register(ast.KindHTMLBlock, r.renderHTMLBlock)
 	reg.Register(ast.KindBlockquote, r.renderBlockquote)
 	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
 	reg.Register(KindTrixBreak, r.renderTrixBreak)
 	reg.Register(KindEscapedAt, r.renderEscapedAt)
+}
+
+// renderParagraph wraps top-level paragraphs in <div>...</div> instead of
+// goldmark's default <p>...</p>. Trix (the editor behind Basecamp's rich
+// text fields) uses <div> blocks natively; <p> blocks get rendered with
+// extra margins, producing double-spaced paragraphs in Basecamp.
+// Paragraphs inside lists and blockquotes are converted to TextBlocks by
+// trixTransformer before reaching the renderer, so this only fires for
+// top-level paragraphs.
+func (r *trixRenderer) renderParagraph(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("<div>")
+	} else {
+		_, _ = w.WriteString("</div>\n")
+	}
+	return ast.WalkContinue, nil
 }
 
 func (r *trixRenderer) renderBlockquote(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -295,7 +329,7 @@ func (r *trixRenderer) renderHTMLBlock(w util.BufWriter, source []byte, node ast
 		escaped := strings.TrimRight(string(util.EscapeHTML(n.ClosureLine.Value(source))), "\n")
 		parts = append(parts, escaped)
 	}
-	_, _ = w.WriteString("<p>" + strings.Join(parts, " ") + "</p>\n")
+	_, _ = w.WriteString("<div>" + strings.Join(parts, " ") + "</div>\n")
 	return ast.WalkContinue, nil
 }
 
@@ -330,7 +364,10 @@ func (r *trixRenderer) renderTrixBreak(w util.BufWriter, _ []byte, _ ast.Node, e
 	if !entering {
 		return ast.WalkContinue, nil
 	}
-	_, _ = w.WriteString("<br>\n")
+	// <div><br></div> is Trix's native empty-line representation.
+	// A bare <br> between <p>/<div> blocks produces double spacing in
+	// Basecamp because the <br> comes in addition to the block margins.
+	_, _ = w.WriteString("<div><br></div>\n")
 	return ast.WalkContinue, nil
 }
 
@@ -359,7 +396,7 @@ func MarkdownToHTML(md string) string {
 
 	var buf bytes.Buffer
 	if err := mdConverter.Convert([]byte(md), &buf); err != nil {
-		return "<p>" + html.EscapeString(md) + "</p>"
+		return "<div>" + html.EscapeString(md) + "</div>"
 	}
 
 	return strings.TrimSpace(buf.String())
@@ -496,11 +533,20 @@ func HTMLToMarkdown(html string) string {
 	// Lists — use balanced-tag replacement to handle nesting correctly.
 	html = replaceBalancedListBlocks(html)
 
+	// Trix-native paragraphs: <div><br></div> is a blank-line separator,
+	// <div>...</div> is a paragraph. Handle before <p> so a document that
+	// mixes both (rare, but possible when Basecamp content is copied from
+	// a non-Trix source) degrades cleanly.
+	html = reDivEmpty.ReplaceAllString(html, "\n\n")
+	html = reDiv.ReplaceAllString(html, "$1\n\n")
+
 	// Paragraphs
 	html = reP.ReplaceAllString(html, "$1\n\n")
 
-	// Line breaks
-	html = reBR.ReplaceAllString(html, "\n")
+	// Line breaks. Use reBRLine so a trailing newline after <br> (goldmark's
+	// hard-break output is "<br>\n") collapses with the <br> to a single
+	// "\n" rather than "\n\n", which would be misread as a paragraph break.
+	html = reBRLine.ReplaceAllString(html, "\n")
 
 	// Horizontal rules
 	html = reHR.ReplaceAllString(html, "\n---\n\n")
@@ -793,19 +839,29 @@ func blockquoteInnerToMarkdown(inner string) string {
 		return convertCodeBlockHTML(s) + "\n\n"
 	})
 	content = replaceBalancedListBlocks(content)
-	// Replace </p> with double newline (paragraph break) to separate adjacent blocks,
-	// then strip <p> openers. Two passes so <p>para1</p><p>para2</p> produces
-	// "para1\n\npara2" (blank line = > separator) rather than "para1para2".
+	// Trix-native paragraph separator inside a blockquote: <div><br></div>
+	// between two <div> text blocks. Collapse to a single newline so the
+	// outer blockquote-line splitter sees it as a blank line (which gets
+	// the ">" prefix alone). Without this we produce multiple ">" lines.
+	content = reDivEmpty.ReplaceAllString(content, "\n")
+	// Replace </p> / </div> with double newline (paragraph break) to separate
+	// adjacent blocks, then strip <p> / <div> openers. Two passes so
+	// <p>para1</p><p>para2</p> produces "para1\n\npara2" (blank line =
+	// > separator) rather than "para1para2".
 	content = reClosingP.ReplaceAllString(content, "\n\n")
 	content = reOpeningP.ReplaceAllString(content, "")
+	content = reClosingDiv.ReplaceAllString(content, "\n\n")
+	content = reOpeningDiv.ReplaceAllString(content, "")
 	content = reBRLine.ReplaceAllString(content, "\n")
 	content = reMultiNewline.ReplaceAllString(content, "\n\n")
 	return strings.TrimSpace(content)
 }
 
 var (
-	reOpeningP = regexp.MustCompile(`(?i)<p(?:\s[^>]*)?>`)
-	reClosingP = regexp.MustCompile(`(?i)</p>`)
+	reOpeningP   = regexp.MustCompile(`(?i)<p(?:\s[^>]*)?>`)
+	reClosingP   = regexp.MustCompile(`(?i)</p>`)
+	reOpeningDiv = regexp.MustCompile(`(?i)<div(?:\s[^>]*)?>`)
+	reClosingDiv = regexp.MustCompile(`(?i)</div>`)
 )
 
 // unescapeHTML converts HTML entities back to their characters.

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -20,7 +20,7 @@ func TestMarkdownToHTML(t *testing.T) {
 		{
 			name:     "plain text",
 			input:    "Hello world",
-			expected: "<p>Hello world</p>",
+			expected: "<div>Hello world</div>",
 		},
 		{
 			name:     "h1 heading",
@@ -40,27 +40,27 @@ func TestMarkdownToHTML(t *testing.T) {
 		{
 			name:     "bold with asterisks",
 			input:    "This is **bold** text",
-			expected: "<p>This is <strong>bold</strong> text</p>",
+			expected: "<div>This is <strong>bold</strong> text</div>",
 		},
 		{
 			name:     "bold with underscores",
 			input:    "This is __bold__ text",
-			expected: "<p>This is <strong>bold</strong> text</p>",
+			expected: "<div>This is <strong>bold</strong> text</div>",
 		},
 		{
 			name:     "italic with asterisk",
 			input:    "This is *italic* text",
-			expected: "<p>This is <em>italic</em> text</p>",
+			expected: "<div>This is <em>italic</em> text</div>",
 		},
 		{
 			name:     "inline code",
 			input:    "Use `code` here",
-			expected: "<p>Use <code>code</code> here</p>",
+			expected: "<div>Use <code>code</code> here</div>",
 		},
 		{
 			name:     "link",
 			input:    "Check [this link](https://example.com)",
-			expected: `<p>Check <a href="https://example.com">this link</a></p>`,
+			expected: `<div>Check <a href="https://example.com">this link</a></div>`,
 		},
 		{
 			name:     "unordered list",
@@ -85,7 +85,7 @@ func TestMarkdownToHTML(t *testing.T) {
 		{
 			name:     "list followed by blank line then paragraph",
 			input:    "- Item 1\n- Item 2\n\nFollowing paragraph.",
-			expected: "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>\n<br>\n<p>Following paragraph.</p>",
+			expected: "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>\n<div><br></div>\n<div>Following paragraph.</div>",
 		},
 		{
 			// CommonMark §5.4: "After" is a lazy continuation of the second list item.
@@ -123,82 +123,82 @@ func TestMarkdownToHTML(t *testing.T) {
 		{
 			name:     "strikethrough",
 			input:    "This is ~~deleted~~ text",
-			expected: "<p>This is <del>deleted</del> text</p>",
+			expected: "<div>This is <del>deleted</del> text</div>",
 		},
 		{
 			name:     "mixed formatting",
 			input:    "# Title\n\nThis is **bold** and *italic* and `code`.",
-			expected: "<h1>Title</h1>\n<br>\n<p>This is <strong>bold</strong> and <em>italic</em> and <code>code</code>.</p>",
+			expected: "<h1>Title</h1>\n<div><br></div>\n<div>This is <strong>bold</strong> and <em>italic</em> and <code>code</code>.</div>",
 		},
 		{
 			name:     "escapes HTML",
 			input:    "Use <script> tags",
-			expected: "<p>Use &lt;script&gt; tags</p>",
+			expected: "<div>Use &lt;script&gt; tags</div>",
 		},
 		{
 			name:     "escapes ampersand",
 			input:    "Tom & Jerry",
-			expected: "<p>Tom &amp; Jerry</p>",
+			expected: "<div>Tom &amp; Jerry</div>",
 		},
 		{
 			name:     "paragraph spacing with blank line",
 			input:    "First paragraph\n\nSecond paragraph",
-			expected: "<p>First paragraph</p>\n<br>\n<p>Second paragraph</p>",
+			expected: "<div>First paragraph</div>\n<div><br></div>\n<div>Second paragraph</div>",
 		},
 		{
 			name:     "multiple blank lines collapse to one break",
 			input:    "First\n\n\n\nSecond",
-			expected: "<p>First</p>\n<br>\n<p>Second</p>",
+			expected: "<div>First</div>\n<div><br></div>\n<div>Second</div>",
 		},
 		{
-			name:     "consecutive lines join into one paragraph",
+			name:     "consecutive lines preserve line breaks",
 			input:    "Line one\nLine two",
-			expected: "<p>Line one\nLine two</p>",
+			expected: "<div>Line one<br>\nLine two</div>",
 		},
 		{
 			name:     "blank line before list",
 			input:    "Intro\n\n- Item 1\n- Item 2",
-			expected: "<p>Intro</p>\n<br>\n<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>",
+			expected: "<div>Intro</div>\n<div><br></div>\n<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>",
 		},
 		{
 			name:     "blank line before code block",
 			input:    "Intro\n\n```\ncode\n```",
-			expected: "<p>Intro</p>\n<br>\n<pre><code>code\n</code></pre>",
+			expected: "<div>Intro</div>\n<div><br></div>\n<pre><code>code\n</code></pre>",
 		},
 		{
 			name:     "leading blank lines ignored",
 			input:    "\n\nHello",
-			expected: "<p>Hello</p>",
+			expected: "<div>Hello</div>",
 		},
 		{
 			name:     "blank line before blockquote",
 			input:    "Intro\n\n> A quote",
-			expected: "<p>Intro</p>\n<br>\n<blockquote>A quote</blockquote>",
+			expected: "<div>Intro</div>\n<div><br></div>\n<blockquote>A quote</blockquote>",
 		},
 		{
 			name:     "blank line before horizontal rule",
 			input:    "Intro\n\n---",
-			expected: "<p>Intro</p>\n<br>\n<hr>",
+			expected: "<div>Intro</div>\n<div><br></div>\n<hr>",
 		},
 		{
 			name:     "heading flushes accumulated paragraph",
 			input:    "Text\n# Heading",
-			expected: "<p>Text</p>\n<h1>Heading</h1>",
+			expected: "<div>Text</div>\n<h1>Heading</h1>",
 		},
 		{
 			name:     "list flushes accumulated paragraph",
 			input:    "Text\n- Item",
-			expected: "<p>Text</p>\n<ul>\n<li>Item</li>\n</ul>",
+			expected: "<div>Text</div>\n<ul>\n<li>Item</li>\n</ul>",
 		},
 		{
 			name:     "blockquote flushes accumulated paragraph",
 			input:    "Text\n> Quote",
-			expected: "<p>Text</p>\n<blockquote>Quote</blockquote>",
+			expected: "<div>Text</div>\n<blockquote>Quote</blockquote>",
 		},
 		{
 			name:     "code fence flushes accumulated paragraph",
 			input:    "Text\n```go\nx\n```",
-			expected: "<p>Text</p>\n<pre language=\"go\"><code>x\n</code></pre>",
+			expected: "<div>Text</div>\n<pre language=\"go\"><code>x\n</code></pre>",
 		},
 		{
 			// CommonMark: "Text\n---" is a setext heading (h2), not paragraph + hr
@@ -209,12 +209,12 @@ func TestMarkdownToHTML(t *testing.T) {
 		{
 			name:     "code span containing HTML tag is converted not passthrough",
 			input:    "the `<div>` container",
-			expected: "<p>the <code>&lt;div&gt;</code> container</p>",
+			expected: "<div>the <code>&lt;div&gt;</code> container</div>",
 		},
 		{
 			name:     "fenced code block containing HTML tags is converted",
 			input:    "intro\n\n```\n<div>hello</div>\n```",
-			expected: "<p>intro</p>\n<br>\n<pre><code>&lt;div&gt;hello&lt;/div&gt;\n</code></pre>",
+			expected: "<div>intro</div>\n<div><br></div>\n<pre><code>&lt;div&gt;hello&lt;/div&gt;\n</code></pre>",
 		},
 	}
 
@@ -237,12 +237,12 @@ func TestMarkdownToHTMLBackslashEscapes(t *testing.T) {
 		{
 			name:     "escaped exclamation mark",
 			input:    `Merged\! Great work`,
-			expected: "<p>Merged! Great work</p>",
+			expected: "<div>Merged! Great work</div>",
 		},
 		{
 			name:     "escaped hash",
 			input:    `\# not a heading`,
-			expected: "<p># not a heading</p>",
+			expected: "<div># not a heading</div>",
 		},
 		{
 			name:     "escaped exclamation in heading",
@@ -262,128 +262,128 @@ func TestMarkdownToHTMLBackslashEscapes(t *testing.T) {
 		{
 			name:     "escaped asterisk prevents italic",
 			input:    `use \*stars\* for emphasis`,
-			expected: "<p>use *stars* for emphasis</p>",
+			expected: "<div>use *stars* for emphasis</div>",
 		},
 		{
 			name:     "escaped backslash",
 			input:    `path\\to\\file`,
-			expected: "<p>path\\to\\file</p>",
+			expected: "<div>path\\to\\file</div>",
 		},
 		{
 			name:     "escaped ampersand",
 			input:    `Tom \& Jerry`,
-			expected: "<p>Tom &amp; Jerry</p>",
+			expected: "<div>Tom &amp; Jerry</div>",
 		},
 		{
 			name:     "escaped angle bracket",
 			input:    `use \< and \> carefully`,
-			expected: "<p>use &lt; and &gt; carefully</p>",
+			expected: "<div>use &lt; and &gt; carefully</div>",
 		},
 		{
 			name:     "escaped period after number",
 			input:    `2025\. What a year`,
-			expected: "<p>2025. What a year</p>",
+			expected: "<div>2025. What a year</div>",
 		},
 		{
 			name:     "escaped double quotes in text",
 			input:    `Say \"hi\"`,
-			expected: "<p>Say &quot;hi&quot;</p>",
+			expected: "<div>Say &quot;hi&quot;</div>",
 		},
 		{
 			name:     "backslash before non-punctuation preserved",
 			input:    `hello\nworld`,
-			expected: "<p>hello\\nworld</p>",
+			expected: "<div>hello\\nworld</div>",
 		},
 		{
 			name:     "escaped bracket prevents link",
 			input:    `\[not a link\](url)`,
-			expected: "<p>[not a link](url)</p>",
+			expected: "<div>[not a link](url)</div>",
 		},
 		{
 			name:     "escaped quotes percent-encoded in link destination",
 			input:    `[x](https://example.com/?q=\"hi\")`,
-			expected: `<p><a href="https://example.com/?q=%22hi%22">x</a></p>`,
+			expected: `<div><a href="https://example.com/?q=%22hi%22">x</a></div>`,
 		},
 		{
 			// goldmark treats \% as literal % in URLs (CommonMark spec)
 			name:     "escaped percent in link destination",
 			input:    `[x](https://example.com/\%20)`,
-			expected: `<p><a href="https://example.com/%20">x</a></p>`,
+			expected: `<div><a href="https://example.com/%20">x</a></div>`,
 		},
 		{
 			name:     "escaped backslash in link destination",
 			input:    `[x](https://example.com/\\path)`,
-			expected: `<p><a href="https://example.com/%5Cpath">x</a></p>`,
+			expected: `<div><a href="https://example.com/%5Cpath">x</a></div>`,
 		},
 		{
 			name:     "escaped angle bracket in link destination",
 			input:    `[x](https://example.com/\<tag)`,
-			expected: `<p><a href="https://example.com/%3Ctag">x</a></p>`,
+			expected: `<div><a href="https://example.com/%3Ctag">x</a></div>`,
 		},
 		{
 			name:     "escaped bracket in link destination",
 			input:    `[x](https://example.com/\[a)`,
-			expected: `<p><a href="https://example.com/%5Ba">x</a></p>`,
+			expected: `<div><a href="https://example.com/%5Ba">x</a></div>`,
 		},
 		{
 			name:     "escaped percent in image src",
 			input:    `![alt](https://example.com/\%20.png)`,
-			expected: `<p><img src="https://example.com/%20.png" alt="alt"></p>`,
+			expected: `<div><img src="https://example.com/%20.png" alt="alt"></div>`,
 		},
 		{
 			name:     "literal-safe chars stay literal in link destination",
 			input:    `[x](https://example.com/\!\?)`,
-			expected: `<p><a href="https://example.com/!?">x</a></p>`,
+			expected: `<div><a href="https://example.com/!?">x</a></div>`,
 		},
 		{
 			name:     "escaped quote in link text stays entity-escaped",
 			input:    `[say \"hi\"](https://example.com/)`,
-			expected: `<p><a href="https://example.com/">say &quot;hi&quot;</a></p>`,
+			expected: `<div><a href="https://example.com/">say &quot;hi&quot;</a></div>`,
 		},
 		{
 			name:     "escaped quote in image alt stays entity-escaped",
 			input:    `![say \"hi\"](https://example.com/img.png)`,
-			expected: `<p><img src="https://example.com/img.png" alt="say &quot;hi&quot;"></p>`,
+			expected: `<div><img src="https://example.com/img.png" alt="say &quot;hi&quot;"></div>`,
 		},
 		{
 			name:     "escaped backtick percent-encoded in link destination",
 			input:    "[x](https://example.com/\\`v)",
-			expected: `<p><a href="https://example.com/%60v">x</a></p>`,
+			expected: `<div><a href="https://example.com/%60v">x</a></div>`,
 		},
 		{
 			name:     "backslash escapes inside inline context",
 			input:    `Say **hello\!** loudly`,
-			expected: "<p>Say <strong>hello!</strong> loudly</p>",
+			expected: "<div>Say <strong>hello!</strong> loudly</div>",
 		},
 		{
 			name:     "multiple escapes in one line",
 			input:    `\*bold\* and \!bang\!`,
-			expected: "<p>*bold* and !bang!</p>",
+			expected: "<div>*bold* and !bang!</div>",
 		},
 		{
 			name:     "escaped backticks do not start code spans",
 			input:    "\\`code\\`",
-			expected: "<p>`code`</p>",
+			expected: "<div>`code`</div>",
 		},
 		{
 			name:     "escaped tilde prevents strikethrough",
 			input:    `\~\~not deleted\~\~`,
-			expected: "<p>~~not deleted~~</p>",
+			expected: "<div>~~not deleted~~</div>",
 		},
 		{
 			name:     "backslash escape in code span preserved",
 			input:    "`\\!` stays literal",
-			expected: "<p><code>\\!</code> stays literal</p>",
+			expected: "<div><code>\\!</code> stays literal</div>",
 		},
 		{
 			name:     "escaped safe HTML tag is rendered as text",
 			input:    `\<div>hello\</div>`,
-			expected: "<p>&lt;div&gt;hello&lt;/div&gt;</p>",
+			expected: "<div>&lt;div&gt;hello&lt;/div&gt;</div>",
 		},
 		{
 			name:     "escaped at sign is preserved to suppress mentions",
 			input:    `\@John hello`,
-			expected: `<p>\@John hello</p>`,
+			expected: `<div>\@John hello</div>`,
 		},
 	}
 
@@ -407,22 +407,22 @@ func TestMarkdownToHTMLBackslashAtCounts(t *testing.T) {
 		{
 			name:     "single backslash at",
 			input:    `\@John`,
-			expected: `<p>\@John</p>`,
+			expected: `<div>\@John</div>`,
 		},
 		{
 			name:     "double backslash at",
 			input:    `\\@John`,
-			expected: `<p>\@John</p>`,
+			expected: `<div>\@John</div>`,
 		},
 		{
 			name:     "triple backslash at",
 			input:    `\\\@John`,
-			expected: `<p>\\@John</p>`,
+			expected: `<div>\\@John</div>`,
 		},
 		{
 			name:     "quadruple backslash at",
 			input:    `\\\\@John`,
-			expected: `<p>\\@John</p>`,
+			expected: `<div>\\@John</div>`,
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestMarkdownToHTMLMultiParagraphBlockquote(t *testing.T) {
 		{
 			name:     "multi-paragraph",
 			input:    "> para1\n>\n> para2",
-			expected: "<blockquote>para1\n<br>\npara2</blockquote>",
+			expected: "<blockquote>para1\n<div><br></div>\npara2</blockquote>",
 		},
 	}
 
@@ -478,12 +478,12 @@ func TestMarkdownToHTMLRawHTMLBlock(t *testing.T) {
 		{
 			name:     "single-line script tag",
 			input:    "<script>alert(1)</script>",
-			expected: "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
+			expected: "<div>&lt;script&gt;alert(1)&lt;/script&gt;</div>",
 		},
 		{
 			name:     "multiline script tag",
 			input:    "<script>\nalert(1)\n</script>",
-			expected: "<p>&lt;script&gt; alert(1) &lt;/script&gt;</p>",
+			expected: "<div>&lt;script&gt; alert(1) &lt;/script&gt;</div>",
 		},
 	}
 
@@ -1332,8 +1332,15 @@ func TestRoundTrip(t *testing.T) {
 		if strings.Contains(back, "\n\n") {
 			t.Errorf("round-trip produced two paragraphs, want one\nhtml: %q\nback: %q", html, back)
 		}
-		if !strings.Contains(back, "Line 1") || !strings.Contains(back, "Line 2") {
-			t.Errorf("round-trip lost content\nhtml: %q\nback: %q", html, back)
+		line1Idx := strings.Index(back, "Line 1")
+		line2Idx := strings.Index(back, "Line 2")
+		if line1Idx == -1 || line2Idx == -1 || line1Idx >= line2Idx {
+			t.Errorf("round-trip did not preserve line order/content\nhtml: %q\nback: %q", html, back)
+			return
+		}
+		between := back[line1Idx+len("Line 1") : line2Idx]
+		if !strings.Contains(between, "\n") {
+			t.Errorf("round-trip did not preserve a line break between lines\nhtml: %q\nback: %q", html, back)
 		}
 	})
 }
@@ -1535,23 +1542,23 @@ func TestResolveMentions(t *testing.T) {
 	}{
 		{
 			name:     "single mention",
-			input:    `<p>Hey @John, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("sgid-john", "John Doe") + `, check this</p>`,
+			input:    `<div>Hey @John, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("sgid-john", "John Doe") + `, check this</div>`,
 		},
 		{
 			name:     "first.last mention",
-			input:    `<p>Hey @Igor.Logachev, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("sgid-igor", "Igor Logachev") + `, check this</p>`,
+			input:    `<div>Hey @Igor.Logachev, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("sgid-igor", "Igor Logachev") + `, check this</div>`,
 		},
 		{
 			name:     "multiple mentions",
-			input:    `<p>@John and @Igor please review</p>`,
-			expected: `<p>` + MentionToHTML("sgid-john", "John Doe") + ` and ` + MentionToHTML("sgid-igor", "Igor Logachev") + ` please review</p>`,
+			input:    `<div>@John and @Igor please review</div>`,
+			expected: `<div>` + MentionToHTML("sgid-john", "John Doe") + ` and ` + MentionToHTML("sgid-igor", "Igor Logachev") + ` please review</div>`,
 		},
 		{
 			name:     "no mentions",
-			input:    `<p>Hello world</p>`,
-			expected: `<p>Hello world</p>`,
+			input:    `<div>Hello world</div>`,
+			expected: `<div>Hello world</div>`,
 		},
 		{
 			name:     "mention at start of line",
@@ -1560,12 +1567,12 @@ func TestResolveMentions(t *testing.T) {
 		},
 		{
 			name:     "email not treated as mention",
-			input:    `<p>Send to user@John.com</p>`,
-			expected: `<p>Send to user@John.com</p>`,
+			input:    `<div>Send to user@John.com</div>`,
+			expected: `<div>Send to user@John.com</div>`,
 		},
 		{
 			name:    "unresolved mention is error",
-			input:   `<p>Hey @Unknown</p>`,
+			input:   `<div>Hey @Unknown</div>`,
 			wantErr: true,
 		},
 		{
@@ -1580,13 +1587,13 @@ func TestResolveMentions(t *testing.T) {
 		},
 		{
 			name:     "unicode name mention",
-			input:    `<p>Hey @José, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("sgid-jose", "José García") + `, check this</p>`,
+			input:    `<div>Hey @José, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("sgid-jose", "José García") + `, check this</div>`,
 		},
 		{
 			name:     "mention inside code block is skipped",
-			input:    `<p>Use <code>@John</code> syntax</p>`,
-			expected: `<p>Use <code>@John</code> syntax</p>`,
+			input:    `<div>Use <code>@John</code> syntax</div>`,
+			expected: `<div>Use <code>@John</code> syntax</div>`,
 		},
 		{
 			name:     "mention inside pre block is skipped",
@@ -1606,41 +1613,41 @@ func TestResolveMentions(t *testing.T) {
 		// Expanded prefix tests
 		{
 			name:     "mention after open paren",
-			input:    `<p>(@John) check this</p>`,
-			expected: `<p>(` + MentionToHTML("sgid-john", "John Doe") + `) check this</p>`,
+			input:    `<div>(@John) check this</div>`,
+			expected: `<div>(` + MentionToHTML("sgid-john", "John Doe") + `) check this</div>`,
 		},
 		{
 			name:     "mention after open bracket",
-			input:    `<p>[@John] check this</p>`,
-			expected: `<p>[` + MentionToHTML("sgid-john", "John Doe") + `] check this</p>`,
+			input:    `<div>[@John] check this</div>`,
+			expected: `<div>[` + MentionToHTML("sgid-john", "John Doe") + `] check this</div>`,
 		},
 		{
 			name:     "mention after double quote",
-			input:    `<p>"@John" check this</p>`,
-			expected: `<p>"` + MentionToHTML("sgid-john", "John Doe") + `" check this</p>`,
+			input:    `<div>"@John" check this</div>`,
+			expected: `<div>"` + MentionToHTML("sgid-john", "John Doe") + `" check this</div>`,
 		},
 		{
 			name:     "mention after single quote",
-			input:    `<p>'@John' check this</p>`,
-			expected: `<p>'` + MentionToHTML("sgid-john", "John Doe") + `' check this</p>`,
+			input:    `<div>'@John' check this</div>`,
+			expected: `<div>'` + MentionToHTML("sgid-john", "John Doe") + `' check this</div>`,
 		},
 		// Trailing-character bailout tests
 		{
 			name:     "hyphen bailout",
-			input:    `<p>Hey @John-Doe</p>`,
-			expected: `<p>Hey @John-Doe</p>`,
+			input:    `<div>Hey @John-Doe</div>`,
+			expected: `<div>Hey @John-Doe</div>`,
 			wantErr:  false,
 		},
 		{
 			name:     "apostrophe letter bailout",
-			input:    `<p>Hey @John's stuff</p>`,
-			expected: `<p>Hey @John's stuff</p>`,
+			input:    `<div>Hey @John's stuff</div>`,
+			expected: `<div>Hey @John's stuff</div>`,
 			wantErr:  false,
 		},
 		{
 			name:     "apostrophe then non-letter is not bailout",
-			input:    `<p>'@John' said hi</p>`,
-			expected: `<p>'` + MentionToHTML("sgid-john", "John Doe") + `' said hi</p>`,
+			input:    `<div>'@John' said hi</div>`,
+			expected: `<div>'` + MentionToHTML("sgid-john", "John Doe") + `' said hi</div>`,
 		},
 		// Case-insensitive bc-attachment guard
 		{
@@ -1687,8 +1694,8 @@ func TestResolveMentions_MentionSGID(t *testing.T) {
 		},
 		{
 			name:     "mention in paragraph",
-			input:    `<p>Hey <a href="mention:BAh7CEkiCG">@Jane Smith</a>, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("BAh7CEkiCG", "Jane Smith") + `, check this</p>`,
+			input:    `<div>Hey <a href="mention:BAh7CEkiCG">@Jane Smith</a>, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("BAh7CEkiCG", "Jane Smith") + `, check this</div>`,
 		},
 		{
 			name:     "mention inside code block is skipped",
@@ -1760,8 +1767,8 @@ func TestResolveMentions_PersonID(t *testing.T) {
 		},
 		{
 			name:     "person scheme in paragraph",
-			input:    `<p>Hey <a href="person:42000">@Jane</a>, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("sgid-jane", "Jane Smith") + `, check this</p>`,
+			input:    `<div>Hey <a href="person:42000">@Jane</a>, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("sgid-jane", "Jane Smith") + `, check this</div>`,
 		},
 		{
 			name:    "person scheme — not pingable",
@@ -1802,8 +1809,8 @@ func TestResolveMentions_SGIDInline(t *testing.T) {
 	}{
 		{
 			name:     "sgid inline — direct embed",
-			input:    `<p>Hey @sgid:BAh7CEkiCG, check this</p>`,
-			expected: `<p>Hey ` + MentionToHTML("BAh7CEkiCG", "BAh7CEkiCG") + `, check this</p>`,
+			input:    `<div>Hey @sgid:BAh7CEkiCG, check this</div>`,
+			expected: `<div>Hey ` + MentionToHTML("BAh7CEkiCG", "BAh7CEkiCG") + `, check this</div>`,
 		},
 		{
 			name:     "sgid at start of line",
@@ -1812,8 +1819,8 @@ func TestResolveMentions_SGIDInline(t *testing.T) {
 		},
 		{
 			name:     "sgid with base64 chars",
-			input:    `<p>Hey @sgid:BAh7+CG/k=, check</p>`,
-			expected: `<p>Hey ` + MentionToHTML("BAh7+CG/k=", "BAh7+CG/k=") + `, check</p>`,
+			input:    `<div>Hey @sgid:BAh7+CG/k=, check</div>`,
+			expected: `<div>Hey ` + MentionToHTML("BAh7+CG/k=", "BAh7+CG/k=") + `, check</div>`,
 		},
 		{
 			name:     "sgid inside code is skipped",


### PR DESCRIPTION
## Summary

**Rebased onto current main.** The original three commits targeted the pre-#415 regex-based MarkdownToHTML pipeline, which #415 replaced with goldmark. This PR is now a single commit that re-implements the same Trix-compatibility goals on the goldmark architecture.

- **`<div>` instead of `<p>`** — Trix stores paragraphs as `<div>` blocks. goldmark's default `<p>` output renders in Basecamp with the block margins of `<p>` *plus* the intervening `<br>`, producing double spacing where the user typed a single blank line.
- **`<div><br></div>` for blank lines** — Trix's native empty-line shape, replacing the bare `<br>\n` the `TrixBreak` node previously emitted.
- **HTMLToMarkdown round-trip** — accept `<div>` and `<div><br></div>` on input so content authored in Basecamp parses cleanly back to Markdown (and so MarkdownToHTML's own output round-trips).

Before: `MarkdownToHTML("Line 1\n\nLine 2")` → `<p>Line 1</p>\n<br>\n<p>Line 2</p>` (double-spaced in Basecamp).

After: `MarkdownToHTML("Line 1\n\nLine 2")` → `<div>Line 1</div>\n<div><br></div>\n<div>Line 2</div>` (correct single spacing).

## Implementation notes

- `trixRenderer` now registers `renderParagraph` so top-level paragraphs become `<div>`. `trixTransformer` already converts paragraphs inside lists and blockquotes into `TextBlock` nodes, so the override only fires where it should — list/blockquote output is unchanged.
- `renderTrixBreak` emits `<div><br></div>\n` instead of `<br>\n`. `renderHTMLBlock`'s raw-HTML wrapper matches.
- HTMLToMarkdown gains `reDivBr` and `reDiv` passes running before the existing `<p>` pipeline, so documents containing either shape (or a mix) degrade cleanly.
- `blockquoteInnerToMarkdown` also handles `<div>` / `<div><br></div>`, otherwise the inner `<div><br></div>` cascades through the outer blockquote line-splitter and produces extra `>` lines. `TestEditLoopRoundTrip/multi-paragraph_blockquote` covers this.
- Inline `<br>` inside a paragraph (consecutive lines joined with a single `\n`) is unchanged — `trixTransformer`'s soft→hard break conversion keeps working, matching Trix's own representation.

## Test plan

- [x] All `TestMarkdownToHTML*` cases updated to the new `<div>` / `<div><br></div>` shape and green.
- [x] `TestEditLoopRoundTrip` round-trips including multi-paragraph blockquotes.
- [x] `TestResolveMentions*` inputs updated to `<div>` wrapper (representative of what MarkdownToHTML now emits and what Trix emits natively). Function behavior is input-shape-preserving so coverage is unchanged.
- [x] Cross-package: `TestCheckinsAnswerCreateDefaultsDateToToday` updated for `<div>` output.
- [x] `make fmt-check`, `go vet`, `golangci-lint` clean.
- [x] `go test ./...` full suite green.
- [x] End-to-end: posted a multi-paragraph comment via CLI, confirmed single-line paragraph spacing in Basecamp matches a hand-edited reference comment's HTML.