### PR TITLE
Preserve untouched document fields in files update

### DIFF
--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1218,8 +1218,28 @@ You can pass either an item ID or a Basecamp URL:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			titleChanged := cmd.Flags().Changed("title")
 			contentChanged := cmd.Flags().Changed("content")
-			if !titleChanged && !contentChanged {
-				return noChanges(cmd)
+			itemType = strings.ToLower(strings.TrimSpace(itemType))
+			switch itemType {
+			case "", "document", "doc":
+				if !titleChanged && !contentChanged {
+					return noChanges(cmd)
+				}
+			case "vault", "folder":
+				if contentChanged {
+					return output.ErrUsage("--content can only be used with --type document or upload")
+				}
+				if !titleChanged {
+					return noChanges(cmd)
+				}
+			case "upload", "file":
+				if !titleChanged && !contentChanged {
+					return noChanges(cmd)
+				}
+			default:
+				return output.ErrUsageHint(
+					fmt.Sprintf("Invalid type: %s", itemType),
+					"Use: vault, document, or upload",
+				)
 			}
 
 			app := appctx.FromContext(cmd.Context())

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1218,22 +1218,27 @@ You can pass either an item ID or a Basecamp URL:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			titleChanged := cmd.Flags().Changed("title")
 			contentChanged := cmd.Flags().Changed("content")
+			titleTrimmed := strings.TrimSpace(title)
+			contentTrimmed := strings.TrimSpace(content)
 			itemType = strings.ToLower(strings.TrimSpace(itemType))
 			switch itemType {
 			case "", "document", "doc":
-				if !titleChanged && !contentChanged {
+				// Explicit "" clears are valid for documents; whitespace-only is not.
+				hasTitle := titleChanged && (title == "" || titleTrimmed != "")
+				hasContent := contentChanged && (content == "" || contentTrimmed != "")
+				if !hasTitle && !hasContent {
 					return noChanges(cmd)
 				}
 			case "vault", "folder":
 				if contentChanged {
 					return output.ErrUsage("--content can only be used with --type document or upload")
 				}
-				if !titleChanged || title == "" {
+				if !titleChanged || titleTrimmed == "" {
 					return noChanges(cmd)
 				}
 			case "upload", "file":
-				hasTitle := titleChanged && title != ""
-				hasContent := contentChanged && content != ""
+				hasTitle := titleChanged && titleTrimmed != ""
+				hasContent := contentChanged && contentTrimmed != ""
 				if !hasTitle && !hasContent {
 					return noChanges(cmd)
 				}
@@ -1349,7 +1354,7 @@ You can pass either an item ID or a Basecamp URL:
 						if contentChanged {
 							return output.ErrUsage("detected a folder/vault; use --title to rename it")
 						}
-						if !titleChanged || title == "" {
+						if !titleChanged || titleTrimmed == "" {
 							return noChanges(cmd)
 						}
 						req := &basecamp.UpdateVaultRequest{Title: title}
@@ -1363,8 +1368,8 @@ You can pass either an item ID or a Basecamp URL:
 						// Try upload
 						_, err = app.Account().Uploads().Get(cmd.Context(), itemID)
 						if err == nil {
-							hasTitle := titleChanged && title != ""
-							hasContent := contentChanged && content != ""
+							hasTitle := titleChanged && titleTrimmed != ""
+							hasContent := contentChanged && contentTrimmed != ""
 							if !hasTitle && !hasContent {
 								return noChanges(cmd)
 							}

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1213,7 +1213,7 @@ For documents, updating only --title or only --content preserves the untouched f
 You can pass either an item ID or a Basecamp URL:
   basecamp files update 789 --title "new title" --in my-project
   basecamp files update 789 --content "new content" --in my-project`,
-		Annotations: map[string]string{"agent_notes": "Document updates preserve untouched title/content by fetching current state first because Basecamp API clears omitted fields on PUT."},
+		Annotations: map[string]string{"agent_notes": "Document updates preserve untouched title/content by fetching current state first because BC3 rebuilds documents from permitted params on PUT; explicit clears via --title \"\"/--content \"\" work because the SDK strips empty strings to absent fields, which the controller then nulls. Upload/vault updates do not clear by omission, so empty-valued flags are rejected CLI-side."},
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			titleChanged := cmd.Flags().Changed("title")
@@ -1228,11 +1228,13 @@ You can pass either an item ID or a Basecamp URL:
 				if contentChanged {
 					return output.ErrUsage("--content can only be used with --type document or upload")
 				}
-				if !titleChanged {
+				if !titleChanged || title == "" {
 					return noChanges(cmd)
 				}
 			case "upload", "file":
-				if !titleChanged && !contentChanged {
+				hasTitle := titleChanged && title != ""
+				hasContent := contentChanged && content != ""
+				if !hasTitle && !hasContent {
 					return noChanges(cmd)
 				}
 			default:
@@ -1347,6 +1349,9 @@ You can pass either an item ID or a Basecamp URL:
 						if contentChanged {
 							return output.ErrUsage("detected a folder/vault; use --title to rename it")
 						}
+						if !titleChanged || title == "" {
+							return noChanges(cmd)
+						}
 						req := &basecamp.UpdateVaultRequest{Title: title}
 						vault, err := app.Account().Vaults().Update(cmd.Context(), itemID, req)
 						if err != nil {
@@ -1358,6 +1363,11 @@ You can pass either an item ID or a Basecamp URL:
 						// Try upload
 						_, err = app.Account().Uploads().Get(cmd.Context(), itemID)
 						if err == nil {
+							hasTitle := titleChanged && title != ""
+							hasContent := contentChanged && content != ""
+							if !hasTitle && !hasContent {
+								return noChanges(cmd)
+							}
 							req := &basecamp.UpdateUploadRequest{Description: content}
 							if title != "" {
 								req.BaseName = title
@@ -1405,10 +1415,14 @@ You can pass either an item ID or a Basecamp URL:
 }
 
 func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, titleChanged, contentChanged bool, title, content string) (*basecamp.UpdateDocumentRequest, error) {
-	// Basecamp document updates are destructive PUTs: omitted title/content
-	// fields are replaced with empty values. Fetch and merge when the caller
-	// updates only one field so the untouched field is preserved, while still
-	// allowing explicit clears via --title "" or --content "".
+	// BC3 rebuilds documents from permitted params on PUT, so omitted
+	// title/content fields are replaced with empty values. Fetch and merge when
+	// the caller updates only one field so the untouched field is preserved.
+	//
+	// Explicit clears via --title "" or --content "" work by composition: the
+	// SDK strips empty strings to absent JSON fields, and the controller then
+	// nulls those absent fields during rebuild. The wire-shape assertion in
+	// TestFilesUpdateDocumentEmptyTitleClearsWhilePreservingContent pins this.
 	if existingDoc == nil && (!titleChanged || !contentChanged) {
 		var err error
 		existingDoc, err = app.Account().Documents().Get(cmd.Context(), itemID)

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1344,6 +1344,9 @@ You can pass either an item ID or a Basecamp URL:
 					// Try vault
 					_, err = app.Account().Vaults().Get(cmd.Context(), itemID)
 					if err == nil {
+						if contentChanged {
+							return output.ErrUsage("detected a folder/vault; use --title to rename it")
+						}
 						req := &basecamp.UpdateVaultRequest{Title: title}
 						vault, err := app.Account().Vaults().Update(cmd.Context(), itemID, req)
 						if err != nil {

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1220,26 +1220,28 @@ You can pass either an item ID or a Basecamp URL:
 			contentChanged := cmd.Flags().Changed("content")
 			titleTrimmed := strings.TrimSpace(title)
 			contentTrimmed := strings.TrimSpace(content)
+			// Effective-set booleans drive both the no-op gate and the request
+			// builders so whitespace-only values never reach the wire.
+			// Documents accept exact "" as an explicit clear; uploads/vaults do not.
+			docTitleSet := titleChanged && (title == "" || titleTrimmed != "")
+			docContentSet := contentChanged && (content == "" || contentTrimmed != "")
+			nonDocTitleSet := titleChanged && titleTrimmed != ""
+			nonDocContentSet := contentChanged && contentTrimmed != ""
 			itemType = strings.ToLower(strings.TrimSpace(itemType))
 			switch itemType {
 			case "", "document", "doc":
-				// Explicit "" clears are valid for documents; whitespace-only is not.
-				hasTitle := titleChanged && (title == "" || titleTrimmed != "")
-				hasContent := contentChanged && (content == "" || contentTrimmed != "")
-				if !hasTitle && !hasContent {
+				if !docTitleSet && !docContentSet {
 					return noChanges(cmd)
 				}
 			case "vault", "folder":
 				if contentChanged {
 					return output.ErrUsage("--content can only be used with --type document or upload")
 				}
-				if !titleChanged || titleTrimmed == "" {
+				if !nonDocTitleSet {
 					return noChanges(cmd)
 				}
 			case "upload", "file":
-				hasTitle := titleChanged && titleTrimmed != ""
-				hasContent := contentChanged && contentTrimmed != ""
-				if !hasTitle && !hasContent {
+				if !nonDocTitleSet && !nonDocContentSet {
 					return noChanges(cmd)
 				}
 			default:
@@ -1301,7 +1303,7 @@ You can pass either an item ID or a Basecamp URL:
 					result = vault
 					detectedType = "vault"
 				case "document", "doc":
-					req, err := buildDocumentUpdateRequest(cmd, app, itemID, nil, titleChanged, contentChanged, title, content)
+					req, err := buildDocumentUpdateRequest(cmd, app, itemID, nil, docTitleSet, docContentSet, title, content)
 					if err != nil {
 						return convertSDKError(err)
 					}
@@ -1312,9 +1314,12 @@ You can pass either an item ID or a Basecamp URL:
 					result = doc
 					detectedType = "document"
 				case "upload", "file":
-					req := &basecamp.UpdateUploadRequest{Description: content}
-					if title != "" {
+					req := &basecamp.UpdateUploadRequest{}
+					if nonDocTitleSet {
 						req.BaseName = title
+					}
+					if nonDocContentSet {
+						req.Description = content
 					}
 					upload, err := app.Account().Uploads().Update(cmd.Context(), itemID, req)
 					if err != nil {
@@ -1336,7 +1341,7 @@ You can pass either an item ID or a Basecamp URL:
 				// Try document first (most common update case)
 				existingDoc, err := app.Account().Documents().Get(cmd.Context(), itemID)
 				if err == nil {
-					req, buildErr := buildDocumentUpdateRequest(cmd, app, itemID, existingDoc, titleChanged, contentChanged, title, content)
+					req, buildErr := buildDocumentUpdateRequest(cmd, app, itemID, existingDoc, docTitleSet, docContentSet, title, content)
 					if buildErr != nil {
 						return convertSDKError(buildErr)
 					}
@@ -1354,7 +1359,7 @@ You can pass either an item ID or a Basecamp URL:
 						if contentChanged {
 							return output.ErrUsage("detected a folder/vault; use --title to rename it")
 						}
-						if !titleChanged || titleTrimmed == "" {
+						if !nonDocTitleSet {
 							return noChanges(cmd)
 						}
 						req := &basecamp.UpdateVaultRequest{Title: title}
@@ -1368,14 +1373,15 @@ You can pass either an item ID or a Basecamp URL:
 						// Try upload
 						_, err = app.Account().Uploads().Get(cmd.Context(), itemID)
 						if err == nil {
-							hasTitle := titleChanged && titleTrimmed != ""
-							hasContent := contentChanged && contentTrimmed != ""
-							if !hasTitle && !hasContent {
+							if !nonDocTitleSet && !nonDocContentSet {
 								return noChanges(cmd)
 							}
-							req := &basecamp.UpdateUploadRequest{Description: content}
-							if title != "" {
+							req := &basecamp.UpdateUploadRequest{}
+							if nonDocTitleSet {
 								req.BaseName = title
+							}
+							if nonDocContentSet {
+								req.Description = content
 							}
 							upload, err := app.Account().Uploads().Update(cmd.Context(), itemID, req)
 							if err != nil {
@@ -1419,7 +1425,7 @@ You can pass either an item ID or a Basecamp URL:
 	return cmd
 }
 
-func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, titleChanged, contentChanged bool, title, content string) (*basecamp.UpdateDocumentRequest, error) {
+func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, setTitle, setContent bool, title, content string) (*basecamp.UpdateDocumentRequest, error) {
 	// BC3 rebuilds documents from permitted params on PUT, so omitted
 	// title/content fields are replaced with empty values. Fetch and merge when
 	// the caller updates only one field so the untouched field is preserved.
@@ -1428,7 +1434,12 @@ func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int6
 	// SDK strips empty strings to absent JSON fields, and the controller then
 	// nulls those absent fields during rebuild. The wire-shape assertion in
 	// TestFilesUpdateDocumentEmptyTitleClearsWhilePreservingContent pins this.
-	if existingDoc == nil && (!titleChanged || !contentChanged) {
+	//
+	// setTitle/setContent are caller-computed effective flags: they're true when
+	// the user provided either a non-whitespace value or an explicit empty
+	// string. Whitespace-only values arrive as setTitle=false/setContent=false
+	// so the existing field is preserved.
+	if existingDoc == nil && (!setTitle || !setContent) {
 		var err error
 		existingDoc, err = app.Account().Documents().Get(cmd.Context(), itemID)
 		if err != nil {
@@ -1442,10 +1453,10 @@ func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int6
 		req.Content = existingDoc.Content
 	}
 
-	if titleChanged {
+	if setTitle {
 		req.Title = title
 	}
-	if contentChanged {
+	if setContent {
 		if content == "" {
 			req.Content = ""
 			return req, nil

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1208,10 +1208,13 @@ func newFilesUpdateCmd(project *string) *cobra.Command {
 		Short: "Update a document, vault, or upload",
 		Long: `Update a document, vault, or upload.
 
+For documents, updating only --title or only --content preserves the untouched field.
+
 You can pass either an item ID or a Basecamp URL:
   basecamp files update 789 --title "new title" --in my-project
   basecamp files update 789 --content "new content" --in my-project`,
-		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{"agent_notes": "Document updates preserve untouched title/content by fetching current state first because Basecamp API clears omitted fields on PUT."},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if strings.TrimSpace(title) == "" && strings.TrimSpace(content) == "" && itemType == "" {
 				return noChanges(cmd)
@@ -1269,12 +1272,10 @@ You can pass either an item ID or a Basecamp URL:
 					result = vault
 					detectedType = "vault"
 				case "document", "doc":
-					docHTML := richtext.MarkdownToHTML(content)
-					docHTML, err = resolveLocalImages(cmd, app, docHTML)
+					req, err := buildDocumentUpdateRequest(cmd, app, itemID, nil, title, content)
 					if err != nil {
-						return err
+						return convertSDKError(err)
 					}
-					req := &basecamp.UpdateDocumentRequest{Title: title, Content: docHTML}
 					doc, err := app.Account().Documents().Update(cmd.Context(), itemID, req)
 					if err != nil {
 						return convertSDKError(err)
@@ -1304,14 +1305,12 @@ You can pass either an item ID or a Basecamp URL:
 				var firstErr error
 
 				// Try document first (most common update case)
-				_, err := app.Account().Documents().Get(cmd.Context(), itemID)
+				existingDoc, err := app.Account().Documents().Get(cmd.Context(), itemID)
 				if err == nil {
-					docHTML := richtext.MarkdownToHTML(content)
-					docHTML, resolveErr := resolveLocalImages(cmd, app, docHTML)
-					if resolveErr != nil {
-						return resolveErr
+					req, buildErr := buildDocumentUpdateRequest(cmd, app, itemID, existingDoc, title, content)
+					if buildErr != nil {
+						return convertSDKError(buildErr)
 					}
-					req := &basecamp.UpdateDocumentRequest{Title: title, Content: docHTML}
 					doc, err := app.Account().Documents().Update(cmd.Context(), itemID, req)
 					if err != nil {
 						return convertSDKError(err)
@@ -1378,6 +1377,40 @@ You can pass either an item ID or a Basecamp URL:
 	cmd.Flags().StringVar(&itemType, "type", "", "Item type (vault, document, upload)")
 
 	return cmd
+}
+
+func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, title, content string) (*basecamp.UpdateDocumentRequest, error) {
+	// BC3 document updates are destructive PUTs: omitted title/content fields are
+	// replaced with empty values. Fetch and merge when the caller only updates
+	// one field so untouched content is preserved.
+	if existingDoc == nil && (title == "" || content == "") {
+		var err error
+		existingDoc, err = app.Account().Documents().Get(cmd.Context(), itemID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req := &basecamp.UpdateDocumentRequest{}
+	if existingDoc != nil {
+		req.Title = existingDoc.Title
+		req.Content = existingDoc.Content
+	}
+
+	if title != "" {
+		req.Title = title
+	}
+	if content != "" {
+		docHTML := richtext.MarkdownToHTML(content)
+		var err error
+		docHTML, err = resolveLocalImages(cmd, app, docHTML)
+		if err != nil {
+			return nil, err
+		}
+		req.Content = docHTML
+	}
+
+	return req, nil
 }
 
 func newFilesDownloadCmd(project *string) *cobra.Command {

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1216,7 +1216,9 @@ You can pass either an item ID or a Basecamp URL:
 		Annotations: map[string]string{"agent_notes": "Document updates preserve untouched title/content by fetching current state first because Basecamp API clears omitted fields on PUT."},
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(title) == "" && strings.TrimSpace(content) == "" && itemType == "" {
+			titleChanged := cmd.Flags().Changed("title")
+			contentChanged := cmd.Flags().Changed("content")
+			if !titleChanged && !contentChanged {
 				return noChanges(cmd)
 			}
 
@@ -1272,7 +1274,7 @@ You can pass either an item ID or a Basecamp URL:
 					result = vault
 					detectedType = "vault"
 				case "document", "doc":
-					req, err := buildDocumentUpdateRequest(cmd, app, itemID, nil, title, content)
+					req, err := buildDocumentUpdateRequest(cmd, app, itemID, nil, titleChanged, contentChanged, title, content)
 					if err != nil {
 						return convertSDKError(err)
 					}
@@ -1307,7 +1309,7 @@ You can pass either an item ID or a Basecamp URL:
 				// Try document first (most common update case)
 				existingDoc, err := app.Account().Documents().Get(cmd.Context(), itemID)
 				if err == nil {
-					req, buildErr := buildDocumentUpdateRequest(cmd, app, itemID, existingDoc, title, content)
+					req, buildErr := buildDocumentUpdateRequest(cmd, app, itemID, existingDoc, titleChanged, contentChanged, title, content)
 					if buildErr != nil {
 						return convertSDKError(buildErr)
 					}
@@ -1379,11 +1381,12 @@ You can pass either an item ID or a Basecamp URL:
 	return cmd
 }
 
-func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, title, content string) (*basecamp.UpdateDocumentRequest, error) {
-	// BC3 document updates are destructive PUTs: omitted title/content fields are
-	// replaced with empty values. Fetch and merge when the caller only updates
-	// one field so untouched content is preserved.
-	if existingDoc == nil && (title == "" || content == "") {
+func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int64, existingDoc *basecamp.Document, titleChanged, contentChanged bool, title, content string) (*basecamp.UpdateDocumentRequest, error) {
+	// Basecamp document updates are destructive PUTs: omitted title/content
+	// fields are replaced with empty values. Fetch and merge when the caller
+	// updates only one field so the untouched field is preserved, while still
+	// allowing explicit clears via --title "" or --content "".
+	if existingDoc == nil && (!titleChanged || !contentChanged) {
 		var err error
 		existingDoc, err = app.Account().Documents().Get(cmd.Context(), itemID)
 		if err != nil {
@@ -1397,10 +1400,14 @@ func buildDocumentUpdateRequest(cmd *cobra.Command, app *appctx.App, itemID int6
 		req.Content = existingDoc.Content
 	}
 
-	if title != "" {
+	if titleChanged {
 		req.Title = title
 	}
-	if content != "" {
+	if contentChanged {
+		if content == "" {
+			req.Content = ""
+			return req, nil
+		}
 		docHTML := richtext.MarkdownToHTML(content)
 		var err error
 		docHTML, err = resolveLocalImages(cmd, app, docHTML)

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -468,3 +468,102 @@ func TestFilesUpdateTypedDocumentWhitespaceTitleNoChanges(t *testing.T) {
 	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document", "--title", "   ")
 	assert.NoError(t, err)
 }
+
+// TestFilesUpdateDocumentRealTitleWhitespaceContentPreservesExistingContent verifies
+// that a real --title paired with whitespace-only --content writes only the title
+// and preserves existing content (whitespace doesn't reach the wire).
+func TestFilesUpdateDocumentRealTitleWhitespaceContentPreservesExistingContent(t *testing.T) {
+	transport := &mockFilesUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document", "--title", "Updated title", "--content", "   ")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Updated title", body["title"])
+	assert.Equal(t, "<div>Existing body</div>", body["content"])
+}
+
+// mockFilesUploadUpdateTransport supports typed --type upload PUTs; captures the body.
+type mockFilesUploadUpdateTransport struct {
+	capturedBody []byte
+}
+
+func (t *mockFilesUploadUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/projects.json"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":456,"name":"Test Project"}]`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/uploads/999"):
+		if req.Body != nil {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, fmt.Errorf("reading request body: %w", err)
+			}
+			t.capturedBody = body
+			_ = req.Body.Close()
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"id":999,"filename":"report.pdf"}`)),
+			Header:     header,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+	}
+}
+
+// TestFilesUpdateUploadRealTitleWhitespaceContentSendsOnlyBaseName verifies that a
+// real --title paired with whitespace-only --content sends only base_name on the
+// wire (no description), so whitespace doesn't overwrite the existing description.
+func TestFilesUpdateUploadRealTitleWhitespaceContentSendsOnlyBaseName(t *testing.T) {
+	transport := &mockFilesUploadUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "upload", "--title", "report.pdf", "--content", "   ")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "report.pdf", body["base_name"])
+	_, hasDescription := body["description"]
+	assert.False(t, hasDescription, "description must not be sent for whitespace-only --content")
+}
+
+// TestFilesUpdateUploadWhitespaceTitleRealContentSendsOnlyDescription verifies the
+// inverse: whitespace --title paired with real --content sends only description.
+func TestFilesUpdateUploadWhitespaceTitleRealContentSendsOnlyDescription(t *testing.T) {
+	transport := &mockFilesUploadUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "upload", "--title", "   ", "--content", "Quarterly report")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Quarterly report", body["description"])
+	_, hasBaseName := body["base_name"]
+	assert.False(t, hasBaseName, "base_name must not be sent for whitespace-only --title")
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -313,3 +313,48 @@ func TestFilesUpdateVaultWithoutTitleShowsHelp(t *testing.T) {
 	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "vault")
 	assert.NoError(t, err)
 }
+
+type mockFilesAutodetectVaultTransport struct{}
+
+func (t *mockFilesAutodetectVaultTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/projects.json"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":456,"name":"Test Project"}]`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/documents/999"):
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/vaults/999"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"id":999,"title":"Existing folder"}`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodPut:
+		return nil, fmt.Errorf("unexpected update request: %s", req.URL.Path)
+	default:
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+	}
+}
+
+func TestFilesUpdateAutodetectVaultRejectsContentOnly(t *testing.T) {
+	app := showTestApp(t, &mockFilesAutodetectVaultTransport{})
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--content", "desc")
+	require.Error(t, err)
+
+	var e *output.Error
+	require.True(t, errors.As(err, &e), "expected *output.Error, got %T: %v", err, err)
+	assert.Contains(t, e.Message, "detected a folder/vault; use --title to rename it")
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -441,3 +441,30 @@ func TestFilesUpdateAutodetectUploadEmptyContentNoChanges(t *testing.T) {
 	err := executeMessagesCommand(cmd, app, "update", "999", "--content", "")
 	assert.NoError(t, err)
 }
+
+func TestFilesUpdateTypedVaultWhitespaceTitleNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "vault", "--title", "   ")
+	assert.NoError(t, err)
+}
+
+func TestFilesUpdateTypedUploadWhitespaceContentNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "upload", "--content", "   ")
+	assert.NoError(t, err)
+}
+
+func TestFilesUpdateTypedDocumentWhitespaceTitleNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document", "--title", "   ")
+	assert.NoError(t, err)
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -244,3 +244,50 @@ func TestFilesUpdateDocumentContentPreservesExistingTitle(t *testing.T) {
 	assert.Equal(t, "Existing title", body["title"])
 	assert.Equal(t, "<p>Updated <strong>body</strong></p>", body["content"])
 }
+
+func TestFilesUpdateDocumentEmptyTitleClearsWhilePreservingContent(t *testing.T) {
+	transport := &mockFilesUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document", "--title", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	_, hasTitle := body["title"]
+	assert.False(t, hasTitle)
+	assert.Equal(t, "<div>Existing body</div>", body["content"])
+}
+
+func TestFilesUpdateDocumentEmptyContentClearsWhilePreservingTitle(t *testing.T) {
+	transport := &mockFilesUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--content", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Existing title", body["title"])
+	_, hasContent := body["content"]
+	assert.False(t, hasContent)
+}
+
+func TestFilesUpdateTypeWithoutChangesShowsHelp(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document")
+	assert.NoError(t, err)
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -291,3 +291,25 @@ func TestFilesUpdateTypeWithoutChangesShowsHelp(t *testing.T) {
 	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document")
 	assert.NoError(t, err)
 }
+
+func TestFilesUpdateVaultRejectsContentFlag(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "vault", "--content", "desc")
+	require.Error(t, err)
+
+	var e *output.Error
+	require.True(t, errors.As(err, &e), "expected *output.Error, got %T: %v", err, err)
+	assert.Contains(t, e.Message, "--content can only be used with --type document or upload")
+}
+
+func TestFilesUpdateVaultWithoutTitleShowsHelp(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "vault")
+	assert.NoError(t, err)
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -358,3 +358,86 @@ func TestFilesUpdateAutodetectVaultRejectsContentOnly(t *testing.T) {
 	require.True(t, errors.As(err, &e), "expected *output.Error, got %T: %v", err, err)
 	assert.Contains(t, e.Message, "detected a folder/vault; use --title to rename it")
 }
+
+func TestFilesUpdateTypedVaultEmptyTitleNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "vault", "--title", "")
+	assert.NoError(t, err)
+}
+
+func TestFilesUpdateTypedUploadEmptyTitleNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "upload", "--title", "")
+	assert.NoError(t, err)
+}
+
+func TestFilesUpdateTypedUploadEmptyContentNoChanges(t *testing.T) {
+	app, _ := setupMessagesTestApp(t)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "upload", "--content", "")
+	assert.NoError(t, err)
+}
+
+func TestFilesUpdateAutodetectVaultEmptyTitleNoChanges(t *testing.T) {
+	app := showTestApp(t, &mockFilesAutodetectVaultTransport{})
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--title", "")
+	assert.NoError(t, err)
+}
+
+type mockFilesAutodetectUploadTransport struct{}
+
+func (t *mockFilesAutodetectUploadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/projects.json"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":456,"name":"Test Project"}]`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/documents/999"):
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/vaults/999"):
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/uploads/999"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"id":999,"filename":"report.pdf"}`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodPut:
+		return nil, fmt.Errorf("unexpected update request: %s", req.URL.Path)
+	default:
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+	}
+}
+
+func TestFilesUpdateAutodetectUploadEmptyContentNoChanges(t *testing.T) {
+	app := showTestApp(t, &mockFilesAutodetectUploadTransport{})
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--content", "")
+	assert.NoError(t, err)
+}

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -3,7 +3,11 @@ package commands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -156,4 +160,87 @@ func TestFilesDownloadStdoutStreamsUploadID(t *testing.T) {
 
 	assert.Equal(t, fileContent, stdout.String(),
 		"upload body should be streamed directly to stdout")
+}
+
+type mockFilesUpdateTransport struct {
+	capturedBody []byte
+	requests     []string
+}
+
+func (t *mockFilesUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.requests = append(t.requests, req.Method+" "+req.URL.Path)
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	switch {
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/projects.json"):
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`[{"id":456,"name":"Test Project"}]`)),
+			Header:     header,
+		}, nil
+	case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/documents/999"):
+		return &http.Response{
+			StatusCode: 200,
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":999,"title":"Existing title","content":"<div>Existing body</div>","status":"active","bucket":{"id":456,"name":"Test Project","type":"Project"}}`,
+			)),
+			Header: header,
+		}, nil
+	case req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/documents/999"):
+		if req.Body != nil {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, fmt.Errorf("reading request body: %w", err)
+			}
+			t.capturedBody = body
+			_ = req.Body.Close()
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":999,"title":"Updated title","content":"<div>Existing body</div>","status":"active","bucket":{"id":456,"name":"Test Project","type":"Project"}}`,
+			)),
+			Header: header,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+	}
+}
+
+func TestFilesUpdateDocumentTitlePreservesExistingContent(t *testing.T) {
+	transport := &mockFilesUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--type", "document", "--title", "Updated title")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Updated title", body["title"])
+	assert.Equal(t, "<div>Existing body</div>", body["content"])
+}
+
+func TestFilesUpdateDocumentContentPreservesExistingTitle(t *testing.T) {
+	transport := &mockFilesUpdateTransport{}
+	app := showTestApp(t, transport)
+	app.Config.ProjectID = "456"
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "update", "999", "--content", "Updated **body**")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Existing title", body["title"])
+	assert.Equal(t, "<p>Updated <strong>body</strong></p>", body["content"])
 }

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -533,7 +533,11 @@ basecamp files doc create "Doc" "Body" --in <project>
 basecamp files doc create "Draft" --draft --in <project>
 basecamp files doc create "Notes" "..." --no-subscribe --in <project>
 basecamp files update <id> --title "New" --content "Updated"
+basecamp files update <id> --title "New" --in <project>      # Preserves existing document content
+basecamp files update <id> --content "Updated" --in <project> # Preserves existing document title
 ```
+
+**Document update semantics:** `basecamp files update <document_id>` is safe for partial updates in the CLI: when you pass only `--title` or only `--content`, the CLI first fetches the current document and preserves the untouched field.
 
 **Subcommands:** `folders`, `uploads`, `documents` (each with pagination flags)
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -532,9 +532,9 @@ basecamp files folder create "Folder" --in <project>
 basecamp files doc create "Doc" "Body" --in <project>
 basecamp files doc create "Draft" --draft --in <project>
 basecamp files doc create "Notes" "..." --no-subscribe --in <project>
-basecamp files update <id> --title "New" --content "Updated"
-basecamp files update <id> --title "New" --in <project>      # Preserves existing document content
-basecamp files update <id> --content "Updated" --in <project> # Preserves existing document title
+basecamp files update <document_id> --title "New" --content "Updated"
+basecamp files update <document_id> --title "New" --in <project>      # Preserves existing document content
+basecamp files update <document_id> --content "Updated" --in <project> # Preserves existing document title
 ```
 
 **Document update semantics:** `basecamp files update <document_id>` is safe for partial updates in the CLI: when you pass only `--title` or only `--content`, the CLI first fetches the current document and preserves the untouched field.


### PR DESCRIPTION
## Summary

Fixes a data-loss hazard in `basecamp files update` for documents. When callers updated only `--title` or only `--content`, the untouched field could be cleared because document updates are backed by a destructive PUT-style API contract. The CLI now fetches the current document first and preserves the existing title/content before applying the requested change, so partial document updates behave the way users and agents expect.

Ref: https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9805158815

Also adds regression coverage for title-only and content-only document updates, and updates the Basecamp skill/docs to make the safer partial-update behavior explicit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss in `basecamp files update` for documents and blocks invalid/no-op updates for vaults and uploads. Preserves untouched doc fields on partial updates and filters whitespace-only values so they never reach the API; exact-empty clears remain document-only.

- **Bug Fixes**
  - Documents: fetch and merge existing title/content for partial updates; respect `--title ""` / `--content ""` clears; ignore whitespace-only values; convert Markdown and resolve local images only when content actually changes.
  - Validation/no-ops: for documents, `""` clears while whitespace-only is a no-op; for `vault`/`folder` and `upload`, empty or whitespace-only `--title`/`--content` are no-ops; `--content` for vault is disallowed. Autodetect applies the same rules (e.g., content-only against a vault errors).
  - Safety: require a real change per type and skip sending unset fields so whitespace doesn’t hit the wire; show a no-op message when nothing changes. Added tests and updated help text and `skills/basecamp/SKILL.md`.

<sup>Written for commit 37e6be7e52d853d522b22576b168a0d7820f5543. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



