### PR TITLE
Surface failing request IDs in CLI errors

### DIFF
--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -98,7 +98,7 @@ func newAPIPostCmd() *cobra.Command {
 
 			resp, err := app.Account().Post(cmd.Context(), path, body)
 			if err != nil {
-				return err
+				return convertSDKError(err)
 			}
 
 			summary := fmt.Sprintf("POST %s: %s", path, apiSummary(resp.Data))
@@ -147,7 +147,7 @@ func newAPIPutCmd() *cobra.Command {
 
 			resp, err := app.Account().Put(cmd.Context(), path, body)
 			if err != nil {
-				return err
+				return convertSDKError(err)
 			}
 
 			summary := fmt.Sprintf("PUT %s: %s", path, apiSummary(resp.Data))
@@ -179,7 +179,7 @@ func newAPIDeleteCmd() *cobra.Command {
 			path := parsePath(args[0])
 			resp, err := app.Account().Delete(cmd.Context(), path)
 			if err != nil {
-				return err
+				return convertSDKError(err)
 			}
 
 			summary := fmt.Sprintf("DELETE %s", path)

--- a/internal/commands/api_test.go
+++ b/internal/commands/api_test.go
@@ -1,11 +1,15 @@
 package commands
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/output"
 )
 
 func TestParsePath(t *testing.T) {
@@ -46,4 +50,23 @@ func TestAPIPathArgs(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path required")
 	})
+}
+
+func TestConvertSDKErrorPreservesRequestID(t *testing.T) {
+	sdkErr := &basecamp.Error{
+		Code:       basecamp.CodeAPI,
+		Message:    "server error",
+		HTTPStatus: 500,
+		RequestID:  "req-cli-123",
+	}
+
+	err := convertSDKError(sdkErr)
+
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr), "expected *output.Error, got %T", err)
+	assert.Equal(t, output.CodeAPI, outErr.Code)
+
+	var gotSDK *basecamp.Error
+	require.True(t, errors.As(err, &gotSDK), "expected wrapped *basecamp.Error, got %T", err)
+	assert.Equal(t, "req-cli-123", gotSDK.RequestID)
 }

--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -445,6 +445,7 @@ func convertSDKError(err error) error {
 			Hint:       sdkErr.Hint,
 			HTTPStatus: sdkErr.HTTPStatus,
 			Retryable:  sdkErr.Retryable,
+			Cause:      sdkErr,
 		}
 	}
 	return err

--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -453,6 +453,7 @@ func convertSDKError(err error) error {
 			Hint:       sdkErr.Hint,
 			HTTPStatus: sdkErr.HTTPStatus,
 			Retryable:  sdkErr.Retryable,
+			Cause:      sdkErr,
 		}
 	}
 	return err

--- a/internal/names/resolver.go
+++ b/internal/names/resolver.go
@@ -724,6 +724,7 @@ func convertSDKError(err error) error {
 			Hint:       sdkErr.Hint,
 			HTTPStatus: sdkErr.HTTPStatus,
 			Retryable:  sdkErr.Retryable,
+			Cause:      sdkErr,
 		}
 	}
 	return err

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -158,7 +158,10 @@ func (w *Writer) Err(err error, opts ...ErrorResponseOption) error {
 		Hint:  e.Hint,
 	}
 	if requestID := RequestID(err); requestID != "" {
-		resp.Meta = map[string]any{"request_id": requestID}
+		if resp.Meta == nil {
+			resp.Meta = make(map[string]any)
+		}
+		resp.Meta["request_id"] = requestID
 	}
 	for _, opt := range opts {
 		opt(resp)

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -157,6 +157,9 @@ func (w *Writer) Err(err error, opts ...ErrorResponseOption) error {
 		Code:  e.Code,
 		Hint:  e.Hint,
 	}
+	if requestID := RequestID(err); requestID != "" {
+		resp.Meta = map[string]any{"request_id": requestID}
+	}
 	for _, opt := range opts {
 		opt(resp)
 	}

--- a/internal/output/errors.go
+++ b/internal/output/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 	clioutput "github.com/basecamp/cli/output"
 )
 
@@ -29,7 +30,30 @@ func ErrAPI(status int, msg string) *Error { return clioutput.ErrAPI(status, msg
 func ErrAmbiguous(resource string, matches []string) *Error {
 	return clioutput.ErrAmbiguous(resource, matches)
 }
-func AsError(err error) *Error { return clioutput.AsError(err) }
+
+func AsError(err error) *Error {
+	var sdkErr *basecamp.Error
+	if errors.As(err, &sdkErr) {
+		return &Error{
+			Code:       sdkErr.Code,
+			Message:    sdkErr.Message,
+			Hint:       sdkErr.Hint,
+			HTTPStatus: sdkErr.HTTPStatus,
+			Retryable:  sdkErr.Retryable,
+			Cause:      sdkErr,
+		}
+	}
+	return clioutput.AsError(err)
+}
+
+// RequestID returns the SDK request ID carried by err, if present.
+func RequestID(err error) string {
+	var sdkErr *basecamp.Error
+	if errors.As(err, &sdkErr) {
+		return sdkErr.RequestID
+	}
+	return ""
+}
 
 // App-specific error constructors with basecamp-cli hints.
 

--- a/internal/output/errors.go
+++ b/internal/output/errors.go
@@ -34,9 +34,16 @@ func ErrAmbiguous(resource string, matches []string) *Error {
 func AsError(err error) *Error {
 	var sdkErr *basecamp.Error
 	if errors.As(err, &sdkErr) {
+		message := err.Error()
+		if sdkErr.Hint != "" {
+			message = strings.TrimSuffix(message, ": "+sdkErr.Hint)
+		}
+		if message == "" {
+			message = sdkErr.Message
+		}
 		return &Error{
 			Code:       sdkErr.Code,
-			Message:    sdkErr.Message,
+			Message:    message,
 			Hint:       sdkErr.Hint,
 			HTTPStatus: sdkErr.HTTPStatus,
 			Retryable:  sdkErr.Retryable,

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+
 	"github.com/basecamp/basecamp-cli/internal/observability"
 )
 
@@ -420,6 +422,30 @@ func TestWriterErr(t *testing.T) {
 
 	assert.False(t, resp.OK)
 	assert.Equal(t, CodeNotFound, resp.Code)
+}
+
+func TestWriterErrIncludesRequestIDMeta(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(Options{
+		Format: FormatJSON,
+		Writer: &buf,
+	})
+
+	err := w.Err(&basecamp.Error{
+		Code:       basecamp.CodeAPI,
+		Message:    "server error",
+		HTTPStatus: 500,
+		RequestID:  "req-cli-123",
+	})
+	require.NoError(t, err, "Err() failed")
+
+	var resp ErrorResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp), "Failed to unmarshal output")
+
+	assert.False(t, resp.OK)
+	assert.Equal(t, CodeAPI, resp.Code)
+	require.NotNil(t, resp.Meta)
+	assert.Equal(t, "req-cli-123", resp.Meta["request_id"])
 }
 
 func TestWriterQuietFormat(t *testing.T) {
@@ -2211,6 +2237,44 @@ func TestWriterStyledErrorWithHint(t *testing.T) {
 	assert.Contains(t, output, "basecamp projects")
 	// Should have ANSI codes (styled output)
 	assert.Contains(t, output, "\x1b[", "Expected ANSI escape codes in styled output")
+}
+
+func TestWriterStyledErrorIncludesRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(Options{
+		Format: FormatStyled,
+		Writer: &buf,
+	})
+
+	writeErr := w.Err(&basecamp.Error{
+		Code:       basecamp.CodeAPI,
+		Message:    "server error",
+		HTTPStatus: 500,
+		RequestID:  "req-cli-123",
+	})
+	require.NoError(t, writeErr, "Err() failed")
+
+	output := buf.String()
+	assert.Contains(t, output, "Request ID: req-cli-123")
+}
+
+func TestWriterMarkdownErrorIncludesRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	w := New(Options{
+		Format: FormatMarkdown,
+		Writer: &buf,
+	})
+
+	writeErr := w.Err(&basecamp.Error{
+		Code:       basecamp.CodeAPI,
+		Message:    "server error",
+		HTTPStatus: 500,
+		RequestID:  "req-cli-123",
+	})
+	require.NoError(t, writeErr, "Err() failed")
+
+	output := buf.String()
+	assert.Contains(t, output, "Request ID: req-cli-123")
 }
 
 // =============================================================================

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -325,6 +325,23 @@ func TestAsErrorWithWrappedOutputError(t *testing.T) {
 	assert.Equal(t, CodeAuth, result.Code)
 }
 
+func TestAsErrorWithWrappedSDKErrorPreservesContext(t *testing.T) {
+	original := &basecamp.Error{
+		Code:       basecamp.CodeForbidden,
+		Message:    "access denied",
+		Hint:       "retry later",
+		HTTPStatus: 403,
+		RequestID:  "req-cli-123",
+	}
+	wrapped := fmt.Errorf("GET /projects.json: %w", original)
+
+	result := AsError(wrapped)
+	assert.Equal(t, CodeForbidden, result.Code)
+	assert.Equal(t, "GET /projects.json: access denied", result.Message)
+	assert.Equal(t, "retry later", result.Hint)
+	assert.Equal(t, original, result.Cause)
+}
+
 // Note: AsError(nil) panics because it calls err.Error() on nil.
 // This is expected behavior - callers should not pass nil to AsError.
 
@@ -2250,12 +2267,13 @@ func TestWriterStyledErrorIncludesRequestID(t *testing.T) {
 		Code:       basecamp.CodeAPI,
 		Message:    "server error",
 		HTTPStatus: 500,
-		RequestID:  "req-cli-123",
+		RequestID:  "req-cli-123\x1b[31m\nnext",
 	})
 	require.NoError(t, writeErr, "Err() failed")
 
-	output := buf.String()
-	assert.Contains(t, output, "Request ID: req-cli-123")
+	output := ansi.Strip(buf.String())
+	assert.Contains(t, output, "Request ID: req-cli-123 next")
+	assert.NotContains(t, output, "[31m")
 }
 
 func TestWriterMarkdownErrorIncludesRequestID(t *testing.T) {
@@ -2269,12 +2287,13 @@ func TestWriterMarkdownErrorIncludesRequestID(t *testing.T) {
 		Code:       basecamp.CodeAPI,
 		Message:    "server error",
 		HTTPStatus: 500,
-		RequestID:  "req-cli-123",
+		RequestID:  "req*cli`123\x1b[31m",
 	})
 	require.NoError(t, writeErr, "Err() failed")
 
 	output := buf.String()
-	assert.Contains(t, output, "Request ID: req-cli-123")
+	assert.Contains(t, output, "Request ID: req\\*cli\\`123")
+	assert.NotContains(t, output, "\x1b")
 }
 
 // =============================================================================

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -2287,12 +2287,12 @@ func TestWriterMarkdownErrorIncludesRequestID(t *testing.T) {
 		Code:       basecamp.CodeAPI,
 		Message:    "server error",
 		HTTPStatus: 500,
-		RequestID:  "req*cli`123\x1b[31m",
+		RequestID:  "req*cli`123\\x\x1b[31m",
 	})
 	require.NoError(t, writeErr, "Err() failed")
 
 	output := buf.String()
-	assert.Contains(t, output, "Request ID: req\\*cli\\`123")
+	assert.Contains(t, output, "Request ID: req\\*cli\\`123\\\\x")
 	assert.NotContains(t, output, "\x1b")
 }
 

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/table"
@@ -191,7 +192,9 @@ func (r *Renderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 		}
 		if requestID := errorRequestID(resp); requestID != "" {
 			contentLines = append(contentLines, "")
-			contentLines = append(contentLines, r.Hint.Render("Request ID: "+requestID))
+			for _, line := range wrappedRequestIDLines(requestID, maxWidth) {
+				contentLines = append(contentLines, r.Hint.Render(line))
+			}
 		}
 
 		// Create bordered box with error color border
@@ -213,8 +216,10 @@ func (r *Renderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 			b.WriteString("\n")
 		}
 		if requestID := errorRequestID(resp); requestID != "" {
-			b.WriteString("Request ID: " + requestID)
-			b.WriteString("\n")
+			for _, line := range wrappedRequestIDLines(requestID, r.width) {
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
 		}
 	}
 
@@ -228,6 +233,64 @@ func errorRequestID(resp *ErrorResponse) string {
 	}
 	requestID, _ := resp.Meta["request_id"].(string)
 	return requestID
+}
+
+func wrappedRequestIDLines(requestID string, width int) []string {
+	const prefix = "Request ID: "
+	sanitized := sanitizeRequestID(requestID)
+	if sanitized == "" {
+		return nil
+	}
+	wrapped := wrapText(sanitized, max(width-len(prefix), 1))
+	lines := strings.Split(wrapped, "\n")
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(lines))
+	for i, line := range lines {
+		if i == 0 {
+			out = append(out, prefix+line)
+			continue
+		}
+		out = append(out, strings.Repeat(" ", len(prefix))+line)
+	}
+	return out
+}
+
+func sanitizeRequestID(requestID string) string {
+	requestID = ansi.Strip(requestID)
+	requestID = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			return ' '
+		case unicode.IsControl(r):
+			return -1
+		default:
+			return r
+		}
+	}, requestID)
+	return strings.Join(strings.Fields(requestID), " ")
+}
+
+func escapeMarkdownText(s string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\\`,
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"{", "\\{",
+		"}", "\\}",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		"!", "\\!",
+		"|", "\\|",
+	)
+	return replacer.Replace(s)
 }
 
 // wrapText wraps text to fit within maxWidth, preserving words and newlines.
@@ -1180,8 +1243,8 @@ func (r *MarkdownRenderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 	if resp.Hint != "" {
 		b.WriteString("\n*Hint: " + resp.Hint + "*\n")
 	}
-	if requestID := errorRequestID(resp); requestID != "" {
-		b.WriteString("\n*Request ID: " + requestID + "*\n")
+	if requestID := sanitizeRequestID(errorRequestID(resp)); requestID != "" {
+		b.WriteString("\nRequest ID: " + escapeMarkdownText(requestID) + "\n")
 	}
 
 	_, err := io.WriteString(w, b.String())

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -189,6 +189,10 @@ func (r *Renderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 				}
 			}
 		}
+		if requestID := errorRequestID(resp); requestID != "" {
+			contentLines = append(contentLines, "")
+			contentLines = append(contentLines, r.Hint.Render("Request ID: "+requestID))
+		}
 
 		// Create bordered box with error color border
 		boxStyle := lipgloss.NewStyle().
@@ -208,10 +212,22 @@ func (r *Renderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 			b.WriteString("Hint: " + resp.Hint)
 			b.WriteString("\n")
 		}
+		if requestID := errorRequestID(resp); requestID != "" {
+			b.WriteString("Request ID: " + requestID)
+			b.WriteString("\n")
+		}
 	}
 
 	_, err := io.WriteString(w, b.String())
 	return err
+}
+
+func errorRequestID(resp *ErrorResponse) string {
+	if resp == nil || resp.Meta == nil {
+		return ""
+	}
+	requestID, _ := resp.Meta["request_id"].(string)
+	return requestID
 }
 
 // wrapText wraps text to fit within maxWidth, preserving words and newlines.
@@ -1163,6 +1179,9 @@ func (r *MarkdownRenderer) RenderError(w io.Writer, resp *ErrorResponse) error {
 	b.WriteString("**Error:** " + resp.Error + "\n")
 	if resp.Hint != "" {
 		b.WriteString("\n*Hint: " + resp.Hint + "*\n")
+	}
+	if requestID := errorRequestID(resp); requestID != "" {
+		b.WriteString("\n*Request ID: " + requestID + "*\n")
 	}
 
 	_, err := io.WriteString(w, b.String())

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -274,7 +274,7 @@ func sanitizeRequestID(requestID string) string {
 
 func escapeMarkdownText(s string) string {
 	replacer := strings.NewReplacer(
-		`\\`, `\\`,
+		`\`, `\\`,
 		"`", "\\`",
 		"*", "\\*",
 		"_", "\\_",


### PR DESCRIPTION
## Summary
- surface failing SDK request ids in CLI error output
- include `request_id` in JSON error metadata and render it for human-facing formats
- make raw `basecamp api post/put/delete` error handling use the same SDK->CLI conversion path as `api get`

## SDK dependency
- Requires the SDK change from basecamp/basecamp-sdk#277 (carries `X-Request-Id` on `basecamp.Error`), which is now in `main` — this branch is rebased on top of it and builds against SDK `v0.7.4-0.20260629111348-cc8e9772e729`.

## Problem
The Basecamp API already emits `X-Request-Id`, and the SDK now preserves that value consistently on `basecamp.Error` for both generated-service calls and raw client calls.

Before this PR, the CLI still dropped that information:
- `convertSDKError()` copied SDK code/message/hint/status fields but discarded the underlying SDK error
- JSON error envelopes had nowhere to expose the request id
- styled/plain/markdown error rendering did not show it
- `basecamp api post/put/delete` returned raw SDK errors instead of using the same conversion path as `api get`

That meant users still could not see the failing request id when the CLI hit an API error, even though the SDK had it available.

## What changed
- taught `internal/output.AsError()` to convert raw `*basecamp.Error` values into CLI errors while preserving the SDK error as the cause
- added `output.RequestID(err)` to recover the SDK request id from the error chain
- included `meta.request_id` in JSON error responses when present
- rendered `Request ID: ...` in styled, plain-text, and markdown error output
- updated `convertSDKError()` to retain the wrapped SDK error as the cause
- made `basecamp api post`, `put`, and `delete` use `convertSDKError()` just like `api get`
- added tests for request-id JSON metadata, human rendering, and SDK->CLI conversion

## Resulting UX
JSON errors now look like:

```json
{
  "ok": false,
  "error": "server error",
  "code": "api_error",
  "meta": {
    "request_id": "req-cli-123"
  }
}
```

Human-facing error output now includes a dedicated request-id line, e.g.:

```text
Error: server error
Request ID: req-cli-123
```

## Testing
```bash
go test ./internal/output -run 'TestWriterErrIncludesRequestIDMeta|TestWriterStyledErrorIncludesRequestID|TestWriterMarkdownErrorIncludesRequestID|TestWriterErr|TestWriterStyledErrorWithHint'
go test ./internal/commands -run 'TestConvertSDKErrorPreservesRequestID|TestParsePath|TestAPIPathArgs'
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show failing Basecamp API request IDs in CLI errors for easier debugging and support. Adds the request ID to JSON error metadata and all human-facing formats with sanitization and wrapping.

- **Bug Fixes**
  - Handle raw or wrapped `*basecamp.Error` in `output.AsError()`; preserve it as the cause and keep request context.
  - Include `meta.request_id` in JSON error responses using `output.RequestID(err)`.
  - Render “Request ID: …” in styled, plain text, and markdown outputs; sanitize control/ANSI chars, correctly escape markdown (including single backslashes), and wrap long IDs.
  - Route `basecamp api post/put/delete` through `convertSDKError()` like `api get`.
  - Add tests for JSON metadata, human rendering, sanitization, markdown backslash escaping, and SDK→CLI conversion.

- **Dependencies**
  - Requires `basecamp-sdk` update that carries `X-Request-Id` in `basecamp.Error` (basecamp/basecamp-sdk#277).

<sup>Written for commit ea2e26f08f523e30033ab4d7c8ad2e5bcb210579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

