### PR TITLE
skill: document project archive/unarchive via api put

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -404,7 +404,20 @@ basecamp projects list --json               # List all
 basecamp projects show <id> --json          # Show details
 basecamp projects create "Name" --json      # Create
 basecamp projects update <id> --name "New"  # Update
+basecamp projects trash <id>                # Move to trash (recoverable)
 ```
+
+**Archiving a project:** the CLI does not have a dedicated archive command, but the
+underlying status endpoint can be hit via raw API. Same path works for restoring
+to active or moving to trashed.
+
+```bash
+basecamp api put "projects/<id>/status/archived" -d '{}' --json   # Archive
+basecamp api put "projects/<id>/status/active" -d '{}' --json     # Unarchive
+basecamp api put "projects/<id>/status/trashed" -d '{}' --json    # Trash (same as `projects trash`)
+```
+
+Verify with `basecamp projects show <id> --jq '.data.status'`.
 
 ### Todos
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -405,7 +405,20 @@ basecamp projects list --json               # List all
 basecamp projects show <id> --json          # Show details
 basecamp projects create "Name" --json      # Create
 basecamp projects update <id> --name "New"  # Update
+basecamp projects trash <id>                # Move to trash (recoverable)
 ```
+
+**Archiving a project:** the CLI does not have a dedicated archive command, but the
+underlying status endpoint can be hit via raw API. Same path works for restoring
+to active or moving to trashed.
+
+```bash
+basecamp api put "projects/<id>/status/archived" -d '{}' --json   # Archive
+basecamp api put "projects/<id>/status/active" -d '{}' --json     # Unarchive
+basecamp api put "projects/<id>/status/trashed" -d '{}' --json    # Trash (same as `projects trash`)
+```
+
+Verify with `basecamp projects show <id> --jq '.data.status'`.
 
 ### Todos
 


### PR DESCRIPTION
## Summary

The skill's Projects section only lists `projects trash` for changing a project's status, so anyone looking to archive a project either trashes by accident or gives up and does it in the web UI. The status endpoint that the web UI hits (`PUT /projects/<id>/status/<status>.json`) already works through `basecamp api put`, so this PR surfaces it inline in the skill.

- Adds the `archived` / `active` / `trashed` recipes via `basecamp api put` to `### Projects`
- Adds `projects trash` to the existing command list for symmetry

No CLI code changes — skill text only.

## Test plan

- [x] `basecamp api put "projects/<id>/status/archived" -d '{}'` archives a real project (verified against an internal test project; `basecamp projects show` reports `status: archived` afterwards)
- [x] Markdown renders cleanly in the skill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only update that shows how to archive, unarchive, or trash a project via `basecamp api put "projects/<id>/status/<status>"`. Also adds `basecamp projects trash` to the Projects command list to reduce reliance on the web UI and avoid accidental trashing.

<sup>Written for commit 87cf696d3ef494e9d6c2b4c17e2337bce1d19f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

