### PR TITLE
Fix `cards column color` 404 from missing bucket in URL

### DIFF
--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -1271,7 +1271,7 @@ func newCardsColumnCmd(project, cardTable *string) *cobra.Command {
 		newCardsColumnUnwatchCmd(),
 		newCardsColumnOnHoldCmd(),
 		newCardsColumnNoOnHoldCmd(),
-		newCardsColumnColorCmd(),
+		newCardsColumnColorCmd(project),
 	)
 
 	return cmd
@@ -1726,7 +1726,7 @@ You can pass either a column ID or a Basecamp URL:
 	return cmd
 }
 
-func newCardsColumnColorCmd() *cobra.Command {
+func newCardsColumnColorCmd(project *string) *cobra.Command {
 	var color string
 
 	cmd := &cobra.Command{
@@ -1750,14 +1750,43 @@ You can pass either a column ID or a Basecamp URL:
 				return err
 			}
 
-			// Extract ID from URL if provided
-			columnIDStr := extractID(args[0])
+			// Extract ID and project from URL if provided
+			columnIDStr, urlProjectID := extractWithProject(args[0])
 			columnID, err := strconv.ParseInt(columnIDStr, 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid column ID")
 			}
 
-			col, err := app.Account().CardColumns().SetColor(cmd.Context(), columnID, color)
+			// Resolve project - use URL > flag > config, with interactive fallback.
+			// The color endpoint requires a bucket-scoped path (PUT /buckets/<id>/card_tables/columns/<id>/color.json).
+			projectID := *project
+			if projectID == "" && urlProjectID != "" {
+				projectID = urlProjectID
+			}
+			if projectID == "" {
+				projectID = app.Flags.Project
+			}
+			if projectID == "" {
+				projectID = app.Config.ProjectID
+			}
+			if projectID == "" {
+				if err := ensureProject(cmd, app); err != nil {
+					return err
+				}
+				projectID = app.Config.ProjectID
+			}
+
+			resolvedProjectID, _, err := app.Names.ResolveProject(cmd.Context(), projectID)
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/buckets/%s/card_tables/columns/%d/color.json", resolvedProjectID, columnID)
+			if _, err := app.Account().Put(cmd.Context(), path, map[string]string{"color": color}); err != nil {
+				return convertSDKError(err)
+			}
+
+			col, err := app.Account().CardColumns().Get(cmd.Context(), columnID)
 			if err != nil {
 				return convertSDKError(err)
 			}

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -127,7 +127,8 @@ func TestCardsColumnColorShowsHelp(t *testing.T) {
 	// Configure app with project
 	app.Config.ProjectID = "123"
 
-	cmd := newCardsColumnColorCmd()
+	project := ""
+	cmd := newCardsColumnColorCmd(&project)
 
 	err := executeCommand(cmd, app, "456") // column ID but no --color
 	assert.NoError(t, err, "expected help output, not error")


### PR DESCRIPTION
## Summary
- `basecamp cards column color` was sending `PUT /{account}/card_tables/columns/{id}/color.json` (no bucket segment) and 404ing on every invocation. Reported in [Basecamp card 9825845889](https://3.basecamp.com/2914079/buckets/27/card_tables/cards/9825845889).
- Root cause is in `basecamp-sdk/go` v0.7.3: the generated client at `pkg/generated/client.gen.go:7757` builds the path without `/buckets/{bucket_id}`. The SDK's `pkg/basecamp/url-routes.json` (lines 165, 183, 200) shows the same bucket-less pattern for `GetCardColumn`, `SetCardColumnColor`, `EnableCardColumnOnHold`, `DisableCardColumnOnHold`. Basecamp tolerates the bucket-less path for the read/update endpoints but rejects it for `/color.json` and `/on_hold.json`.
- This PR works around the SDK bug for `color` only — `on-hold` and `no-on-hold` have the same problem and need separate fixes.

## Reproduction (verified live)
- Broken: `PUT /3642500/card_tables/columns/7103332776/color.json` → **404 Not Found**
- Correct: `PUT /3642500/buckets/36395297/card_tables/columns/7103332776/color.json` → **200 OK**

## Fix
`internal/commands/cards.go`:
- `newCardsColumnColorCmd(project *string)` — accept the project pointer plumbed from the `cards` command group (cards.go:1274), matching the existing pattern used by `column show`, `column move`, etc.
- Resolve the bucket from URL > `--in`/`--project` flag > config > interactive (the same 8-line pattern repeated in 23 sites across 8 command files).
- Send the PUT via `app.Account().Put(ctx, "/buckets/<id>/card_tables/columns/<id>/color.json", body)` — the existing raw API escape hatch already used by `todos.go:1157` for similar SDK gaps. This bypasses the broken generated client path.
- Re-fetch the column via SDK `Get` (which works on the bucket-less path) so the response is still a typed `*CardColumn`.

`internal/commands/cards_test.go`:
- Update the existing `TestCardsColumnColorShowsHelp` call site for the new signature.

## Verified live
- `basecamp cards column color 7103332776 --color blue --account 3642500 --in 36395297 -vv` → `PUT .../buckets/36395297/.../color.json` → 200, color updated.
- URL form `basecamp cards column color https://3.basecamp.com/.../columns/7103332776 --color blue` → resolves project from URL, hits correct path, returns 200.

## Test plan
- [x] `make fmt-check vet test check-bare-groups check-skill-drift check-surface` all pass locally.
- [x] Repro on real account: command was 404ing; with fix, returns 200.
- [x] URL-arg form resolves bucket from the URL.
- [ ] CI green.

## Follow-ups (separate, not blocking this PR)
1. File an issue on `basecamp-sdk` for the missing `bucketId` path parameter on `SetCardColumnColor`, `EnableCardColumnOnHold`, `DisableCardColumnOnHold` (and review whether `GetCardColumn`/`UpdateCardColumn` should also include it now that the API requires it for some sibling endpoints).
2. Apply the same workaround in `newCardsColumnOnHoldCmd` and `newCardsColumnNoOnHoldCmd` — they 404 today for the same reason.
3. Once the SDK is fixed and bumped, this PR's raw-PUT workaround can be reverted to a clean `app.Account().CardColumns().SetColor(...)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)