### PR TITLE
Read comment content from stdin when using dash

### DIFF
--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -198,13 +199,21 @@ func newCommentsUpdateCmd() *cobra.Command {
 
 You can pass either a comment ID or a Basecamp URL:
   basecamp comments update 789 "new text"
-  basecamp comments update https://3.basecamp.com/123/buckets/456/todos/111#__recording_789 "new text"`,
+  basecamp comments update https://3.basecamp.com/123/buckets/456/todos/111#__recording_789 "new text"
+
+Use - as the content argument to read the updated content from stdin:
+  basecamp comments update 789 - < body.md`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return missingArg(cmd, "<id|url>")
 			}
 			if len(args) < 2 {
 				return missingArg(cmd, "<content>")
+			}
+
+			content, err := contentArgOrStdin(cmd, args[1:])
+			if err != nil {
+				return err
 			}
 
 			app := appctx.FromContext(cmd.Context())
@@ -215,8 +224,6 @@ You can pass either a comment ID or a Basecamp URL:
 			// Extract comment ID from URL if provided
 			// Uses extractCommentWithProject to prefer CommentID from URL fragments
 			commentIDStr, _ := extractCommentWithProject(args[0])
-
-			content := strings.Join(args[1:], " ")
 
 			commentID, err := strconv.ParseInt(commentIDStr, 10, 64)
 			if err != nil {
@@ -299,7 +306,10 @@ Comma-separated IDs add the same comment to multiple items:
   basecamp comment https://3.basecamp.com/123/buckets/456/todos/789 "Looks good!"
 
 Content supports Markdown and @mentions (@Name or @First.Last):
-  basecamp comment 789 "Hey @Jane.Smith, **please review**"`,
+  basecamp comment 789 "Hey @Jane.Smith, **please review**"
+
+Use - as the content argument to read content from stdin:
+  basecamp comment 789 - < body.md`,
 		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
@@ -314,7 +324,11 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 
 			var content string
 			if len(args) > 1 {
-				content = strings.Join(args[1:], " ")
+				var err error
+				content, err = contentArgOrStdin(cmd, args[1:])
+				if err != nil {
+					return err
+				}
 			}
 
 			if edit && content != "" {
@@ -478,4 +492,15 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file (repeatable)")
 
 	return cmd
+}
+
+func contentArgOrStdin(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) == 1 && args[0] == "-" {
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", output.ErrUsage(fmt.Sprintf("failed to read content from stdin: %v", err))
+		}
+		return string(b), nil
+	}
+	return strings.Join(args, " "), nil
 }

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -322,6 +322,10 @@ Use - as the content argument to read content from stdin:
 			// First arg is always the recording ID(s)
 			recordingArg := args[0]
 
+			if edit && len(args) > 1 {
+				return output.ErrUsage("cannot combine --edit and positional content")
+			}
+
 			var content string
 			if len(args) > 1 {
 				var err error
@@ -329,10 +333,6 @@ Use - as the content argument to read content from stdin:
 				if err != nil {
 					return err
 				}
-			}
-
-			if edit && content != "" {
-				return output.ErrUsage("cannot combine --edit and positional content")
 			}
 			if edit {
 				fi, err := os.Stdin.Stat()

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -198,13 +199,21 @@ func newCommentsUpdateCmd() *cobra.Command {
 
 You can pass either a comment ID or a Basecamp URL:
   basecamp comments update 789 "new text"
-  basecamp comments update https://3.basecamp.com/123/buckets/456/todos/111#__recording_789 "new text"`,
+  basecamp comments update https://3.basecamp.com/123/buckets/456/todos/111#__recording_789 "new text"
+
+Use - as the content argument to read the updated content from stdin:
+  basecamp comments update 789 - < body.md`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return missingArg(cmd, "<id|url>")
 			}
 			if len(args) < 2 {
 				return missingArg(cmd, "<content>")
+			}
+
+			content, err := contentArgOrStdin(cmd, args[1:])
+			if err != nil {
+				return err
 			}
 
 			app := appctx.FromContext(cmd.Context())
@@ -215,8 +224,6 @@ You can pass either a comment ID or a Basecamp URL:
 			// Extract comment ID from URL if provided
 			// Uses extractCommentWithProject to prefer CommentID from URL fragments
 			commentIDStr, _ := extractCommentWithProject(args[0])
-
-			content := strings.Join(args[1:], " ")
 
 			commentID, err := strconv.ParseInt(commentIDStr, 10, 64)
 			if err != nil {
@@ -302,7 +309,10 @@ Content can also be piped from stdin:
   printf 'Looks good!' | basecamp comment 789
 
 Content supports Markdown and @mentions (@Name or @First.Last):
-  basecamp comment 789 "Hey @Jane.Smith, **please review**"`,
+  basecamp comment 789 "Hey @Jane.Smith, **please review**"
+
+Use - as the content argument to read content from stdin:
+  basecamp comment 789 - < body.md`,
 		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
@@ -317,7 +327,11 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 
 			var content string
 			if len(args) > 1 {
-				content = strings.Join(args[1:], " ")
+				var err error
+				content, err = contentArgOrStdin(cmd, args[1:])
+				if err != nil {
+					return err
+				}
 			}
 
 			if edit && content != "" {
@@ -488,4 +502,15 @@ Content supports Markdown and @mentions (@Name or @First.Last):
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file (repeatable)")
 
 	return cmd
+}
+
+func contentArgOrStdin(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) == 1 && args[0] == "-" {
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", output.ErrUsage(fmt.Sprintf("failed to read content from stdin: %v", err))
+		}
+		return string(b), nil
+	}
+	return strings.Join(args, " "), nil
 }

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -215,6 +215,9 @@ Use - as the content argument to read the updated content from stdin:
 			if err != nil {
 				return err
 			}
+			if strings.TrimSpace(content) == "" {
+				return missingArg(cmd, "<content>")
+			}
 
 			app := appctx.FromContext(cmd.Context())
 			if err := ensureAccount(cmd, app); err != nil {
@@ -349,7 +352,10 @@ Use - as the content argument to read content from stdin:
 			}
 
 			if !edit && strings.TrimSpace(content) == "" {
-				stdinContent, hasPipedStdin := readPipedStdin()
+				stdinContent, hasPipedStdin, err := readPipedStdin(cmd)
+				if err != nil {
+					return err
+				}
 				if hasPipedStdin {
 					content = stdinContent
 				}

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -325,6 +325,10 @@ Use - as the content argument to read content from stdin:
 			// First arg is always the recording ID(s)
 			recordingArg := args[0]
 
+			if edit && len(args) > 1 {
+				return output.ErrUsage("cannot combine --edit and positional content")
+			}
+
 			var content string
 			if len(args) > 1 {
 				var err error
@@ -332,10 +336,6 @@ Use - as the content argument to read content from stdin:
 				if err != nil {
 					return err
 				}
-			}
-
-			if edit && content != "" {
-				return output.ErrUsage("cannot combine --edit and positional content")
 			}
 			if edit {
 				fi, err := os.Stdin.Stat()

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -1,10 +1,19 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/names"
 )
 
 // TestCommentShortcutAcceptsInFlag tests that the top-level 'comment' shortcut
@@ -55,4 +64,77 @@ func TestCommentsGroupAcceptsInFlag(t *testing.T) {
 	require.NotNil(t, err)
 	assert.NotContains(t, err.Error(), "unknown flag")
 	assert.NotContains(t, err.Error(), "unknown shorthand")
+}
+
+func TestCommentsCreateReadsDashContentFromStdin(t *testing.T) {
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
+
+	cmd := newCommentsCreateCmd()
+	cmd.SetIn(strings.NewReader("Hello from stdin\n\n**works**\n"))
+
+	err := executeCommand(cmd, app, "789", "-")
+	require.NoError(t, err)
+	require.Len(t, transport.capturedBodies, 1)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
+	assert.Contains(t, body["content"], "Hello from stdin")
+	assert.Contains(t, body["content"], "<strong>works</strong>")
+	assert.NotEqual(t, "<p>-</p>", body["content"])
+}
+
+func TestCommentsUpdateReadsDashContentFromStdin(t *testing.T) {
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
+
+	cmd := NewCommentsCmd()
+	cmd.SetIn(strings.NewReader("Updated from stdin\n"))
+
+	err := executeCommand(cmd, app, "update", "1234", "-")
+	require.NoError(t, err)
+	require.Len(t, transport.capturedBodies, 1)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
+	assert.Equal(t, "<p>Updated from stdin</p>", body["content"])
+}
+
+type mockCommentWriteTransport struct {
+	capturedBodies [][]byte
+}
+
+func (t *mockCommentWriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		t.capturedBodies = append(t.capturedBodies, body)
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	status := http.StatusOK
+	if req.Method == http.MethodPost {
+		status = http.StatusCreated
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(`{"id":1234,"content":"ok","status":"active"}`)),
+		Header:     header,
+	}, nil
+}
+
+func setupCommentsWriteTestApp(t *testing.T, transport http.RoundTripper) (*appctx.App, *bytes.Buffer) {
+	t.Helper()
+
+	app, buf := setupTestApp(t)
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &testTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	app.SDK = sdkClient
+	app.Names = names.NewResolver(sdkClient, app.Auth, app.Config.AccountID)
+	return app, buf
 }

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/names"
+	"github.com/basecamp/basecamp-cli/internal/output"
 )
 
 // TestCommentShortcutAcceptsInFlag tests that the top-level 'comment' shortcut
@@ -89,10 +91,10 @@ func TestCommentsUpdateReadsDashContentFromStdin(t *testing.T) {
 	transport := &mockCommentWriteTransport{}
 	app, _ := setupCommentsWriteTestApp(t, transport)
 
-	cmd := NewCommentsCmd()
+	cmd := newCommentsUpdateCmd()
 	cmd.SetIn(strings.NewReader("Updated from stdin\n"))
 
-	err := executeCommand(cmd, app, "update", "1234", "-")
+	err := executeCommand(cmd, app, "1234", "-")
 	require.NoError(t, err)
 	require.Len(t, transport.capturedBodies, 1)
 
@@ -101,25 +103,30 @@ func TestCommentsUpdateReadsDashContentFromStdin(t *testing.T) {
 	assert.Equal(t, "<p>Updated from stdin</p>", body["content"])
 }
 
+func TestCommentsUpdateRejectsEmptyDashContent(t *testing.T) {
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
+	app.Flags.JSON = true
+
+	cmd := newCommentsUpdateCmd()
+	cmd.SetIn(strings.NewReader("  \n"))
+
+	err := executeCommand(cmd, app, "1234", "-")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr), "expected *output.Error, got %T: %v", err, err)
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+	assert.Equal(t, "<content> required", outErr.Message)
+	assert.Empty(t, transport.capturedBodies)
+}
+
 func TestCommentCreateReadsContentFromStdin(t *testing.T) {
 	transport := &mockCommentWriteTransport{}
 	app, _ := setupCommentsWriteTestApp(t, transport)
 
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	_, err = io.WriteString(w, "hello from stdin")
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	origStdin := os.Stdin
-	os.Stdin = r
-	t.Cleanup(func() {
-		os.Stdin = origStdin
-		r.Close()
-	})
-
 	cmd := NewCommentCmd()
-	err = executeCommand(cmd, app, "123")
+	cmd.SetIn(strings.NewReader("hello from stdin"))
+	err := executeCommand(cmd, app, "123")
 	require.NoError(t, err)
 	require.Len(t, transport.capturedBodies, 1)
 
@@ -132,21 +139,9 @@ func TestCommentCreatePrefersPositionalContentOverStdin(t *testing.T) {
 	transport := &mockCommentWriteTransport{}
 	app, _ := setupCommentsWriteTestApp(t, transport)
 
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	_, err = io.WriteString(w, "ignored stdin")
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	origStdin := os.Stdin
-	os.Stdin = r
-	t.Cleanup(func() {
-		os.Stdin = origStdin
-		r.Close()
-	})
-
 	cmd := NewCommentCmd()
-	err = executeCommand(cmd, app, "123", "hello from args")
+	cmd.SetIn(strings.NewReader("ignored stdin"))
+	err := executeCommand(cmd, app, "123", "hello from args")
 	require.NoError(t, err)
 	require.Len(t, transport.capturedBodies, 1)
 
@@ -159,21 +154,9 @@ func TestCommentsCreateReadsContentFromStdin(t *testing.T) {
 	transport := &mockCommentWriteTransport{}
 	app, _ := setupCommentsWriteTestApp(t, transport)
 
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	_, err = io.WriteString(w, "hello from stdin")
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	origStdin := os.Stdin
-	os.Stdin = r
-	t.Cleanup(func() {
-		os.Stdin = origStdin
-		r.Close()
-	})
-
 	cmd := NewCommentsCmd()
-	err = executeCommand(cmd, app, "create", "123")
+	cmd.SetIn(strings.NewReader("hello from stdin"))
+	err := executeCommand(cmd, app, "create", "123")
 	require.NoError(t, err)
 	require.Len(t, transport.capturedBodies, 1)
 
@@ -192,14 +175,12 @@ func TestCommentCreateMissingContentReturnsUsageBeforeAccountResolution(t *testi
 		t.Skip("dev null not available")
 	}
 
-	origStdin := os.Stdin
-	os.Stdin = devNull
 	t.Cleanup(func() {
-		os.Stdin = origStdin
 		devNull.Close()
 	})
 
 	cmd := NewCommentCmd()
+	cmd.SetIn(devNull)
 	err = executeCommand(cmd, app, "123")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "<content> required")
@@ -212,13 +193,10 @@ func TestReadPipedStdinIgnoresUnreadableStdin(t *testing.T) {
 	require.NoError(t, r.Close())
 	require.NoError(t, w.Close())
 
-	origStdin := os.Stdin
-	os.Stdin = r
-	t.Cleanup(func() {
-		os.Stdin = origStdin
-	})
-
-	content, hasPipedStdin := readPipedStdin()
+	cmd := newCommentsCreateCmd()
+	cmd.SetIn(r)
+	content, hasPipedStdin, err := readPipedStdin(cmd)
+	require.NoError(t, err)
 	assert.Empty(t, content)
 	assert.False(t, hasPipedStdin)
 }

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -1,16 +1,20 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/names"
 )
 
 // TestCommentShortcutAcceptsInFlag tests that the top-level 'comment' shortcut
@@ -63,37 +67,43 @@ func TestCommentsGroupAcceptsInFlag(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown shorthand")
 }
 
-type mockCommentCreateTransport struct {
-	capturedBody []byte
+func TestCommentsCreateReadsDashContentFromStdin(t *testing.T) {
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
+
+	cmd := newCommentsCreateCmd()
+	cmd.SetIn(strings.NewReader("Hello from stdin\n\n**works**\n"))
+
+	err := executeCommand(cmd, app, "789", "-")
+	require.NoError(t, err)
+	require.Len(t, transport.capturedBodies, 1)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
+	assert.Contains(t, body["content"], "Hello from stdin")
+	assert.Contains(t, body["content"], "<strong>works</strong>")
+	assert.NotEqual(t, "<p>-</p>", body["content"])
 }
 
-func (t *mockCommentCreateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	header := make(http.Header)
-	header.Set("Content-Type", "application/json")
+func TestCommentsUpdateReadsDashContentFromStdin(t *testing.T) {
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
 
-	if req.Method != http.MethodPost {
-		return nil, errors.New("unexpected request")
-	}
-	if !strings.HasSuffix(req.URL.Path, "/comments.json") {
-		return nil, errors.New("unexpected path: " + req.URL.Path)
-	}
+	cmd := NewCommentsCmd()
+	cmd.SetIn(strings.NewReader("Updated from stdin\n"))
 
-	if req.Body != nil {
-		body, _ := io.ReadAll(req.Body)
-		t.capturedBody = body
-		req.Body.Close()
-	}
+	err := executeCommand(cmd, app, "update", "1234", "-")
+	require.NoError(t, err)
+	require.Len(t, transport.capturedBodies, 1)
 
-	return &http.Response{
-		StatusCode: 201,
-		Body:       io.NopCloser(strings.NewReader(`{"id": 999, "content": "<p>hello from stdin</p>", "status": "active"}`)),
-		Header:     header,
-	}, nil
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
+	assert.Equal(t, "<p>Updated from stdin</p>", body["content"])
 }
 
 func TestCommentCreateReadsContentFromStdin(t *testing.T) {
-	transport := &mockCommentCreateTransport{}
-	app, _ := newTestAppWithTransport(t, transport)
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
 
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
@@ -111,16 +121,16 @@ func TestCommentCreateReadsContentFromStdin(t *testing.T) {
 	cmd := NewCommentCmd()
 	err = executeCommand(cmd, app, "123")
 	require.NoError(t, err)
-	require.NotEmpty(t, transport.capturedBody)
+	require.Len(t, transport.capturedBodies, 1)
 
 	var body map[string]any
-	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
 	assert.Equal(t, "<p>hello from stdin</p>", body["content"])
 }
 
 func TestCommentCreatePrefersPositionalContentOverStdin(t *testing.T) {
-	transport := &mockCommentCreateTransport{}
-	app, _ := newTestAppWithTransport(t, transport)
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
 
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
@@ -138,16 +148,16 @@ func TestCommentCreatePrefersPositionalContentOverStdin(t *testing.T) {
 	cmd := NewCommentCmd()
 	err = executeCommand(cmd, app, "123", "hello from args")
 	require.NoError(t, err)
-	require.NotEmpty(t, transport.capturedBody)
+	require.Len(t, transport.capturedBodies, 1)
 
 	var body map[string]any
-	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
 	assert.Equal(t, "<p>hello from args</p>", body["content"])
 }
 
 func TestCommentsCreateReadsContentFromStdin(t *testing.T) {
-	transport := &mockCommentCreateTransport{}
-	app, _ := newTestAppWithTransport(t, transport)
+	transport := &mockCommentWriteTransport{}
+	app, _ := setupCommentsWriteTestApp(t, transport)
 
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
@@ -165,10 +175,10 @@ func TestCommentsCreateReadsContentFromStdin(t *testing.T) {
 	cmd := NewCommentsCmd()
 	err = executeCommand(cmd, app, "create", "123")
 	require.NoError(t, err)
-	require.NotEmpty(t, transport.capturedBody)
+	require.Len(t, transport.capturedBodies, 1)
 
 	var body map[string]any
-	require.NoError(t, json.Unmarshal(transport.capturedBody, &body))
+	require.NoError(t, json.Unmarshal(transport.capturedBodies[0], &body))
 	assert.Equal(t, "<p>hello from stdin</p>", body["content"])
 }
 
@@ -211,4 +221,43 @@ func TestReadPipedStdinIgnoresUnreadableStdin(t *testing.T) {
 	content, hasPipedStdin := readPipedStdin()
 	assert.Empty(t, content)
 	assert.False(t, hasPipedStdin)
+}
+
+func setupCommentsWriteTestApp(t *testing.T, transport http.RoundTripper) (*appctx.App, *bytes.Buffer) {
+	t.Helper()
+
+	app, buf := setupTestApp(t)
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &testTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	app.SDK = sdkClient
+	app.Names = names.NewResolver(sdkClient, app.Auth, app.Config.AccountID)
+	return app, buf
+}
+
+type mockCommentWriteTransport struct {
+	capturedBodies [][]byte
+}
+
+func (t *mockCommentWriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		t.capturedBodies = append(t.capturedBodies, body)
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	status := http.StatusOK
+	if req.Method == http.MethodPost {
+		status = http.StatusCreated
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(`{"id":1234,"content":"ok","status":"active"}`)),
+		Header:     header,
+	}, nil
 }

--- a/internal/commands/edit_test.go
+++ b/internal/commands/edit_test.go
@@ -37,6 +37,19 @@ func TestEditContentMutualExclusion(t *testing.T) {
 		}
 	})
 
+	t.Run("comment --edit with dash content", func(t *testing.T) {
+		err := runCmdWithFlagsAndArgs(NewCommentCmd,
+			map[string]string{"edit": "true"},
+			[]string{"12345", "-"},
+		)
+		if err == nil {
+			t.Fatal("expected error for --edit + dash content, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot combine") {
+			t.Errorf("error = %q, want 'cannot combine' message", err)
+		}
+	})
+
 	t.Run("message --edit with positional body", func(t *testing.T) {
 		err := runCmdWithFlagsAndArgs(NewMessageCmd,
 			map[string]string{"edit": "true"},

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -80,20 +80,23 @@ func isMachineOutput(cmd *cobra.Command) bool {
 	return false
 }
 
-func readPipedStdin() (string, bool) {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return "", false
-	}
-	if (fi.Mode() & os.ModeCharDevice) != 0 {
-		return "", false
+func readPipedStdin(cmd *cobra.Command) (string, bool, error) {
+	stdin := cmd.InOrStdin()
+	if f, ok := stdin.(*os.File); ok {
+		fi, _ := f.Stat()
+		if fi == nil {
+			return "", false, nil
+		}
+		if (fi.Mode() & os.ModeCharDevice) != 0 {
+			return "", false, nil
+		}
 	}
 
-	data, err := io.ReadAll(os.Stdin)
+	data, err := io.ReadAll(stdin)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("failed to read stdin: %w", err)
 	}
-	return string(data), true
+	return string(data), true, nil
 }
 
 // DockTool represents a tool in a project's dock.


### PR DESCRIPTION
## Summary

Fix comment creation and updates so using `-` reads the comment body from stdin instead of posting a literal dash. This supports heredoc/pipe workflows and prevents silent wrong-comment posts.

## Relationship to #414

#414 is merged. This PR is now rebased onto `main` and complements #414: #414 covers implicit piped stdin when comment creation omits positional content; this PR covers the explicit `-` stdin convention and also applies it to comment updates.

## Live verification

Tested against the Rob Zolkos account in the Verdant Coffee Roasters project,
Fusilli todolist, using a locally built branch with #414 and this PR.

- `printf ... | basecamp comment <todo_id> -` created a comment with the piped content, not a literal `-`.
- `printf ... | basecamp comments update <comment_id> -` updated the comment with the piped content.
- `printf ... | basecamp comments create <todo_id>` still works for #414's implicit stdin path.
- `printf ... | basecamp comment <todo_id> - --edit` fails fast with `cannot combine --edit and positional content`.
- Empty stdin for `basecamp comments update <comment_id> -` fails with `<content> required` and does not send an API update.

Ref: https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9890985489
