### PR TITLE
Document multiple identity profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ basecamp auth login --scope full # Full read+write access (BC3 OAuth only)
 basecamp auth token              # Print token for scripts
 ```
 
+### Multiple Identities
+
+Use named profiles when the same machine or agent gateway needs more than one Basecamp identity. Each profile has its own stored OAuth credentials and can be selected per command:
+
+```bash
+basecamp profile create design-agent
+basecamp profile create ops-agent
+basecamp --profile design-agent todo "Fix bug" --in 12345 --list 67890
+```
+
+Set a default with `basecamp profile set-default <name>`, or set `BASECAMP_PROFILE=<name>` for a process. Actions are posted as the authenticated user for the selected profile.
+
 ### Custom OAuth Credentials
 
 To use your own OAuth app (e.g., a custom Launchpad integration):

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -141,6 +141,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 - `--assignee me` resolves to current user
 - `--due tomorrow` / `--due +3` / `--due "next week"` - natural date parsing
 - Project from `.basecamp/config.json` if `--in` not specified
+- Multiple identities use named profiles: `basecamp profile create <name>`, then select one with global `--profile <name>` or `BASECAMP_PROFILE=<name>`.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- Add a lightweight README section for named profiles and per-command `--profile` usage
- Add a compact skill note so agents know to use profiles for multiple identities

Addresses #476.

## Tests
- `make check-skill-drift`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to use named profiles for multiple Basecamp identities, including per-command `--profile`, the `BASECAMP_PROFILE` env var, and setting a default. Adds a “Multiple Identities” section to the README and a short note in `skills/basecamp/SKILL.md`; addresses Linear #476.

<sup>Written for commit 36b32500ec3b127f686e242ce8b1ce753ee8e793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

