### PR TITLE
Require Go 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/basecamp-cli
 
-go 1.26
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary
- require Go 1.26.4 so GitHub Actions installs the patched standard library
- resolves govulncheck findings GO-2026-5039 and GO-2026-5037 seen on PR #488

## Tests
- GOWORK=off GOTOOLCHAIN=go1.26.4 bin/ci
- GOWORK=off GOTOOLCHAIN=go1.26.4 govulncheck -tags dev ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require Go 1.26.4 so CI installs the patched standard library and clears `govulncheck` advisories GO-2026-5039 and GO-2026-5037. Updates go.mod from 1.26 to 1.26.4.

- **Migration**
  - Update your Go toolchain to 1.26.4, or set `GOTOOLCHAIN=go1.26.4` for builds/tests.
  - Verify locally with `govulncheck -tags dev ./...` or run `bin/ci`.

<sup>Written for commit 1e07fe5ed3e7fec4a6ff206934e909f4ba5d5f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

