### PR TITLE
Support release candidate publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,7 @@ jobs:
           subject-checksums: ./dist/checksums.txt
 
       - name: Publish to AUR
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
         run: |
@@ -325,7 +326,7 @@ jobs:
   nix-verify:
     name: Verify Nix flake
     needs: [release]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -347,7 +348,7 @@ jobs:
   sync-skills:
     name: Sync skills
     needs: [release]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     continue-on-error: true
     concurrency:
       group: sync-skills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,8 +256,20 @@ jobs:
         with:
           subject-checksums: ./dist/checksums.txt
 
-      - name: Publish to AUR
+      - name: Check AUR publishing configuration
+        id: aur-publish
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+        env:
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+        run: |
+          if [ -n "$AUR_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to AUR
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && steps.aur-publish.outputs.enabled == 'true'
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ project_name: basecamp
 before:
   hooks:
     - sh -c 'mkdir -p completions && go run ./cmd/basecamp completion bash > completions/basecamp.bash && go run ./cmd/basecamp completion zsh > completions/_basecamp && go run ./cmd/basecamp completion fish > completions/basecamp.fish'
-    - sh -c 'if [ "{{ .Prerelease }}" = "true" ]; then echo "Skipping Claude plugin version stamp for prerelease {{ .Version }}"; else scripts/stamp-plugin-version.sh {{ .Version }}; fi'
+    - sh -c '{{ if .Prerelease }}echo "Skipping Claude plugin version stamp for prerelease {{ .Version }}"{{ else }}scripts/stamp-plugin-version.sh {{ .Version }}{{ end }}'
 
 builds:
   - id: basecamp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ project_name: basecamp
 before:
   hooks:
     - sh -c 'mkdir -p completions && go run ./cmd/basecamp completion bash > completions/basecamp.bash && go run ./cmd/basecamp completion zsh > completions/_basecamp && go run ./cmd/basecamp completion fish > completions/basecamp.fish'
-    - scripts/stamp-plugin-version.sh {{ .Version }}
+    - sh -c 'if [ "{{ .Prerelease }}" = "true" ]; then echo "Skipping Claude plugin version stamp for prerelease {{ .Version }}"; else scripts/stamp-plugin-version.sh {{ .Version }}; fi'
 
 builds:
   - id: basecamp
@@ -120,6 +120,7 @@ release:
     name: basecamp-cli
   draft: false
   prerelease: auto
+  make_latest: "{{ if .Prerelease }}false{{ else }}auto{{ end }}"
   replace_existing_artifacts: true
   name_template: "{{.ProjectName}} v{{.Version}}"
   header: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,6 +6,12 @@
 make release VERSION=0.2.0
 ```
 
+## Release candidate
+
+```bash
+make release VERSION=0.2.0-rc.1
+```
+
 ## Dry run
 
 ```bash
@@ -16,7 +22,7 @@ make release VERSION=0.2.0 DRY_RUN=1
 
 1. Validates semver format, main branch, clean tree, synced with remote
 2. Checks for `replace` directives in go.mod
-3. Updates `nix/package.nix` version and recomputes `vendorHash` via Docker if `go.mod` changed
+3. Updates stable release metadata (`nix/package.nix` and `.claude-plugin/plugin.json`) for stable versions
 4. Runs `make release-check` (quality checks, vuln scan, replace-check, race-test, surface compat)
 5. Creates annotated tag `v$VERSION` and pushes to origin
 6. GitHub Actions [release workflow](.github/workflows/release.yml) runs:
@@ -28,15 +34,39 @@ make release VERSION=0.2.0 DRY_RUN=1
    - Signs and notarizes macOS binaries via GoReleaser's built-in notarize (embedded quill)
    - Signs checksums with cosign (keyless via Sigstore OIDC)
    - Generates SBOM for supply chain transparency
-   - Updates Homebrew cask (`basecamp-cli`) in `basecamp/homebrew-tap`
-   - Updates Scoop manifest (`basecamp-cli`) in `basecamp/homebrew-tap`
-   - Updates AUR `basecamp-cli` package (when `AUR_KEY` is configured)
-   - Verifies Nix flake builds successfully
+   - Updates Homebrew cask (`basecamp-cli`) in `basecamp/homebrew-tap` for stable tags
+   - Updates Scoop manifest (`basecamp-cli`) in `basecamp/homebrew-tap` for stable tags
+   - Updates AUR `basecamp-cli` package for stable tags when `AUR_KEY` is configured
+   - Verifies Nix flake builds successfully for stable tags
 
 ## Versioning
 
-Pre-1.0: minor bumps for features, patch bumps for fixes. Prerelease tags
-(e.g. `0.2.0-rc.1`) are marked as prereleases automatically by GoReleaser.
+Pre-1.0: minor bumps for features, patch bumps for fixes. Use prerelease
+versions such as `0.2.0-rc.1` when testers need a release candidate before
+the next stable version.
+
+Stable releases publish to every normal distribution channel. Prereleases publish
+GitHub Release assets for explicit tester installs while keeping stable package
+manager channels and agent distribution metadata on the latest stable version.
+
+| Surface | Stable version `0.2.0` | Prerelease version `0.2.0-rc.1` |
+|---------|-------------------------|----------------------------------|
+| GitHub Releases | Published as a normal release and eligible for GitHub's latest release. | Published as a GitHub prerelease while GitHub's latest release points at stable. |
+| Release assets | Binaries, archives, checksums, SBOMs, and Linux packages are uploaded. | The same downloadable assets are uploaded for explicit tester installs. |
+| Homebrew | Updates the `basecamp-cli` cask in `basecamp/homebrew-tap`. | The stable cask remains active. |
+| Scoop | Updates the `basecamp-cli` manifest in `basecamp/homebrew-tap`. | The stable manifest remains active. |
+| AUR | Updates the `basecamp-cli` package when `AUR_KEY` is configured. | The stable AUR package remains active. |
+| Nix flake | Updates `nix/package.nix` and verifies the flake. | Nix metadata remains on the latest stable version. |
+| Claude plugin metadata | Updates `.claude-plugin/plugin.json`. | Plugin metadata remains on the latest stable version. |
+| Skills distribution | Syncs skills to the distribution repo. | Uses the skill embedded in the prerelease binary. |
+
+The prerelease binary embeds the matching `skills/basecamp/SKILL.md`. Testers can
+print or install that skill with:
+
+```bash
+basecamp skill
+basecamp skill install
+```
 
 ## Requirements
 
@@ -74,9 +104,9 @@ Pre-1.0: minor bumps for features, patch bumps for fixes. Prerelease tags
 
 ## Nix flake maintenance
 
-The `flake.nix` provides `nix profile install github:basecamp/basecamp-cli`. The release
-script automatically updates `nix/package.nix` version and recomputes `vendorHash` when
-`go.mod` changes (requires Docker).
+The `flake.nix` provides `nix profile install github:basecamp/basecamp-cli`. Stable
+releases update `nix/package.nix` version and recompute `vendorHash` when `go.mod`
+changes (requires Docker).
 
 To manually update the vendorHash (e.g. after an SDK bump):
 ```bash
@@ -88,9 +118,9 @@ make update-nix-hash
 | Channel | Location | Updated by |
 |---------|----------|------------|
 | GitHub Releases | [basecamp/basecamp-cli](https://github.com/basecamp/basecamp-cli/releases) | GoReleaser |
-| Homebrew cask (`basecamp-cli`) | `basecamp/homebrew-tap` Casks/ | GoReleaser |
-| Scoop (`basecamp-cli`) | `basecamp/homebrew-tap` root | GoReleaser |
-| AUR | `basecamp-cli` | GoReleaser |
+| Homebrew cask (`basecamp-cli`) | `basecamp/homebrew-tap` Casks/ | GoReleaser (stable tags) |
+| Scoop (`basecamp-cli`) | `basecamp/homebrew-tap` root | GoReleaser (stable tags) |
+| AUR | `basecamp-cli` | `scripts/publish-aur.sh` (stable tags) |
 | deb/rpm/apk packages | GitHub Release assets | GoReleaser (nfpm) |
 | Nix flake | `flake.nix` in repo | Self-serve (`nix profile install github:basecamp/basecamp-cli`) |
 | go install | `go install github.com/basecamp/basecamp-cli/cmd/basecamp@latest` | Go module proxy |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,8 +22,8 @@ make release VERSION=0.2.0 DRY_RUN=1
 
 1. Validates semver format, main branch, clean tree, synced with remote
 2. Checks for `replace` directives in go.mod
-3. Updates stable release metadata (`nix/package.nix` and `.claude-plugin/plugin.json`) for stable versions
-4. Runs `make release-check` (quality checks, vuln scan, replace-check, race-test, surface compat)
+3. Runs `make release-check` (quality checks, vuln scan, replace-check, race-test, surface compat)
+4. Updates stable release metadata (`nix/package.nix` and `.claude-plugin/plugin.json`) for stable versions
 5. Creates annotated tag `v$VERSION` and pushes to origin
 6. GitHub Actions [release workflow](.github/workflows/release.yml) runs:
    - Security scan + full test suite + CLI surface compatibility check

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,6 +37,10 @@ if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
 fi
 
 TAG="v${VERSION}"
+PRERELEASE=false
+if [[ "${VERSION}" == *-* ]]; then
+  PRERELEASE=true
+fi
 
 if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
   info "Dry run — no tags will be created or pushed"
@@ -76,32 +80,39 @@ fi
 info "Running release checks"
 make release-check
 
-# --- Update Nix flake ---
-info "Updating Nix flake"
-if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
-  echo "  (skipped — dry run)"
+# --- Update stable release metadata ---
+if [[ "${PRERELEASE}" == "true" ]]; then
+  info "Skipping stable release metadata for prerelease"
+  echo "  nix flake: unchanged"
+  echo "  Claude plugin metadata: unchanged"
 else
-  NIX_RC=0
-  scripts/update-nix-flake.sh "${VERSION}" || NIX_RC=$?
-  if [[ "$NIX_RC" -eq 0 ]]; then
-    : # nix flake updated
-  elif [[ "$NIX_RC" -eq 2 ]]; then
-    echo "  nix flake: no changes needed"
+  # --- Update Nix flake ---
+  info "Updating Nix flake"
+  if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
+    echo "  (skipped — dry run)"
   else
-    die "scripts/update-nix-flake.sh failed (exit $NIX_RC)"
+    NIX_RC=0
+    scripts/update-nix-flake.sh "${VERSION}" || NIX_RC=$?
+    if [[ "$NIX_RC" -eq 0 ]]; then
+      : # nix flake updated
+    elif [[ "$NIX_RC" -eq 2 ]]; then
+      echo "  nix flake: no changes needed"
+    else
+      die "scripts/update-nix-flake.sh failed (exit $NIX_RC)"
+    fi
+  fi
+
+  # --- Stamp plugin version ---
+  info "Stamping plugin version"
+  if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
+    echo "  (skipped — dry run)"
+  else
+    scripts/stamp-plugin-version.sh "${VERSION}"
   fi
 fi
 
-# --- Stamp plugin version ---
-info "Stamping plugin version"
-if [[ "${DRY_RUN}" == "true" || "${DRY_RUN}" == "1" ]]; then
-  echo "  (skipped — dry run)"
-else
-  scripts/stamp-plugin-version.sh "${VERSION}"
-fi
-
 # --- Commit release prep ---
-if [[ "${DRY_RUN}" != "true" && "${DRY_RUN}" != "1" ]]; then
+if [[ "${PRERELEASE}" != "true" && "${DRY_RUN}" != "true" && "${DRY_RUN}" != "1" ]]; then
   git add nix/package.nix .claude-plugin/plugin.json
   if ! git diff --cached --quiet; then
     STAGED=$(git diff --cached --name-only)

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -27,7 +27,9 @@ if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
 fi
 
 # --- Check if vendorHash needs recomputing ---
-PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+# Prerelease tags skip Nix metadata updates, so compare dependency changes
+# against the latest stable tag instead of an intervening RC tag.
+PREV_TAG=$(git tag --merged HEAD --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' | awk '!/-/ { print; exit }')
 NEED_HASH=false
 if [[ -z "$PREV_TAG" ]]; then
   NEED_HASH=true


### PR DESCRIPTION
## Summary
- publish prerelease tags as GitHub prereleases without marking them latest
- keep stable-only distribution metadata and package channels on stable releases
- keep Nix `vendorHash` comparisons anchored to the latest stable tag after RC tags
- document release candidate behavior, including embedded skill installs from prerelease binaries

## Tests
- `PATH=$HOME/go/bin:$PATH GOWORK=off GOTOOLCHAIN=go1.26.4 bin/ci`
- `goreleaser check`
- `bash -n scripts/release.sh scripts/update-nix-flake.sh scripts/stamp-plugin-version.sh scripts/publish-aur.sh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds release candidate publishing. Tags like v0.2.0-rc.1 publish as GitHub prereleases without becoming latest; stable-only channels stay on the last stable release.

- **New Features**
  - Mark prerelease tags as GitHub prereleases and set `make_latest: false` in `GoReleaser`; fix guard to skip Claude plugin version stamping on prereleases in both `GoReleaser` and `scripts/release.sh`.
  - Gate stable-only steps to stable tags: AUR publish (only when `AUR_KEY` is set), Nix flake verify, and skills sync.
  - Skip Nix/package metadata updates on prereleases; use the latest stable tag as the baseline for Nix `vendorHash` checks.
  - Update docs with RC flow, stable vs prerelease channels, and how embedded skills work in prerelease binaries.

<sup>Written for commit 392f5a8b87e3ed7b195ec3b6bd7fbe9e1ed28043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
