### PR TITLE
fix(cards): carry over step title when updating assignees or due date

### DIFF
--- a/internal/commands/assign.go
+++ b/internal/commands/assign.go
@@ -644,7 +644,10 @@ func doAssignStep(cmd *cobra.Command, app *appctx.App, stepIDStr, assigneeID str
 	}
 	assigneeIDs = append(assigneeIDs, assigneeIDInt)
 
+	// The API rejects step updates without a title, so carry over the
+	// current one.
 	updated, err := app.Account().CardSteps().Update(cmd.Context(), stepID, &basecamp.UpdateStepRequest{
+		Title:       step.Title,
 		AssigneeIDs: assigneeIDs,
 	})
 	if err != nil {
@@ -746,7 +749,10 @@ func doUnassignStep(cmd *cobra.Command, app *appctx.App, stepIDStr string, assig
 
 	assigneeIDs := removeID(existingAssigneeIDs(step.Assignees), assigneeIDInt)
 
+	// The API rejects step updates without a title, so carry over the
+	// current one.
 	updated, err := app.Account().CardSteps().Update(cmd.Context(), stepID, &basecamp.UpdateStepRequest{
+		Title:       step.Title,
 		AssigneeIDs: assigneeIDs,
 	})
 	if err != nil {

--- a/internal/commands/assign_test.go
+++ b/internal/commands/assign_test.go
@@ -723,18 +723,24 @@ func (m *mockStepAssignTransport) RoundTrip(req *http.Request) (*http.Response, 
 
 	switch req.Method {
 	case "GET":
-		body := `{}`
-		if strings.Contains(req.URL.Path, "/card_tables/steps/") {
+		var body string
+		switch {
+		case strings.Contains(req.URL.Path, "/card_tables/steps/"):
 			body = stepJSON
-		} else if strings.Contains(req.URL.Path, "/projects.json") {
+		case strings.Contains(req.URL.Path, "/projects.json"):
 			body = `[{"id": 123, "name": "Test Project"}]`
-		} else if strings.Contains(req.URL.Path, "/projects/") {
+		case strings.Contains(req.URL.Path, "/projects/"):
 			body = `{"id": 123, "dock": [{"name": "kanban_board", "id": 789, "title": "Card Table"}]}`
-		} else if strings.Contains(req.URL.Path, "/people.json") {
+		case strings.Contains(req.URL.Path, "/people.json"):
 			body = `[{"id": 11, "name": "Existing Person"}, {"id": 99, "name": "New Person"}]`
+		default:
+			return nil, fmt.Errorf("unexpected GET path: %s", req.URL.Path)
 		}
 		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: header}, nil
 	case "PUT":
+		if !strings.HasSuffix(req.URL.Path, "/card_tables/steps/456") {
+			return nil, fmt.Errorf("unexpected PUT path: %s", req.URL.Path)
+		}
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
@@ -778,5 +784,5 @@ func TestUnassignStepCarriesTitle(t *testing.T) {
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
 	assert.Equal(t, "Existing step", body["title"])
-	assert.Empty(t, body["assignee_ids"])
+	assert.Equal(t, []any{}, body["assignee_ids"])
 }

--- a/internal/commands/assign_test.go
+++ b/internal/commands/assign_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -705,4 +706,77 @@ func TestAssignBatchAllFailNeverResolvesAssignee(t *testing.T) {
 		assert.NotContains(t, entry, "/my/profile.json",
 			"person resolution should not be attempted when all items fail validation")
 	}
+}
+
+// mockStepAssignTransport serves the current step on GET and captures the
+// PUT body so the assign/unassign step paths can be checked for the
+// carried-over title the API requires.
+type mockStepAssignTransport struct {
+	capturedPut []byte
+}
+
+func (m *mockStepAssignTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	stepJSON := `{"id": 456, "title": "Existing step", "completed": false, "assignees": [{"id": 11, "name": "Existing Person"}]}`
+
+	switch req.Method {
+	case "GET":
+		body := `{}`
+		if strings.Contains(req.URL.Path, "/card_tables/steps/") {
+			body = stepJSON
+		} else if strings.Contains(req.URL.Path, "/projects.json") {
+			body = `[{"id": 123, "name": "Test Project"}]`
+		} else if strings.Contains(req.URL.Path, "/projects/") {
+			body = `{"id": 123, "dock": [{"name": "kanban_board", "id": 789, "title": "Card Table"}]}`
+		} else if strings.Contains(req.URL.Path, "/people.json") {
+			body = `[{"id": 11, "name": "Existing Person"}, {"id": 99, "name": "New Person"}]`
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: header}, nil
+	case "PUT":
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		m.capturedPut = body
+		if err := req.Body.Close(); err != nil {
+			return nil, err
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(stepJSON)), Header: header}, nil
+	default:
+		return nil, fmt.Errorf("unexpected request method: %s", req.Method)
+	}
+}
+
+// TestAssignStepCarriesTitle verifies that assigning a person to a step sends
+// the current title in the update, which the API requires.
+func TestAssignStepCarriesTitle(t *testing.T) {
+	transport := &mockStepAssignTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := NewAssignCmd()
+	err := executeAssignCommand(cmd, app, "456", "--step", "--to", "99")
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
+	assert.Equal(t, "Existing step", body["title"])
+	assert.Equal(t, []any{float64(11), float64(99)}, body["assignee_ids"])
+}
+
+// TestUnassignStepCarriesTitle verifies that removing a person from a step
+// also sends the current title in the update.
+func TestUnassignStepCarriesTitle(t *testing.T) {
+	transport := &mockStepAssignTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := NewUnassignCmd()
+	err := executeAssignCommand(cmd, app, "456", "--step", "--from", "11")
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
+	assert.Equal(t, "Existing step", body["title"])
+	assert.Empty(t, body["assignee_ids"])
 }

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -2009,6 +2009,14 @@ You can pass either a step ID or a Basecamp URL:
 			req := &basecamp.UpdateStepRequest{}
 			if title != "" {
 				req.Title = title
+			} else {
+				// The API rejects step updates without a title, so carry
+				// over the current one when only other fields change.
+				current, err := app.Account().CardSteps().Get(cmd.Context(), stepID)
+				if err != nil {
+					return convertSDKError(err)
+				}
+				req.Title = current.Title
 			}
 			if dueOn != "" {
 				req.DueOn = dateparse.Parse(dueOn)

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -189,6 +189,75 @@ func TestCardsStepUpdateRequiresFields(t *testing.T) {
 	assert.NoError(t, err, "expected help output, not error")
 }
 
+// mockStepUpdateTransport serves the current step on GET and captures the
+// update body on PUT.
+type mockStepUpdateTransport struct {
+	getCount    int
+	capturedPut []byte
+}
+
+func (t *mockStepUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	stepJSON := `{"id": 456, "title": "Current title", "completed": false, "assignees": []}`
+
+	switch req.Method {
+	case "GET":
+		t.getCount++
+	case "PUT":
+		if req.Body != nil {
+			body, _ := io.ReadAll(req.Body)
+			t.capturedPut = body
+			req.Body.Close()
+		}
+	default:
+		return nil, errors.New("unexpected request")
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(stepJSON)),
+		Header:     header,
+	}, nil
+}
+
+// TestCardsStepUpdateAssigneesOnlyCarriesTitle verifies that updating only
+// assignees fetches the current step and includes its title in the request —
+// the API rejects step updates without a title.
+func TestCardsStepUpdateAssigneesOnlyCarriesTitle(t *testing.T) {
+	transport := &mockStepUpdateTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := newCardsStepUpdateCmd()
+	err := executeCommand(cmd, app, "456", "--assignees", "789")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, transport.getCount)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
+	assert.Equal(t, "Current title", body["title"])
+	assert.Equal(t, []any{float64(789)}, body["assignee_ids"])
+}
+
+// TestCardsStepUpdateWithTitleSkipsFetch verifies that an explicit title is
+// sent as-is without fetching the current step.
+func TestCardsStepUpdateWithTitleSkipsFetch(t *testing.T) {
+	transport := &mockStepUpdateTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := newCardsStepUpdateCmd()
+	err := executeCommand(cmd, app, "456", "New title")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, transport.getCount)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
+	assert.Equal(t, "New title", body["title"])
+}
+
 // TestCardsStepMoveRequiresCard tests that --card is required for step move.
 func TestCardsStepMoveShowsHelp(t *testing.T) {
 	app, _ := setupTestApp(t)

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -259,6 +259,24 @@ func TestCardsStepUpdateAssigneesOnlyCarriesTitle(t *testing.T) {
 	assert.Equal(t, []any{float64(789)}, body["assignee_ids"])
 }
 
+// TestCardsStepUpdateDueOnlyCarriesTitle verifies that updating only the due
+// date fetches the current step and includes its title in the request.
+func TestCardsStepUpdateDueOnlyCarriesTitle(t *testing.T) {
+	transport := &mockStepUpdateTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := newCardsStepUpdateCmd()
+	err := executeCommand(cmd, app, "456", "--due", "2026-07-04")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, transport.getCount)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.capturedPut, &body))
+	assert.Equal(t, "Current title", body["title"])
+	assert.Equal(t, "2026-07-04", body["due_on"])
+}
+
 // TestCardsStepUpdateWithTitleSkipsFetch verifies that an explicit title is
 // sent as-is without fetching the current step.
 func TestCardsStepUpdateWithTitleSkipsFetch(t *testing.T) {

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -201,7 +201,7 @@ func (t *mockStepUpdateTransport) RoundTrip(req *http.Request) (*http.Response, 
 	header := make(http.Header)
 	header.Set("Content-Type", "application/json")
 
-	if req.URL.Path != "/99999/card_tables/steps/456" {
+	if !strings.HasSuffix(req.URL.Path, "/card_tables/steps/456") {
 		return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
 	}
 

--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -190,7 +190,8 @@ func TestCardsStepUpdateRequiresFields(t *testing.T) {
 }
 
 // mockStepUpdateTransport serves the current step on GET and captures the
-// update body on PUT.
+// update body on PUT. It only answers the single-step endpoint so a stray
+// call to the wrong path fails the test instead of passing on stale data.
 type mockStepUpdateTransport struct {
 	getCount    int
 	capturedPut []byte
@@ -200,20 +201,37 @@ func (t *mockStepUpdateTransport) RoundTrip(req *http.Request) (*http.Response, 
 	header := make(http.Header)
 	header.Set("Content-Type", "application/json")
 
-	stepJSON := `{"id": 456, "title": "Current title", "completed": false, "assignees": []}`
+	if req.URL.Path != "/99999/card_tables/steps/456" {
+		return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+	}
 
 	switch req.Method {
 	case "GET":
 		t.getCount++
 	case "PUT":
-		if req.Body != nil {
-			body, _ := io.ReadAll(req.Body)
-			t.capturedPut = body
-			req.Body.Close()
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		t.capturedPut = body
+		if err := req.Body.Close(); err != nil {
+			return nil, err
 		}
 	default:
-		return nil, errors.New("unexpected request")
+		return nil, fmt.Errorf("unexpected request method: %s", req.Method)
 	}
+
+	// Echo the title back so callers see the effective value, not a constant.
+	title := "Current title"
+	if t.capturedPut != nil {
+		var put struct {
+			Title string `json:"title"`
+		}
+		if err := json.Unmarshal(t.capturedPut, &put); err == nil && put.Title != "" {
+			title = put.Title
+		}
+	}
+	stepJSON := fmt.Sprintf(`{"id": 456, "title": %q, "completed": false, "assignees": []}`, title)
 
 	return &http.Response{
 		StatusCode: 200,


### PR DESCRIPTION
## Problem

`basecamp cards step update <id> --assignees <person>` always fails with 400 Bad Request. Same for `basecamp assign <id> --step` and `basecamp unassign <id> --step`.

The server rejects a step update whose body has no `title` key, even though the [API docs](https://github.com/basecamp/bc3-api/blob/master/sections/card_table_steps.md#update-a-step) list every parameter as optional. All three code paths sent `{"assignee_ids": [...]}` with no title, so every assignee-only or due-date-only update failed. The same request with the current title included succeeds.

## Fix

Carry over the current title when the caller does not provide a new one:

- `cards step update`: when invoked without a new title, fetch the step first and reuse its title.
- `assign --step` / `unassign --step`: pass the title of the step object these paths already fetch. No extra request.

## Tests

Added two unit tests with a capturing mock transport: assignee-only updates fetch the step once and send its current title, and explicit-title updates skip the fetch and send the new title as-is. `bin/ci` is green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry over the current step title when updating only assignees or the due date to prevent 400 Bad Request errors. This fixes `basecamp cards step update`, `basecamp assign --step`, and `basecamp unassign --step` when no new title is given.

- **Bug Fixes**
  - `cards step update`: if no title is provided, fetch the step and include its current title in the update.
  - `assign --step` / `unassign --step`: include `step.Title` in the update without extra requests; send `assignee_ids: []` explicitly on unassign.
  - Tests: coverage for assign/unassign title carry-over; assignees-only and due-only step updates carry the title; explicit-title updates skip fetching; assert single-step endpoint (suffix match); fail on unexpected routes; echo title in mock responses; surface mock IO errors.

<sup>Written for commit 46d4cb82f5700f57a92e9bd213309a9f6ba35271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

