### PR TITLE
Document todo subtask API usage in Basecamp skill

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -496,12 +496,11 @@ the todo UI.
 Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
 check for subtasks under a todo. The
 `/card_tables/cards/<parent_todo_id>/steps.json` endpoint works for `POST`
-creation, but in testing `GET` index requests to that same path returned
-`not_found` for todo-backed steps; direct `GET` requests to
-`/card_tables/cards/<parent_todo_id>.json` and
-`/todos/<parent_todo_id>/steps.json` also returned `not_found`. To inspect
-trashed subtasks, add `--status trashed`; archived parents may require
-`--status archived`.
+creation. In testing with todo-backed steps, these direct `GET` requests
+returned `not_found`: `/card_tables/cards/<parent_todo_id>/steps.json`,
+`/card_tables/cards/<parent_todo_id>.json`, and
+`/todos/<parent_todo_id>/steps.json`. To inspect trashed subtasks, add
+`--status trashed`; archived parents may require `--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
 with metadata changes; omitting it may reset the step title to `Untitled`. The

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -450,7 +450,7 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 and filter by `parent.id` to list/check subtasks for a todo.
 
 ```bash
-# Create a subtask under a todo
+# Create a subtask under a todo. Use the todo ID in this card-style path.
 basecamp api post /buckets/<project>/card_tables/cards/<todo_id>/steps.json \
   --data '{"title":"Subtask title"}' \
   --json
@@ -483,7 +483,9 @@ basecamp recordings trash <step_id> --in <project> --json
 ```
 
 Replace numeric placeholders such as `<todo_id>` and `<person_id>` before
-running the JSON or `--jq` examples.
+running the JSON or `--jq` examples. For creating todo subtasks, Basecamp
+accepts the parent todo ID in the `/card_tables/cards/<todo_id>/steps.json`
+path.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
@@ -492,11 +494,12 @@ Completed subtasks have `completed: true` and a `completion` object with
 the todo UI.
 
 Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
-check for subtasks under a todo. Direct `GET` requests to
-`/card_tables/cards/<todo_id>/steps.json`, `/card_tables/cards/<todo_id>.json`,
-and `/todos/<todo_id>/steps.json` may return `not_found` for todo-backed steps.
-To inspect trashed subtasks, add `--status trashed`; archived parents may
-require `--status archived`.
+check for subtasks under a todo. The `/card_tables/cards/<todo_id>/steps.json`
+endpoint works for `POST` creation, but verified `GET` index requests to that
+same path may return `not_found` for todo-backed steps; direct `GET` requests to
+`/card_tables/cards/<todo_id>.json` and `/todos/<todo_id>/steps.json` may also
+return `not_found`. To inspect trashed subtasks, add `--status trashed`;
+archived parents may require `--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
 with metadata changes; omitting it may reset the step title to `Untitled`. The

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -468,9 +468,10 @@ PARENT_TODO_ID=<parent_todo_id> \
 basecamp recordings list --in <project> --type Kanban::Step --all --json \
   --jq '.data[] | select(.parent.id==(env.PARENT_TODO_ID | tonumber)) | {id,title,status,parent:.parent.id,url}'
 
-# Assign or set a due date. Include the current title when updating metadata.
+# Assign or set a due date.
+# Include the current title and every person who should remain assigned.
 basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>.json \
-  --data '{"title":"Current subtask title","assignee_ids":[<person_id>],"due_on":"<YYYY-MM-DD>"}' \
+  --data '{"title":"Current subtask title","assignee_ids":[<person_id>,<existing_person_id>],"due_on":"<YYYY-MM-DD>"}' \
   --json
 
 # Complete or reopen a subtask
@@ -509,10 +510,12 @@ subtasks, add `--status trashed`; archived parents may require
 `--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
-with metadata changes; omitting it may reset the step title to `Untitled`. The
-generic `basecamp assign <step_id> --step ...` command is intended for card
-steps and may fail with `Bad Request` for todo-backed steps, so prefer
-`assignee_ids` on the raw step update endpoint for todo subtasks.
+with metadata changes; omitting it may reset the step title to `Untitled`.
+`assignee_ids` sets the full assignee list for the step, so include every person
+who should remain assigned. The generic
+`basecamp assign <step_id> --step ...` command is intended for card steps and
+may fail with `Bad Request` for todo-backed steps, so prefer `assignee_ids` on
+the raw step update endpoint for todo subtasks.
 
 ### Todolists
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -444,6 +444,52 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 
 **Flags:** `--assignee` (todos only - not available on cards/messages), `--status` (completed/incomplete/archived/trashed), `--overdue`, `--list`, `--due`, `--limit`, `--all`
 
+**Todo Subtasks (checklist steps):** Basecamp to-do subtasks are stored as
+`Kanban::Step` records, even when their parent is a normal `Todo`. The regular
+`todos show` response may not include them; use search to discover a step ID, or
+read it directly once you know the ID.
+
+```bash
+# Create a subtask under a todo
+basecamp api post /buckets/<project>/card_tables/cards/<todo_id>/steps.json \
+  --data '{"title":"Subtask title"}' \
+  --json
+
+# Read or edit a subtask
+basecamp api get /buckets/<project>/card_tables/steps/<step_id>.json --json
+basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
+  --data '{"title":"Updated subtask title"}' \
+  --json
+
+# Assign or set a due date. Include the current title when updating metadata.
+basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
+  --data '{"title":"Current subtask title","assignee_ids":[12345],"due_on":"2026-06-10"}' \
+  --json
+
+# Complete or reopen a subtask
+basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json \
+  --data '{"completion":"on"}' \
+  --json
+basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json \
+  --data '{"completion":"off"}' \
+  --json
+
+# Delete a subtask from the todo UI by trashing the step recording
+basecamp recordings trash <step_id> --in <project> --json
+```
+
+Completed subtasks have `completed: true` and a `completion` object with
+`created_at` and `creator`. Open subtasks have `completed: false` and no
+`completion` object. Trashed subtasks may still be readable directly with
+`status: "trashed"` and `inherits_status: false`, but they no longer appear in
+the todo UI.
+
+When updating a todo subtask with the raw API, include the existing `title` along
+with metadata changes; omitting it may reset the step title to `Untitled`. The
+generic `basecamp assign <step_id> --step ...` command is intended for card
+steps and may fail with `Bad Request` for todo-backed steps, so prefer
+`assignee_ids` on the raw step update endpoint for todo subtasks.
+
 ### Todolists
 
 Todolists are containers for todos. Create a todolist before adding todos.

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -451,7 +451,7 @@ and filter by `parent.id` to list/check subtasks for a todo.
 
 ```bash
 # Create a subtask under a todo. Use the todo ID in this card-style path.
-basecamp api post /buckets/<project>/card_tables/cards/<todo_id>/steps.json \
+basecamp api post /buckets/<project>/card_tables/cards/<parent_todo_id>/steps.json \
   --data '{"title":"Subtask title"}' \
   --json
 
@@ -463,7 +463,7 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
 
 # List active subtasks for a todo
 basecamp recordings list --in <project> --type Kanban::Step --all --json \
-  --jq '.data[] | select(.parent.id==<todo_id>) | {id,title,status,parent:.parent.id,url}'
+  --jq '.data[] | select(.parent.id==<parent_todo_id>) | {id,title,status,parent:.parent.id,url}'
 
 # Assign or set a due date. Include the current title when updating metadata.
 basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
@@ -482,10 +482,10 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json
 basecamp recordings trash <step_id> --in <project> --json
 ```
 
-Replace numeric placeholders such as `<todo_id>` and `<person_id>` before
+Replace numeric placeholders such as `<parent_todo_id>` and `<person_id>` before
 running the JSON or `--jq` examples. For creating todo subtasks, Basecamp
-accepts the parent todo ID in the `/card_tables/cards/<todo_id>/steps.json`
-path.
+accepts the parent todo ID in the
+`/card_tables/cards/<parent_todo_id>/steps.json` path.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
@@ -494,12 +494,14 @@ Completed subtasks have `completed: true` and a `completion` object with
 the todo UI.
 
 Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
-check for subtasks under a todo. The `/card_tables/cards/<todo_id>/steps.json`
-endpoint works for `POST` creation, but verified `GET` index requests to that
-same path may return `not_found` for todo-backed steps; direct `GET` requests to
-`/card_tables/cards/<todo_id>.json` and `/todos/<todo_id>/steps.json` may also
-return `not_found`. To inspect trashed subtasks, add `--status trashed`;
-archived parents may require `--status archived`.
+check for subtasks under a todo. The
+`/card_tables/cards/<parent_todo_id>/steps.json` endpoint works for `POST`
+creation, but verified `GET` index requests to that same path may return
+`not_found` for todo-backed steps; direct `GET` requests to
+`/card_tables/cards/<parent_todo_id>.json` and
+`/todos/<parent_todo_id>/steps.json` may also return `not_found`. To inspect
+trashed subtasks, add `--status trashed`; archived parents may require
+`--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
 with metadata changes; omitting it may reset the step title to `Untitled`. The

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -446,8 +446,9 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 
 **Todo Subtasks (checklist steps):** Basecamp to-do subtasks are stored as
 `Kanban::Step` records, even when their parent is a normal `Todo`. The regular
-`todos show` response may not include them; browse `Kanban::Step` recordings
-and filter by `parent.id` to list/check subtasks for a todo.
+`todos show` response may not include them; use
+`basecamp recordings list --type Kanban::Step` and filter by `parent.id` to
+list/check subtasks for a todo.
 
 ```bash
 # Create a subtask under a todo. Use the todo ID in this card-style path.
@@ -479,13 +480,16 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json
   --data '{"completion":"off"}' \
   --json
 
-# Delete a subtask from the todo UI by trashing the step record (Kanban::Step)
+# Trash a subtask from the todo UI by trashing the step record (Kanban::Step)
 basecamp recordings trash <step_id> --in <project> --json
 ```
 
-Replace numeric placeholders such as `<parent_todo_id>` and `<person_id>` before
-running the examples. For creating todo subtasks, Basecamp accepts the parent
-todo ID in the `/card_tables/cards/<parent_todo_id>/steps.json` path.
+Key points: replace numeric placeholders such as `<parent_todo_id>` and
+`<person_id>` before running the examples. For creating todo subtasks, Basecamp
+accepts the parent todo ID in the `/card_tables/cards/<parent_todo_id>/steps.json`
+path. To list subtasks under a todo, use
+`basecamp recordings list --type Kanban::Step` with the `parent.id` filter shown
+above.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
@@ -493,11 +497,8 @@ Completed subtasks have `completed: true` and a `completion` object with
 `status: "trashed"` and `inherits_status: false`, but they no longer appear in
 the todo UI.
 
-Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
-check for subtasks under a todo. The
-`/card_tables/cards/<parent_todo_id>/steps.json` endpoint works for `POST`
-creation. In testing with todo-backed steps, these direct `GET` requests
-returned `not_found`: `/card_tables/cards/<parent_todo_id>/steps.json`,
+In testing with todo-backed steps, these direct `GET` requests returned
+`not_found`: `/card_tables/cards/<parent_todo_id>/steps.json`,
 `/card_tables/cards/<parent_todo_id>.json`, and
 `/todos/<parent_todo_id>/steps.json`. To inspect trashed subtasks, add
 `--status trashed`; archived parents may require `--status archived`.

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -446,8 +446,8 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 
 **Todo Subtasks (checklist steps):** Basecamp to-do subtasks are stored as
 `Kanban::Step` records, even when their parent is a normal `Todo`. The regular
-`todos show` response may not include them; use search to discover a step ID, or
-read it directly once you know the ID.
+`todos show` response may not include them; browse `Kanban::Step` recordings
+and filter by `parent.id` to list/check subtasks for a todo.
 
 ```bash
 # Create a subtask under a todo
@@ -461,9 +461,13 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
   --data '{"title":"Updated subtask title"}' \
   --json
 
+# List active subtasks for a todo
+basecamp recordings list --in <project> --type Kanban::Step --all --json \
+  --jq '.data[] | select(.parent.id==<todo_id>) | {id,title,status,parent:.parent.id,url}'
+
 # Assign or set a due date. Include the current title when updating metadata.
 basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
-  --data '{"title":"Current subtask title","assignee_ids":[12345],"due_on":"<YYYY-MM-DD>"}' \
+  --data '{"title":"Current subtask title","assignee_ids":[<person_id>],"due_on":"<YYYY-MM-DD>"}' \
   --json
 
 # Complete or reopen a subtask
@@ -478,11 +482,21 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json
 basecamp recordings trash <step_id> --in <project> --json
 ```
 
+Replace numeric placeholders such as `<todo_id>` and `<person_id>` before
+running the JSON or `--jq` examples.
+
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
 `completion` object. Trashed subtasks may still be readable directly with
 `status: "trashed"` and `inherits_status: false`, but they no longer appear in
 the todo UI.
+
+Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
+check for subtasks under a todo. Direct `GET` requests to
+`/card_tables/cards/<todo_id>/steps.json`, `/card_tables/cards/<todo_id>.json`,
+and `/todos/<todo_id>/steps.json` may return `not_found` for todo-backed steps.
+To inspect trashed subtasks, add `--status trashed`; archived parents may
+require `--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
 with metadata changes; omitting it may reset the step title to `Untitled`. The

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -451,14 +451,15 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 list/check subtasks for a todo.
 
 ```bash
-# Create a subtask under a todo. Use the todo ID in this card-style path.
-basecamp api post /buckets/<project>/card_tables/cards/<parent_todo_id>/steps.json \
+# Create a subtask under a todo.
+# Use the numeric project ID and todo ID in this card-style path.
+basecamp api post /buckets/<project_id>/card_tables/cards/<parent_todo_id>/steps.json \
   --data '{"title":"Subtask title"}' \
   --json
 
 # Read or edit a subtask
-basecamp api get /buckets/<project>/card_tables/steps/<step_id>.json --json
-basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
+basecamp api get /buckets/<project_id>/card_tables/steps/<step_id>.json --json
+basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>.json \
   --data '{"title":"Updated subtask title"}' \
   --json
 
@@ -468,15 +469,15 @@ basecamp recordings list --in <project> --type Kanban::Step --all --json \
   --jq '.data[] | select(.parent.id==(env.PARENT_TODO_ID | tonumber)) | {id,title,status,parent:.parent.id,url}'
 
 # Assign or set a due date. Include the current title when updating metadata.
-basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
+basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>.json \
   --data '{"title":"Current subtask title","assignee_ids":[<person_id>],"due_on":"<YYYY-MM-DD>"}' \
   --json
 
 # Complete or reopen a subtask
-basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json \
+basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>/completions.json \
   --data '{"completion":"on"}' \
   --json
-basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json \
+basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>/completions.json \
   --data '{"completion":"off"}' \
   --json
 
@@ -484,12 +485,14 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json
 basecamp recordings trash <step_id> --in <project> --json
 ```
 
-Key points: replace numeric placeholders such as `<parent_todo_id>` and
-`<person_id>` before running the examples. For creating todo subtasks, Basecamp
-accepts the parent todo ID in the `/card_tables/cards/<parent_todo_id>/steps.json`
-path. To list subtasks under a todo, use
-`basecamp recordings list --type Kanban::Step` with the `parent.id` filter shown
-above.
+Key points: replace numeric placeholders such as `<project_id>`,
+`<parent_todo_id>`, and `<person_id>` before running the examples. Bucket-scoped
+API paths require a numeric project/bucket ID; `--in <project>` can still accept
+a project name where CLI commands support name resolution. For creating todo
+subtasks, Basecamp accepts the parent todo ID in the
+`/buckets/<project_id>/card_tables/cards/<parent_todo_id>/steps.json` path. To
+list subtasks under a todo, use `basecamp recordings list --type Kanban::Step`
+with the `parent.id` filter shown above.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
@@ -497,11 +500,13 @@ Completed subtasks have `completed: true` and a `completion` object with
 `status: "trashed"` and `inherits_status: false`, but they no longer appear in
 the todo UI.
 
-In testing with todo-backed steps, these direct `GET` requests returned
-`not_found`: `/card_tables/cards/<parent_todo_id>/steps.json`,
-`/card_tables/cards/<parent_todo_id>.json`, and
-`/todos/<parent_todo_id>/steps.json`. To inspect trashed subtasks, add
-`--status trashed`; archived parents may require `--status archived`.
+In testing with todo-backed steps, these bucket-scoped direct `GET` requests
+returned `not_found`:
+`/buckets/<project_id>/card_tables/cards/<parent_todo_id>/steps.json`,
+`/buckets/<project_id>/card_tables/cards/<parent_todo_id>.json`, and
+`/buckets/<project_id>/todos/<parent_todo_id>/steps.json`. To inspect trashed
+subtasks, add `--status trashed`; archived parents may require
+`--status archived`.
 
 When updating a todo subtask with the raw API, include the existing `title` along
 with metadata changes; omitting it may reset the step title to `Untitled`. The

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -463,7 +463,7 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
 
 # Assign or set a due date. Include the current title when updating metadata.
 basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
-  --data '{"title":"Current subtask title","assignee_ids":[12345],"due_on":"2026-06-10"}' \
+  --data '{"title":"Current subtask title","assignee_ids":[12345],"due_on":"<YYYY-MM-DD>"}' \
   --json
 
 # Complete or reopen a subtask
@@ -474,7 +474,7 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>/completions.json
   --data '{"completion":"off"}' \
   --json
 
-# Delete a subtask from the todo UI by trashing the step recording
+# Delete a subtask from the todo UI by trashing the step record (Kanban::Step)
 basecamp recordings trash <step_id> --in <project> --json
 ```
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -446,9 +446,9 @@ basecamp todos sweep --overdue --complete --comment "Done" --in <project>
 
 **Todo Subtasks (checklist steps):** Basecamp to-do subtasks are stored as
 `Kanban::Step` records, even when their parent is a normal `Todo`. The regular
-`todos show` response may not include them; use
-`basecamp recordings list --type Kanban::Step` and filter by `parent.id` to
-list/check subtasks for a todo.
+`basecamp todos show` response may not include them; use
+`basecamp recordings list --in <project> --type Kanban::Step` and filter by
+`parent.id` to list/check subtasks for a todo.
 
 ```bash
 # Create a subtask under a todo.
@@ -465,7 +465,7 @@ basecamp api put /buckets/<project_id>/card_tables/steps/<step_id>.json \
 
 # List subtasks for a todo
 PARENT_TODO_ID=<parent_todo_id> \
-basecamp recordings list --in <project> --type Kanban::Step --all --json \
+basecamp recordings list --in <project> --type Kanban::Step --all \
   --jq '.data[] | select(.parent.id==(env.PARENT_TODO_ID | tonumber)) | {id,title,status,parent:.parent.id,url}'
 
 # Assign or set a due date.
@@ -492,8 +492,9 @@ API paths require a numeric project/bucket ID; `--in <project>` can still accept
 a project name where CLI commands support name resolution. For creating todo
 subtasks, Basecamp accepts the parent todo ID in the
 `/buckets/<project_id>/card_tables/cards/<parent_todo_id>/steps.json` path. To
-list subtasks under a todo, use `basecamp recordings list --type Kanban::Step`
-with the `parent.id` filter shown above.
+list subtasks under a todo, use
+`basecamp recordings list --in <project> --type Kanban::Step` with the
+`parent.id` filter shown above.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -461,9 +461,10 @@ basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
   --data '{"title":"Updated subtask title"}' \
   --json
 
-# List active subtasks for a todo
+# List subtasks for a todo
+PARENT_TODO_ID=<parent_todo_id> \
 basecamp recordings list --in <project> --type Kanban::Step --all --json \
-  --jq '.data[] | select(.parent.id==<parent_todo_id>) | {id,title,status,parent:.parent.id,url}'
+  --jq '.data[] | select(.parent.id==(env.PARENT_TODO_ID | tonumber)) | {id,title,status,parent:.parent.id,url}'
 
 # Assign or set a due date. Include the current title when updating metadata.
 basecamp api put /buckets/<project>/card_tables/steps/<step_id>.json \
@@ -483,9 +484,8 @@ basecamp recordings trash <step_id> --in <project> --json
 ```
 
 Replace numeric placeholders such as `<parent_todo_id>` and `<person_id>` before
-running the JSON or `--jq` examples. For creating todo subtasks, Basecamp
-accepts the parent todo ID in the
-`/card_tables/cards/<parent_todo_id>/steps.json` path.
+running the examples. For creating todo subtasks, Basecamp accepts the parent
+todo ID in the `/card_tables/cards/<parent_todo_id>/steps.json` path.
 
 Completed subtasks have `completed: true` and a `completion` object with
 `created_at` and `creator`. Open subtasks have `completed: false` and no
@@ -496,10 +496,10 @@ the todo UI.
 Use `basecamp recordings list --type Kanban::Step` with a `parent.id` filter to
 check for subtasks under a todo. The
 `/card_tables/cards/<parent_todo_id>/steps.json` endpoint works for `POST`
-creation, but verified `GET` index requests to that same path may return
+creation, but in testing `GET` index requests to that same path returned
 `not_found` for todo-backed steps; direct `GET` requests to
 `/card_tables/cards/<parent_todo_id>.json` and
-`/todos/<parent_todo_id>/steps.json` may also return `not_found`. To inspect
+`/todos/<parent_todo_id>/steps.json` also returned `not_found`. To inspect
 trashed subtasks, add `--status trashed`; archived parents may require
 `--status archived`.
 


### PR DESCRIPTION
## What

Document Basecamp todo subtask/checklist-step handling in `skills/basecamp/SKILL.md`:

- Todo subtasks are represented as `Kanban::Step` records even when parented to a normal `Todo`.
- Add raw API examples for creating, reading, editing, assigning, setting due dates, completing/reopening, and trashing todo subtasks.
- Note practical agent gotchas discovered during testing: preserve `title` when updating metadata, use `assignee_ids` instead of `basecamp assign --step` for todo-backed steps, and use `recordings trash` rather than `DELETE` to remove the subtask from the todo UI.

## Why

The existing skill documents card steps, but todo-backed subtasks are not exposed through the normal `todos` commands and can be easy for agents to miss or handle incorrectly. This gives agents a verified workflow for managing these subtasks through the raw API until/if first-class CLI commands exist.

## Testing

- Manually verified against a real Basecamp todo subtask:
  - Created and read todo subtasks through the `card_tables/steps` API.
  - Assigned a subtask and set `due_on` via raw step update with `assignee_ids`.
  - Confirmed `basecamp assign --step` returned `Bad Request` for a todo-backed step.
  - Trashed a subtask with `basecamp recordings trash` and confirmed it disappeared from the todo UI while direct reads returned `status: "trashed"`.
- [ ] `make check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how to manage Basecamp to‑do subtasks (checklist steps) in `skills/basecamp/SKILL.md` using raw `card_tables/steps` APIs, with explicit `basecamp recordings list` (filter by `parent.id`, use `--status trashed`/`--status archived`) and `recordings trash` examples, plus create/read/update, assignment + due dates, complete/reopen (`/completions.json`), and trash.

Clarifies subtasks are `Kanban::Step` records, the create path `/card_tables/cards/<parent_todo_id>/steps.json`, numeric bucket IDs, fields like `status: "trashed"`/`inherits_status: false`, known `GET` routes that return `not_found`, and update gotchas (preserve `title`, prefer `assignee_ids`, and note `assignee_ids` replaces the full assignee list).

<sup>Written for commit 53179dc1645404d853e2136dbf732cd8836d52d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

