### PR TITLE
Fix --version over-propagation in check-cli-surface.sh

### DIFF
--- a/scripts/check-cli-surface.sh
+++ b/scripts/check-cli-surface.sh
@@ -15,7 +15,10 @@ fi
 
 # Capture root persistent flags once — these are available on every subcommand
 # but --help --agent only reports them on the root command itself.
-ROOT_FLAGS=$("$BINARY" --help --agent 2>/dev/null | jq -c '[.flags // [] | .[] | {name, type}]')
+# Use a child command's inherited_flags to get only persistent flags, excluding
+# local-only root flags like --version that Cobra does not propagate.
+_first_sub=$("$BINARY" --help --agent 2>/dev/null | jq -r '.subcommands[0].name')
+ROOT_FLAGS=$("$BINARY" "${_first_sub}" --help --agent 2>/dev/null | jq -c '[.inherited_flags // [] | .[] | {name, type}]')
 
 walk_commands() {
   local cmd_path="$1"


### PR DESCRIPTION
## Summary

`scripts/check-cli-surface.sh` merged ALL root `.flags` (22 entries) into every subcommand, including local-only flags like `--version` that Cobra does not propagate to children. This created a ~612-entry divergence vs the Go surface walker (`github.com/basecamp/cli/surface`).

## Fix

Derive `$ROOT_FLAGS` from a child command's `inherited_flags` instead of the root's `.flags`. This captures only the 5 persistent flags Cobra actually propagates (`account`, `json`, `md`, `project`, `quiet`), excluding 17 local-only flags (`version`, `agent`, `verbose`, `cache-dir`, etc.).

## Before → After

| Metric | Before | After |
|--------|--------|-------|
| Root flags merged into subcommands | 22 | 5 |
| `--version` in subcommand surface | ✗ | ✓ (correctly omitted) |
| Surface lines | ~10,900 | ~7,750 |

## Testing

```bash
# Verify root still has all its flags
./bin/basecamp --help --agent | jq ".flags | length"  # 22

# Verify children only inherit persistent flags
./bin/basecamp todos --help --agent | jq ".inherited_flags | length"  # 5

# Regenerate surface and confirm no --version in subcommands
bash scripts/check-cli-surface.sh ./bin/basecamp /tmp/surface.txt
grep "FLAG basecamp account --version" /tmp/surface.txt  # no match
grep "FLAG basecamp --version" /tmp/surface.txt          # match (root only)
```

Closes #368

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect flag propagation in `scripts/check-cli-surface.sh` by only inheriting persistent flags for subcommands. This removes `--version` and other local-only flags from subcommand surfaces and restores parity with the Go walker `github.com/basecamp/cli/surface`.

- **Bug Fixes**
  - Derive `ROOT_FLAGS` from a subcommand’s `inherited_flags` instead of the root’s `.flags`.
  - Subcommands now include only 5 persistent flags; `--version` is root-only; surface size drops from ~10,900 to ~7,750 lines.

<sup>Written for commit 9e45417ada86b5ad08a032219c9f84520d890d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

