### PR TITLE
Test cards update preserves HTML body

### DIFF
--- a/internal/commands/cards_test.go
+++ b/internal/commands/cards_test.go
@@ -1597,6 +1597,24 @@ func TestCardsUpdateContentIsHTML(t *testing.T) {
 	assert.Contains(t, content, "<strong>bold</strong>")
 }
 
+func TestCardsUpdatePreservesHTMLBody(t *testing.T) {
+	transport := &mockCardCreateTransport{}
+	app := setupCardsMockApp(t, transport)
+
+	cmd := NewCardsCmd()
+	err := executeCommand(cmd, app, "update", "999", "--body", "<p>Hello <code>world</code></p>")
+	require.NoError(t, err)
+	require.NotEmpty(t, transport.capturedBody)
+
+	var body map[string]any
+	err = json.Unmarshal(transport.capturedBody, &body)
+	require.NoError(t, err)
+
+	content, ok := body["content"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "<p>Hello <code>world</code></p>", content)
+}
+
 func TestCardsCreateLocalImageErrors(t *testing.T) {
 	transport := &mockCardCreateTransport{}
 	app := setupCardsMockApp(t, transport)


### PR DESCRIPTION
## Summary
- Add a regression test for `cards update --body '<p>Hello <code>world</code></p>'`
- Assert preformatted HTML is sent as the card `content` payload unchanged

## Validation
- `GOWORK=off go test ./internal/commands -run 'TestCardsUpdate(PreservesHTMLBody|ContentIsHTML)'`

Refs #420.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test verifying that `cards update --body '<p>Hello <code>world</code></p>'` preserves the HTML body and sends it unchanged as the `content` payload. Addresses #420.

<sup>Written for commit 5dd8bf2cc50372d9ea06ff115691af899e0fef99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

