### PR TITLE
Return fresh project after update

### DIFF
--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -351,12 +351,11 @@ Examples:
 				Description: description,
 			}
 
-			project, err := app.Account().Projects().Update(cmd.Context(), projectID, req)
-			if err != nil {
+			if _, err := app.Account().Projects().Update(cmd.Context(), projectID, req); err != nil {
 				return convertSDKError(err)
 			}
 
-			project, err = app.Account().Projects().Get(cmd.Context(), projectID)
+			project, err := app.Account().Projects().Get(cmd.Context(), projectID)
 			if err != nil {
 				return convertSDKError(err)
 			}

--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -351,19 +351,23 @@ Examples:
 				Description: description,
 			}
 
-			if _, err := app.Account().Projects().Update(cmd.Context(), projectID, req); err != nil {
-				return convertSDKError(err)
-			}
-
-			project, err := app.Account().Projects().Get(cmd.Context(), projectID)
+			project, err := app.Account().Projects().Update(cmd.Context(), projectID, req)
 			if err != nil {
 				return convertSDKError(err)
 			}
 
-			return app.OK(project,
+			respOpts := []output.ResponseOption{
 				output.WithEntity("project"),
 				output.WithSummary("Project updated"),
-			)
+			}
+			freshProject, err := app.Account().Projects().Get(cmd.Context(), projectID)
+			if err != nil {
+				respOpts = append(respOpts, output.WithDiagnostic(fmt.Sprintf("Project updated, but fetching the latest project state failed: %v", err)))
+			} else {
+				project = freshProject
+			}
+
+			return app.OK(project, respOpts...)
 		},
 	}
 

--- a/internal/commands/projects.go
+++ b/internal/commands/projects.go
@@ -356,6 +356,11 @@ Examples:
 				return convertSDKError(err)
 			}
 
+			project, err = app.Account().Projects().Get(cmd.Context(), projectID)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
 			return app.OK(project,
 				output.WithEntity("project"),
 				output.WithSummary("Project updated"),

--- a/internal/commands/projects_test.go
+++ b/internal/commands/projects_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 type mockProjectUpdateTransport struct {
-	getCount int
-	putCount int
+	getCount       int
+	putCount       int
+	putName        string
+	putDescription string
 }
 
 func (t *mockProjectUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -46,6 +48,16 @@ func (t *mockProjectUpdateTransport) RoundTrip(req *http.Request) (*http.Respons
 		return jsonResponse(200, fmt.Sprintf(`{"id":123,"name":"Test Project","description":%q,"updated_at":%q}`, description, updatedAt), header), nil
 	case http.MethodPut:
 		t.putCount++
+		var body map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			return nil, fmt.Errorf("decode update body: %w", err)
+		}
+		if name, ok := body["name"].(string); ok {
+			t.putName = name
+		}
+		if description, ok := body["description"].(string); ok {
+			t.putDescription = description
+		}
 		return jsonResponse(200, `{"id":123,"name":"Test Project","description":"Old description","updated_at":"2026-06-01T00:00:00.000Z"}`, header), nil
 	default:
 		return nil, fmt.Errorf("unexpected method: %s", req.Method)
@@ -90,6 +102,8 @@ func TestProjectsUpdateReturnsFreshProjectAfterDescriptionChange(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, transport.putCount)
+	assert.Equal(t, "Test Project", transport.putName)
+	assert.Equal(t, "New description", transport.putDescription)
 	assert.Equal(t, 2, transport.getCount, "description-only update should fetch the current name, then refetch the fresh project after update")
 
 	var envelope struct {

--- a/internal/commands/projects_test.go
+++ b/internal/commands/projects_test.go
@@ -26,6 +26,7 @@ type mockProjectUpdateTransport struct {
 	putCount       int
 	putName        string
 	putDescription string
+	failRefetch    bool
 }
 
 func (t *mockProjectUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -39,6 +40,9 @@ func (t *mockProjectUpdateTransport) RoundTrip(req *http.Request) (*http.Respons
 	switch req.Method {
 	case http.MethodGet:
 		t.getCount++
+		if t.getCount > 1 && t.failRefetch {
+			return jsonResponse(400, `{"error":"boom"}`, header), nil
+		}
 		description := "Old description"
 		updatedAt := "2026-06-01T00:00:00.000Z"
 		if t.getCount > 1 {
@@ -106,19 +110,43 @@ func TestProjectsUpdateReturnsFreshProjectAfterDescriptionChange(t *testing.T) {
 	assert.Equal(t, "New description", transport.putDescription)
 	assert.Equal(t, 2, transport.getCount, "description-only update should fetch the current name, then refetch the fresh project after update")
 
-	var envelope struct {
-		OK   bool `json:"ok"`
-		Data struct {
-			ID          int64  `json:"id"`
-			Name        string `json:"name"`
-			Description string `json:"description"`
-			UpdatedAt   string `json:"updated_at"`
-		} `json:"data"`
-	}
+	var envelope projectUpdateEnvelope
 	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope))
 	assert.True(t, envelope.OK)
 	assert.Equal(t, int64(123), envelope.Data.ID)
 	assert.Equal(t, "Test Project", envelope.Data.Name)
 	assert.Equal(t, "New description", envelope.Data.Description)
 	assert.Equal(t, "2026-06-02T00:00:00Z", envelope.Data.UpdatedAt)
+	assert.Empty(t, envelope.Notice)
+}
+
+func TestProjectsUpdateFallsBackToUpdateResponseWhenRefetchFails(t *testing.T) {
+	transport := &mockProjectUpdateTransport{failRefetch: true}
+	app, out := setupProjectsMockApp(t, transport)
+
+	cmd := NewProjectsCmd()
+	err := executeCommand(cmd, app, "update", "123", "--description", "New description")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, transport.putCount)
+	assert.Equal(t, 2, transport.getCount)
+
+	var envelope projectUpdateEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope))
+	assert.True(t, envelope.OK)
+	assert.Equal(t, int64(123), envelope.Data.ID)
+	assert.Equal(t, "Test Project", envelope.Data.Name)
+	assert.Equal(t, "Old description", envelope.Data.Description)
+	assert.Contains(t, envelope.Notice, "Project updated, but fetching the latest project state failed")
+}
+
+type projectUpdateEnvelope struct {
+	OK     bool   `json:"ok"`
+	Notice string `json:"notice"`
+	Data   struct {
+		ID          int64  `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		UpdatedAt   string `json:"updated_at"`
+	} `json:"data"`
 }

--- a/internal/commands/projects_test.go
+++ b/internal/commands/projects_test.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/auth"
+	"github.com/basecamp/basecamp-cli/internal/config"
+	"github.com/basecamp/basecamp-cli/internal/names"
+	"github.com/basecamp/basecamp-cli/internal/output"
+)
+
+type mockProjectUpdateTransport struct {
+	getCount int
+	putCount int
+}
+
+func (t *mockProjectUpdateTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	if !strings.Contains(req.URL.Path, "/projects/123") {
+		return nil, fmt.Errorf("unexpected request path: %s", req.URL.Path)
+	}
+
+	switch req.Method {
+	case http.MethodGet:
+		t.getCount++
+		description := "Old description"
+		updatedAt := "2026-06-01T00:00:00.000Z"
+		if t.getCount > 1 {
+			description = "New description"
+			updatedAt = "2026-06-02T00:00:00.000Z"
+		}
+		return jsonResponse(200, fmt.Sprintf(`{"id":123,"name":"Test Project","description":%q,"updated_at":%q}`, description, updatedAt), header), nil
+	case http.MethodPut:
+		t.putCount++
+		return jsonResponse(200, `{"id":123,"name":"Test Project","description":"Old description","updated_at":"2026-06-01T00:00:00.000Z"}`, header), nil
+	default:
+		return nil, fmt.Errorf("unexpected method: %s", req.Method)
+	}
+}
+
+func jsonResponse(status int, body string, header http.Header) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}
+}
+
+func setupProjectsMockApp(t *testing.T, transport http.RoundTripper) (*appctx.App, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	cfg := &config.Config{AccountID: "99999"}
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &testTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	authMgr := auth.NewManager(cfg, nil)
+	buf := &bytes.Buffer{}
+
+	return &appctx.App{
+		Config: cfg,
+		Auth:   authMgr,
+		SDK:    sdkClient,
+		Names:  names.NewResolver(sdkClient, authMgr, cfg.AccountID),
+		Output: output.New(output.Options{Format: output.FormatJSON, Writer: buf}),
+	}, buf
+}
+
+func TestProjectsUpdateReturnsFreshProjectAfterDescriptionChange(t *testing.T) {
+	transport := &mockProjectUpdateTransport{}
+	app, out := setupProjectsMockApp(t, transport)
+
+	cmd := NewProjectsCmd()
+	err := executeCommand(cmd, app, "update", "123", "--description", "New description")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, transport.putCount)
+	assert.Equal(t, 2, transport.getCount, "description-only update should fetch the current name, then refetch the fresh project after update")
+
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			ID          int64  `json:"id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			UpdatedAt   string `json:"updated_at"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope))
+	assert.True(t, envelope.OK)
+	assert.Equal(t, int64(123), envelope.Data.ID)
+	assert.Equal(t, "Test Project", envelope.Data.Name)
+	assert.Equal(t, "New description", envelope.Data.Description)
+	assert.Equal(t, "2026-06-02T00:00:00Z", envelope.Data.UpdatedAt)
+}


### PR DESCRIPTION
## Summary
- Refetch projects after `projects update` before returning the response envelope
- Add a red/green regression test for stale update responses

## Validation
Reproduced on current main against Rob Zolkos test account/project: the update response returned the old description while a follow-up `projects show` returned the new description.

After this change, the same live validation returns the updated description in the `projects update` response.

Local tests:

```bash
GOWORK=off go test ./internal/commands -run TestProjectsUpdateReturnsFreshProjectAfterDescriptionChange
GOWORK=off go test ./internal/commands
```

Closes #468.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the fresh project after `projects update` by refetching, fixing stale fields in the response. If the refetch fails, fall back to the update response and include a diagnostic. Closes #468.

- **Bug Fixes**
  - After a successful update, refetch with `Projects().Get` and return that result so `description` and `updated_at` are current.
  - When refetch fails, return the update response and add a notice via `output.WithDiagnostic`; tests also assert the PUT body includes the current `name` when only `description` changes.

<sup>Written for commit eefed1754423573bb8e84b1686c9d56071f20470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

