### PR TITLE
Fix TestFormatDueDate year-boundary flake

### DIFF
--- a/internal/tui/workspace/views/detail.go
+++ b/internal/tui/workspace/views/detail.go
@@ -1549,11 +1549,17 @@ func fetchSubscriptionState(sub *basecamp.Subscription, err error) bool {
 
 // formatDueDate converts an ISO date string to a human-friendly label.
 func formatDueDate(iso string) string {
+	return formatDueDateAt(iso, time.Now())
+}
+
+// formatDueDateAt formats a due date relative to a caller-supplied now, so the
+// relative labels ("Today"/"Tomorrow"/same-year) are deterministic and testable
+// without depending on the wall clock. formatDueDate passes time.Now().
+func formatDueDateAt(iso string, now time.Time) string {
 	t, err := time.ParseInLocation("2006-01-02", iso, time.Local)
 	if err != nil {
 		return iso
 	}
-	now := time.Now()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 	switch {
 	case t.Equal(today):

--- a/internal/tui/workspace/views/detail_test.go
+++ b/internal/tui/workspace/views/detail_test.go
@@ -809,12 +809,18 @@ func TestFormatDueDate(t *testing.T) {
 	assert.Equal(t, "Tomorrow", formatDueDate(tomorrow))
 	assert.Equal(t, "Yesterday", formatDueDate(yesterday))
 
-	// Same year, far enough from today to avoid collisions
-	farDate := now.AddDate(0, 6, 0) // 6 months ahead
-	farISO := farDate.Format("2006-01-02")
-	result := formatDueDate(farISO)
-	assert.Contains(t, result, farDate.Format("Jan 2"))
-	assert.NotContains(t, result, farDate.Format("2006"), "same-year dates should omit year")
+	// A date in the same calendar year as today, comfortably away from today.
+	// Pick the opposite half of the year so it stays same-year and clear of the
+	// today/tomorrow/yesterday window no matter when in the year this runs —
+	// AddDate(0, 6, 0) would cross into next year for any date after June.
+	sameYearMonth := time.November
+	if now.Month() >= time.July {
+		sameYearMonth = time.February
+	}
+	sameYear := time.Date(now.Year(), sameYearMonth, 15, 0, 0, 0, 0, now.Location())
+	result := formatDueDate(sameYear.Format("2006-01-02"))
+	assert.Contains(t, result, sameYear.Format("Jan 2"))
+	assert.NotContains(t, result, sameYear.Format("2006"), "same-year dates should omit year")
 
 	// Different year: includes year
 	otherYear := now.AddDate(-2, 0, 0).Format("2006-01-02")

--- a/internal/tui/workspace/views/detail_test.go
+++ b/internal/tui/workspace/views/detail_test.go
@@ -800,35 +800,34 @@ func TestDetail_EditingCallsRelayout(t *testing.T) {
 }
 
 func TestFormatDueDate(t *testing.T) {
-	now := time.Now()
+	// Fixed reference time so the test is fully deterministic — it never reads
+	// the wall clock, so there's no midnight/New-Year race between the test's
+	// now and the one formatDueDate would compute internally.
+	now := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.Local)
+	format := func(iso string) string { return formatDueDateAt(iso, now) }
+
 	today := now.Format("2006-01-02")
 	tomorrow := now.AddDate(0, 0, 1).Format("2006-01-02")
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 
-	assert.Equal(t, "Today", formatDueDate(today))
-	assert.Equal(t, "Tomorrow", formatDueDate(tomorrow))
-	assert.Equal(t, "Yesterday", formatDueDate(yesterday))
+	assert.Equal(t, "Today", format(today))
+	assert.Equal(t, "Tomorrow", format(tomorrow))
+	assert.Equal(t, "Yesterday", format(yesterday))
 
-	// A date in the same calendar year as today, comfortably away from today.
-	// Pick the opposite half of the year so it stays same-year and clear of the
-	// today/tomorrow/yesterday window no matter when in the year this runs —
-	// AddDate(0, 6, 0) would cross into next year for any date after June.
-	sameYearMonth := time.November
-	if now.Month() >= time.July {
-		sameYearMonth = time.February
-	}
-	sameYear := time.Date(now.Year(), sameYearMonth, 15, 0, 0, 0, 0, now.Location())
-	result := formatDueDate(sameYear.Format("2006-01-02"))
+	// Same calendar year as now, comfortably away from the today/tomorrow/
+	// yesterday window.
+	sameYear := time.Date(now.Year(), time.February, 15, 0, 0, 0, 0, now.Location())
+	result := format(sameYear.Format("2006-01-02"))
 	assert.Contains(t, result, sameYear.Format("Jan 2"))
 	assert.NotContains(t, result, sameYear.Format("2006"), "same-year dates should omit year")
 
-	// Different year: includes year
-	otherYear := now.AddDate(-2, 0, 0).Format("2006-01-02")
-	result = formatDueDate(otherYear)
-	assert.Contains(t, result, now.AddDate(-2, 0, 0).Format("2006"))
+	// Different year: includes year.
+	otherYear := now.AddDate(-2, 0, 0)
+	result = format(otherYear.Format("2006-01-02"))
+	assert.Contains(t, result, otherYear.Format("2006"))
 
-	// Invalid input: pass through
-	assert.Equal(t, "not-a-date", formatDueDate("not-a-date"))
+	// Invalid input: pass through.
+	assert.Equal(t, "not-a-date", format("not-a-date"))
 }
 
 func TestDetail_SyncPreview_DueDateFormatted(t *testing.T) {


### PR DESCRIPTION
## Problem

`TestFormatDueDate` fails on any run after June, blocking CI on `main` and every open PR:

```
Error:    "Sat, Jan 2, 2027" should not contain "2027"
Messages: same-year dates should omit year
```

The "same year" case built its date with `now.AddDate(0, 6, 0)` (6 months ahead). From July onward that lands in the **next** calendar year, so `formatDueDate` correctly includes the year — and the `NotContains(year)` assertion fails. It's a latent test bug that started firing as the calendar rolled forward; the production `formatDueDate` is unaffected.

## Fix

Pick a same-year date in the **opposite half** of the current year (Feb if now is in H2, Nov if now is in H1). That guarantees it stays in the current calendar year and clear of the today/tomorrow/yesterday window no matter when in the year the suite runs.

## Verification

- Before: `TestFormatDueDate` red (reproduces on clean `main`).
- After: `TestFormatDueDate` and the full `internal/tui/workspace/views` package green.
- `gofmt`/`go vet` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky `TestFormatDueDate` and makes it fully deterministic by driving it from a fixed `now`. Keeps CI green without changing `formatDueDate` behavior.

- **Bug Fixes**
  - Extracted `formatDueDateAt(iso, now)` and have `formatDueDate` call it with `time.Now()` to remove midnight/New‑Year races.
  - Assert the same‑year case using Feb 15 of the current year, safely away from today/tomorrow/yesterday.

<sup>Written for commit 2fc8ef577d65644a2276dec355e64cd2a56e1633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

