### PR TITLE
docs: note Termux/Android SIGSYS crash and build-from-source workaround

### DIFF
--- a/install.md
+++ b/install.md
@@ -160,8 +160,9 @@ basecamp auth login --scope full
 
 **Termux / Android (`SIGSYS: bad system call` on startup):**
 
-On Termux, the prebuilt binaries and `go install …@latest` crash immediately —
-even `basecamp --help` — with `SIGSYS: bad system call`. A transitive
+On Termux, the prebuilt binaries and
+`go install github.com/basecamp/basecamp-cli/cmd/basecamp@latest` crash
+immediately — even `basecamp --help` — with `SIGSYS: bad system call`. A transitive
 dependency probes for clipboard tools in its package initializer, and Android's
 seccomp policy kills the resulting `faccessat2` syscall before the program
 starts. Building from source with Termux's own Go toolchain avoids the blocked
@@ -175,5 +176,5 @@ go build -o basecamp ./cmd/basecamp   # or: make build → bin/basecamp
 ```
 
 Then move the `basecamp` binary onto your PATH. Requires Go 1.26+; if your
-Termux Go is an earlier patch release, lower the `toolchain`/`go` line in
-`go.mod` to match the version you have installed.
+Termux Go is an earlier patch release, lower the `go` line in `go.mod` to
+match the version you have installed.

--- a/install.md
+++ b/install.md
@@ -157,3 +157,23 @@ basecamp auth logout && basecamp auth login
 ```bash
 basecamp auth login --scope full
 ```
+
+**Termux / Android (`SIGSYS: bad system call` on startup):**
+
+On Termux, the prebuilt binaries and `go install …@latest` crash immediately —
+even `basecamp --help` — with `SIGSYS: bad system call`. A transitive
+dependency probes for clipboard tools in its package initializer, and Android's
+seccomp policy kills the resulting `faccessat2` syscall before the program
+starts. Building from source with Termux's own Go toolchain avoids the blocked
+syscall:
+
+```bash
+pkg install golang git
+git clone https://github.com/basecamp/basecamp-cli
+cd basecamp-cli
+go build -o basecamp ./cmd/basecamp   # or: make build → bin/basecamp
+```
+
+Then move the `basecamp` binary onto your PATH. Requires Go 1.26+; if your
+Termux Go is an earlier patch release, lower the `toolchain`/`go` line in
+`go.mod` to match the version you have installed.


### PR DESCRIPTION
Addresses #506.

## What

Adds a Troubleshooting entry to `install.md` for Termux/Android, where the prebuilt binaries and `go install …@latest` crash on startup with `SIGSYS: bad system call` — even for `basecamp --help`.

## Why (root cause)

`atotto/clipboard` — an indirect dependency pulled in by the TUI via `charm.land/bubbles/v2/textinput` — calls `exec.LookPath` in its package `init()`. That triggers the `faccessat2` syscall, which Android's seccomp policy kills with `SIGSYS` **before `main` runs**, so nothing the CLI does can catch it.

## Why docs-only (no code fix)

There is no `go install`-safe local fix:

- **Bump the dependency** — `bubbles/v2 v2.1.0` (already our version) is the latest and still imports `atotto/clipboard`.
- **`replace` directive to lazy-load clipboard** — `go install pkg@latest` *errors* when the target module's go.mod contains `replace`/`exclude` directives, so this would break installs on **every** platform.
- **Build-tag out the TUI** — `internal/tui` is wired into the presenter/output/root render paths and many everyday commands; it can't be cleanly excluded.

The durable fix belongs upstream (making `textinput`'s clipboard init lazy). This PR documents the one method that works today — building from source with Termux's patched Go toolchain, which sidesteps the blocked syscall (confirmed by the reporter in #506).

## Change

Docs only — one new Troubleshooting entry in `install.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Troubleshooting entry to `install.md` for Termux/Android where prebuilt binaries and `go install github.com/basecamp/basecamp-cli/cmd/basecamp@latest` crash on startup with `SIGSYS: bad system call`. It explains the cause and shows a build-from-source workaround using Termux’s Go, with the full `go install` command and a note to adjust the `go` line in `go.mod` if your Termux Go is older.

<sup>Written for commit fc2d89a7572d092fdc080792f7a9190a42170677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

