### PR TITLE
docs: warn against bash ANSI-C quoting for multiline comment content

### DIFF
--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -202,7 +202,11 @@ You can pass either a comment ID or a Basecamp URL:
   basecamp comments update https://3.basecamp.com/123/buckets/456/todos/111#__recording_789 "new text"
 
 Use - as the content argument to read the updated content from stdin:
-  basecamp comments update 789 - < body.md`,
+  basecamp comments update 789 - < body.md
+
+For multiline or non-ASCII content, prefer stdin over bash ANSI-C quoting
+($'...') — under a POSIX /bin/sh it posts a literal leading $ and keeps \n
+as backslash-n.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return missingArg(cmd, "<id|url>")
@@ -301,7 +305,12 @@ Content supports Markdown and @mentions (@Name or @First.Last):
   basecamp comments create 789 "Hey @Jane.Smith, **please review**"
 
 Use - as the content argument to read content from stdin:
-  basecamp comments create 789 - < body.md`,
+  basecamp comments create 789 - < body.md
+
+For multiline or non-ASCII content, prefer stdin over bash ANSI-C quoting
+($'...'). $'...' is a bash/zsh extension; under a POSIX /bin/sh (dash,
+busybox-ash) it posts a literal leading $ and keeps \n as backslash-n:
+  printf '%s\n' 'First line' '' '<bc-attachment ...>' | basecamp comments create 789 -`,
 		Annotations: map[string]string{"agent_notes": "Comments are flat — reply to parent item, not to other comments\nURL fragments (#__recording_456) are comment IDs — comment on the parent recording_id, not the comment_id\nComments are on items (todos, messages, cards, etc.) — not on other comments"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -91,6 +91,11 @@ Full CLI coverage: 155 endpoints across todos, cards, messages, files, schedule,
    - **`@sgid:VALUE`** — inline SGID embed for pipeline composability
    - **`@Name` / `@First.Last`** — fuzzy name resolution (may be ambiguous)
    For todos, documents, and cards, content is sent as-is — use plain text or HTML directly.
+
+   **Multiline / non-ASCII content:** do not rely on bash ANSI-C quoting (`$'...\n...'`) — it is a bash/zsh extension. Under a POSIX `/bin/sh` (dash, busybox-ash, common in sandboxes) the `$` is passed through literally and posts a stray leading `$`, and `\n` stays a literal backslash-n. Pipe the content via stdin instead, using `-` as the content argument:
+   ```bash
+   printf '%s\n' '海报 mockup 方向稿：' '' '<bc-attachment ...>' | basecamp comments create <recording_id> - --in <project> --json
+   ```
 6. **Project scope is mandatory for most commands** — via `--in <project>` or `.basecamp/config.json`. Cross-project exceptions: `basecamp reports assigned` for assigned work, `basecamp assignments` for structured assignment views, `basecamp reports overdue` for overdue todos, `basecamp reports schedule` for upcoming schedule across all projects, `basecamp recordings <type>` for browsing by type, `basecamp notifications` for notifications, `basecamp gauges list` for account-wide gauges.
 
 ### Output Modes


### PR DESCRIPTION
## Summary

Documentation-only change addressing #459, where `basecamp comment` posted a comment with a stray leading `$`.

## Root cause

Not a CLI bug — a shell quoting issue. The reporter used bash ANSI-C quoting:

```bash
basecamp comment 9802493119 $'海报 mockup 方向稿：\n\n<bc-attachment ...>' --in ... --json
```

`$'...'` is a **bash/zsh extension**, not POSIX. Under a POSIX `/bin/sh` (dash, busybox-ash — the default in most Linux sandboxes and "agent workflow" shells), `$'...'` is parsed as a literal `$` followed by an ordinary single-quoted string. The CLI then faithfully posts exactly what the shell handed it.

The smoking gun is in the issue's own output: the posted HTML contains **both** the literal `$` **and** literal `\n\n` (backslash-n, not real newlines). If bash had interpreted `$'...'`, the `\n` would have become real newlines and the `$`/quotes consumed. Their survival proves a POSIX `sh` ran the command.

## Why not "fix" it in the CLI

The issue floated stripping the `$'...'` wrapper inside the CLI. Rejected: `$` and `'` are legitimate content characters (prices, code, apostrophes), and the app can't know a leading `$` was an unintended quote wrapper. Guessing at shell intent would silently corrupt real content.

The safe alternative — stdin via `-`, bare pipe, and `--edit` — already exists. This PR just documents it.

## Changes

- `comments create` / `comments update` help text: warn against `$'...'` for multiline/non-ASCII content, recommend the stdin (`-`) pattern.
- `skills/basecamp/SKILL.md`: same guidance in the content-fields section, extending the existing `printf %q` quoting advice.

## Note

`bin/ci` currently fails on this branch's base due to a **pre-existing, unrelated** build breakage in `internal/commands/cards.go` (the SDK's `CardColumns.EnableOnHold/DisableOnHold/SetColor` gained a `columnID` parameter that `cards.go` hasn't been updated for). It exists on the clean base independent of this change; this PR only touches help-text strings and Markdown (gofmt-clean).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns against using bash ANSI-C quoting `$'...'` for multiline or non-ASCII comment content, which under POSIX `/bin/sh` posts a stray `$` and keeps `\n` literally. Updates the `basecamp comments create`/`update` help to recommend stdin with `-`, and adds the same guidance to `skills/basecamp/SKILL.md` (addresses #459).

<sup>Written for commit 471fdc7dec058da76ef31ab416448246471e043a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

