### PR TITLE
Surface Todoset-level todos in todos list

### DIFF
--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -478,6 +478,15 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 		allTodos = append(allTodos, todos...)
 	}
 
+	// Basecamp 5 lets todos live directly under the Todoset without a
+	// Todolist. Those "listless" todos are invisible to the per-todolist
+	// enumeration above, so fetch them via the Recordings API and merge them
+	// in. Assignee/overdue filters below apply to them too.
+	if projectID, perr := strconv.ParseInt(project, 10, 64); perr == nil {
+		allTodos = append(allTodos,
+			fetchTodosetLevelTodos(cmd.Context(), app, projectID, todosetID, sdkStatus, sdkCompleted)...)
+	}
+
 	// Apply filters
 	var result []basecamp.Todo
 	for _, todo := range allTodos {
@@ -543,6 +552,61 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 	// because limit is applied per-list, not globally. Use --list for accurate notices.
 
 	return app.OK(result, respOpts...)
+}
+
+// fetchTodosetLevelTodos returns todos that live directly under the project's
+// Todoset rather than inside a Todolist. Basecamp 5 allows creating such
+// "listless" todos; the /todolists/{id}/todos.json index endpoint the SDK uses
+// to enumerate a todoset's lists cannot see them (it 404s when handed a Todoset
+// ID). They are only reachable via the Recordings API, which returns every Todo
+// in the bucket regardless of parent. We fetch those recordings, keep the ones
+// parented directly to this todoset, and hydrate each into a full Todo — the
+// Recording payload the SDK exposes lacks the completion/assignee/due fields the
+// list output and its filters need.
+//
+// completed mirrors the server-side completion filter applied to todolist todos.
+// The Recordings status is lifecycle-only (active/archived/trashed) and does not
+// distinguish completed from incomplete, so that split is applied client-side.
+//
+// Errors are non-fatal: the caller still gets the todolist todos.
+func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, todosetID int64, sdkStatus string, completed bool) []basecamp.Todo {
+	recStatus := sdkStatus
+	if recStatus == "" {
+		recStatus = "active"
+	}
+
+	result, err := app.Account().Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
+		Bucket: []int64{projectID},
+		Status: recStatus,
+		Limit:  -1,
+	})
+	if err != nil {
+		return nil
+	}
+
+	var todos []basecamp.Todo
+	for _, rec := range result.Recordings {
+		if rec.Parent == nil || rec.Parent.Type != "Todoset" || rec.Parent.ID != todosetID {
+			continue
+		}
+
+		todo, err := app.Account().Todos().Get(ctx, rec.ID)
+		if err != nil {
+			continue // Skip todos we can't hydrate.
+		}
+
+		// Recordings' lifecycle status can't express completed vs incomplete,
+		// so apply that split here to match the todolist path. Only do so for
+		// the active view (sdkStatus == ""); archived/trashed views return all
+		// matching todos regardless of completion, just like the todolist path.
+		if sdkStatus == "" && todo.Completed != completed {
+			continue
+		}
+
+		todos = append(todos, *todo)
+	}
+
+	return todos
 }
 
 func newTodosShowCmd() *cobra.Command {

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -458,9 +458,13 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 		return convertSDKError(err)
 	}
 
-	// Determine per-list limit to pass through to each fetch.
+	// Determine per-list limit to pass through to each fetch (todolists and the
+	// listless-todo recordings scan alike). When a client-side filter
+	// (assignee/overdue) is active, fetch everything so the post-fetch filter
+	// doesn't miss matches beyond the default cap — mirroring the single-list
+	// path. Any explicit --limit is then applied after filtering, below.
 	sdkLimit := 0 // SDK default
-	if all {
+	if all || assignee != "" || overdue {
 		sdkLimit = -1
 	} else if limit > 0 {
 		sdkLimit = limit
@@ -517,6 +521,13 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 		}
 
 		result = append(result, todo)
+	}
+
+	// When a client-side filter forced an unlimited fetch above, apply the
+	// explicit --limit after filtering so the cap reflects the filtered set
+	// rather than the pre-filter fetch (mirrors the single-list path).
+	if (assignee != "" || overdue) && !all && limit > 0 && len(result) > limit {
+		result = result[:limit]
 	}
 
 	// Apply client-side sort when requested (field validated early in runTodosList,

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -427,10 +427,13 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 	if sortField == "position" {
 		return output.ErrUsage("--sort position requires --list (position is per-todolist)")
 	}
-	// Sorting the aggregate path without --all is misleading because results
-	// are silently sampled per-todolist using default SDK paging.
-	if sortField != "" && !all {
-		return output.ErrUsage("--sort requires --all when listing across todolists (results are sampled per list without it)")
+	// Sorting the aggregate path is only meaningful when the full set is
+	// fetched. That happens with --all, or when a client-side filter
+	// (assignee/overdue) forces an unlimited per-list fetch below. Otherwise
+	// results are sampled per-todolist using default SDK paging and a sort
+	// would be misleading.
+	if sortField != "" && !all && assignee == "" && !overdue {
+		return output.ErrUsage("--sort requires --all (or --assignee/--overdue) when listing across todolists (results are otherwise sampled per list)")
 	}
 	// Resolve assignee name to ID if provided
 	var assigneeID int64
@@ -485,11 +488,15 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 	// Basecamp 5 lets todos live directly under the Todoset without a
 	// Todolist. Those "listless" todos are invisible to the per-todolist
 	// enumeration above, so fetch them via the Recordings API and merge them
-	// in. Assignee/overdue filters below apply to them too.
-	if projectID, perr := strconv.ParseInt(project, 10, 64); perr == nil {
-		allTodos = append(allTodos,
-			fetchTodosetLevelTodos(cmd.Context(), app, projectID, todosetID, sdkStatus, sdkCompleted, sdkLimit)...)
+	// in. Assignee/overdue filters below apply to them too. project is already
+	// resolved to a numeric ID by this point, so a parse failure signals a bug
+	// rather than user input — error out instead of silently dropping them.
+	projectID, err := strconv.ParseInt(project, 10, 64)
+	if err != nil {
+		return output.ErrUsage("Invalid project ID")
 	}
+	allTodos = append(allTodos,
+		fetchTodosetLevelTodos(cmd.Context(), app, projectID, todosetID, sdkStatus, sdkCompleted, sdkLimit)...)
 
 	// Apply filters
 	var result []basecamp.Todo

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -568,10 +568,14 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 // The Recordings status is lifecycle-only (active/archived/trashed) and does not
 // distinguish completed from incomplete, so that split is applied client-side.
 //
-// limit bounds how many listless todos are fetched and hydrated, matching the
-// per-list limit the todolist path uses (0 = SDK default, -1 = all, positive =
-// cap) so ordinary `todos list` / `--limit N` runs don't hydrate and emit every
-// Todoset-level todo. RecordingsListOptions.Limit shares these exact semantics.
+// limit bounds how many listless todos are kept, matching the per-list limit the
+// todolist path uses (0 = SDK default of 100, -1 = all, positive = cap) so
+// ordinary `todos list` / `--limit N` runs don't hydrate and emit every
+// Todoset-level todo. The cap is applied to listless todos *after* filtering by
+// parent — not to the raw recordings, which also include Todolist-parented todos
+// that would otherwise consume the budget and hide listless todos sorted behind
+// them. Listing recordings is a paginated metadata call; the per-todo hydration
+// is the expensive part, and that is what the cap actually bounds.
 //
 // Errors are non-fatal: the caller still gets the todolist todos.
 func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, todosetID int64, sdkStatus string, completed bool, limit int) []basecamp.Todo {
@@ -580,19 +584,33 @@ func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, tod
 		recStatus = "active"
 	}
 
+	// Fetch all Todo recording metadata for the project (Limit -1). The cap
+	// governs listless todos specifically, so it can only be applied after the
+	// parent filter below — hence we cannot delegate it to the recordings fetch.
 	result, err := app.Account().Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
 		Bucket: []int64{projectID},
 		Status: recStatus,
-		Limit:  limit,
+		Limit:  -1,
 	})
 	if err != nil {
 		return nil
+	}
+
+	// Translate the per-list limit into a cap on kept listless todos: 0 falls
+	// back to the SDK default of 100, a negative value means unlimited (--all),
+	// and a positive value is an explicit cap.
+	maxKept := limit
+	if maxKept == 0 {
+		maxKept = 100
 	}
 
 	var todos []basecamp.Todo
 	for _, rec := range result.Recordings {
 		if rec.Parent == nil || rec.Parent.Type != "Todoset" || rec.Parent.ID != todosetID {
 			continue
+		}
+		if maxKept >= 0 && len(todos) >= maxKept {
+			break
 		}
 
 		todo, err := app.Account().Todos().Get(ctx, rec.ID)

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -619,10 +619,14 @@ func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, tod
 		}
 	}
 
+	// Sort/Direction are set explicitly so the bounded scan window is a stable
+	// "most recently created first" slice rather than relying on SDK defaults.
 	result, err := app.Account().Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
-		Bucket: []int64{projectID},
-		Status: recStatus,
-		Limit:  recScan,
+		Bucket:    []int64{projectID},
+		Status:    recStatus,
+		Sort:      "created_at",
+		Direction: "desc",
+		Limit:     recScan,
 	})
 	if err != nil {
 		return nil

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -484,7 +484,7 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 	// in. Assignee/overdue filters below apply to them too.
 	if projectID, perr := strconv.ParseInt(project, 10, 64); perr == nil {
 		allTodos = append(allTodos,
-			fetchTodosetLevelTodos(cmd.Context(), app, projectID, todosetID, sdkStatus, sdkCompleted)...)
+			fetchTodosetLevelTodos(cmd.Context(), app, projectID, todosetID, sdkStatus, sdkCompleted, sdkLimit)...)
 	}
 
 	// Apply filters
@@ -568,8 +568,13 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 // The Recordings status is lifecycle-only (active/archived/trashed) and does not
 // distinguish completed from incomplete, so that split is applied client-side.
 //
+// limit bounds how many listless todos are fetched and hydrated, matching the
+// per-list limit the todolist path uses (0 = SDK default, -1 = all, positive =
+// cap) so ordinary `todos list` / `--limit N` runs don't hydrate and emit every
+// Todoset-level todo. RecordingsListOptions.Limit shares these exact semantics.
+//
 // Errors are non-fatal: the caller still gets the todolist todos.
-func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, todosetID int64, sdkStatus string, completed bool) []basecamp.Todo {
+func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, todosetID int64, sdkStatus string, completed bool, limit int) []basecamp.Todo {
 	recStatus := sdkStatus
 	if recStatus == "" {
 		recStatus = "active"
@@ -578,7 +583,7 @@ func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, tod
 	result, err := app.Account().Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
 		Bucket: []int64{projectID},
 		Status: recStatus,
-		Limit:  -1,
+		Limit:  limit,
 	})
 	if err != nil {
 		return nil

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -568,14 +568,19 @@ func listAllTodos(cmd *cobra.Command, app *appctx.App, project, todosetFlag, ass
 // The Recordings status is lifecycle-only (active/archived/trashed) and does not
 // distinguish completed from incomplete, so that split is applied client-side.
 //
-// limit bounds how many listless todos are kept, matching the per-list limit the
-// todolist path uses (0 = SDK default of 100, -1 = all, positive = cap) so
-// ordinary `todos list` / `--limit N` runs don't hydrate and emit every
-// Todoset-level todo. The cap is applied to listless todos *after* filtering by
-// parent — not to the raw recordings, which also include Todolist-parented todos
-// that would otherwise consume the budget and hide listless todos sorted behind
-// them. Listing recordings is a paginated metadata call; the per-todo hydration
-// is the expensive part, and that is what the cap actually bounds.
+// limit mirrors the per-list limit the todolist path uses (0 = SDK default of
+// 100, -1 = all, positive = cap) and governs how many *listless* todos are kept.
+// The cap is applied after filtering by parent — not to the raw recordings,
+// which also include Todolist-parented todos that would otherwise consume the
+// budget and hide listless todos sorted behind them.
+//
+// The recordings endpoint has no parent-type filter, so listless todos can only
+// be found by scanning Todo recordings. To avoid a full-project traversal on
+// ordinary runs, the scan itself is bounded: --all scans everything for an
+// exhaustive result, while limited/default runs scan only a window of the most
+// recent Todo recordings (at least DefaultRecordingLimit, more when --limit asks
+// for more). Listless todos outside that window require --all — the same
+// best-effort tradeoff the aggregate path already documents for per-list limits.
 //
 // Errors are non-fatal: the caller still gets the todolist todos.
 func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, todosetID int64, sdkStatus string, completed bool, limit int) []basecamp.Todo {
@@ -584,24 +589,32 @@ func fetchTodosetLevelTodos(ctx context.Context, app *appctx.App, projectID, tod
 		recStatus = "active"
 	}
 
-	// Fetch all Todo recording metadata for the project (Limit -1). The cap
-	// governs listless todos specifically, so it can only be applied after the
-	// parent filter below — hence we cannot delegate it to the recordings fetch.
+	// Cap on kept listless todos: 0 → SDK default of 100, negative (--all) →
+	// unlimited, positive → explicit cap.
+	maxKept := limit
+	if maxKept == 0 {
+		maxKept = basecamp.DefaultRecordingLimit
+	}
+
+	// Bound how many recordings we scan. --all (limit < 0) scans everything;
+	// otherwise scan a window sized to what we might keep, with a floor so a
+	// small --limit still scans a useful slice rather than stopping at the first
+	// few recordings (which could all be Todolist-parented).
+	recScan := -1 // unlimited
+	if limit >= 0 {
+		recScan = maxKept
+		if recScan < basecamp.DefaultRecordingLimit {
+			recScan = basecamp.DefaultRecordingLimit
+		}
+	}
+
 	result, err := app.Account().Recordings().List(ctx, basecamp.RecordingTypeTodo, &basecamp.RecordingsListOptions{
 		Bucket: []int64{projectID},
 		Status: recStatus,
-		Limit:  -1,
+		Limit:  recScan,
 	})
 	if err != nil {
 		return nil
-	}
-
-	// Translate the per-list limit into a cap on kept listless todos: 0 falls
-	// back to the SDK default of 100, a negative value means unlimited (--all),
-	// and a positive value is an explicit cap.
-	maxKept := limit
-	if maxKept == 0 {
-		maxKept = 100
 	}
 
 	var todos []basecamp.Todo

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2490,3 +2490,78 @@ func TestTodosListTodosetLevelLimitCountsAfterParentFilter(t *testing.T) {
 	assert.True(t, found, "listless todo must be surfaced even though a Todolist recording sorts first under --limit 1")
 	assert.Equal(t, 1, transport.getTodoCalls, "only the listless todo should be hydrated")
 }
+
+// bulkListlessTodoTransport serves many Todoset-level todos in a single page so
+// scan-window behavior can be asserted: a default run keeps at most the default
+// cap, while --all keeps everything. It hydrates each /todos/{id} on demand.
+type bulkListlessTodoTransport struct {
+	count        int // number of listless recordings to serve
+	getTodoCalls int
+}
+
+func (s *bulkListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		items := make([]string, 0, s.count)
+		for i := 0; i < s.count; i++ {
+			id := 1000 + i
+			items = append(items, fmt.Sprintf(
+				`{"id": %d, "title": "L%d", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}}`, id, i))
+		}
+		body = "[" + strings.Join(items, ",") + "]"
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[]`
+	case strings.Contains(path, "/todos/"):
+		s.getTodoCalls++
+		idStr := path[strings.LastIndex(path, "/")+1:]
+		body = fmt.Sprintf(`{"id": %s, "content": "listless", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`, idStr)
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+func countTodos(t *testing.T, buf *bytes.Buffer) int {
+	t.Helper()
+	var resp struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	return len(resp.Data)
+}
+
+// TestTodosListTodosetLevelScanIsBounded verifies that an ordinary run does not
+// hydrate/emit every listless todo (default cap applies), while --all is
+// exhaustive (issue #474 review follow-up: no forced unlimited scan on ordinary
+// runs).
+func TestTodosListTodosetLevelScanIsBounded(t *testing.T) {
+	// Default run: 150 listless todos available, but only the default 100 kept.
+	transport := &bulkListlessTodoTransport{count: 150}
+	app, buf := setupListlessTodoApp(t, transport)
+	require.NoError(t, executeTodosCommand(NewTodosCmd(), app, "list", "--in", "123"))
+	assert.Equal(t, basecamp.DefaultRecordingLimit, countTodos(t, buf),
+		"default run should cap listless todos at the default limit")
+	assert.Equal(t, basecamp.DefaultRecordingLimit, transport.getTodoCalls,
+		"default run should hydrate only up to the default limit, not every listless todo")
+
+	// --all: exhaustive.
+	transportAll := &bulkListlessTodoTransport{count: 150}
+	appAll, bufAll := setupListlessTodoApp(t, transportAll)
+	require.NoError(t, executeTodosCommand(NewTodosCmd(), appAll, "list", "--in", "123", "--all"))
+	assert.Equal(t, 150, countTodos(t, bufAll), "--all should return every listless todo")
+	assert.Equal(t, 150, transportAll.getTodoCalls, "--all should hydrate every listless todo")
+}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2641,3 +2641,20 @@ func TestTodosListTodosetLevelAssigneeNotStarvedByCap(t *testing.T) {
 	assert.Equal(t, int64(1149), resp.Data[0].ID,
 		"Alice's listless todo beyond the default window must still be found")
 }
+
+// TestTodosListAggregateSortGuard verifies --sort is rejected in the aggregate
+// path when results would be sampled per-list, but allowed once a client-side
+// filter (--assignee/--overdue) forces a full fetch.
+func TestTodosListAggregateSortGuard(t *testing.T) {
+	// No --all and no client-side filter: results are sampled, so --sort errors.
+	app, _ := setupListlessTodoApp(t, &listlessTodoTransport{})
+	err := executeTodosCommand(NewTodosCmd(), app, "list", "--in", "123", "--sort", "title")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires --all")
+
+	// --assignee forces an unlimited fetch, so --sort is meaningful and allowed.
+	transport := &assigneeListlessTodoTransport{total: 3, matchID: 1002, assignee: 42}
+	appA, _ := setupListlessTodoApp(t, transport)
+	errA := executeTodosCommand(NewTodosCmd(), appA, "list", "--in", "123", "--assignee", "Alice", "--sort", "title")
+	require.NoError(t, errA)
+}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2224,7 +2224,7 @@ func (s *listlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, er
 		body = `[]`
 	case strings.Contains(path, "/todolists/10/todos.json"):
 		body = `[{"id": 111, "content": "List todo", "position": 1, "status": "active", "completed": false, "parent": {"id": 10, "type": "Todolist"}}]`
-	case strings.HasSuffix(path, "/todos/500"):
+	case strings.HasSuffix(strings.TrimSuffix(path, ".json"), "/todos/500"):
 		s.getTodoCalls++
 		body = `{"id": 500, "content": "Listless todo", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
 	case strings.Contains(path, "/projects/123"):
@@ -2312,7 +2312,7 @@ func (completedListlessTodoTransport) RoundTrip(req *http.Request) (*http.Respon
 		body = `[{"id": 123, "name": "Test"}]`
 	case strings.Contains(path, "/todosets/100/todolists.json"):
 		body = `[]`
-	case strings.HasSuffix(path, "/todos/500"):
+	case strings.HasSuffix(strings.TrimSuffix(path, ".json"), "/todos/500"):
 		body = `{"id": 500, "content": "Done listless", "status": "active", "completed": true, "parent": {"id": 100, "type": "Todoset"}}`
 	case strings.Contains(path, "/projects/123"):
 		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
@@ -2376,10 +2376,10 @@ func (s *manyListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response
 		body = `[{"id": 123, "name": "Test"}]`
 	case strings.Contains(path, "/todosets/100/todolists.json"):
 		body = `[]`
-	case strings.HasSuffix(path, "/todos/500"):
+	case strings.HasSuffix(strings.TrimSuffix(path, ".json"), "/todos/500"):
 		s.getTodoCalls++
 		body = `{"id": 500, "content": "Listless A", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
-	case strings.HasSuffix(path, "/todos/501"):
+	case strings.HasSuffix(strings.TrimSuffix(path, ".json"), "/todos/501"):
 		s.getTodoCalls++
 		body = `{"id": 501, "content": "Listless B", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
 	case strings.Contains(path, "/projects/123"):
@@ -2444,7 +2444,7 @@ func (s *mixedRecordingOrderTransport) RoundTrip(req *http.Request) (*http.Respo
 		body = `[]`
 	case strings.Contains(path, "/todolists/10/todos.json"):
 		body = `[{"id": 111, "content": "List todo", "position": 1, "status": "active", "completed": false, "parent": {"id": 10, "type": "Todolist"}}]`
-	case strings.HasSuffix(path, "/todos/500"):
+	case strings.HasSuffix(strings.TrimSuffix(path, ".json"), "/todos/500"):
 		s.getTodoCalls++
 		body = `{"id": 500, "content": "Listless todo", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
 	case strings.Contains(path, "/projects/123"):
@@ -2520,7 +2520,7 @@ func (s *bulkListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response
 		body = `[]`
 	case strings.Contains(path, "/todos/"):
 		s.getTodoCalls++
-		idStr := path[strings.LastIndex(path, "/")+1:]
+		idStr := strings.TrimSuffix(path[strings.LastIndex(path, "/")+1:], ".json")
 		body = fmt.Sprintf(`{"id": %s, "content": "listless", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`, idStr)
 	case strings.Contains(path, "/projects/123"):
 		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
@@ -2598,7 +2598,7 @@ func (s *assigneeListlessTodoTransport) RoundTrip(req *http.Request) (*http.Resp
 	case strings.Contains(path, "/todosets/100/todolists.json"):
 		body = `[]`
 	case strings.Contains(path, "/todos/"):
-		idStr := path[strings.LastIndex(path, "/")+1:]
+		idStr := strings.TrimSuffix(path[strings.LastIndex(path, "/")+1:], ".json")
 		assignees := "[]"
 		if idStr == fmt.Sprintf("%d", s.matchID) {
 			assignees = fmt.Sprintf(`[{"id": %d, "name": "Alice"}]`, s.assignee)

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2415,3 +2415,78 @@ func TestTodosListTodosetLevelRespectsLimit(t *testing.T) {
 	require.Len(t, resp.Data, 1, "--limit 1 should cap listless todos to one")
 	assert.Equal(t, 1, transport.getTodoCalls, "only the capped listless todo should be hydrated")
 }
+
+// mixedRecordingOrderTransport returns a Todolist-parented Todo recording
+// BEFORE the listless one. A cap applied to the raw recordings (instead of to
+// listless todos after parent filtering) would drop the listless todo under
+// --limit 1 — this reproduces the issue #474 review follow-up.
+type mixedRecordingOrderTransport struct {
+	getTodoCalls int
+}
+
+func (s *mixedRecordingOrderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		body = `[` +
+			`{"id": 111, "title": "List todo", "type": "Todo", "status": "active", "parent": {"id": 10, "type": "Todolist"}},` +
+			`{"id": 500, "title": "Listless todo", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}}` +
+			`]`
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[{"id": 10, "title": "General", "name": "General"}]`
+	case strings.Contains(path, "/todolists/10/groups.json"):
+		body = `[]`
+	case strings.Contains(path, "/todolists/10/todos.json"):
+		body = `[{"id": 111, "content": "List todo", "position": 1, "status": "active", "completed": false, "parent": {"id": 10, "type": "Todolist"}}]`
+	case strings.HasSuffix(path, "/todos/500"):
+		s.getTodoCalls++
+		body = `{"id": 500, "content": "Listless todo", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+// TestTodosListTodosetLevelLimitCountsAfterParentFilter ensures the per-list
+// limit counts listless todos specifically: a Todolist-parented recording
+// sorting ahead of the listless one must not consume the limit budget.
+func TestTodosListTodosetLevelLimitCountsAfterParentFilter(t *testing.T) {
+	transport := &mixedRecordingOrderTransport{}
+	app, buf := setupListlessTodoApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "list", "--in", "123", "--limit", "1")
+	require.NoError(t, err)
+
+	var resp struct {
+		Data []struct {
+			ID     int64 `json:"id"`
+			Parent struct {
+				Type string `json:"type"`
+			} `json:"parent"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	found := false
+	for _, td := range resp.Data {
+		if td.ID == 500 && td.Parent.Type == "Todoset" {
+			found = true
+		}
+	}
+	assert.True(t, found, "listless todo must be surfaced even though a Todolist recording sorts first under --limit 1")
+	assert.Equal(t, 1, transport.getTodoCalls, "only the listless todo should be hydrated")
+}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2192,3 +2192,163 @@ func TestTodosListInListAssigneeNoGroupsLimitAfterFilter(t *testing.T) {
 	require.Len(t, resp.Data, 1)
 	assert.Equal(t, int64(2), resp.Data[0].ID, "should be Alice's first match via no-groups path")
 }
+
+// listlessTodoTransport serves a project whose todos live both inside a
+// Todolist and directly under the Todoset (Basecamp 5 "listless" todos). The
+// per-todolist enumeration only sees the Todolist todo; the Todoset-level todo
+// is reachable only via the Recordings API, then hydrated with Todos().Get.
+type listlessTodoTransport struct {
+	getTodoCalls int
+}
+
+func (s *listlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		// Two Todos in the bucket: one under a Todolist (must be ignored here,
+		// it's already covered by the todolist enumeration) and one directly
+		// under the Todoset (the listless todo we must surface).
+		body = `[` +
+			`{"id": 500, "title": "Listless todo", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}},` +
+			`{"id": 111, "title": "List todo", "type": "Todo", "status": "active", "parent": {"id": 10, "type": "Todolist"}}` +
+			`]`
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[{"id": 10, "title": "General", "name": "General"}]`
+	case strings.Contains(path, "/todolists/10/groups.json"):
+		body = `[]`
+	case strings.Contains(path, "/todolists/10/todos.json"):
+		body = `[{"id": 111, "content": "List todo", "position": 1, "status": "active", "completed": false, "parent": {"id": 10, "type": "Todolist"}}]`
+	case strings.HasSuffix(path, "/todos/500"):
+		s.getTodoCalls++
+		body = `{"id": 500, "content": "Listless todo", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+func setupListlessTodoApp(t *testing.T, transport http.RoundTripper) (*appctx.App, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	buf := &bytes.Buffer{}
+	cfg := &config.Config{AccountID: "99999", ProjectID: "123"}
+
+	authMgr := auth.NewManager(cfg, nil)
+	sdkClient := basecamp.NewClient(&basecamp.Config{}, &todosTestTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+	)
+	nameResolver := names.NewResolver(sdkClient, authMgr, cfg.AccountID)
+
+	return &appctx.App{
+		Config: cfg,
+		Auth:   authMgr,
+		SDK:    sdkClient,
+		Names:  nameResolver,
+		Output: output.New(output.Options{Format: output.FormatJSON, Writer: buf}),
+	}, buf
+}
+
+// TestTodosListIncludesTodosetLevelTodos covers issue #474: todos that live
+// directly under the Todoset (no Todolist) must appear in `todos list`.
+func TestTodosListIncludesTodosetLevelTodos(t *testing.T) {
+	transport := &listlessTodoTransport{}
+	app, buf := setupListlessTodoApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "list", "--in", "123")
+	require.NoError(t, err)
+
+	var resp struct {
+		Data []struct {
+			ID     int64 `json:"id"`
+			Parent struct {
+				Type string `json:"type"`
+			} `json:"parent"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	ids := map[int64]string{}
+	for _, td := range resp.Data {
+		ids[td.ID] = td.Parent.Type
+	}
+	require.Len(t, resp.Data, 2, "expected the todolist todo plus the listless todoset todo")
+	assert.Equal(t, "Todolist", ids[111], "todolist todo should still be present")
+	assert.Equal(t, "Todoset", ids[500], "listless todoset todo should be surfaced")
+	assert.Equal(t, 1, transport.getTodoCalls, "listless todo should be hydrated exactly once")
+}
+
+// completedListlessTodoTransport serves a completed Todoset-level todo. The
+// Recordings API reports it as lifecycle "active" (completion is not a
+// recordings status), so the completed/incomplete split must be applied
+// client-side after hydration.
+type completedListlessTodoTransport struct{}
+
+func (completedListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		body = `[{"id": 500, "title": "Done listless", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}}]`
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[]`
+	case strings.HasSuffix(path, "/todos/500"):
+		body = `{"id": 500, "content": "Done listless", "status": "active", "completed": true, "parent": {"id": 100, "type": "Todoset"}}`
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+func TestTodosListTodosetLevelCompletionFilter(t *testing.T) {
+	decode := func(buf *bytes.Buffer) []int64 {
+		var resp struct {
+			Data []struct {
+				ID int64 `json:"id"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+		ids := make([]int64, 0, len(resp.Data))
+		for _, d := range resp.Data {
+			ids = append(ids, d.ID)
+		}
+		return ids
+	}
+
+	// Default (incomplete): the completed listless todo must be excluded.
+	app, buf := setupListlessTodoApp(t, completedListlessTodoTransport{})
+	require.NoError(t, executeTodosCommand(NewTodosCmd(), app, "list", "--in", "123"))
+	assert.Empty(t, decode(buf), "completed listless todo must not appear in the default incomplete view")
+
+	// --completed: the completed listless todo must be included.
+	app, buf = setupListlessTodoApp(t, completedListlessTodoTransport{})
+	require.NoError(t, executeTodosCommand(NewTodosCmd(), app, "list", "--in", "123", "--completed"))
+	assert.Equal(t, []int64{500}, decode(buf), "completed listless todo should appear with --completed")
+}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2352,3 +2352,66 @@ func TestTodosListTodosetLevelCompletionFilter(t *testing.T) {
 	require.NoError(t, executeTodosCommand(NewTodosCmd(), app, "list", "--in", "123", "--completed"))
 	assert.Equal(t, []int64{500}, decode(buf), "completed listless todo should appear with --completed")
 }
+
+// manyListlessTodoTransport serves two Todoset-level todos so limit handling
+// can be exercised. Todolists are empty; both listless todos are active and
+// incomplete.
+type manyListlessTodoTransport struct {
+	getTodoCalls int
+}
+
+func (s *manyListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		body = `[` +
+			`{"id": 500, "title": "Listless A", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}},` +
+			`{"id": 501, "title": "Listless B", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}}` +
+			`]`
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[]`
+	case strings.HasSuffix(path, "/todos/500"):
+		s.getTodoCalls++
+		body = `{"id": 500, "content": "Listless A", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
+	case strings.HasSuffix(path, "/todos/501"):
+		s.getTodoCalls++
+		body = `{"id": 501, "content": "Listless B", "status": "active", "completed": false, "parent": {"id": 100, "type": "Todoset"}}`
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+// TestTodosListTodosetLevelRespectsLimit ensures --limit caps how many listless
+// todos are fetched and hydrated, matching the per-list limit semantics (issue
+// #474 review follow-up).
+func TestTodosListTodosetLevelRespectsLimit(t *testing.T) {
+	transport := &manyListlessTodoTransport{}
+	app, buf := setupListlessTodoApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "list", "--in", "123", "--limit", "1")
+	require.NoError(t, err)
+
+	var resp struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	require.Len(t, resp.Data, 1, "--limit 1 should cap listless todos to one")
+	assert.Equal(t, 1, transport.getTodoCalls, "only the capped listless todo should be hydrated")
+}

--- a/internal/commands/todos_test.go
+++ b/internal/commands/todos_test.go
@@ -2565,3 +2565,79 @@ func TestTodosListTodosetLevelScanIsBounded(t *testing.T) {
 	assert.Equal(t, 150, countTodos(t, bufAll), "--all should return every listless todo")
 	assert.Equal(t, 150, transportAll.getTodoCalls, "--all should hydrate every listless todo")
 }
+
+// assigneeListlessTodoTransport serves many listless todos where only the last
+// one (well beyond the default scan window) is assigned to the target person.
+// With --assignee, the scan must not be capped before the client-side assignee
+// filter runs, or that match is silently dropped (issue #474 review follow-up).
+type assigneeListlessTodoTransport struct {
+	total    int   // number of listless recordings
+	matchID  int64 // the todo assigned to the target person
+	assignee int64 // target person ID
+}
+
+func (s *assigneeListlessTodoTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	path := req.URL.Path
+	var body string
+	switch {
+	case strings.Contains(path, "/projects/recordings.json"):
+		items := make([]string, 0, s.total)
+		for i := 0; i < s.total; i++ {
+			id := int64(1000 + i)
+			items = append(items, fmt.Sprintf(
+				`{"id": %d, "title": "L%d", "type": "Todo", "status": "active", "parent": {"id": 100, "type": "Todoset"}}`, id, i))
+		}
+		body = "[" + strings.Join(items, ",") + "]"
+	case strings.Contains(path, "/people.json") || strings.Contains(path, "/my/profile.json"):
+		body = fmt.Sprintf(`[{"id": %d, "name": "Alice", "email_address": "alice@example.com"}]`, s.assignee)
+	case strings.Contains(path, "/projects.json"):
+		body = `[{"id": 123, "name": "Test"}]`
+	case strings.Contains(path, "/todosets/100/todolists.json"):
+		body = `[]`
+	case strings.Contains(path, "/todos/"):
+		idStr := path[strings.LastIndex(path, "/")+1:]
+		assignees := "[]"
+		if idStr == fmt.Sprintf("%d", s.matchID) {
+			assignees = fmt.Sprintf(`[{"id": %d, "name": "Alice"}]`, s.assignee)
+		}
+		body = fmt.Sprintf(`{"id": %s, "content": "listless", "status": "active", "completed": false, "assignees": %s, "parent": {"id": 100, "type": "Todoset"}}`, idStr, assignees)
+	case strings.Contains(path, "/projects/123"):
+		body = `{"id": 123, "dock": [{"name": "todoset", "id": 100, "title": "To-dos", "enabled": true}]}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+	}, nil
+}
+
+// TestTodosListTodosetLevelAssigneeNotStarvedByCap ensures --assignee surfaces a
+// listless todo assigned to the target person even when it sits beyond the
+// default scan window, by fetching all candidates before filtering.
+func TestTodosListTodosetLevelAssigneeNotStarvedByCap(t *testing.T) {
+	const target int64 = 42
+	// 150 listless todos; only the last (id 1149, index 149) is Alice's — well
+	// past the default cap of 100.
+	transport := &assigneeListlessTodoTransport{total: 150, matchID: 1149, assignee: target}
+	app, buf := setupListlessTodoApp(t, transport)
+
+	cmd := NewTodosCmd()
+	err := executeTodosCommand(cmd, app, "list", "--in", "123", "--assignee", "Alice")
+	require.NoError(t, err)
+
+	var resp struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	require.Len(t, resp.Data, 1, "only Alice's listless todo should match")
+	assert.Equal(t, int64(1149), resp.Data[0].ID,
+		"Alice's listless todo beyond the default window must still be found")
+}


### PR DESCRIPTION
## Summary

Fixes #474. In Basecamp 5, todos can live directly under the Todoset without a Todolist (`parent.type: "Todoset"`). `todos list` enumerated todos by looping over the todoset's *todolists*, so these "listless" todos were invisible — the command returned 0 for projects whose todos all live at the Todoset level.

## Root cause

`listAllTodos` lists a project's todolists and fetches todos per-list. When there are zero todolists (or todos parented to the Todoset directly), nothing is returned. Verified live: the API accepts a todo created against a Todoset ID and returns it with `parent.type: "Todoset"`, but `GET /todolists/{todosetId}/todos.json` **404s** — so listless todos are only reachable via the Recordings API (which is why `recordings todos` was the documented workaround).

## Fix

After aggregating todolist todos, `listAllTodos` now calls a new `fetchTodosetLevelTodos` helper that:

- Queries the Recordings API (`type=Todo`, scoped to the project bucket, status mapped from the todos-list filter).
- Keeps only recordings parented directly to *this* todoset.
- Hydrates each via `Todos().Get` — the SDK `Recording` type lacks the completion/assignee/due fields the list output and its filters need.
- Applies the completed/incomplete split client-side, since Recordings status is lifecycle-only (active/archived/trashed).

Existing assignee/overdue filters then apply uniformly. Recordings errors are non-fatal, so the todolist path never regresses. CLI-only change — no SDK bump or API change required.

## Verification

Validated end-to-end against a live project with mixed Todolist + Todoset-level todos:

- Default view returns the todolist todo **and** the incomplete listless todo; the completed listless todo is correctly hidden.
- `--completed` returns only the completed listless todo.
- `--list <id>` and projects without listless todos are unaffected.

Two unit tests added (surfacing listless todos + completion-split filtering). Full `bin/ci` is green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface Todoset-level todos in `todos list`, enforce correct `--limit` semantics, and bound/order the recordings scan to avoid full-project traversals. Allow cross-list `--sort` with `--assignee`/`--overdue`, and error on invalid project IDs. Fixes #474.

- **Bug Fixes**
  - Include Todoset-level (“listless”) todos via Recordings and hydrate with `Todos().Get`; existing filters still apply.
  - With `--assignee`/`--overdue`, fetch all candidates and apply `--limit` after filtering (mirrors single-list).
  - Apply completed/incomplete split client-side for listless todos; Recordings errors are non-fatal.
  - Respect `--limit` and scan efficiently: cap kept listless todos after parent filtering (0=default 100, -1=all); scan a recent, most-recent-first window by default, use `--all` for exhaustive scans.
  - Allow `--sort` when results aren’t sampled (`--all` or `--assignee`/`--overdue`); return a usage error on unparseable project IDs.

<sup>Written for commit 8757516947d7f3d7c9d345018fa1f7f3523d7911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

