### PR TITLE
Separate contiguous paragraphs in HTML passed to the CLI

### DIFF
--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -49,6 +49,9 @@ var (
 	reP  = regexp.MustCompile(`(?is)<p(?:\s[^>]*)?>(.*?)</p>`)
 	reBR = regexp.MustCompile(`(?i)<br\s*/?\s*>`)
 	reHR = regexp.MustCompile(`(?i)<hr\s*/?\s*>`)
+	// reNbsp matches non-breaking-space entities used as visual filler in
+	// otherwise-empty paragraphs (&nbsp;, &#160;, &#xa0; / &#xA0;).
+	reNbsp = regexp.MustCompile(`(?i)&nbsp;|&#160;|&#xa0;`)
 )
 
 // Pre-compiled regexes for HTMLToMarkdown inline elements
@@ -344,7 +347,9 @@ func (r *trixRenderer) renderEscapedAt(w util.BufWriter, _ []byte, _ ast.Node, e
 
 // MarkdownToHTML converts Markdown text to HTML suitable for Basecamp's rich text fields.
 // It uses goldmark with custom AST transformations for Trix editor compatibility.
-// If the input already appears to be HTML, it is returned unchanged to preserve existing formatting.
+// If the input already appears to be HTML, it is passed through with existing
+// formatting preserved, except that a <br> separator is inserted between
+// directly adjacent paragraph blocks (see insertParagraphSeparators).
 func MarkdownToHTML(md string) string {
 	if md == "" {
 		return ""
@@ -422,14 +427,17 @@ func insertParagraphSeparators(s string) string {
 }
 
 // isEmptyParagraph reports whether a <p>...</p> block has no visible content —
-// i.e. it is empty or contains only <br> tags and whitespace. Such paragraphs
-// act as separators, so no additional <br> is inserted adjacent to them.
+// i.e. it is empty or contains only <br> tags and whitespace, including
+// non-breaking-space entities (&nbsp;, &#160;, &#xa0;) that rich text editors
+// commonly use for blank separator lines. Such paragraphs act as separators, so
+// no additional <br> is inserted adjacent to them.
 func isEmptyParagraph(block string) bool {
 	m := reP.FindStringSubmatch(block)
 	if m == nil {
 		return false
 	}
 	inner := reBR.ReplaceAllString(m[1], "")
+	inner = reNbsp.ReplaceAllString(inner, "")
 	return strings.TrimSpace(inner) == ""
 }
 

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -351,7 +351,7 @@ func MarkdownToHTML(md string) string {
 	}
 
 	if IsHTML(md) {
-		return md
+		return insertParagraphSeparators(md)
 	}
 
 	md = strings.ReplaceAll(md, "\r\n", "\n")
@@ -363,6 +363,74 @@ func MarkdownToHTML(md string) string {
 	}
 
 	return strings.TrimSpace(buf.String())
+}
+
+// insertParagraphSeparators inserts a <br> between directly adjacent, non-empty
+// paragraph blocks so that HTML supplied to the CLI renders with visible
+// paragraph spacing.
+//
+// Basecamp's rich text relies on explicit separator nodes for paragraph
+// spacing, not CSS margins: contiguous <p>A</p><p>B</p> renders squished. The
+// Markdown pipeline already inserts a separator between blank-line-separated
+// paragraphs (via TrixBreak), so this brings the raw-HTML passthrough into line
+// with that behavior. Unlike Basecamp's editor, the CLI has no concept of an
+// intentionally-tight single-line-break paragraph (its edit loop collapses that
+// distinction), so contiguous paragraphs from HTML input are treated as
+// separate paragraphs.
+//
+// The transform is byte-preserving apart from the inserted separators and is
+// idempotent: a boundary that already carries a separator — a bare <br> between
+// the paragraphs, or an empty separator paragraph (<p><br></p> or <p></p>) on
+// either side — is left untouched, so running it on already-separated content
+// (including Basecamp editor output) is a no-op. Only directly adjacent <p>
+// blocks are separated; anything between them (whitespace excepted), such as a
+// heading, list, or attachment, already provides its own break and is left
+// alone.
+func insertParagraphSeparators(s string) string {
+	locs := reP.FindAllStringIndex(s, -1)
+	if len(locs) < 2 {
+		return s
+	}
+
+	empty := make([]bool, len(locs))
+	for i, loc := range locs {
+		empty[i] = isEmptyParagraph(s[loc[0]:loc[1]])
+	}
+
+	var b strings.Builder
+	b.Grow(len(s) + len(locs)*4)
+	cursor := 0
+	for i := 0; i < len(locs); i++ {
+		end := locs[i][1]
+		b.WriteString(s[cursor:end])
+		cursor = end
+
+		if i+1 == len(locs) {
+			break
+		}
+
+		nextStart := locs[i+1][0]
+		gap := s[end:nextStart]
+		if !empty[i] && !empty[i+1] && strings.TrimSpace(gap) == "" {
+			b.WriteString(gap)
+			b.WriteString("<br>")
+			cursor = nextStart
+		}
+	}
+	b.WriteString(s[cursor:])
+	return b.String()
+}
+
+// isEmptyParagraph reports whether a <p>...</p> block has no visible content —
+// i.e. it is empty or contains only <br> tags and whitespace. Such paragraphs
+// act as separators, so no additional <br> is inserted adjacent to them.
+func isEmptyParagraph(block string) bool {
+	m := reP.FindStringSubmatch(block)
+	if m == nil {
+		return false
+	}
+	inner := reBR.ReplaceAllString(m[1], "")
+	return strings.TrimSpace(inner) == ""
 }
 
 // escapeHTML escapes special HTML characters.

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -2213,3 +2213,127 @@ func TestParsedAttachmentDisplayURL(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkdownToHTMLInsertsParagraphSeparators(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "two contiguous paragraphs get a separator",
+			input:    "<p>Line 1</p><p>Line 2</p>",
+			expected: "<p>Line 1</p><br><p>Line 2</p>",
+		},
+		{
+			name:     "three contiguous paragraphs get separators between each",
+			input:    "<p>A</p><p>B</p><p>C</p>",
+			expected: "<p>A</p><br><p>B</p><br><p>C</p>",
+		},
+		{
+			name:     "paragraphs with attributes are separated",
+			input:    `<p dir="auto">A</p><p dir="auto">B</p>`,
+			expected: `<p dir="auto">A</p><br><p dir="auto">B</p>`,
+		},
+		{
+			name:     "whitespace-only gap is preserved and separator added",
+			input:    "<p>A</p>\n<p>B</p>",
+			expected: "<p>A</p>\n<br><p>B</p>",
+		},
+		{
+			name:     "existing bare br separator is left untouched (idempotent)",
+			input:    "<p>A</p><br><p>B</p>",
+			expected: "<p>A</p><br><p>B</p>",
+		},
+		{
+			name:     "empty separator paragraph is left untouched (Lexxy canonical)",
+			input:    "<p>A</p><p><br></p><p>B</p>",
+			expected: "<p>A</p><p><br></p><p>B</p>",
+		},
+		{
+			name:     "empty paragraph separator is left untouched",
+			input:    "<p>A</p><p></p><p>B</p>",
+			expected: "<p>A</p><p></p><p>B</p>",
+		},
+		{
+			name:     "single paragraph is unchanged",
+			input:    "<p>Only one</p>",
+			expected: "<p>Only one</p>",
+		},
+		{
+			name:     "heading between paragraphs is left alone",
+			input:    "<p>A</p><h3>H</h3><p>B</p>",
+			expected: "<p>A</p><h3>H</h3><p>B</p>",
+		},
+		{
+			name:     "list between paragraphs is left alone",
+			input:    "<p>A</p><ul><li>x</li></ul><p>B</p>",
+			expected: "<p>A</p><ul><li>x</li></ul><p>B</p>",
+		},
+		{
+			name:     "non-paragraph HTML is unchanged",
+			input:    "<div><strong>Hi</strong></div>",
+			expected: "<div><strong>Hi</strong></div>",
+		},
+		{
+			name:     "paragraph with inline br is still non-empty and separated",
+			input:    "<p>A<br>C</p><p>B</p>",
+			expected: "<p>A<br>C</p><br><p>B</p>",
+		},
+		{
+			name:     "leading empty paragraph is left alone",
+			input:    "<p></p><p>A</p>",
+			expected: "<p></p><p>A</p>",
+		},
+		{
+			name:     "mix of separated and contiguous only fills the gap that lacks a separator",
+			input:    "<p>A</p><p>B</p><br><p>C</p>",
+			expected: "<p>A</p><br><p>B</p><br><p>C</p>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MarkdownToHTML(tt.input)
+			if result != tt.expected {
+				t.Errorf("MarkdownToHTML(%q)\ngot:  %q\nwant: %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// Running the separator insertion on its own output must be a no-op.
+func TestMarkdownToHTMLParagraphSeparatorsIdempotent(t *testing.T) {
+	inputs := []string{
+		"<p>Line 1</p><p>Line 2</p>",
+		"<p>A</p><p>B</p><p>C</p>",
+		`<p dir="auto">A</p><p dir="auto">B</p>`,
+		"<p>A</p>\n<p>B</p>",
+		"<p>A</p><p><br></p><p>B</p>",
+		"<p>A</p><h3>H</h3><p>B</p>",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			once := MarkdownToHTML(in)
+			twice := MarkdownToHTML(once)
+			if once != twice {
+				t.Errorf("not idempotent for %q\nonce:  %q\ntwice: %q", in, once, twice)
+			}
+		})
+	}
+}
+
+// A blank-line Markdown paragraph break and the equivalent contiguous-<p> HTML
+// must converge on the same separated shape.
+func TestMarkdownToHTMLParagraphSeparatorsMatchMarkdownPath(t *testing.T) {
+	fromMarkdown := MarkdownToHTML("Line 1\n\nLine 2")
+	fromHTML := MarkdownToHTML("<p>Line 1</p><p>Line 2</p>")
+
+	if !strings.Contains(fromMarkdown, "<br>") {
+		t.Fatalf("markdown path unexpectedly produced no <br>: %q", fromMarkdown)
+	}
+	if fromHTML != "<p>Line 1</p><br><p>Line 2</p>" {
+		t.Errorf("HTML path = %q, want %q", fromHTML, "<p>Line 1</p><br><p>Line 2</p>")
+	}
+}

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -2256,6 +2256,21 @@ func TestMarkdownToHTMLInsertsParagraphSeparators(t *testing.T) {
 			expected: "<p>A</p><p></p><p>B</p>",
 		},
 		{
+			name:     "nbsp entity separator paragraph is left untouched",
+			input:    "<p>A</p><p>&nbsp;</p><p>B</p>",
+			expected: "<p>A</p><p>&nbsp;</p><p>B</p>",
+		},
+		{
+			name:     "numeric nbsp separator paragraph is left untouched",
+			input:    "<p>A</p><p>&#160;</p><p>B</p>",
+			expected: "<p>A</p><p>&#160;</p><p>B</p>",
+		},
+		{
+			name:     "hex nbsp separator paragraph is left untouched",
+			input:    "<p>A</p><p>&#xa0;</p><p>B</p>",
+			expected: "<p>A</p><p>&#xa0;</p><p>B</p>",
+		},
+		{
 			name:     "single paragraph is unchanged",
 			input:    "<p>Only one</p>",
 			expected: "<p>Only one</p>",


### PR DESCRIPTION
## Problem

Basecamp rich text relies on explicit separator nodes for paragraph spacing, not CSS margins on `<p>`. So contiguous `<p>A</p><p>B</p>` renders squished — the paragraphs run together and don't look separated. This is common with agent/LLM output, which frequently emits contiguous `<p>` blocks.

The Markdown pipeline already handles this: a blank line between paragraphs inserts a separator (via `TrixBreak`). But the raw-HTML passthrough in `MarkdownToHTML` sent HTML through verbatim, so contiguous `<p>` from HTML input rendered squished.

Context: internal card "Missing new lines to separate paragraphs in rich text."

| Before (`main`) | After (this PR) |
| :---: | :---: |
| Contiguous `<p>` renders squished | `<br>` separators inserted |
| <img width="2300" height="760" alt="main-squished-crop" src="https://github.com/user-attachments/assets/810b7631-39c9-4d6a-b4e8-c8ae6064cba1" /> | <img width="2300" height="760" alt="pr-separated-crop" src="https://github.com/user-attachments/assets/9d8ffc90-5ced-4b72-bcd8-0a858632cad7" /> |


## Change

`MarkdownToHTML`'s HTML-passthrough branch now runs `insertParagraphSeparators`, which inserts a bare `<br>` between directly adjacent, non-empty `<p>` blocks. This brings the raw-HTML path into line with what the Markdown path already does.

Properties:

- **Idempotent** — a boundary that already carries a separator (a bare `<br>`, or an empty `<p><br></p>` / `<p></p>` on either side) is left untouched, so already-separated content, including Basecamp editor output, is a no-op.
- **Byte-preserving** apart from the inserted separators.
- **Conservative scope** — only directly adjacent `<p>` pairs are separated. Anything between them (a heading, list, or attachment) already provides its own break and is left alone.

### Why client-side, and why a bare `<br>`

Basecamp's editor stores a single-Enter break as contiguous `<p>A</p><p>B</p>` and a double-Enter break as `<p>A</p><p><br></p><p>B</p>`. Contiguous `<p>` is therefore a legitimate, intentional editor state, byte-identical to what an API client sends when it means "separated" — so the server can't safely normalize it without corrupting editor content and breaking round-trips. The CLI *can*: its input is never editor-authored, and its edit loop already collapses the tight/separated distinction, so treating contiguous HTML paragraphs as separate is consistent with how the CLI already behaves everywhere else.

A bare `<br>` is used to match what the Markdown pipeline already emits. It renders identically to the editor's canonical `<p><br></p>` (verified live).

## Verification

- New tests in `richtext_test.go`: behavior + 14 edge cases, idempotency (`f(f(x)) == f(x)`), and convergence with the Markdown path.
- `richtext`, `commands`, `output`, `presenter`, `tui` packages pass; `gofmt` / `go vet` / `golangci-lint` clean; `check-skill-drift` passes (no CLI surface change).
- Live main-vs-PR comparison against a test project, same input `<p>one</p><p>two</p><p>three</p>`:
  - main build stores `<p>one</p><p>two</p><p>three</p>` → renders squished
  - this build stores `<p>one</p><br><p>two</p><br><p>three</p>` → renders separated

<!-- screenshots: main (squished) vs this PR (separated) -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures HTML passed to the CLI renders separated paragraphs by inserting `"<br>"` between directly adjacent non-empty `<p>` tags, matching Markdown behavior. Now treats `<p>&nbsp;</p>` (and `&#160;`/`&#xa0;`) as empty separator paragraphs.

- **Bug Fixes**
  - `MarkdownToHTML` now runs `insertParagraphSeparators` for HTML input.
  - Inserts `"<br>"` between adjacent non-empty `<p>` blocks; preserves existing separators (`<br>`, empty `<p>`, or `<p>&nbsp;</p>`/`&#160;`/`&#xa0;`).
  - Idempotent and byte-preserving; tests added for behavior, `&nbsp;` variants, and Markdown-path convergence.

<sup>Written for commit 8539d0d6421e0080cec5a769abc2ff0c6ab655af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

