### PR TITLE
Convert Markdown mention links inside HTML blocks to mention chips

### DIFF
--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1063,12 +1064,13 @@ func resolveDeterministicMentions(html string, pattern *regexp.Regexp, groups me
 	}
 
 	htmlLower := strings.ToLower(html)
+	tagIndex := buildHTMLTagIndex(html)
 	result := html
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		fullStart, fullEnd := m[0], m[1]
 
-		if isInsideHTMLTag(html, fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
+		if tagIndex.contains(fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
 			continue
 		}
 
@@ -1114,6 +1116,7 @@ func resolveSGIDMentions(html string) string {
 	}
 
 	htmlLower := strings.ToLower(html)
+	tagIndex := buildHTMLTagIndex(html)
 	result := html
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
@@ -1122,7 +1125,7 @@ func resolveSGIDMentions(html string) string {
 		// Group 3: SGID value
 		sgid := html[m[6]:m[7]]
 
-		if isInsideHTMLTag(html, tokenStart) || isInsideCodeBlock(htmlLower, tokenStart) || isInsideBcAttachment(htmlLower, tokenStart) {
+		if tagIndex.contains(tokenStart) || isInsideCodeBlock(htmlLower, tokenStart) || isInsideBcAttachment(htmlLower, tokenStart) {
 			continue
 		}
 
@@ -1144,13 +1147,14 @@ func resolveNameMentions(html string, lookup MentionLookupFunc) (string, []strin
 
 	result := html
 	htmlLower := strings.ToLower(html)
+	tagIndex := buildHTMLTagIndex(html)
 	var unresolved []string
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		mentionStart, mentionEnd := m[4], m[5]
 
 		// Skip mentions inside HTML tags, code blocks, or existing <bc-attachment> elements
-		if isInsideHTMLTag(html, mentionStart) || isInsideCodeBlock(htmlLower, mentionStart) || isInsideBcAttachment(htmlLower, mentionStart) {
+		if tagIndex.contains(mentionStart) || isInsideCodeBlock(htmlLower, mentionStart) || isInsideBcAttachment(htmlLower, mentionStart) {
 			continue
 		}
 
@@ -1190,18 +1194,25 @@ func resolveNameMentions(html string, lookup MentionLookupFunc) (string, []strin
 	return result, unresolved, nil
 }
 
-// isInsideHTMLTag checks if position pos is inside an HTML tag (between < and >).
-func isInsideHTMLTag(s string, pos int) bool {
-	if pos > len(s) {
-		pos = len(s)
-	}
+type htmlTagSpan struct {
+	start int
+	end   int
+}
 
+type htmlTagIndex []htmlTagSpan
+
+// buildHTMLTagIndex records tag spans in one pass so mention checks do not
+// repeatedly scan the full HTML prefix. Quoted > characters do not end a tag.
+func buildHTMLTagIndex(s string) htmlTagIndex {
+	var index htmlTagIndex
 	inTag := false
+	tagStart := 0
 	var quote byte
-	for i := 0; i < pos; i++ {
+	for i := 0; i < len(s); i++ {
 		if !inTag {
 			if s[i] == '<' {
 				inTag = true
+				tagStart = i + 1
 			}
 			continue
 		}
@@ -1217,10 +1228,21 @@ func isInsideHTMLTag(s string, pos int) bool {
 		case '\'', '"':
 			quote = s[i]
 		case '>':
+			index = append(index, htmlTagSpan{start: tagStart, end: i + 1})
 			inTag = false
 		}
 	}
-	return inTag
+	if inTag {
+		index = append(index, htmlTagSpan{start: tagStart, end: len(s) + 1})
+	}
+	return index
+}
+
+func (index htmlTagIndex) contains(pos int) bool {
+	i := sort.Search(len(index), func(i int) bool {
+		return index[i].end > pos
+	})
+	return i < len(index) && index[i].start <= pos
 }
 
 // isInsideCodeBlock checks if position pos is inside a <code> or <pre> element.

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -91,6 +91,15 @@ var reMentionInput = regexp.MustCompile(`(^|[\s>(\["'])(@[\pL\pN_]+(?:\.[\pL\pN_
 // Group 3: display text (may include leading @).
 var reMentionAnchor = regexp.MustCompile(`<a href="(mention|person):([^"]+)">([^<]*)</a>`)
 
+// reMentionMarkdownLink matches a literal Markdown mention link that was never
+// converted to an <a> anchor — this happens when the link was embedded inside an
+// author-supplied HTML block, which MarkdownToHTML passes through verbatim.
+// Group 1: display text including the leading @.
+// Group 2: scheme (mention or person).
+// Group 3: value (SGID for mention:, person ID for person:).
+// SGIDs and person IDs never contain ')', so [^)]+ is a safe value terminator.
+var reMentionMarkdownLink = regexp.MustCompile(`\[(@[^\]]+)\]\((mention|person):([^)]+)\)`)
+
 // reSGIDMention matches inline @sgid:VALUE syntax.
 // Group 1: prefix character.
 // Group 2: the full @sgid:VALUE token.
@@ -969,10 +978,12 @@ func MentionToHTML(sgid, name string) string {
 		escapeHTML(name) + `</bc-attachment>`
 }
 
-// ResolveMentions processes mention syntax in HTML in three passes:
+// ResolveMentions processes mention syntax in HTML in four passes:
 //  1. Markdown mention anchors: <a href="mention:SGID">@Name</a> and <a href="person:ID">@Name</a>
-//  2. Inline @sgid:VALUE syntax
-//  3. Fuzzy @Name and @First.Last patterns
+//  2. Literal Markdown mention links [@Name](mention:SGID) / [@Name](person:ID) that were
+//     never converted to anchors (e.g. embedded inside an author-supplied HTML block)
+//  3. Inline @sgid:VALUE syntax
+//  4. Fuzzy @Name and @First.Last patterns
 //
 // Each pass replaces matches with <bc-attachment> tags. Subsequent passes skip regions
 // already converted by earlier passes via isInsideBcAttachment.
@@ -987,10 +998,16 @@ func ResolveMentions(html string, lookup MentionLookupFunc, lookupByID PersonByI
 		return MentionResult{}, err
 	}
 
-	// Pass 2: @sgid:VALUE
+	// Pass 2: literal Markdown mention links that were not converted to anchors
+	html, err = resolveMentionMarkdownLinks(html, lookupByID)
+	if err != nil {
+		return MentionResult{}, err
+	}
+
+	// Pass 3: @sgid:VALUE
 	html = resolveSGIDMentions(html)
 
-	// Pass 3: fuzzy @Name (skip when no lookup function provided)
+	// Pass 4: fuzzy @Name (skip when no lookup function provided)
 	var unresolved []string
 	if lookup != nil {
 		html, unresolved, err = resolveNameMentions(html, lookup)
@@ -1036,6 +1053,64 @@ func resolveMentionAnchors(html string, lookupByID PersonByIDFunc) (string, erro
 
 		case "person":
 			// One API lookup — ID → SGID via pingable set
+			if lookupByID == nil {
+				return "", fmt.Errorf("person:%s syntax requires a person lookup function", value)
+			}
+			sgid, canonicalName, err := lookupByID(value)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve person:%s: %w", value, err)
+			}
+			tag = MentionToHTML(sgid, canonicalName)
+		}
+
+		result = result[:fullStart] + tag + result[fullEnd:]
+	}
+
+	return result, nil
+}
+
+// resolveMentionMarkdownLinks converts literal [@Name](mention:SGID) and
+// [@Name](person:ID) Markdown links into <bc-attachment> mention tags.
+//
+// These survive as literal text when the link was authored inside an HTML block:
+// MarkdownToHTML detects the input as HTML and passes it through verbatim, so
+// goldmark never turns the link into an <a> anchor and resolveMentionAnchors
+// cannot match it. Without this pass the fuzzy @Name matcher would match only the
+// first name token (it stops at the first space) and leave the remainder — e.g.
+// " Manrubia](mention:SGID)" — as garbage text next to a half-formed chip.
+//
+// Matches inside code blocks, existing bc-attachments, or HTML tags are skipped:
+// those are documentation or already-resolved content, not live mentions.
+func resolveMentionMarkdownLinks(html string, lookupByID PersonByIDFunc) (string, error) {
+	matches := reMentionMarkdownLink.FindAllStringSubmatchIndex(html, -1)
+	if len(matches) == 0 {
+		return html, nil
+	}
+
+	htmlLower := strings.ToLower(html)
+	result := html
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		fullStart, fullEnd := m[0], m[1]
+
+		if isInsideHTMLTag(html, fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
+			continue
+		}
+
+		displayText := html[m[2]:m[3]]
+		scheme := html[m[4]:m[5]]
+		value := html[m[6]:m[7]]
+
+		var tag string
+		switch scheme {
+		case "mention":
+			// Zero API calls — value is the SGID, link text is the display name.
+			// Unescape because the HTML-block passthrough leaves author entities
+			// intact and MentionToHTML re-escapes — without this we'd double-encode.
+			name := unescapeHTML(strings.TrimPrefix(displayText, "@"))
+			tag = MentionToHTML(value, name)
+
+		case "person":
 			if lookupByID == nil {
 				return "", fmt.Errorf("person:%s syntax requires a person lookup function", value)
 			}

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -97,8 +97,9 @@ var reMentionAnchor = regexp.MustCompile(`<a href="(mention|person):([^"]+)">([^
 // Group 1: display text including the leading @.
 // Group 2: scheme (mention or person).
 // Group 3: value (SGID for mention:, person ID for person:).
-// SGIDs and person IDs never contain ')', so [^)]+ is a safe value terminator.
-var reMentionMarkdownLink = regexp.MustCompile(`\[(@[^\]]+)\]\((mention|person):([^)]+)\)`)
+// SGIDs and person IDs use the same base64-safe character set as inline SGIDs.
+// Excluding '<' from display text prevents a match from spanning HTML elements.
+var reMentionMarkdownLink = regexp.MustCompile(`\[(@[^\]<]+)\]\((mention|person):([\w+=/-]+)\)`)
 
 // reSGIDMention matches inline @sgid:VALUE syntax.
 // Group 1: prefix character.
@@ -988,8 +989,8 @@ func MentionToHTML(sgid, name string) string {
 // Each pass replaces matches with <bc-attachment> tags. Subsequent passes skip regions
 // already converted by earlier passes via isInsideBcAttachment.
 //
-// lookupByID may be nil if person:ID syntax is not needed; encountering a person:ID
-// anchor with a nil lookupByID returns an error.
+// lookupByID may be nil if person:ID syntax is not needed; encountering any
+// person:ID syntax with a nil lookupByID returns an error.
 func ResolveMentions(html string, lookup MentionLookupFunc, lookupByID PersonByIDFunc) (MentionResult, error) {
 	// Pass 1: Markdown mention anchors
 	var err error
@@ -1213,16 +1214,35 @@ func resolveNameMentions(html string, lookup MentionLookupFunc) (string, []strin
 
 // isInsideHTMLTag checks if position pos is inside an HTML tag (between < and >).
 func isInsideHTMLTag(s string, pos int) bool {
-	// Walk backwards from pos looking for < or >
-	for i := pos - 1; i >= 0; i-- {
-		if s[i] == '>' {
-			return false // closed tag before us
+	if pos > len(s) {
+		pos = len(s)
+	}
+
+	inTag := false
+	var quote byte
+	for i := 0; i < pos; i++ {
+		if !inTag {
+			if s[i] == '<' {
+				inTag = true
+			}
+			continue
 		}
-		if s[i] == '<' {
-			return true // inside a tag
+
+		if quote != 0 {
+			if s[i] == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch s[i] {
+		case '\'', '"':
+			quote = s[i]
+		case '>':
+			inTag = false
 		}
 	}
-	return false
+	return inTag
 }
 
 // isInsideCodeBlock checks if position pos is inside a <code> or <pre> element.

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -988,7 +988,7 @@ func MentionToHTML(sgid, name string) string {
 //  4. Fuzzy @Name and @First.Last patterns
 //
 // Each pass replaces matches with <bc-attachment> tags. Subsequent passes skip regions
-// already converted by earlier passes via isInsideBcAttachment.
+// already converted by earlier passes via the mention exclusion index.
 //
 // lookupByID may be nil if person:ID syntax is not needed; encountering any
 // person:ID syntax with a nil lookupByID returns an error.
@@ -1063,14 +1063,13 @@ func resolveDeterministicMentions(html string, pattern *regexp.Regexp, groups me
 		return html, nil
 	}
 
-	htmlLower := strings.ToLower(html)
-	tagIndex := buildHTMLTagIndex(html)
+	exclusions := buildMentionExclusionIndex(html)
 	result := html
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		fullStart, fullEnd := m[0], m[1]
 
-		if tagIndex.contains(fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
+		if exclusions.contains(fullStart) {
 			continue
 		}
 
@@ -1115,8 +1114,7 @@ func resolveSGIDMentions(html string) string {
 		return html
 	}
 
-	htmlLower := strings.ToLower(html)
-	tagIndex := buildHTMLTagIndex(html)
+	exclusions := buildMentionExclusionIndex(html)
 	result := html
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
@@ -1125,7 +1123,7 @@ func resolveSGIDMentions(html string) string {
 		// Group 3: SGID value
 		sgid := html[m[6]:m[7]]
 
-		if tagIndex.contains(tokenStart) || isInsideCodeBlock(htmlLower, tokenStart) || isInsideBcAttachment(htmlLower, tokenStart) {
+		if exclusions.contains(tokenStart) {
 			continue
 		}
 
@@ -1146,15 +1144,14 @@ func resolveNameMentions(html string, lookup MentionLookupFunc) (string, []strin
 	}
 
 	result := html
-	htmlLower := strings.ToLower(html)
-	tagIndex := buildHTMLTagIndex(html)
+	exclusions := buildMentionExclusionIndex(html)
 	var unresolved []string
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
 		mentionStart, mentionEnd := m[4], m[5]
 
 		// Skip mentions inside HTML tags, code blocks, or existing <bc-attachment> elements
-		if tagIndex.contains(mentionStart) || isInsideCodeBlock(htmlLower, mentionStart) || isInsideBcAttachment(htmlLower, mentionStart) {
+		if exclusions.contains(mentionStart) {
 			continue
 		}
 
@@ -1194,17 +1191,34 @@ func resolveNameMentions(html string, lookup MentionLookupFunc) (string, []strin
 	return result, unresolved, nil
 }
 
-type htmlTagSpan struct {
+type textSpan struct {
 	start int
 	end   int
 }
 
-type htmlTagIndex []htmlTagSpan
+type textSpanIndex []textSpan
+
+type mentionExclusionIndex struct {
+	tags      textSpanIndex
+	protected textSpanIndex
+}
+
+func buildMentionExclusionIndex(s string) mentionExclusionIndex {
+	tags := buildHTMLTagIndex(s)
+	return mentionExclusionIndex{
+		tags:      tags,
+		protected: buildProtectedElementIndex(s, tags),
+	}
+}
+
+func (index mentionExclusionIndex) contains(pos int) bool {
+	return index.tags.contains(pos) || index.protected.contains(pos)
+}
 
 // buildHTMLTagIndex records tag spans in one pass so mention checks do not
 // repeatedly scan the full HTML prefix. Quoted > characters do not end a tag.
-func buildHTMLTagIndex(s string) htmlTagIndex {
-	var index htmlTagIndex
+func buildHTMLTagIndex(s string) textSpanIndex {
+	var index textSpanIndex
 	inTag := false
 	tagStart := 0
 	var quote byte
@@ -1228,72 +1242,85 @@ func buildHTMLTagIndex(s string) htmlTagIndex {
 		case '\'', '"':
 			quote = s[i]
 		case '>':
-			index = append(index, htmlTagSpan{start: tagStart, end: i + 1})
+			index = append(index, textSpan{start: tagStart, end: i + 1})
 			inTag = false
 		}
 	}
 	if inTag {
-		index = append(index, htmlTagSpan{start: tagStart, end: len(s) + 1})
+		index = append(index, textSpan{start: tagStart, end: len(s) + 1})
 	}
 	return index
 }
 
-func (index htmlTagIndex) contains(pos int) bool {
+func buildProtectedElementIndex(s string, tags textSpanIndex) textSpanIndex {
+	var index textSpanIndex
+	var depths [3]int
+	depth := 0
+	protectedStart := 0
+
+	for _, tag := range tags {
+		tagEnd := min(tag.end-1, len(s))
+		contents := strings.TrimSpace(s[tag.start:tagEnd])
+		closing := strings.HasPrefix(contents, "/")
+		if closing {
+			contents = strings.TrimSpace(strings.TrimPrefix(contents, "/"))
+		}
+
+		nameEnd := strings.IndexAny(contents, " \t\r\n/")
+		if nameEnd == -1 {
+			nameEnd = len(contents)
+		}
+		kind := protectedElementKind(contents[:nameEnd])
+		if kind == -1 {
+			continue
+		}
+
+		if closing {
+			if depths[kind] == 0 {
+				continue
+			}
+			depths[kind]--
+			depth--
+			if depth == 0 {
+				index = append(index, textSpan{start: protectedStart, end: tag.start})
+			}
+			continue
+		}
+
+		if strings.HasSuffix(contents, "/") {
+			continue
+		}
+		if depth == 0 {
+			protectedStart = tag.end
+		}
+		depths[kind]++
+		depth++
+	}
+
+	if depth > 0 {
+		index = append(index, textSpan{start: protectedStart, end: len(s) + 1})
+	}
+	return index
+}
+
+func protectedElementKind(name string) int {
+	switch {
+	case strings.EqualFold(name, "code"):
+		return 0
+	case strings.EqualFold(name, "pre"):
+		return 1
+	case strings.EqualFold(name, "bc-attachment"):
+		return 2
+	default:
+		return -1
+	}
+}
+
+func (index textSpanIndex) contains(pos int) bool {
 	i := sort.Search(len(index), func(i int) bool {
 		return index[i].end > pos
 	})
 	return i < len(index) && index[i].start <= pos
-}
-
-// isInsideCodeBlock checks if position pos is inside a <code> or <pre> element.
-// s must be pre-lowercased by the caller.
-func isInsideCodeBlock(s string, pos int) bool {
-	prefix := s[:pos]
-	for _, tag := range []string{"code", "pre"} {
-		open := "<" + tag
-		searchIn := prefix
-		for {
-			openIdx := strings.LastIndex(searchIn, open)
-			if openIdx == -1 {
-				break
-			}
-			// Verify tag boundary: next char must be '>', ' ', tab, or newline
-			// to avoid matching partial names like <preview> for <pre>
-			nextPos := openIdx + len(open)
-			if nextPos < len(prefix) && prefix[nextPos] != '>' && prefix[nextPos] != ' ' && prefix[nextPos] != '\t' && prefix[nextPos] != '\n' {
-				// Not a real tag, keep searching earlier in the string
-				searchIn = prefix[:openIdx]
-				continue
-			}
-			between := prefix[openIdx:]
-			if !strings.Contains(between, "</"+tag+">") {
-				return true
-			}
-			break
-		}
-	}
-	return false
-}
-
-// isInsideBcAttachment checks if position pos is inside a <bc-attachment>...</bc-attachment> element.
-// s must be pre-lowercased by the caller for case-insensitive matching.
-func isInsideBcAttachment(s string, pos int) bool {
-	// Find the last <bc-attachment before pos
-	prefix := s[:pos]
-	openIdx := strings.LastIndex(prefix, "<bc-attachment")
-	if openIdx == -1 {
-		return false
-	}
-	between := s[openIdx:pos]
-	// Self-closing tag (e.g., <bc-attachment ... />) — mention is after it, not inside
-	if strings.Contains(between, "/>") {
-		return false
-	}
-	// Check for closing tag between the open and pos
-	if strings.Contains(between, "</bc-attachment>") {
-		return false
-	}
-	return true
 }
 
 // IsHTML attempts to detect if the input string contains HTML.

--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -1023,7 +1023,41 @@ func ResolveMentions(html string, lookup MentionLookupFunc, lookupByID PersonByI
 // resolveMentionAnchors processes <a href="mention:SGID">@Name</a> and
 // <a href="person:ID">@Name</a> anchors produced by MarkdownToHTML.
 func resolveMentionAnchors(html string, lookupByID PersonByIDFunc) (string, error) {
-	matches := reMentionAnchor.FindAllStringSubmatchIndex(html, -1)
+	return resolveDeterministicMentions(html, reMentionAnchor, mentionMatchGroups{
+		scheme:  1,
+		value:   2,
+		display: 3,
+	}, lookupByID)
+}
+
+// resolveMentionMarkdownLinks converts literal [@Name](mention:SGID) and
+// [@Name](person:ID) Markdown links into <bc-attachment> mention tags.
+//
+// These survive as literal text when the link was authored inside an HTML block:
+// MarkdownToHTML detects the input as HTML and passes it through verbatim, so
+// goldmark never turns the link into an <a> anchor and resolveMentionAnchors
+// cannot match it. Without this pass the fuzzy @Name matcher would match only the
+// first name token (it stops at the first space) and leave the remainder — e.g.
+// " Manrubia](mention:SGID)" — as garbage text next to a half-formed chip.
+//
+// Matches inside code blocks, existing bc-attachments, or HTML tags are skipped:
+// those are documentation or already-resolved content, not live mentions.
+func resolveMentionMarkdownLinks(html string, lookupByID PersonByIDFunc) (string, error) {
+	return resolveDeterministicMentions(html, reMentionMarkdownLink, mentionMatchGroups{
+		scheme:  2,
+		value:   3,
+		display: 1,
+	}, lookupByID)
+}
+
+type mentionMatchGroups struct {
+	scheme  int
+	value   int
+	display int
+}
+
+func resolveDeterministicMentions(html string, pattern *regexp.Regexp, groups mentionMatchGroups, lookupByID PersonByIDFunc) (string, error) {
+	matches := pattern.FindAllStringSubmatchIndex(html, -1)
 	if len(matches) == 0 {
 		return html, nil
 	}
@@ -1034,26 +1068,22 @@ func resolveMentionAnchors(html string, lookupByID PersonByIDFunc) (string, erro
 		m := matches[i]
 		fullStart, fullEnd := m[0], m[1]
 
-		// Skip anchors inside code blocks, existing bc-attachments, or HTML tags
 		if isInsideHTMLTag(html, fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
 			continue
 		}
 
-		scheme := html[m[2]:m[3]]
-		value := html[m[4]:m[5]]
-		displayText := html[m[6]:m[7]]
+		scheme := submatch(html, m, groups.scheme)
+		value := submatch(html, m, groups.value)
+		displayText := submatch(html, m, groups.display)
 
 		var tag string
 		switch scheme {
 		case "mention":
-			// Zero API calls — use value as SGID, link text as display name (caller-trusted).
-			// Unescape HTML because goldmark already escaped the link text (e.g. & → &amp;)
-			// and MentionToHTML will re-escape — without this we'd double-encode.
+			// Both goldmark output and HTML-block passthrough may contain entities.
 			name := unescapeHTML(strings.TrimPrefix(displayText, "@"))
 			tag = MentionToHTML(value, name)
 
 		case "person":
-			// One API lookup — ID → SGID via pingable set
 			if lookupByID == nil {
 				return "", fmt.Errorf("person:%s syntax requires a person lookup function", value)
 			}
@@ -1070,62 +1100,10 @@ func resolveMentionAnchors(html string, lookupByID PersonByIDFunc) (string, erro
 	return result, nil
 }
 
-// resolveMentionMarkdownLinks converts literal [@Name](mention:SGID) and
-// [@Name](person:ID) Markdown links into <bc-attachment> mention tags.
-//
-// These survive as literal text when the link was authored inside an HTML block:
-// MarkdownToHTML detects the input as HTML and passes it through verbatim, so
-// goldmark never turns the link into an <a> anchor and resolveMentionAnchors
-// cannot match it. Without this pass the fuzzy @Name matcher would match only the
-// first name token (it stops at the first space) and leave the remainder — e.g.
-// " Manrubia](mention:SGID)" — as garbage text next to a half-formed chip.
-//
-// Matches inside code blocks, existing bc-attachments, or HTML tags are skipped:
-// those are documentation or already-resolved content, not live mentions.
-func resolveMentionMarkdownLinks(html string, lookupByID PersonByIDFunc) (string, error) {
-	matches := reMentionMarkdownLink.FindAllStringSubmatchIndex(html, -1)
-	if len(matches) == 0 {
-		return html, nil
-	}
-
-	htmlLower := strings.ToLower(html)
-	result := html
-	for i := len(matches) - 1; i >= 0; i-- {
-		m := matches[i]
-		fullStart, fullEnd := m[0], m[1]
-
-		if isInsideHTMLTag(html, fullStart) || isInsideCodeBlock(htmlLower, fullStart) || isInsideBcAttachment(htmlLower, fullStart) {
-			continue
-		}
-
-		displayText := html[m[2]:m[3]]
-		scheme := html[m[4]:m[5]]
-		value := html[m[6]:m[7]]
-
-		var tag string
-		switch scheme {
-		case "mention":
-			// Zero API calls — value is the SGID, link text is the display name.
-			// Unescape because the HTML-block passthrough leaves author entities
-			// intact and MentionToHTML re-escapes — without this we'd double-encode.
-			name := unescapeHTML(strings.TrimPrefix(displayText, "@"))
-			tag = MentionToHTML(value, name)
-
-		case "person":
-			if lookupByID == nil {
-				return "", fmt.Errorf("person:%s syntax requires a person lookup function", value)
-			}
-			sgid, canonicalName, err := lookupByID(value)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve person:%s: %w", value, err)
-			}
-			tag = MentionToHTML(sgid, canonicalName)
-		}
-
-		result = result[:fullStart] + tag + result[fullEnd:]
-	}
-
-	return result, nil
+func submatch(input string, indexes []int, group int) string {
+	start := indexes[group*2]
+	end := indexes[group*2+1]
+	return input[start:end]
 }
 
 // resolveSGIDMentions processes inline @sgid:VALUE syntax.

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -2352,3 +2352,99 @@ func TestMarkdownToHTMLParagraphSeparatorsMatchMarkdownPath(t *testing.T) {
 		t.Errorf("HTML path = %q, want %q", fromHTML, "<p>Line 1</p><br><p>Line 2</p>")
 	}
 }
+
+// TestResolveMentions_MarkdownLinkInHTMLBlock covers the regression from the
+// "broken @mention rendering" report: a [@Name](mention:SGID) link authored
+// inside an HTML block is passed through verbatim by MarkdownToHTML (never
+// becoming an anchor), and must be converted to a single clean mention chip
+// rather than being mangled by the fuzzy @Name matcher.
+func TestResolveMentions_MarkdownLinkInHTMLBlock(t *testing.T) {
+	lookup := func(name string) (sgid, displayName string, err error) {
+		// "Jorge" resolves — this is what the fuzzy pass would latch onto if the
+		// literal link were not handled first, producing the reported garbage.
+		if name == "Jorge" || name == "Jorge Manrubia" {
+			return "sgid-jorge", "Jorge Manrubia", nil
+		}
+		return "", "", fmt.Errorf("%w: not found: %s", ErrMentionSkip, name)
+	}
+	lookupByID := func(id string) (sgid, canonicalName string, err error) {
+		if id == "42" {
+			return "sgid-jorge", "Jorge Manrubia", nil
+		}
+		return "", "", fmt.Errorf("not found: %s", id)
+	}
+
+	sgid := "BAh7CEkiCG9pZA__c122645233a25510b54af45164e6002c0f99e870"
+	mentionChip := MentionToHTML(sgid, "Jorge Manrubia")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "mention scheme inside div block",
+			input:    `<div dir="auto">Ready for your review. [@Jorge Manrubia](mention:` + sgid + `)</div>`,
+			expected: `<div dir="auto">Ready for your review. ` + mentionChip + `</div>`,
+		},
+		{
+			name:     "person scheme inside div block",
+			input:    `<div dir="auto">cc [@Jorge Manrubia](person:42)</div>`,
+			expected: `<div dir="auto">cc ` + MentionToHTML("sgid-jorge", "Jorge Manrubia") + `</div>`,
+		},
+		{
+			name:     "literal link inside code is documentation, left untouched",
+			input:    `<p>Use <code>[@Name](mention:SGID)</code> for mentions</p>`,
+			expected: `<p>Use <code>[@Name](mention:SGID)</code> for mentions</p>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolveMentions(tt.input, lookup, lookupByID)
+			if err != nil {
+				t.Fatalf("ResolveMentions() error = %v", err)
+			}
+			if result.HTML != tt.expected {
+				t.Errorf("ResolveMentions() =\n  %q\nwant:\n  %q", result.HTML, tt.expected)
+			}
+			// No half-formed chip: the raw markdown-link residue must be gone.
+			if strings.Contains(result.HTML, "](mention:") || strings.Contains(result.HTML, "](person:") {
+				if !strings.Contains(tt.input, "<code>") {
+					t.Errorf("residual markdown mention link left in output: %q", result.HTML)
+				}
+			}
+		})
+	}
+}
+
+// TestMentionInHTMLBlock_FullPipeline exercises the exact production sequence
+// (MarkdownToHTML then ResolveMentions) against the reported card payload and
+// asserts the output carries exactly one mention chip and no literal residue.
+func TestMentionInHTMLBlock_FullPipeline(t *testing.T) {
+	lookup := func(name string) (sgid, displayName string, err error) {
+		if name == "Jorge" || name == "Jorge Manrubia" {
+			return "sgid-jorge", "Jorge Manrubia", nil
+		}
+		return "", "", fmt.Errorf("%w: not found: %s", ErrMentionSkip, name)
+	}
+
+	sgid := "BAh7CEkiCG9pZA__c122645233a25510b54af45164e6002c0f99e870"
+	input := `<div dir="auto">Ready for your review. [@Jorge Manrubia](mention:` + sgid + `)</div>`
+
+	html := MarkdownToHTML(input)
+	res, err := ResolveMentions(html, lookup, nil)
+	if err != nil {
+		t.Fatalf("pipeline error = %v", err)
+	}
+
+	if n := strings.Count(res.HTML, "<bc-attachment"); n != 1 {
+		t.Errorf("want exactly 1 mention chip, got %d: %q", n, res.HTML)
+	}
+	if strings.Contains(res.HTML, "Manrubia](mention:") {
+		t.Errorf("literal mention-link residue survived: %q", res.HTML)
+	}
+	if !strings.Contains(res.HTML, `sgid="`+sgid+`"`) {
+		t.Errorf("chip does not carry the supplied SGID: %q", res.HTML)
+	}
+}

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -1594,6 +1594,16 @@ func TestResolveMentions(t *testing.T) {
 			expected: `<pre>@John example</pre>`,
 		},
 		{
+			name:     "mention after closed code block is resolved",
+			input:    `<code>@John</code> @John`,
+			expected: `<code>@John</code> ` + MentionToHTML("sgid-john", "John Doe"),
+		},
+		{
+			name:     "mention after closed attachment is resolved",
+			input:    `<bc-attachment sgid="x">@John</bc-attachment> @John`,
+			expected: `<bc-attachment sgid="x">@John</bc-attachment> ` + MentionToHTML("sgid-john", "John Doe"),
+		},
+		{
 			name:     "mention after self-closing bc-attachment is resolved",
 			input:    `<bc-attachment sgid="x" content-type="image/png"/> @John check this`,
 			expected: `<bc-attachment sgid="x" content-type="image/png"/> ` + MentionToHTML("sgid-john", "John Doe") + ` check this`,

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -2413,6 +2413,11 @@ func TestResolveMentions_MarkdownLinkInHTMLBlock(t *testing.T) {
 			expected: `<div data-example="> [@Name](mention:SGID)">body</div>`,
 		},
 		{
+			name:     "literal link after quoted less-than resolves",
+			input:    `<div data-example="<sample">body</div>[@Jorge](person:42)`,
+			expected: `<div data-example="<sample">body</div>` + MentionToHTML("sgid-jorge", "Jorge Manrubia"),
+		},
+		{
 			name:     "entity-bearing display name is not double encoded",
 			input:    `<div>[@AT&amp;T](mention:` + sgid + `)</div>`,
 			expected: `<div>` + MentionToHTML(sgid, "AT&T") + `</div>`,

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -2397,6 +2397,32 @@ func TestResolveMentions_MarkdownLinkInHTMLBlock(t *testing.T) {
 			input:    `<p>Use <code>[@Name](mention:SGID)</code> for mentions</p>`,
 			expected: `<p>Use <code>[@Name](mention:SGID)</code> for mentions</p>`,
 		},
+		{
+			name:     "literal link inside pre is documentation, left untouched",
+			input:    `<pre>[@Name](mention:SGID)</pre>`,
+			expected: `<pre>[@Name](mention:SGID)</pre>`,
+		},
+		{
+			name:     "literal link inside attachment is left untouched",
+			input:    `<bc-attachment sgid="existing">[@Name](mention:SGID)</bc-attachment>`,
+			expected: `<bc-attachment sgid="existing">[@Name](mention:SGID)</bc-attachment>`,
+		},
+		{
+			name:     "literal link inside quoted attribute is left untouched",
+			input:    `<div data-example="> [@Name](mention:SGID)">body</div>`,
+			expected: `<div data-example="> [@Name](mention:SGID)">body</div>`,
+		},
+		{
+			name:     "entity-bearing display name is not double encoded",
+			input:    `<div>[@AT&amp;T](mention:` + sgid + `)</div>`,
+			expected: `<div>` + MentionToHTML(sgid, "AT&T") + `</div>`,
+		},
+		{
+			name:  "multiple literal links resolve from right to left",
+			input: `<div>[@Jorge Manrubia](mention:` + sgid + `) [@Jorge](person:42)</div>`,
+			expected: `<div>` + mentionChip + ` ` +
+				MentionToHTML("sgid-jorge", "Jorge Manrubia") + `</div>`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2409,13 +2435,44 @@ func TestResolveMentions_MarkdownLinkInHTMLBlock(t *testing.T) {
 				t.Errorf("ResolveMentions() =\n  %q\nwant:\n  %q", result.HTML, tt.expected)
 			}
 			// No half-formed chip: the raw markdown-link residue must be gone.
-			if strings.Contains(result.HTML, "](mention:") || strings.Contains(result.HTML, "](person:") {
-				if !strings.Contains(tt.input, "<code>") {
-					t.Errorf("residual markdown mention link left in output: %q", result.HTML)
-				}
+			if tt.expected != tt.input &&
+				(strings.Contains(result.HTML, "](mention:") || strings.Contains(result.HTML, "](person:")) {
+				t.Errorf("residual markdown mention link left in output: %q", result.HTML)
 			}
 		})
 	}
+}
+
+func TestResolveMentions_MarkdownLinkDoesNotCrossHTML(t *testing.T) {
+	input := `<div>[@Jorge <strong>Manrubia</strong>](mention:SGID)</div>`
+	result, err := ResolveMentions(input, nil, nil)
+	if err != nil {
+		t.Fatalf("ResolveMentions() error = %v", err)
+	}
+	if result.HTML != input {
+		t.Errorf("ResolveMentions() = %q, want unchanged input", result.HTML)
+	}
+}
+
+func TestResolveMentions_MarkdownPersonLinkErrors(t *testing.T) {
+	input := `<div>[@Jane](person:42)</div>`
+
+	t.Run("nil lookup", func(t *testing.T) {
+		_, err := ResolveMentions(input, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "requires a person lookup function") {
+			t.Fatalf("ResolveMentions() error = %v", err)
+		}
+	})
+
+	t.Run("lookup error", func(t *testing.T) {
+		lookupByID := func(id string) (string, string, error) {
+			return "", "", fmt.Errorf("not pingable: %s", id)
+		}
+		_, err := ResolveMentions(input, nil, lookupByID)
+		if err == nil || !strings.Contains(err.Error(), "failed to resolve person:42") {
+			t.Fatalf("ResolveMentions() error = %v", err)
+		}
+	})
 }
 
 // TestMentionInHTMLBlock_FullPipeline exercises the exact production sequence


### PR DESCRIPTION
## Summary

A `[@Name](mention:SGID)` or `[@Name](person:ID)` mention authored **inside an author-supplied HTML block** rendered as a correct chip for the first name token followed by literal garbage — e.g. a valid `@Jorge` chip immediately trailed by the literal text `Manrubia](mention:SGID)`.

## Root cause

When input is detected as HTML, `MarkdownToHTML` passes it through verbatim and never runs goldmark, so the Markdown mention link is never converted to an `<a href="mention:...">` anchor. `resolveMentionAnchors` matched nothing, and the fuzzy `@Name` pass then matched only the first name token (its regex stops at the first space) — turning that into a chip and leaving the rest of the link as literal text.

## Fix

Add a `resolveMentionMarkdownLinks` pass to `ResolveMentions` that recognizes the literal `[@Name](mention:SGID)` / `[@Name](person:ID)` form and converts it to a `<bc-attachment>` mention **before** the fuzzy pass runs. It reuses the existing skip guards, so links inside `<code>`, existing attachments, or tags (i.e. documentation) are left untouched.

Because the fix lives in the richtext layer, it covers every call site that composes rich text: comments, messages, cards, chat, check-ins, documents, todos, and schedule.

## Validation

- New regression tests: `TestResolveMentions_MarkdownLinkInHTMLBlock` (mention scheme, person scheme, and the `<code>` documentation guard) and `TestMentionInHTMLBlock_FullPipeline` (full `MarkdownToHTML → ResolveMentions` sequence asserting exactly one chip and no residue).
- Existing fuzzy/anchor/sgid mention tests unchanged and green.
- Verified end-to-end against live Basecamp: before the fix, a mention link in an HTML block stored a chip plus trailing literal `](mention:…)` text; after the fix, the same input stores a single clean mention chip with no residue.
- `bin/ci` passes.

Reported in card 10088583638.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown mention links inside author-supplied HTML blocks so they render as a single clean mention chip across rich-text surfaces. Adds a faster exclusion index to skip tags/code/attachments and prevent partial chips.

- **Bug Fixes**
  - Convert literal `[@Name](mention:SGID)` / `[@Name](person:ID)` in HTML blocks to `<bc-attachment>` before the fuzzy pass; `person:` uses `lookupByID`.
  - Hardened matching: no cross-tag matches; skip inside `<code>`, `<pre>`, existing `<bc-attachment>`, or quoted attributes; unescape entities; error on `person:` when no lookup is provided.

- **Refactors**
  - Share deterministic mention resolution for anchors and Markdown links; precompute mention exclusion spans (HTML tags and protected elements) and binary-search for containment.
  - Expanded tests cover both schemes, guards, multiple links, resolution after closed blocks/attachments, error paths, and the full `MarkdownToHTML → ResolveMentions` pipeline.

<sup>Written for commit 1e8c29129242577d52b7557123be84f57773fc24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

