### PR TITLE
Bump Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/basecamp-cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from 1.26.4 to 1.26.5 to address **GO-2026-5856** — an Encrypted Client Hello privacy leak in `crypto/tls`, present in the Go standard library at 1.26.4 and fixed in 1.26.5.

All CI workflows install Go via `go-version-file: 'go.mod'`, so the pinned patch version determines the toolchain used. Once this advisory landed in the vuln DB, the `Security` / `govulncheck` job started failing on every open branch (it's a stdlib vuln, independent of any code change). This bump clears it.

## Verification

- `govulncheck -tags dev ./...` under **go1.26.4** → exit 3, reports `GO-2026-5856` in `crypto/tls`.
- Same command under **go1.26.5** → exit 0, *"No vulnerabilities found."*
- `go build -tags dev ./...` clean; `go mod tidy` is a no-op (no dependency changes).

Unblocks the Security check on the currently-open PRs once they rebase onto main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `go` directive in `go.mod` from 1.26.4 to 1.26.5 to patch the `crypto/tls` ECH privacy leak (GO-2026-5856). CI uses this pinned version, so this unblocks failing `govulncheck` runs.

<sup>Written for commit ec69e23478efa9cd4729a2622ae5776fa67ab943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

