### PR TITLE
Add hidden agent-hook command for shared plugin hooks

### DIFF
--- a/e2e/agent_hook.bats
+++ b/e2e/agent_hook.bats
@@ -52,12 +52,15 @@ assert_hook_context_contains() {
 }
 
 @test "agent-hook tolerates invalid config (exit 0, still emits)" {
-  # Non-localhost http base_url fails the root command's HTTPS enforcement
-  # with exit 7 — the hook lifecycle must bypass that and stay non-blocking.
-  run bash -c 'echo "{}" | BASECAMP_BASE_URL=http://example.test basecamp agent-hook session-start'
-  assert_success
-  is_valid_json
-  assert_json_value ".hookSpecificOutput.hookEventName" "SessionStart"
+  # Values the SDK client constructor rejects (panics on): non-localhost
+  # http, a non-HTTP scheme, and a bare host with no scheme. The hook
+  # lifecycle must neutralize all of them and stay non-blocking.
+  for bad_url in "http://example.test" "ftp://example.test" "example.test"; do
+    run bash -c "echo '{}' | BASECAMP_BASE_URL='$bad_url' basecamp agent-hook session-start"
+    assert_success
+    is_valid_json
+    assert_json_value ".hookSpecificOutput.hookEventName" "SessionStart"
+  done
 }
 
 @test "agent-hook tolerates multiple profiles without a default (exit 0)" {

--- a/e2e/agent_hook.bats
+++ b/e2e/agent_hook.bats
@@ -6,6 +6,7 @@ load test_helper
 setup_extra() {
   export CLAUDE_PLUGIN_DATA="$TEST_TEMP_DIR/plugin-data"
   export GIT_CONFIG_NOSYSTEM=1
+  export GIT_CONFIG_GLOBAL=/dev/null
   # Git wrappers (e.g. git-ai) write into .git after commit, racing teardown
   export GIT_AI_SKIP_ALL_HOOKS=1
 
@@ -25,6 +26,16 @@ hook_payload() {
     "$event" "$REPO"
 }
 
+assert_hook_context_contains() {
+  local needle="$1"
+  local context
+  context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+  if [[ "$context" != *"$needle"* ]]; then
+    echo "additionalContext missing '$needle': $context"
+    return 1
+  fi
+}
+
 @test "agent-hook is hidden from help" {
   run basecamp --help
   assert_success
@@ -35,8 +46,35 @@ hook_payload() {
   run bash -c 'echo "{}" | basecamp agent-hook session-start'
   assert_success
   is_valid_json
-  assert_output_contains "hookSpecificOutput"
-  assert_output_contains "SessionStart"
+  assert_json_value ".hookSpecificOutput.hookEventName" "SessionStart"
+  assert_json_not_null ".hookSpecificOutput.additionalContext"
+  assert_hook_context_contains "Basecamp is active"
+}
+
+@test "agent-hook tolerates invalid config (exit 0, still emits)" {
+  # Non-localhost http base_url fails the root command's HTTPS enforcement
+  # with exit 7 — the hook lifecycle must bypass that and stay non-blocking.
+  run bash -c 'echo "{}" | BASECAMP_BASE_URL=http://example.test basecamp agent-hook session-start'
+  assert_success
+  is_valid_json
+  assert_json_value ".hookSpecificOutput.hookEventName" "SessionStart"
+}
+
+@test "agent-hook tolerates multiple profiles without a default (exit 0)" {
+  # Multiple profiles and no default_profile make the root lifecycle fail
+  # with a profile-resolution error — hooks must not inherit that.
+  cat > "$TEST_HOME/.config/basecamp/config.json" <<'EOF'
+{
+  "profiles": {
+    "work": {"base_url": "https://3.basecampapi.com", "account_id": "111"},
+    "personal": {"base_url": "https://3.basecampapi.com", "account_id": "222"}
+  }
+}
+EOF
+  run bash -c 'echo "{}" | basecamp agent-hook session-start'
+  assert_success
+  is_valid_json
+  assert_json_value ".hookSpecificOutput.hookEventName" "SessionStart"
 }
 
 @test "agent-hook nudges after a referenced commit" {
@@ -51,8 +89,9 @@ hook_payload() {
   run bash -c "echo '$(hook_payload PostToolUse)' | basecamp agent-hook post-commit"
   assert_success
   is_valid_json
-  assert_output_contains "BC-123"
-  assert_output_contains "Nothing was posted"
+  assert_json_value ".hookSpecificOutput.hookEventName" "PostToolUse"
+  assert_hook_context_contains "BC-123"
+  assert_hook_context_contains "Nothing was posted"
 }
 
 @test "agent-hook stays silent when no commit happened" {

--- a/e2e/agent_hook.bats
+++ b/e2e/agent_hook.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# agent_hook.bats - Tests for the hidden agent-hook plugin commands
+
+load test_helper
+
+setup_extra() {
+  export CLAUDE_PLUGIN_DATA="$TEST_TEMP_DIR/plugin-data"
+  export GIT_CONFIG_NOSYSTEM=1
+  # Git wrappers (e.g. git-ai) write into .git after commit, racing teardown
+  export GIT_AI_SKIP_ALL_HOOKS=1
+
+  REPO="$TEST_TEMP_DIR/repo"
+  git init -q -b main "$REPO"
+  git -C "$REPO" config user.email "agent-hook@example.com"
+  git -C "$REPO" config user.name "Agent Hook Test"
+  git -C "$REPO" config commit.gpgsign false
+  echo one > "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -q -m "initial"
+}
+
+hook_payload() {
+  local event="$1"
+  printf '{"session_id":"e2e-session","tool_use_id":"e2e-tool-use","hook_event_name":"%s","cwd":"%s","tool_input":{"command":"git commit -m ship"}}' \
+    "$event" "$REPO"
+}
+
+@test "agent-hook is hidden from help" {
+  run basecamp --help
+  assert_success
+  ! echo "$output" | grep -q "agent-hook"
+}
+
+@test "agent-hook session-start emits hook JSON on stdout" {
+  run bash -c 'echo "{}" | basecamp agent-hook session-start'
+  assert_success
+  is_valid_json
+  assert_output_contains "hookSpecificOutput"
+  assert_output_contains "SessionStart"
+}
+
+@test "agent-hook nudges after a referenced commit" {
+  run bash -c "echo '$(hook_payload PreToolUse)' | basecamp agent-hook pre-commit-snapshot"
+  assert_success
+  [ -z "$output" ]
+
+  echo two >> "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -q -m "BC-123 ship it"
+
+  run bash -c "echo '$(hook_payload PostToolUse)' | basecamp agent-hook post-commit"
+  assert_success
+  is_valid_json
+  assert_output_contains "BC-123"
+  assert_output_contains "Nothing was posted"
+}
+
+@test "agent-hook stays silent when no commit happened" {
+  run bash -c "echo '$(hook_payload PreToolUse)' | basecamp agent-hook pre-commit-snapshot"
+  assert_success
+
+  run bash -c "echo '$(hook_payload PostToolUse)' | basecamp agent-hook post-commit"
+  assert_success
+  [ -z "$output" ]
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -342,6 +342,7 @@ func Execute() {
 	cmd.AddCommand(commands.NewNotificationsCmd())
 	cmd.AddCommand(commands.NewTUICmd())
 	cmd.AddCommand(commands.NewBonfireCmd())
+	cmd.AddCommand(commands.NewAgentHookCmd())
 
 	// Use ExecuteC to get the executed command (for correct context access)
 	executedCmd, err := cmd.ExecuteC()

--- a/internal/commands/agent_hook.go
+++ b/internal/commands/agent_hook.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/config"
+	"github.com/basecamp/basecamp-cli/internal/hostutil"
 )
 
 const (
@@ -41,14 +43,50 @@ type agentHookInput struct {
 
 // NewAgentHookCmd creates the hidden command group used by the plugin hooks
 // shared between Claude Code and Codex.
+//
+// The group declares its own persistent lifecycle, which replaces the root
+// command's for this subtree (Cobra runs only the innermost declaration).
+// The root lifecycle validates config, resolves profiles, and enforces
+// base_url HTTPS — any of which can fail with a nonzero exit, breaking the
+// hooks' never-block contract. Hooks tolerate every config problem instead:
+// they fall back to defaults, which still supports BASECAMP_TOKEN and
+// stored-credential auth detection plus the cache-directory fallback.
 func NewAgentHookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "agent-hook",
 		Short:  "Run agent plugin hooks",
 		Hidden: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if appctx.FromContext(cmd.Context()) != nil {
+				return nil
+			}
+			cmd.SetContext(appctx.WithApp(cmd.Context(), newAgentHookApp()))
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if app := appctx.FromContext(cmd.Context()); app != nil {
+				app.Close()
+			}
+			return nil
+		},
 	}
 	cmd.AddCommand(newAgentHookSessionStartCmd(), newAgentHookPreCommitSnapshotCmd(), newAgentHookPostCommitCmd())
 	return cmd
+}
+
+// newAgentHookApp builds the hook app from whatever config is usable. An
+// insecure base_url must be neutralized before NewApp: the SDK client
+// constructor panics on a non-localhost http URL, and root's HTTPS gate —
+// which normally catches it first — is bypassed by the hook lifecycle.
+func newAgentHookApp() *appctx.App {
+	cfg, err := config.Load(config.FlagOverrides{})
+	if err != nil || cfg == nil {
+		cfg = config.Default()
+	}
+	if hostutil.RequireSecureURL(cfg.BaseURL) != nil {
+		cfg.BaseURL = config.Default().BaseURL
+	}
+	return appctx.NewApp(cfg)
 }
 
 func newAgentHookSessionStartCmd() *cobra.Command {
@@ -104,12 +142,19 @@ func newAgentHookPostCommitCmd() *cobra.Command {
 			if dir == "" {
 				return nil
 			}
+			// Claim the snapshot with an atomic rename before reading so
+			// concurrent deliveries (PostToolUse and PostToolUseFailure can
+			// both fire for one tool call) produce exactly one nudge.
 			path := filepath.Join(dir, agentHookSnapshotName(input))
-			data, err := os.ReadFile(path) //nolint:gosec // G304: path is a hash inside our own state directory
-			if err != nil {
-				return nil //nolint:nilerr // no snapshot means no commit to prove — stay silent
+			claimed := path + ".claim"
+			if err := os.Rename(path, claimed); err != nil {
+				return nil //nolint:nilerr // no snapshot (or already claimed) means nothing to prove — stay silent
 			}
-			_ = os.Remove(path)
+			data, err := os.ReadFile(claimed) //nolint:gosec // G304: path is a hash inside our own state directory
+			_ = os.Remove(claimed)
+			if err != nil {
+				return nil //nolint:nilerr // unreadable snapshot — stay silent
+			}
 
 			reference, revision, ok := agentHookCommitReference(cmd.Context(), input.CWD, strings.TrimSpace(string(data)))
 			if !ok {
@@ -168,11 +213,21 @@ func agentHookHead(ctx context.Context, cwd string) (string, bool) {
 	if inside, err := gitOutput(ctx, cwd, "rev-parse", "--is-inside-work-tree"); err != nil || inside != "true" {
 		return "", false
 	}
-	head, err := gitOutput(ctx, cwd, "rev-parse", "HEAD")
-	if err != nil {
+	// ^{commit} verifies HEAD resolves to an existing commit object — a
+	// detached HEAD at a missing object "resolves" textually but must not
+	// be recorded as known state.
+	head, err := gitOutput(ctx, cwd, "rev-parse", "--verify", "HEAD^{commit}")
+	if err == nil {
+		return head, true
+	}
+	// HEAD did not verify. Claim EMPTY only for a proven unborn branch —
+	// HEAD is still a symbolic ref to a branch with no commits. Any other
+	// failure (transient git error, broken HEAD) stays silent rather than
+	// risk a later nudge against state the snapshot never established.
+	if _, symErr := gitOutput(ctx, cwd, "symbolic-ref", "-q", "HEAD"); symErr == nil {
 		return unbornHeadSnapshot, true
 	}
-	return head, true
+	return "", false
 }
 
 // agentHookCommitReference proves a commit happened (HEAD moved and the last
@@ -182,7 +237,7 @@ func agentHookCommitReference(ctx context.Context, cwd, before string) (string, 
 	if cwd == "" {
 		cwd = "."
 	}
-	head, err := gitOutput(ctx, cwd, "rev-parse", "HEAD")
+	head, err := gitOutput(ctx, cwd, "rev-parse", "--verify", "HEAD^{commit}")
 	if err != nil || head == before {
 		return "", "", false
 	}
@@ -264,17 +319,17 @@ func atomicWriteAgentHookFile(path string, data []byte) error {
 	tmpPath := tmpFile.Name()
 
 	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpPath)
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmpFile.Chmod(0600); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpPath)
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmpFile.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 
@@ -283,7 +338,7 @@ func atomicWriteAgentHookFile(path string, data []byte) error {
 			_ = os.Remove(path)
 			return os.Rename(tmpPath, path)
 		}
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	return nil

--- a/internal/commands/agent_hook.go
+++ b/internal/commands/agent_hook.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,20 +76,42 @@ func NewAgentHookCmd() *cobra.Command {
 	return cmd
 }
 
-// newAgentHookApp builds the hook app from whatever config is usable. An
-// insecure base_url must be neutralized before NewApp: the SDK client
-// constructor panics on a non-localhost http URL, and root's HTTPS gate —
-// which normally catches it first — is bypassed by the hook lifecycle.
+// newAgentHookApp builds the hook app from whatever config is usable. A
+// base_url the SDK rejects must be neutralized before NewApp: the SDK client
+// constructor panics on it, and root's HTTPS gate — which normally catches
+// bad values first — is bypassed by the hook lifecycle.
 func newAgentHookApp() *appctx.App {
 	cfg, err := config.Load(config.FlagOverrides{})
 	if err != nil || cfg == nil {
 		cfg = config.Default()
 	}
 	applyAgentHookProfile(cfg)
-	if hostutil.RequireSecureURL(cfg.BaseURL) != nil {
+	if !agentHookSDKAcceptsBaseURL(cfg.BaseURL) {
 		cfg.BaseURL = config.Default().BaseURL
 	}
 	return appctx.NewApp(cfg)
+}
+
+// agentHookSDKAcceptsBaseURL mirrors the SDK client constructor's base-URL
+// validation: empty is skipped, https is accepted anywhere, and http only on
+// localhost. Everything else — including non-HTTP schemes and bare hosts,
+// which hostutil.RequireSecureURL passes — makes the constructor panic.
+func agentHookSDKAcceptsBaseURL(raw string) bool {
+	if raw == "" {
+		return true
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return true
+	case "http":
+		return hostutil.IsLocalhost(u.Host)
+	default:
+		return false
+	}
 }
 
 // applyAgentHookProfile applies an unambiguous profile selection so stored

--- a/internal/commands/agent_hook.go
+++ b/internal/commands/agent_hook.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -83,10 +84,38 @@ func newAgentHookApp() *appctx.App {
 	if err != nil || cfg == nil {
 		cfg = config.Default()
 	}
+	applyAgentHookProfile(cfg)
 	if hostutil.RequireSecureURL(cfg.BaseURL) != nil {
 		cfg.BaseURL = config.Default().BaseURL
 	}
 	return appctx.NewApp(cfg)
+}
+
+// applyAgentHookProfile applies an unambiguous profile selection so stored
+// profile credentials (keyed "profile:<name>") are detected: BASECAMP_PROFILE,
+// else default_profile, else the single configured profile. Ambiguity or any
+// error skips profile selection — hooks tolerate rather than fail.
+func applyAgentHookProfile(cfg *config.Config) {
+	name := os.Getenv("BASECAMP_PROFILE")
+	if _, ok := cfg.Profiles[name]; !ok {
+		name = ""
+	}
+	if name == "" {
+		if _, ok := cfg.Profiles[cfg.DefaultProfile]; ok {
+			name = cfg.DefaultProfile
+		}
+	}
+	if name == "" && len(cfg.Profiles) == 1 {
+		for only := range cfg.Profiles {
+			name = only
+		}
+	}
+	if name == "" || cfg.ApplyProfile(name) != nil {
+		return
+	}
+	// Per the ApplyProfile contract, re-apply env values so precedence stays
+	// env > profile > file. Flags don't apply — hooks accept none.
+	_ = config.LoadFromEnv(cfg)
 }
 
 func newAgentHookSessionStartCmd() *cobra.Command {
@@ -113,7 +142,8 @@ func newAgentHookPreCommitSnapshotCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input, ok := readAgentHookInput(cmd.InOrStdin())
-			if !ok || !strings.Contains(strings.ToLower(agentHookCommand(input.ToolInput)), "commit") {
+			if !ok || !agentHookHasSnapshotKey(input) ||
+				!strings.Contains(strings.ToLower(agentHookCommand(input.ToolInput)), "commit") {
 				return nil
 			}
 			head, ok := agentHookHead(cmd.Context(), input.CWD)
@@ -135,7 +165,7 @@ func newAgentHookPostCommitCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input, ok := readAgentHookInput(cmd.InOrStdin())
-			if !ok {
+			if !ok || !agentHookHasSnapshotKey(input) {
 				return nil
 			}
 			dir := agentHookStateDir(cmd.Context())
@@ -220,12 +250,19 @@ func agentHookHead(ctx context.Context, cwd string) (string, bool) {
 	if err == nil {
 		return head, true
 	}
-	// HEAD did not verify. Claim EMPTY only for a proven unborn branch —
-	// HEAD is still a symbolic ref to a branch with no commits. Any other
-	// failure (transient git error, broken HEAD) stays silent rather than
-	// risk a later nudge against state the snapshot never established.
-	if _, symErr := gitOutput(ctx, cwd, "symbolic-ref", "-q", "HEAD"); symErr == nil {
-		return unbornHeadSnapshot, true
+	// HEAD did not verify. Claim EMPTY only for a proven unborn branch:
+	// HEAD is a symbolic ref to a branch ref that does not exist yet.
+	// show-ref --verify exits 1 for exactly that missing-ref state; an
+	// existing ref here means HEAD^{commit} failed for another reason
+	// (e.g. the ref points at a missing object). Everything else —
+	// transient git errors included — stays silent rather than risk a
+	// later nudge against state the snapshot never established.
+	if ref, symErr := gitOutput(ctx, cwd, "symbolic-ref", "-q", "HEAD"); symErr == nil && ref != "" {
+		_, verifyErr := gitOutput(ctx, cwd, "show-ref", "--verify", "--quiet", ref)
+		var exitErr *exec.ExitError
+		if errors.As(verifyErr, &exitErr) && exitErr.ExitCode() == 1 {
+			return unbornHeadSnapshot, true
+		}
 	}
 	return "", false
 }
@@ -278,6 +315,14 @@ func agentHookStateDir(ctx context.Context) string {
 		return ""
 	}
 	return filepath.Join(app.Config.CacheDir, "agent-hook")
+}
+
+// agentHookHasSnapshotKey requires both identifiers that key a snapshot to
+// one tool call. Payloads missing either would all collapse onto one shared
+// hash, letting unrelated deliveries collide with or consume each other's
+// snapshots — such payloads are ignored.
+func agentHookHasSnapshotKey(input agentHookInput) bool {
+	return input.SessionID != "" && input.ToolUseID != ""
 }
 
 // agentHookSnapshotName keys a snapshot to one tool call without exposing the

--- a/internal/commands/agent_hook.go
+++ b/internal/commands/agent_hook.go
@@ -1,0 +1,302 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+)
+
+const (
+	maxAgentHookInput    = 1 << 20
+	agentHookSnapshotTTL = time.Hour
+	agentHookGitTimeout  = 2 * time.Second
+	unbornHeadSnapshot   = "EMPTY"
+)
+
+var basecampReferencePattern = regexp.MustCompile(`(?i)\b(BC|todo|basecamp)-([0-9]+)\b`)
+
+// agentHookInput carries the fields both agents send on every hook event.
+// tool_response is deliberately absent: neither agent promises an exit code
+// there, so commit success is proven from repository state instead.
+type agentHookInput struct {
+	CWD           string          `json:"cwd"`
+	SessionID     string          `json:"session_id"`
+	ToolUseID     string          `json:"tool_use_id"`
+	HookEventName string          `json:"hook_event_name"`
+	ToolInput     json.RawMessage `json:"tool_input"`
+}
+
+// NewAgentHookCmd creates the hidden command group used by the plugin hooks
+// shared between Claude Code and Codex.
+func NewAgentHookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "agent-hook",
+		Short:  "Run agent plugin hooks",
+		Hidden: true,
+	}
+	cmd.AddCommand(newAgentHookSessionStartCmd(), newAgentHookPreCommitSnapshotCmd(), newAgentHookPostCommitCmd())
+	return cmd
+}
+
+func newAgentHookSessionStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "session-start",
+		Short: "Report Basecamp integration status at session start",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			message := "Basecamp is active. OAuth is not ready; run `basecamp auth login` before using Basecamp commands."
+			if app != nil && app.Auth.IsAuthenticated() {
+				message = "Basecamp is active and OAuth is ready. Use the Basecamp skills for project work."
+			}
+			emitAgentHookContext(cmd, "SessionStart", message)
+			return nil
+		},
+	}
+}
+
+func newAgentHookPreCommitSnapshotCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pre-commit-snapshot",
+		Short: "Record HEAD before a shell command that may commit",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, ok := readAgentHookInput(cmd.InOrStdin())
+			if !ok || !strings.Contains(strings.ToLower(agentHookCommand(input.ToolInput)), "commit") {
+				return nil
+			}
+			head, ok := agentHookHead(cmd.Context(), input.CWD)
+			if !ok {
+				return nil
+			}
+			if dir := agentHookStateDir(cmd.Context()); dir != "" {
+				_ = writeAgentHookSnapshot(dir, agentHookSnapshotName(input), head)
+			}
+			return nil
+		},
+	}
+}
+
+func newAgentHookPostCommitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "post-commit",
+		Short: "Suggest Basecamp follow-up after referenced commits",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, ok := readAgentHookInput(cmd.InOrStdin())
+			if !ok {
+				return nil
+			}
+			dir := agentHookStateDir(cmd.Context())
+			if dir == "" {
+				return nil
+			}
+			path := filepath.Join(dir, agentHookSnapshotName(input))
+			data, err := os.ReadFile(path) //nolint:gosec // G304: path is a hash inside our own state directory
+			if err != nil {
+				return nil //nolint:nilerr // no snapshot means no commit to prove — stay silent
+			}
+			_ = os.Remove(path)
+
+			reference, revision, ok := agentHookCommitReference(cmd.Context(), input.CWD, strings.TrimSpace(string(data)))
+			if !ok {
+				return nil
+			}
+			event := input.HookEventName
+			if event == "" {
+				event = "PostToolUse"
+			}
+			emitAgentHookContext(cmd, event, "Basecamp reference "+reference+" detected in commit "+revision+". "+
+				"Use the Basecamp skill to link the commit or complete the referenced item. "+
+				"Nothing was posted to Basecamp automatically.")
+			return nil
+		},
+	}
+}
+
+func emitAgentHookContext(cmd *cobra.Command, event, message string) {
+	_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+		"hookSpecificOutput": map[string]string{
+			"hookEventName":     event,
+			"additionalContext": message,
+		},
+	})
+}
+
+func readAgentHookInput(r io.Reader) (agentHookInput, bool) {
+	data, err := io.ReadAll(io.LimitReader(r, maxAgentHookInput+1))
+	if err != nil || len(data) > maxAgentHookInput {
+		return agentHookInput{}, false
+	}
+	var input agentHookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return agentHookInput{}, false
+	}
+	return input, true
+}
+
+func agentHookCommand(raw json.RawMessage) string {
+	var input struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return ""
+	}
+	return input.Command
+}
+
+// agentHookHead resolves HEAD in cwd, reporting unbornHeadSnapshot for a
+// repository with no commits yet and false for anything that is not a work
+// tree at all.
+func agentHookHead(ctx context.Context, cwd string) (string, bool) {
+	if cwd == "" {
+		cwd = "."
+	}
+	if inside, err := gitOutput(ctx, cwd, "rev-parse", "--is-inside-work-tree"); err != nil || inside != "true" {
+		return "", false
+	}
+	head, err := gitOutput(ctx, cwd, "rev-parse", "HEAD")
+	if err != nil {
+		return unbornHeadSnapshot, true
+	}
+	return head, true
+}
+
+// agentHookCommitReference proves a commit happened (HEAD moved and the last
+// reflog action was a commit) and returns the first Basecamp reference found
+// in the new subject or branch name, with the short revision.
+func agentHookCommitReference(ctx context.Context, cwd, before string) (string, string, bool) {
+	if cwd == "" {
+		cwd = "."
+	}
+	head, err := gitOutput(ctx, cwd, "rev-parse", "HEAD")
+	if err != nil || head == before {
+		return "", "", false
+	}
+	action, err := gitOutput(ctx, cwd, "reflog", "-1", "--format=%gs")
+	if err != nil || !strings.HasPrefix(action, "commit") {
+		return "", "", false
+	}
+	subject, err := gitOutput(ctx, cwd, "log", "-1", "--format=%s")
+	if err != nil {
+		return "", "", false
+	}
+	reference := basecampReferencePattern.FindString(subject)
+	if reference == "" {
+		branch, err := gitOutput(ctx, cwd, "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil {
+			return "", "", false
+		}
+		reference = basecampReferencePattern.FindString(branch)
+	}
+	if reference == "" {
+		return "", "", false
+	}
+	revision, err := gitOutput(ctx, cwd, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", "", false
+	}
+	return reference, revision, true
+}
+
+// agentHookStateDir prefers the persistent per-plugin data directory both
+// agents provide to plugin hooks, falling back to the CLI cache directory.
+func agentHookStateDir(ctx context.Context) string {
+	if data := os.Getenv("CLAUDE_PLUGIN_DATA"); data != "" {
+		return filepath.Join(data, "commit-snapshots")
+	}
+	app := appctx.FromContext(ctx)
+	if app == nil || app.Config == nil || app.Config.CacheDir == "" {
+		return ""
+	}
+	return filepath.Join(app.Config.CacheDir, "agent-hook")
+}
+
+// agentHookSnapshotName keys a snapshot to one tool call without exposing the
+// session or tool-use identifiers in the filename.
+func agentHookSnapshotName(input agentHookInput) string {
+	sum := sha256.Sum256([]byte(input.SessionID + "|" + input.ToolUseID))
+	return hex.EncodeToString(sum[:])
+}
+
+func writeAgentHookSnapshot(dir, name, head string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	removeExpiredAgentHookSnapshots(dir)
+	return atomicWriteAgentHookFile(filepath.Join(dir, name), []byte(head+"\n"))
+}
+
+func removeExpiredAgentHookSnapshots(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-agentHookSnapshotTTL)
+	for _, entry := range entries {
+		if info, err := entry.Info(); err == nil && !entry.IsDir() && info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+}
+
+// atomicWriteAgentHookFile writes data atomically via temp+rename, mirroring
+// config.atomicWriteTrustFile including its Windows remove-then-rename fallback.
+func atomicWriteAgentHookFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Chmod(0600); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		if runtime.GOOS == "windows" {
+			_ = os.Remove(path)
+			return os.Rename(tmpPath, path)
+		}
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// gitOutput runs one git command with its own deadline so a single slow
+// invocation cannot starve the calls after it; the hook-level timeout in
+// hooks.json remains the overall backstop.
+func gitOutput(parent context.Context, cwd string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, agentHookGitTimeout)
+	defer cancel()
+	commandArgs := append([]string{"-C", cwd}, args...)
+	cmd := exec.CommandContext(ctx, "git", commandArgs...) //nolint:gosec // executable is fixed and arguments are passed without a shell
+	output, err := cmd.Output()
+	return strings.TrimSpace(string(output)), err
+}

--- a/internal/commands/agent_hook_test.go
+++ b/internal/commands/agent_hook_test.go
@@ -1,0 +1,391 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/config"
+)
+
+func TestAgentHookCommandIsHidden(t *testing.T) {
+	cmd := NewAgentHookCmd()
+
+	assert.True(t, cmd.Hidden)
+	assert.Equal(t, "agent-hook", cmd.Name())
+	assert.NotNil(t, findSubcommand(cmd, "session-start"))
+	assert.NotNil(t, findSubcommand(cmd, "pre-commit-snapshot"))
+	assert.NotNil(t, findSubcommand(cmd, "post-commit"))
+}
+
+func TestAgentHookSessionStartReportsAuthenticated(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "test-token")
+
+	output := runAgentHook(t, "session-start", "", "")
+
+	event, context := hookSpecificOutput(t, output)
+	assert.Equal(t, "SessionStart", event)
+	assert.Contains(t, context, "Basecamp is active")
+	assert.Contains(t, context, "OAuth is ready")
+	assert.NotContains(t, context, "test-token")
+}
+
+func TestAgentHookSessionStartReportsUnauthenticated(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+
+	output := runAgentHook(t, "session-start", "", "")
+
+	_, context := hookSpecificOutput(t, output)
+	assert.Contains(t, context, "Basecamp is active")
+	assert.Contains(t, context, "basecamp auth login")
+}
+
+func TestAgentHookNudgesWithCodexPayload(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	pre := `{"session_id":"s1","tool_use_id":"t1","hook_event_name":"PreToolUse",` +
+		`"tool_input":{"command":"git commit -m 'BC-123 ship'"},"turn_id":"turn-1","model":"gpt-5"}`
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", pre, repo))
+
+	commitFile(t, repo, "feature.txt", "BC-123 ship native hooks")
+
+	post := `{"session_id":"s1","tool_use_id":"t1","hook_event_name":"PostToolUse",` +
+		`"tool_input":{"command":"git commit -m 'BC-123 ship'"},` +
+		`"tool_response":"[main abc1234] BC-123 ship","turn_id":"turn-1","model":"gpt-5"}`
+	event, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", post, repo))
+	assert.Equal(t, "PostToolUse", event)
+	assert.Contains(t, context, "BC-123")
+	assert.Contains(t, context, "Nothing was posted")
+}
+
+func TestAgentHookNudgesWithClaudePayload(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	pre := `{"session_id":"s2","tool_use_id":"t2","hook_event_name":"PreToolUse",` +
+		`"tool_input":{"command":"git commit -m 'BC-77 ship'"}}`
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", pre, repo))
+
+	commitFile(t, repo, "feature.txt", "BC-77 ship native hooks")
+
+	post := `{"session_id":"s2","tool_use_id":"t2","hook_event_name":"PostToolUse",` +
+		`"tool_input":{"command":"git commit -m 'BC-77 ship'"},` +
+		`"tool_response":{"stdout":"[main abc1234] BC-77 ship","stderr":""}}`
+	event, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", post, repo))
+	assert.Equal(t, "PostToolUse", event)
+	assert.Contains(t, context, "BC-77")
+}
+
+func TestAgentHookNudgesOnPostToolUseFailure(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	pre := agentHookPayload("PreToolUse", "s3", "t3", "git commit -m ship && git push")
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", pre, repo))
+
+	// Simulate `git commit && git push` where the commit landed but the push
+	// failed: HEAD advanced, then the tool reported failure.
+	commitFile(t, repo, "feature.txt", "todo-456 ship")
+
+	post := agentHookPayload("PostToolUseFailure", "s3", "t3", "git commit -m ship && git push")
+	event, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", post, repo))
+	assert.Equal(t, "PostToolUseFailure", event)
+	assert.Contains(t, context, "todo-456")
+}
+
+func TestAgentHookUsesBranchReference(t *testing.T) {
+	repo := newGitRepo(t, "basecamp-789-native-hook", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+	commitFile(t, repo, "feature.txt", "ship native hooks")
+
+	_, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m ship"), repo))
+	assert.Contains(t, context, "basecamp-789")
+}
+
+func TestAgentHookStaysSilentWhenCommitFails(t *testing.T) {
+	repo := newGitRepo(t, "main", "BC-123 initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+
+	// No commit happens: HEAD is unchanged, so no nudge even though the
+	// branch history already references BC-123.
+	assert.Empty(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m ship"), repo))
+}
+
+func TestAgentHookDoesNotRenudgeAfterFailedSecondCommit(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t1", "git commit -m ship"), repo))
+	commitFile(t, repo, "feature.txt", "BC-123 ship")
+	_, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t1", "git commit -m ship"), repo))
+	assert.Contains(t, context, "BC-123")
+
+	// Second tool call tries another commit that fails: HEAD stays at the
+	// already-nudged commit, so no duplicate nudge.
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t2", "git commit -m again"), repo))
+	assert.Empty(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t2", "git commit -m again"), repo))
+}
+
+func TestAgentHookRejectsHeadMovedByCheckout(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+	runGit(t, repo, "checkout", "-q", "-b", "bc-42-feature")
+	commitFile(t, repo, "feature.txt", "feature work")
+	runGit(t, repo, "checkout", "-q", "main")
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git checkout bc-42-feature # then commit"), repo))
+	runGit(t, repo, "checkout", "-q", "bc-42-feature")
+
+	// HEAD moved, but the last reflog action is a checkout, not a commit.
+	assert.Empty(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git checkout bc-42-feature # then commit"), repo))
+}
+
+func TestAgentHookNudgesAfterAmend(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit --amend"), repo))
+	runGit(t, repo, "commit", "--amend", "-m", "BC-321 amended")
+
+	_, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit --amend"), repo))
+	assert.Contains(t, context, "BC-321")
+}
+
+func TestAgentHookStaysSilentWithoutSnapshot(t *testing.T) {
+	repo := newGitRepo(t, "main", "BC-123 initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m ship"), repo))
+}
+
+func TestAgentHookRemovesExpiredSnapshots(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+	stateDir := filepath.Join(data, "commit-snapshots")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	expired := filepath.Join(stateDir, strings.Repeat("0", 64))
+	require.NoError(t, os.WriteFile(expired, []byte("stale\n"), 0o600))
+	old := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(expired, old, old))
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+
+	_, err := os.Stat(expired)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	entries, err := os.ReadDir(stateDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestAgentHookSnapshotFileIsPrivateAndHashNamed(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "secret-session", "secret-tool-use", "git commit -m ship"), repo))
+
+	entries, err := os.ReadDir(filepath.Join(data, "commit-snapshots"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	name := entries[0].Name()
+	assert.Regexp(t, regexp.MustCompile(`^[0-9a-f]{64}$`), name)
+	assert.NotContains(t, name, "secret")
+	if runtime.GOOS != "windows" {
+		info, err := entries[0].Info()
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+}
+
+func TestAgentHookPrefilterSkipsNonCommitCommands(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git status"), repo))
+
+	_, err := os.Stat(filepath.Join(data, "commit-snapshots"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestAgentHookIgnoresNonRepository(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m BC-123"), t.TempDir()))
+
+	_, err := os.Stat(filepath.Join(data, "commit-snapshots"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestAgentHookStaysSilentWithoutReference(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+	commitFile(t, repo, "feature.txt", "ship without reference")
+
+	assert.Empty(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m ship"), repo))
+}
+
+func TestAgentHookNudgesOnFirstCommitFromUnbornHead(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.email", "agent-hook@example.com")
+	runGit(t, repo, "config", "user.name", "Agent Hook Test")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m 'BC-9 first'"), repo))
+
+	entries, err := os.ReadDir(filepath.Join(data, "commit-snapshots"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	snapshot, err := os.ReadFile(filepath.Join(data, "commit-snapshots", entries[0].Name()))
+	require.NoError(t, err)
+	assert.Equal(t, "EMPTY", strings.TrimSpace(string(snapshot)))
+
+	commitFile(t, repo, "README.md", "BC-9 first commit")
+
+	_, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m 'BC-9 first'"), repo))
+	assert.Contains(t, context, "BC-9")
+}
+
+func TestAgentHookIgnoresMalformedInput(t *testing.T) {
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", "not json", ""))
+	assert.Empty(t, runAgentHook(t, "post-commit", "not json", ""))
+}
+
+func TestAgentHookIgnoresOversizedInput(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+	oversized := `{"session_id":"s","tool_use_id":"t","cwd":"` + strings.Repeat("a", maxAgentHookInput) + `"}`
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", oversized, ""))
+	assert.Empty(t, runAgentHook(t, "post-commit", oversized, ""))
+
+	_, err := os.Stat(filepath.Join(data, "commit-snapshots"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestAgentHookFallsBackToCacheDirState(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", "")
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+
+	entries, err := os.ReadDir(filepath.Join(cache, "basecamp", "agent-hook"))
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+
+	commitFile(t, repo, "feature.txt", "BC-55 ship")
+
+	_, context := hookSpecificOutput(t, runAgentHook(t, "post-commit", agentHookPayload("PostToolUse", "s", "t", "git commit -m ship"), repo))
+	assert.Contains(t, context, "BC-55")
+}
+
+func agentHookPayload(event, sessionID, toolUseID, command string) string {
+	payload, err := json.Marshal(map[string]any{
+		"session_id":      sessionID,
+		"tool_use_id":     toolUseID,
+		"hook_event_name": event,
+		"tool_input":      map[string]string{"command": command},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(payload)
+}
+
+func runAgentHook(t *testing.T, subcommand, input, cwd string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	app := appctx.NewApp(config.Default())
+	t.Cleanup(app.Close)
+
+	cmd := NewAgentHookCmd()
+	var stdout bytes.Buffer
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{subcommand})
+	cmd.SetContext(appctx.WithApp(context.Background(), app))
+	if cwd != "" {
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(input), &payload))
+		payload["cwd"] = cwd
+		encoded, err := json.Marshal(payload)
+		require.NoError(t, err)
+		cmd.SetIn(bytes.NewReader(encoded))
+	}
+	require.NoError(t, cmd.Execute())
+	return strings.TrimSpace(stdout.String())
+}
+
+func hookSpecificOutput(t *testing.T, output string) (string, string) {
+	t.Helper()
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &payload))
+	return payload.HookSpecificOutput.HookEventName, payload.HookSpecificOutput.AdditionalContext
+}
+
+func commitFile(t *testing.T, repo, name, subject string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, name), []byte("fixture\n"), 0o644))
+	runGit(t, repo, "add", name)
+	runGit(t, repo, "commit", "-m", subject)
+}
+
+func newGitRepo(t *testing.T, branch, subject string) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", branch)
+	runGit(t, repo, "config", "user.email", "agent-hook@example.com")
+	runGit(t, repo, "config", "user.name", "Agent Hook Test")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "README.md"), []byte("fixture\n"), 0o644))
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", subject)
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	// Git wrappers (e.g. git-ai) spawn background work that writes into .git
+	// after a commit returns, racing t.TempDir cleanup.
+	cmd.Env = append(os.Environ(), "GIT_AI_SKIP_ALL_HOOKS=1")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}

--- a/internal/commands/agent_hook_test.go
+++ b/internal/commands/agent_hook_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/auth"
 	"github.com/basecamp/basecamp-cli/internal/config"
 )
 
@@ -336,6 +337,87 @@ func TestAgentHookDoesNotClaimEmptyForBrokenHead(t *testing.T) {
 	// later commit would nudge against state the snapshot never established.
 	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git", "HEAD"),
 		[]byte(strings.Repeat("0", 40)+"\n"), 0o644))
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+
+	entries, err := os.ReadDir(filepath.Join(data, "commit-snapshots"))
+	if err == nil {
+		assert.Empty(t, entries)
+	} else {
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestAgentHookSessionStartDetectsStoredProfileCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_PROFILE", "")
+
+	configDir := config.GlobalConfigDir()
+	require.NoError(t, os.MkdirAll(configDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{
+		"default_profile": "work",
+		"profiles": {
+			"work": {"base_url": "https://3.basecampapi.com", "account_id": "111"},
+			"personal": {"base_url": "https://3.basecampapi.com", "account_id": "222"}
+		}
+	}`), 0o600))
+	require.NoError(t, auth.NewStore(configDir).Save("profile:work", &auth.Credentials{
+		AccessToken: "stored-profile-token",
+		OAuthType:   "bc3",
+	}))
+
+	// No injected app: the hook lifecycle must build one itself, applying
+	// the default profile so the profile-keyed credentials are found.
+	cmd := NewAgentHookCmd()
+	var stdout bytes.Buffer
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"session-start"})
+	require.NoError(t, cmd.Execute())
+
+	_, context := hookSpecificOutput(t, strings.TrimSpace(stdout.String()))
+	assert.Contains(t, context, "OAuth is ready")
+	assert.NotContains(t, context, "stored-profile-token")
+}
+
+func TestAgentHookIgnoresPayloadMissingSnapshotIDs(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	// Missing tool_use_id: no snapshot may be written — otherwise every
+	// incomplete payload hashes the same shared key.
+	pre := `{"session_id":"s","hook_event_name":"PreToolUse","tool_input":{"command":"git commit -m ship"}}`
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", pre, repo))
+	_, err := os.Stat(filepath.Join(data, "commit-snapshots"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// Missing session_id on delivery: must not read (or consume) any state.
+	require.NoError(t, os.MkdirAll(filepath.Join(data, "commit-snapshots"), 0o700))
+	shared := filepath.Join(data, "commit-snapshots", agentHookSnapshotName(agentHookInput{}))
+	require.NoError(t, os.WriteFile(shared, []byte("EMPTY\n"), 0o600))
+	post := `{"tool_use_id":"t","hook_event_name":"PostToolUse","tool_input":{"command":"git commit -m ship"}}`
+	assert.Empty(t, runAgentHook(t, "post-commit", post, repo))
+	_, err = os.Stat(shared)
+	assert.NoError(t, err, "incomplete payload must not consume the shared-key snapshot")
+}
+
+func TestAgentHookDoesNotClaimEmptyForBrokenSymbolicRef(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	// Symbolic HEAD pointing at a branch ref whose object is missing:
+	// HEAD^{commit} fails, symbolic-ref succeeds, but show-ref --verify
+	// finds the ref — this is a broken ref, not an unborn branch.
+	runGit(t, repo, "symbolic-ref", "HEAD", "refs/heads/broken")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git", "refs", "heads", "broken"),
+		[]byte("1111111111111111111111111111111111111111\n"), 0o644))
 
 	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
 

--- a/internal/commands/agent_hook_test.go
+++ b/internal/commands/agent_hook_test.go
@@ -485,6 +485,10 @@ func runAgentHook(t *testing.T, subcommand, input, cwd string) string {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("BASECAMP_NO_KEYRING", "1")
+	// The hook's git subprocesses inherit this env: keep wrappers (git-ai)
+	// out of them too, or their overhead can blow the hook's per-command
+	// git timeout under load.
+	t.Setenv("GIT_AI_SKIP_ALL_HOOKS", "1")
 
 	app := appctx.NewApp(config.Default())
 	t.Cleanup(app.Close)

--- a/internal/commands/agent_hook_test.go
+++ b/internal/commands/agent_hook_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -269,6 +270,83 @@ func TestAgentHookNudgesOnFirstCommitFromUnbornHead(t *testing.T) {
 	assert.Contains(t, context, "BC-9")
 }
 
+func TestAgentHookNudgesExactlyOnceUnderConcurrentDelivery(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+	commitFile(t, repo, "feature.txt", "BC-123 ship")
+
+	// PostToolUse and PostToolUseFailure can both fire for one tool call;
+	// the atomic snapshot claim must allow exactly one to nudge.
+	app := appctx.NewApp(config.Default())
+	t.Cleanup(app.Close)
+	events := []string{"PostToolUse", "PostToolUseFailure"}
+	outputs := make([]string, len(events))
+	var wg sync.WaitGroup
+	for i, event := range events {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var payload map[string]any
+			if !assert.NoError(t, json.Unmarshal([]byte(agentHookPayload(event, "s", "t", "git commit -m ship")), &payload)) {
+				return
+			}
+			payload["cwd"] = repo
+			encoded, err := json.Marshal(payload)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			cmd := NewAgentHookCmd()
+			var stdout bytes.Buffer
+			cmd.SetIn(bytes.NewReader(encoded))
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{"post-commit"})
+			cmd.SetContext(appctx.WithApp(context.Background(), app))
+			assert.NoError(t, cmd.Execute())
+			outputs[i] = strings.TrimSpace(stdout.String())
+		}()
+	}
+	wg.Wait()
+
+	var nudges []string
+	for _, output := range outputs {
+		if output != "" {
+			nudges = append(nudges, output)
+		}
+	}
+	require.Len(t, nudges, 1, "exactly one delivery must nudge")
+	assert.Contains(t, nudges[0], "BC-123")
+}
+
+func TestAgentHookDoesNotClaimEmptyForBrokenHead(t *testing.T) {
+	repo := newGitRepo(t, "main", "initial")
+	data := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_DATA", data)
+
+	// Detach HEAD onto a nonexistent object: HEAD^{commit} fails to verify,
+	// and the repository is not unborn (symbolic-ref fails too). The
+	// snapshot must stay silent instead of recording EMPTY — otherwise a
+	// later commit would nudge against state the snapshot never established.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".git", "HEAD"),
+		[]byte(strings.Repeat("0", 40)+"\n"), 0o644))
+
+	assert.Empty(t, runAgentHook(t, "pre-commit-snapshot", agentHookPayload("PreToolUse", "s", "t", "git commit -m ship"), repo))
+
+	entries, err := os.ReadDir(filepath.Join(data, "commit-snapshots"))
+	if err == nil {
+		assert.Empty(t, entries)
+	} else {
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
 func TestAgentHookIgnoresMalformedInput(t *testing.T) {
 	t.Setenv("CLAUDE_PLUGIN_DATA", t.TempDir())
 
@@ -383,9 +461,14 @@ func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
-	// Git wrappers (e.g. git-ai) spawn background work that writes into .git
-	// after a commit returns, racing t.TempDir cleanup.
-	cmd.Env = append(os.Environ(), "GIT_AI_SKIP_ALL_HOOKS=1")
+	// Isolate from user/system git config (gpgsign, hooks) so tests pass on
+	// any developer machine, and from git wrappers (e.g. git-ai) whose
+	// background work writes into .git after a commit returns, racing
+	// t.TempDir cleanup.
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_AI_SKIP_ALL_HOOKS=1")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 }

--- a/scripts/check-bare-groups.sh
+++ b/scripts/check-bare-groups.sh
@@ -42,7 +42,10 @@ for file in "$COMMANDS_DIR"/*.go; do
     body=$(sed -n "/^func ${func_name}(/,/^func /p" "$file" | sed '$d')
 
     has_addcommand=$(echo "$body" | grep -Ec 'AddCommand|cmd\.AddCommand' || true)
-    has_rune=$(echo "$body" | grep -c 'RunE:' || true)
+    # Match RunE: only when not preceded by an identifier character, so
+    # PersistentPreRunE:/PersistentPostRunE: (lifecycle hooks, allowed on
+    # groups) don't count as a bare-invocation handler.
+    has_rune=$(echo "$body" | grep -Ec '(^|[^[:alnum:]_])RunE:' || true)
 
     if [[ "$has_addcommand" -gt 0 && "$has_rune" -gt 0 ]]; then
       if ! is_allowed "$func_name"; then


### PR DESCRIPTION
# feat: hidden `agent-hook` command for shared plugin hooks

## What

Adds a hidden `basecamp agent-hook` command group with three subcommands, the CLI half of the shared plugin hooks for Claude Code and Codex. **No `hooks/hooks.json` ships in this PR** — a hidden command with no hooks file referencing it is inert everywhere. The hooks file + docs land separately (PR 2b) and merge only after the first CLI release containing this command, so a refreshed plugin payload never references a command the released CLI lacks.

### Subcommands

- `session-start` — no network; reports auth status (`BASECAMP_TOKEN` env, then stored creds) as `hookSpecificOutput.additionalContext` so the agent knows whether Basecamp is ready.
- `pre-commit-snapshot` — when the Bash tool's command mentions `commit` (case-insensitive) and cwd is a git work tree, records `git rev-parse HEAD` (or `EMPTY` for an unborn branch) keyed by `sha256(session_id|tool_use_id)`. Atomic write (temp + chmod 0600 + rename, with the Windows remove-then-rename fallback from `config.atomicWriteTrustFile`), 0700 dir, snapshots older than 1h GC'd on each write.
- `post-commit` — serves both PostToolUse and PostToolUseFailure. Reads-and-deletes the snapshot, then requires **proof from repository state**: HEAD changed vs the snapshot AND the last reflog action has prefix `commit` (rejects checkout/reset HEAD moves; amends still match). Scans the new subject, then the branch name, for `(?i)\b(BC|todo|basecamp)-(\d+)\b` and nudges via `hookSpecificOutput.additionalContext`, echoing the input's `hook_event_name`. The nudge points at the Basecamp skill and states nothing was posted automatically — no fabricated commands with BC-shorthand numbers (they aren't recording IDs).

### Design invariants

- **Repo state is the source of truth.** Neither agent exposes the Bash exit code in the hook payload (Codex sends `tool_response` as a plain JSON string; Claude's shape is undocumented). The command reads only `tool_input.command`, `cwd`, `session_id`, `tool_use_id`, `hook_event_name` — `tool_response` is never parsed, so payload-shape independence holds by construction.
- **Never blocks, never errors.** Malformed or >1 MiB stdin, non-repo cwd, missing git, missing snapshot: all exit 0 silently. Input is size-checked with `io.ReadAll(io.LimitReader(r, max+1))` so truncation can't masquerade as valid JSON.
- **State dir**: `$CLAUDE_PLUGIN_DATA/commit-snapshots/` when set (both agents set it for plugin hooks; Codex also exports it as a compat alias), else `<CacheDir>/agent-hook/`.
- **Registration**: `internal/cli/root.go` only — per the `codex-hook` precedent, omitted from `commandCategories()` and `buildRootWithAllCommands`, so catalog parity and the `.surface` snapshot are untouched by mutual absence. Hidden commands never reach `.surface`.

## Tests

Unit matrix in `agent_hook_test.go` (harness recovered from pre-squash `63c5feb0`, minus the bash-AST table the substring prefilter replaced): real Codex payload (string `tool_response`, `turn_id`/`model` extras) and real Claude payload (object `tool_response`) both nudge; echoed `hookEventName` incl. PostToolUseFailure (commit-then-failed-push); failed commit silent; no re-nudge after a failed second commit; checkout rejected by reflog; amend nudges; unborn-HEAD first commit nudges; GC; 0600 hash-named state files with no session-ID leakage; malformed/oversized stdin; cache-dir fallback. Plus `e2e/agent_hook.bats` piping real payloads through the built binary.

## Sequencing

1. ~~Phase 3 dead-payload cleanup~~ (independent)
2. **This PR** — merge now; rides the next CLI release (release N, held on bc5 SDK updates)
3. PR 2b (`hooks/hooks.json` + docs/wizard trust guidance) — opened now, merges after release N ships
4. Release N+1 bumps the stamped manifest version, which is what actually delivers hooks to Claude installs

Compatibility floor (stated honestly): hooks require CLI ≥ N. A refreshed plugin payload on an older CLI produces non-blocking unknown-command hook errors on either agent; remediation is `basecamp upgrade`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hidden `basecamp agent-hook` command group with `session-start`, `pre-commit-snapshot`, and `post-commit` for shared plugin hooks in Claude Code and Codex. It stays inert until `hooks/hooks.json` lands and never blocks, even with bad config.

- **New Features**
  - Hidden CLI group; registered in `internal/cli/root.go`; not shown in help or `.surface`.
  - Hooks: `session-start` prints auth status JSON; `pre-commit-snapshot` saves HEAD (or `EMPTY`) with atomic 0600 writes and 1h GC; `post-commit` proves a real commit (HEAD changed + reflog "commit") and nudges on `BC|todo|basecamp-<id>` in subject/branch; state lives in `$CLAUDE_PLUGIN_DATA/commit-snapshots` or cache.
  - Safe by default: never parses `tool_response`; ignores malformed/oversized input, non-repos, and missing snapshots.

- **Bug Fixes**
  - Dedicated lifecycle bypasses root validation and mirrors the SDK’s base_url rules: empty ok, `https://` anywhere, `http://` only on localhost; rejects non-HTTP schemes and bare hosts; tolerant config load; always exits 0 and emits valid hook JSON.
  - Auth detection is profile-aware: selects `BASECAMP_PROFILE`, else `default_profile`, else the single profile so stored profile credentials are recognized by `session-start`.
  - Snapshot integrity: requires both `session_id` and `tool_use_id`; atomic snapshot claim avoids duplicate nudges under concurrent delivery.
  - Unborn proof: records `EMPTY` only when `symbolic-ref` + `show-ref --verify` proves the branch ref is missing; broken or transient HEAD states stay silent. CI check updated to ignore `Persistent*RunE` on groups. Tests ensure the hook’s git subprocesses skip wrappers to avoid timeouts under load.

<sup>Written for commit c18685a6f8b63d9129129665275c4fb5046ede98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

