### PR TITLE
Ship shared plugin hooks

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -14,7 +14,7 @@
   "interface": {
     "displayName": "Basecamp",
     "shortDescription": "Work with Basecamp from Codex.",
-    "longDescription": "Find assignments, create and update Basecamp work, and diagnose the integration. Requires the Basecamp CLI (basecamp) installed and on your PATH.",
+    "longDescription": "Find assignments, create and update Basecamp work, diagnose the integration, and connect Git commits to Basecamp todos. Requires the Basecamp CLI (basecamp) installed and on your PATH.",
     "developerName": "37signals",
     "category": "Productivity",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ basecamp-cli/
 │   └── version/      # Version info
 ├── e2e/              # BATS integration tests
 ├── skills/           # Agent skills
+├── hooks/            # Agent lifecycle hooks (both agents)
 ├── .claude-plugin/   # Claude Code integration
 └── .codex-plugin/    # Codex plugin manifest
 ```

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ Both `BASECAMP_OAUTH_CLIENT_ID` and `BASECAMP_OAUTH_CLIENT_SECRET` must be set t
 
 Both plugins require the `basecamp` CLI installed and on your PATH.
 
+The plugin hooks additionally need a CLI new enough to carry the `agent-hook`
+command. If hook errors appear after installing or refreshing the plugin, the
+CLI is older than the hooks: run `basecamp upgrade`, then start a new session.
+Check with `basecamp agent-hook --help` — an "unknown command" reply means the
+CLI needs upgrading.
+
 **Claude Code:** `basecamp setup claude` — installs the plugin with skills, hooks, and agent workflow support.
 
 **Codex:** `basecamp setup codex` — registers the 37signals marketplace and installs the native plugin with Basecamp skills, diagnostics, and opt-in hooks. In Codex, review and trust the plugin hooks with `/hooks`, then start a new thread to load the skills and hooks.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ Both `BASECAMP_OAUTH_CLIENT_ID` and `BASECAMP_OAUTH_CLIENT_SECRET` must be set t
 
 Both plugins require the `basecamp` CLI installed and on your PATH.
 
-**Claude Code:** `basecamp setup claude` — installs the plugin with skills and agent workflow support.
+**Claude Code:** `basecamp setup claude` — installs the plugin with skills, hooks, and agent workflow support.
 
-**Codex:** `basecamp setup codex` — registers the 37signals marketplace and installs the native plugin with Basecamp skills and diagnostics. Start a new Codex thread afterward to load the skills.
+**Codex:** `basecamp setup codex` — registers the 37signals marketplace and installs the native plugin with Basecamp skills, diagnostics, and opt-in hooks. In Codex, review and trust the plugin hooks with `/hooks`, then start a new thread to load the skills and hooks.
 
 Manual Codex installation uses the same marketplace:
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,54 @@
+{
+  "description": "Basecamp agent hooks: session context and commit-reference nudges.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "basecamp agent-hook session-start",
+            "timeout": 5,
+            "statusMessage": "Checking Basecamp status"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "basecamp agent-hook pre-commit-snapshot",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "basecamp agent-hook post-commit",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "basecamp agent-hook post-commit",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,7 +21,7 @@
           {
             "type": "command",
             "command": "basecamp agent-hook pre-commit-snapshot",
-            "timeout": 5
+            "timeout": 10
           }
         ]
       }
@@ -33,7 +33,7 @@
           {
             "type": "command",
             "command": "basecamp agent-hook post-commit",
-            "timeout": 5
+            "timeout": 12
           }
         ]
       }
@@ -45,7 +45,7 @@
           {
             "type": "command",
             "command": "basecamp agent-hook post-commit",
-            "timeout": 5
+            "timeout": 12
           }
         ]
       }

--- a/install.md
+++ b/install.md
@@ -130,6 +130,11 @@ basecamp setup claude
 
 This registers the marketplace and installs the plugin with skills, hooks, and agent workflow support.
 
+The hooks call the CLI's `agent-hook` command, so they need a `basecamp` new
+enough to have it. If hook errors appear after installing or refreshing the
+plugin, run `basecamp upgrade` and start a new session; `basecamp agent-hook
+--help` replying "unknown command" confirms the CLI is the old one.
+
 ### Codex
 
 ```bash

--- a/install.md
+++ b/install.md
@@ -128,7 +128,7 @@ The piped installer (Step 1) already installs the baseline skill and attempts to
 basecamp setup claude
 ```
 
-This registers the marketplace and installs the plugin with skills and agent workflow support.
+This registers the marketplace and installs the plugin with skills, hooks, and agent workflow support.
 
 ### Codex
 
@@ -136,7 +136,7 @@ This registers the marketplace and installs the plugin with skills and agent wor
 basecamp setup codex
 ```
 
-This installs the shared Basecamp skill, registers the 37signals Codex marketplace, and installs the native plugin. Start a new Codex thread after setup to load the skills.
+This installs the shared Basecamp skill, registers the 37signals Codex marketplace, and installs the native plugin. After setup, review and trust the plugin hooks with `/hooks` (Codex lists untrusted hooks but does not run them until trusted), then start a new Codex thread to load the skills and hooks.
 
 For a manual install:
 

--- a/internal/commands/wizard_codex.go
+++ b/internal/commands/wizard_codex.go
@@ -65,7 +65,10 @@ func runCodexSetup(cmd *cobra.Command, styles *tui.Styles) error {
 	fmt.Fprintln(w, styles.RenderStatus(true, "37signals marketplace ready"))
 	fmt.Fprintln(w, styles.RenderStatus(true, "Codex plugin installed and enabled"))
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, styles.Muted.Render("  Start a new Codex thread to load the Basecamp skills."))
+	// Trust must come first: an untrusted SessionStart hook is silently
+	// skipped, so a thread started before trusting gets no hook context.
+	fmt.Fprintln(w, styles.Muted.Render("  Review and trust the plugin hooks with /hooks."))
+	fmt.Fprintln(w, styles.Muted.Render("  Then start a new Codex thread to load the Basecamp skills."))
 	return nil
 }
 

--- a/internal/commands/wizard_codex_test.go
+++ b/internal/commands/wizard_codex_test.go
@@ -156,9 +156,14 @@ func TestRunCodexSetupInteractiveExplainsNextSteps(t *testing.T) {
 
 	assert.Contains(t, output.String(), "Registering 37signals marketplace")
 	assert.Contains(t, output.String(), "Installing basecamp plugin")
-	assert.Contains(t, output.String(), "Start a new Codex thread")
-	// No hooks ship yet — setup must not point users at /hooks trust.
-	assert.NotContains(t, output.String(), "/hooks")
+	// Codex lists untrusted hooks but does not run them until trusted, and
+	// an untrusted SessionStart is skipped — so the trust step must come
+	// before the new-thread step.
+	trustAt := strings.Index(output.String(), "trust the plugin hooks with /hooks")
+	newThreadAt := strings.Index(output.String(), "start a new Codex thread")
+	require.GreaterOrEqual(t, trustAt, 0)
+	require.GreaterOrEqual(t, newThreadAt, 0)
+	assert.Less(t, trustAt, newThreadAt, "trust guidance must precede the new-thread step")
 }
 
 func TestRunCodexSetupInteractiveFailureWarnsAndContinues(t *testing.T) {


### PR DESCRIPTION
# feat: ship shared plugin hooks (`hooks/hooks.json`) + docs

**Merge gate cleared — release N shipped as stable `v0.8.0` on 2026-08-03, and it is Latest.**

This PR was held because a plugin installed from the default branch would have called `agent-hook`, a command the then-published `v0.7.2` did not have. Verified against the shipped artifact rather than the source tree, since that is what users actually download: `basecamp_0.8.0_darwin_arm64.tar.gz` reports `basecamp version 0.8.0` and exposes exactly the three subcommands `hooks/hooks.json` invokes (`session-start`, `pre-commit-snapshot`, `post-commit`). The full flow was then exercised end to end against that binary: snapshot → commit `BC-4455` → nudge emitted with the reference and short hash.

Rebased onto `main` (was 45 commits behind); `bin/ci` exit 0.

## What

One `hooks/hooks.json` at the plugin root serves both agents (both read the same location, same matcher semantics, same `hookSpecificOutput` wire):

- **SessionStart** (`startup|resume|clear|compact`) → `basecamp agent-hook session-start` — auth status as model context, with a spinner label.
- **PreToolUse / PostToolUse** (`Bash`) → `pre-commit-snapshot` / `post-commit` — the paired HEAD-snapshot commit nudge. No `statusMessage` on these: they run on every Bash call and stay visually silent.
- **PostToolUseFailure** (`Bash`) → `post-commit` — closes the old accepted asymmetry: on Claude, `git commit && git push` with a failed push still nudges (the commit is proven from repo state, not the tool result). Codex ignores unknown event names inside `hooks` (verified: `HookEventsToml` lacks `deny_unknown_fields`), so this key is inert there; Codex's own PostToolUse fires regardless of exit status. No other top-level keys — Codex hard-errors on unknown top-level keys in hooks.json.

Commands are plain `basecamp agent-hook <sub>` strings — valid under all four hook shells (`sh -lc`, `cmd.exe /C`, Git Bash, PowerShell); no wrapper, no `commandWindows`, no per-agent split.

Docs/setup restoration (reverses the Phase 1 deferrals from `cb139726`):

- README + install.md: "hooks" back in the plugin feature lists; Codex sections regain "review and trust the plugin hooks with `/hooks`" (Codex lists untrusted hooks but silently does not run them until trusted). Claude needs no trust step — install consent covers it.
- `runCodexSetup`: re-adds the muted "Review and trust the plugin hooks with /hooks." next-step line; the wizard test flips from proving `/hooks` absent to proving it present.
- AGENTS.md tree: `hooks/` entry back (agent-neutral wording).
- `.codex-plugin/plugin.json` `longDescription`: restores the connect-commits clause.

`TestHooksFileCommandsInvokeBasecamp` (dormant since #534) activates automatically now that `hooks/hooks.json` exists.

## Compatibility floor

**Hooks require CLI ≥ release N.** Users of either agent with an older CLI may see non-blocking hook errors after their plugin payload refreshes (Codex: on `marketplace upgrade`; Claude: at the release N+1 manifest version bump, which can auto-update the plugin while the user still runs CLI < N). Remediation: `basecamp upgrade`. Codex additionally keeps new hooks inert until `/hooks` trust.

## Rollout

- Codex users get the payload on `codex plugin marketplace upgrade 37signals` (or `basecamp setup codex`), then must trust via `/hooks`.
- Claude users get it at release N+1's manifest version bump (plugin auto-update).
- Production verification happens after N+1: session-start context, the nudge matrix, doctor at matching versions. Staging passes before merge don't substitute.

## Staging verification (pre-merge, candidate payload + dev-build CLI)

Both agents were verified against **this branch's SHA** (`4f28a810`) with production plugins isolated first (Codex: throwaway `CODEX_HOME` + staging marketplace `37signals-staging` pinned to the SHA, install positively attributed; Claude: production `basecamp@37signals` disabled, candidate loaded via `--plugin-dir`), then production state restored.

- **Codex 0.144.6** (`codex exec --dangerously-bypass-hook-trust`, dev-build `basecamp` on PATH): SessionStart context injected verbatim ("Basecamp is active and OAuth is ready…"); scratch repo commit with `BC-123` → nudge delivered as developer context with the short hash; failed commit (nothing staged) → NONE. `/hooks` trust flow itself not exercisable non-interactively — the bypass flag exercises the same execution path post-trust.
- **Claude Code 2.1.216**: `PostToolUse` nudge on `todo-456` commit quoted back by the model; `PostToolUseFailure` on commit-then-failed-push quoted the `BC-777` nudge verbatim — the asymmetry this event closes, verified live. SessionStart verified at the transcript level: hook executed, stdout parsed, context attached as `hook_additional_context` (models don't always attribute it when asked, but injection is proven).
- `TestHooksFileCommandsInvokeBasecamp` now runs (not skipped) and passes; full `bin/ci` green on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships shared plugin hooks for Codex and Claude via `hooks/hooks.json` to add session-start status and Git commit-to-todo nudges. Widens hook timeouts and updates docs to require a CLI with `agent-hook`, plus trust-first guidance in Codex.

- **New Features**
  - Single `hooks/hooks.json` for both agents: `SessionStart` injects auth status; Bash `PreToolUse`/`PostToolUse` drive commit nudges; `PostToolUseFailure` (Claude) also nudges after a failed push; timeouts set to 5s/10s/12s.
  - Hooks run `basecamp agent-hook <sub>` across shells and stay silent on Bash. Codex ignores unknown hook event names and rejects unknown top-level keys.
  - Docs/setup: README/install document the `agent-hook` CLI requirement; Codex setup now says “trust hooks with `/hooks`” before “start a new thread”; `.codex-plugin/plugin.json` mentions commit linking; `AGENTS.md` lists `hooks/`.

- **Migration**
  - Requires `basecamp` CLI with `agent-hook` (release N+). If hook errors appear after install/refresh, run `basecamp upgrade`, start a new session, and check with `basecamp agent-hook --help` (“unknown command” means the CLI is too old).
  - Codex: trust hooks with `/hooks`, then start a new thread. Claude needs no trust step.

<sup>Written for commit 7e605ddbdd4832e34cd1b695577f1ef9ec961031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


