### PR TITLE
Bump SDK to 81660dc1 and surface BC5 forward-compat fields

### DIFF
--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -26,9 +26,9 @@ The **Since** column tags each row with the Basecamp version that introduced its
 |---------|-----------|-------------|--------|-------|----------|-------|
 | **Core** |
 | projects | 9 | `projects` | ✅ | BC4 | - | list, show, create, update, delete |
-| todos | 11 | `todos`, `todo`, `done`, `reopen` | ✅ | BC4 | - | list, show, create, update, complete, uncomplete, position |
+| todos | 11 | `todos`, `todo`, `done`, `reopen` | ✅ | BC4 | - | list, show, create, update, complete, uncomplete, position (BC5: `steps` shown on `todos show`; edit via `cards step`) |
 | todolists | 8 | `todolists` | ✅ | BC4 | - | list, show, create, update |
-| todosets | 3 | `todosets` | ✅ | BC4 | - | Container for todolists, accessed via project dock |
+| todosets | 3 | `todosets` | ✅ | BC4 | - | Container for todolists, accessed via project dock (BC5: `todos_count`, `completed_loose_todos_count`, `todos_url`, `app_todos_url`) |
 | todolist_groups | 8 | `todolistgroups` | ✅ | BC4 | - | list, show, create, update, position |
 | **Hill Charts** |
 | hill_charts | 2 | `hillcharts` | ✅ | BC4 | - | show, track/untrack todolists |
@@ -40,14 +40,14 @@ The **Since** column tags each row with the Basecamp version that introduced its
 | campfires | 14 | `chat` | ✅ | BC4 | - | list, messages, post, line show/delete. @mentions in content |
 | comments | 8 | `comment`, `comments` | ✅ | BC4 | - | list, show, create, update. @mentions in content |
 | boosts | 6 | `boost`, `react` | ✅ | BC4 | - | list (recording + event), show, create (recording + event), delete |
-| notifications | 2 | `notifications` | ✅ | BC4 | - | list, mark as read |
+| notifications | 2 | `notifications` | ✅ | BC4 | - | list, mark as read (BC5: `bubble_ups`/`scheduled_bubble_ups` sections; `memories` is BC4-only) |
 | **Cards (Kanban)** |
 | card_tables | 3 | `cards` | ✅ | BC4 | - | Accessed via project dock |
 | card_table_cards | 9 | `cards` | ✅ | BC4 | - | list, show, create, update, move |
 | card_table_columns | 11 | `cards columns` | ✅ | BC4 | - | list columns |
 | card_table_steps | 4 | `cards steps` | ✅ | BC4 | - | Workflow steps on cards |
 | **People** |
-| people | 12 | `people`, `me` | ✅ | BC4 | - | list, show, pingable, add, remove |
+| people | 12 | `people`, `me` | ✅ | BC4 | - | list, show, pingable, add, remove (BC5: `tagline` alias of `bio` on person output) |
 | **Search & Recordings** |
 | my_assignments | 3 | `assignments` | ✅ | BC4 | - | list (priorities/non-priorities), completed, due (with scope filter) |
 | search | 2 | `search` | ✅ | BC4 | - | Full-text search |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
-	github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260718061625-d15f023f64dc
+	github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260722045210-81660dc101d5
 	github.com/basecamp/cli v0.2.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0
@@ -66,7 +66,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/oapi-codegen/runtime v1.4.2 // indirect
+	github.com/oapi-codegen/runtime v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260718061625-d15f023f64dc h1:QGxZGLVQktaOpJDyKhj7/AY0oVqcBkL8jeFxlSn5zhs=
-github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260718061625-d15f023f64dc/go.mod h1:8VLJY4RwlazhxmA5rb37e6fOC0U6vwg3yjeFyT5xBW0=
+github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260722045210-81660dc101d5 h1:pOXigTfLk9GNEQ5sZEOIo7/122goh5LabvsdjhbZ04o=
+github.com/basecamp/basecamp-sdk/go v0.7.4-0.20260722045210-81660dc101d5/go.mod h1:eX5mEKCdtxSfEL4P/n5AwOl21JVA/K+gRPic/Hd8W/Y=
 github.com/basecamp/cli v0.2.1 h1:8GyehPVtsTXla0oOPu4QgXRjwwzJ99prlByvyi+0HRQ=
 github.com/basecamp/cli v0.2.1/go.mod h1:p8tt/DatJ2LAzWO6N6tNfV8x3gF5T3IxDTo+U8FfWPo=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
@@ -131,8 +131,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
-github.com/oapi-codegen/runtime v1.4.2 h1:GMxFVYLzoYLua+/KvzgSphkyK1lLTReQI9Vf4hvATKE=
-github.com/oapi-codegen/runtime v1.4.2/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
+github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=
+github.com/oapi-codegen/runtime v1.6.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/commands/notifications.go
+++ b/internal/commands/notifications.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/output"
 )
@@ -18,12 +20,13 @@ func NewNotificationsCmd() *cobra.Command {
 		Short: "View and manage notifications",
 		Long: `View and manage your notifications.
 
-Shows unread, read, and memory notifications. Use 'read' to mark
-notifications as read.`,
+Shows unread and read notifications, plus resurfaced items: Bubble Ups
+(and Scheduled Bubble Ups) on Basecamp 5, Memories on Basecamp 4.
+Use 'read' to mark notifications as read.`,
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
 			"agent_notes": "Account-wide notifications — no --in <project> needed.\n" +
-				"Returns unreads, reads, and memories sections.\n" +
+				"Returns unreads and reads sections, plus bubble_ups/scheduled_bubble_ups (BC5) or memories (BC4).\n" +
 				"Use 'read' with notification IDs to mark as read.",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,10 +71,23 @@ func runNotificationsList(cmd *cobra.Command, page int32) error {
 		return convertSDKError(err)
 	}
 
-	total := len(result.Unreads) + len(result.Reads) + len(result.Memories)
+	// BC5 carries resurfaced items in BubbleUps and may also populate
+	// Memories as a compat alias of the same list; BC4 populates Memories
+	// only. Count whichever list carries them, never both.
+	resurfaced := len(result.BubbleUps)
+	if resurfaced == 0 {
+		resurfaced = len(result.Memories)
+	}
+	total := len(result.Unreads) + len(result.Reads) + resurfaced + len(result.ScheduledBubbleUps)
 	summary := fmt.Sprintf("%d notification(s)", total)
 	if len(result.Unreads) > 0 {
 		summary += fmt.Sprintf(" (%d unread)", len(result.Unreads))
+	}
+	if len(result.BubbleUps) > 0 {
+		summary += fmt.Sprintf(", %d bubble-up(s)", len(result.BubbleUps))
+	}
+	if len(result.ScheduledBubbleUps) > 0 {
+		summary += fmt.Sprintf(", %d scheduled bubble-up(s)", len(result.ScheduledBubbleUps))
 	}
 
 	nextPage := page + 1
@@ -137,19 +153,15 @@ match the page you listed (defaults to first page).
 
 			// Build ID → SGID map from all notification sections
 			sgidMap := make(map[int64]string)
-			for _, n := range result.Unreads {
-				if n.ReadableSGID != "" {
-					sgidMap[n.ID] = n.ReadableSGID
-				}
+			sections := [][]basecamp.Notification{
+				result.Unreads, result.Reads, result.Memories,
+				result.BubbleUps, result.ScheduledBubbleUps,
 			}
-			for _, n := range result.Reads {
-				if n.ReadableSGID != "" {
-					sgidMap[n.ID] = n.ReadableSGID
-				}
-			}
-			for _, n := range result.Memories {
-				if n.ReadableSGID != "" {
-					sgidMap[n.ID] = n.ReadableSGID
+			for _, section := range sections {
+				for _, n := range section {
+					if n.ReadableSGID != "" {
+						sgidMap[n.ID] = n.ReadableSGID
+					}
 				}
 			}
 

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -729,6 +729,16 @@ You can pass either a todo ID or a Basecamp URL:
 			),
 		}
 
+		if len(todo.Steps) > 0 {
+			opts = append(opts, output.WithBreadcrumbs(
+				output.Breadcrumb{
+					Action:      "steps",
+					Cmd:         "basecamp cards step complete <step-id>",
+					Description: "Complete a step (step IDs in --output json)",
+				},
+			))
+		}
+
 		data := any(todo)
 		attachmentNotice := ""
 		attachments := downloadableAttachments(richtext.ParseAttachments(todo.Description))

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -734,7 +734,7 @@ You can pass either a todo ID or a Basecamp URL:
 				output.Breadcrumb{
 					Action:      "steps",
 					Cmd:         "basecamp cards step complete <step-id>",
-					Description: "Complete a step (step IDs in --output json)",
+					Description: "Complete a step (step IDs in --json output)",
 				},
 			))
 		}

--- a/internal/commands/todosets.go
+++ b/internal/commands/todosets.go
@@ -215,19 +215,33 @@ func runTodosetShow(cmd *cobra.Command, project, todosetID string) error {
 		completedRatio = "0.0"
 	}
 
+	summary := fmt.Sprintf("%d todolists (%s%% complete)", todoset.TodolistsCount, completedRatio)
+	if todoset.TodosCount > 0 {
+		summary += fmt.Sprintf(", %d todos", todoset.TodosCount)
+	}
+
+	breadcrumbs := []output.Breadcrumb{
+		{
+			Action:      "todolists",
+			Cmd:         fmt.Sprintf("basecamp todolists --in %s", resolvedProjectID),
+			Description: "List all todolists",
+		},
+		{
+			Action:      "project",
+			Cmd:         fmt.Sprintf("basecamp projects show %s", resolvedProjectID),
+			Description: "View project details",
+		},
+	}
+	if todoset.TodosURL != "" {
+		breadcrumbs = append(breadcrumbs, output.Breadcrumb{
+			Action:      "todos",
+			Cmd:         fmt.Sprintf("basecamp todos list --in %s", resolvedProjectID),
+			Description: "List all todos, including listless ones",
+		})
+	}
+
 	return app.OK(todoset,
-		output.WithSummary(fmt.Sprintf("%d todolists (%s%% complete)", todoset.TodolistsCount, completedRatio)),
-		output.WithBreadcrumbs(
-			output.Breadcrumb{
-				Action:      "todolists",
-				Cmd:         fmt.Sprintf("basecamp todolists --in %s", resolvedProjectID),
-				Description: "List all todolists",
-			},
-			output.Breadcrumb{
-				Action:      "project",
-				Cmd:         fmt.Sprintf("basecamp projects show %s", resolvedProjectID),
-				Description: "View project details",
-			},
-		),
+		output.WithSummary(summary),
+		output.WithBreadcrumbs(breadcrumbs...),
 	)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -4055,8 +4055,12 @@ func TestEntityPresenterRendersComments(t *testing.T) {
 			require.NoError(t, err)
 
 			out := ansi.Strip(buf.String())
-			// Presenter artifact from todo.yaml schema
-			assert.Contains(t, out, "Status")
+			// Presenter artifact from todo.yaml schema: the affordance hint
+			// only the schema-driven presenter emits. (The Status section is
+			// deliberately absent — every field formats empty for this data,
+			// and empty sections are skipped, heading included.)
+			assert.Contains(t, out, "basecamp todos complete 42")
+			assert.NotContains(t, out, "Status")
 			// Comment rendered after presenter
 			assert.Contains(t, out, "Annie Bryan")
 			assert.Contains(t, out, "Great idea")

--- a/internal/presenter/format.go
+++ b/internal/presenter/format.go
@@ -60,6 +60,7 @@ func formatSteps(val any) string {
 	var lines []string
 	for _, m := range items {
 		title, _ := m["title"].(string)
+		title = richtext.SanitizeSingleLine(title)
 		marker := "[ ]"
 		if completed, ok := m["completed"].(bool); ok && completed {
 			marker = "[x]"

--- a/internal/presenter/format.go
+++ b/internal/presenter/format.go
@@ -28,9 +28,61 @@ func FormatField(spec FieldSpec, key string, val any, locale Locale) string {
 		return formatNumber(val, locale)
 	case "dock":
 		return formatDock(val)
+	case "steps":
+		return formatSteps(val)
 	default:
 		return formatText(val)
 	}
+}
+
+// formatSteps renders a CardStep array as a multi-line checklist.
+// Each step prefixes its title with [x] for completed, [ ] for active.
+func formatSteps(val any) string {
+	var items []map[string]any
+	switch v := val.(type) {
+	case []map[string]any:
+		items = v
+	case []any:
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				items = append(items, m)
+			}
+		}
+	}
+	if len(items) == 0 {
+		return ""
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return stepPosition(items[i]) < stepPosition(items[j])
+	})
+
+	var lines []string
+	for _, m := range items {
+		title, _ := m["title"].(string)
+		marker := "[ ]"
+		if completed, ok := m["completed"].(bool); ok && completed {
+			marker = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("%s %s", marker, title))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func stepPosition(m map[string]any) int {
+	switch v := m["position"].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case json.Number:
+		if n, err := strconv.Atoi(v.String()); err == nil {
+			return n
+		}
+	}
+	return 1<<31 - 1
 }
 
 // formatBoolean converts a boolean to a label from the spec, or "yes"/"no".

--- a/internal/presenter/presenter_test.go
+++ b/internal/presenter/presenter_test.go
@@ -109,8 +109,8 @@ func TestSchemaViews(t *testing.T) {
 		t.Errorf("First list column = %q, want %q", schema.Views.List.Columns[0], "id")
 	}
 
-	if len(schema.Views.Detail.Sections) != 3 {
-		t.Errorf("Detail sections = %d, want 3", len(schema.Views.Detail.Sections))
+	if len(schema.Views.Detail.Sections) != 4 {
+		t.Errorf("Detail sections = %d, want 4", len(schema.Views.Detail.Sections))
 	}
 
 	// Markdown list view config

--- a/internal/presenter/presenter_test.go
+++ b/internal/presenter/presenter_test.go
@@ -248,6 +248,31 @@ func TestFormatFieldPeopleEmpty(t *testing.T) {
 	}
 }
 
+func TestFormatFieldSteps(t *testing.T) {
+	spec := FieldSpec{Format: "steps"}
+
+	steps := []any{
+		map[string]any{"title": "Second", "completed": true, "position": float64(2)},
+		map[string]any{"title": "First", "completed": false, "position": float64(1)},
+	}
+	want := "[ ] First\n[x] Second"
+	assert.Equal(t, want, FormatField(spec, "steps", steps, enUS))
+
+	assert.Empty(t, FormatField(spec, "steps", []any{}, enUS))
+	assert.Empty(t, FormatField(spec, "steps", nil, enUS))
+}
+
+func TestFormatFieldStepsSanitizesTitles(t *testing.T) {
+	spec := FieldSpec{Format: "steps"}
+
+	steps := []any{
+		map[string]any{"title": "evil\x1b]8;;https://example.com\x1b\\link\ntwo lines", "completed": false},
+	}
+	got := FormatField(spec, "steps", steps, enUS)
+	assert.NotContains(t, got, "\x1b")
+	assert.Equal(t, "[ ] evillink two lines", got)
+}
+
 func TestFormatFieldText(t *testing.T) {
 	spec := FieldSpec{Format: "text"}
 
@@ -972,6 +997,32 @@ func TestRenderDetailMarkdown(t *testing.T) {
 	if strings.Contains(out, "\x1b[") {
 		t.Errorf("Markdown output should contain no ANSI codes, got:\n%q", out)
 	}
+
+	// Todo without steps skips the Steps section entirely, heading included
+	if strings.Contains(out, "#### Steps") {
+		t.Errorf("Markdown detail should omit empty Steps section, got:\n%s", out)
+	}
+}
+
+func TestRenderDetailMarkdownSteps(t *testing.T) {
+	schema := LookupByName("todo")
+	require.NotNil(t, schema)
+
+	data := map[string]any{
+		"id":      float64(12345),
+		"content": "Fix the login bug",
+		"steps": []any{
+			map[string]any{"title": "Reproduce", "completed": true, "position": float64(1)},
+			map[string]any{"title": "Fix", "completed": false, "position": float64(2)},
+		},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, RenderDetailMarkdown(&buf, schema, data, enUS))
+	out := buf.String()
+
+	assert.Contains(t, out, "#### Steps")
+	assert.Contains(t, out, "[x] Reproduce\n[ ] Fix")
 }
 
 func TestRenderListMarkdown(t *testing.T) {

--- a/internal/presenter/presenter_test.go
+++ b/internal/presenter/presenter_test.go
@@ -1004,6 +1004,50 @@ func TestRenderDetailMarkdown(t *testing.T) {
 	}
 }
 
+func TestRenderDetailSkipsEmptySections(t *testing.T) {
+	schema := LookupByName("todo")
+	require.NotNil(t, schema)
+
+	// Incomplete todo with no due date or assignees: every Status field
+	// formats to "", so the heading must not render either.
+	data := map[string]any{
+		"id":        float64(42),
+		"content":   "Buy milk",
+		"completed": false,
+	}
+
+	t.Run("styled", func(t *testing.T) {
+		styles := NewStyles(tui.NoColorTheme(), false)
+		var buf strings.Builder
+		require.NoError(t, RenderDetail(&buf, schema, data, styles, enUS))
+		assert.NotContains(t, buf.String(), "Status")
+		assert.NotContains(t, buf.String(), "Steps")
+	})
+
+	t.Run("markdown", func(t *testing.T) {
+		var buf strings.Builder
+		require.NoError(t, RenderDetailMarkdown(&buf, schema, data, enUS))
+		assert.NotContains(t, buf.String(), "#### Status")
+		assert.NotContains(t, buf.String(), "#### Steps")
+	})
+
+	// With a due date, Status renders again in both modes.
+	data["due_on"] = "2026-01-15"
+
+	t.Run("styled_with_due_date", func(t *testing.T) {
+		styles := NewStyles(tui.NoColorTheme(), false)
+		var buf strings.Builder
+		require.NoError(t, RenderDetail(&buf, schema, data, styles, enUS))
+		assert.Contains(t, buf.String(), "Status")
+	})
+
+	t.Run("markdown_with_due_date", func(t *testing.T) {
+		var buf strings.Builder
+		require.NoError(t, RenderDetailMarkdown(&buf, schema, data, enUS))
+		assert.Contains(t, buf.String(), "#### Status")
+	})
+}
+
 func TestRenderDetailMarkdownSteps(t *testing.T) {
 	schema := LookupByName("todo")
 	require.NotNil(t, schema)

--- a/internal/presenter/render.go
+++ b/internal/presenter/render.go
@@ -693,10 +693,9 @@ func extractDotPath(data map[string]any, path string) string {
 }
 
 func renderDetailSectionMarkdown(b *strings.Builder, schema *EntitySchema, section DetailSection, data map[string]any, locale Locale) {
-	if section.Heading != "" {
-		b.WriteString("\n#### " + section.Heading + "\n\n")
-	}
-
+	// Same visible-field prepass as the styled renderDetailSection: body
+	// fields count only when non-empty, detail fields whenever present.
+	var visibleFields []string
 	for _, name := range section.Fields {
 		spec := schema.Fields[name]
 		val := data[name]
@@ -707,8 +706,28 @@ func renderDetailSectionMarkdown(b *strings.Builder, schema *EntitySchema, secti
 		if spec.Role == "title" {
 			continue
 		}
+		if spec.Role == "body" {
+			if !isEmpty(val) {
+				visibleFields = append(visibleFields, name)
+			}
+			continue
+		}
 
-		formatted := FormatField(spec, name, val, locale)
+		visibleFields = append(visibleFields, name)
+	}
+
+	// Skip the whole section (heading included) when nothing renders.
+	if len(visibleFields) == 0 {
+		return
+	}
+
+	if section.Heading != "" {
+		b.WriteString("\n#### " + section.Heading + "\n\n")
+	}
+
+	for _, name := range visibleFields {
+		spec := schema.Fields[name]
+		formatted := FormatField(spec, name, data[name], locale)
 
 		if spec.Role == "body" {
 			if formatted != "" {
@@ -721,8 +740,7 @@ func renderDetailSectionMarkdown(b *strings.Builder, schema *EntitySchema, secti
 			continue
 		}
 
-		label := fieldLabel(name)
-		b.WriteString("- **" + label + ":** " + formatted + "\n")
+		b.WriteString("- **" + fieldLabel(name) + ":** " + formatted + "\n")
 	}
 }
 

--- a/internal/presenter/render.go
+++ b/internal/presenter/render.go
@@ -157,10 +157,18 @@ func RenderList(w io.Writer, schema *EntitySchema, data []map[string]any, styles
 	return err
 }
 
-func renderDetailSection(b *strings.Builder, schema *EntitySchema, section DetailSection, data map[string]any, styles Styles, locale Locale) {
-	// Find max label length for alignment
-	maxLen := 0
-	var visibleFields []string
+// renderedField pairs a section field with its formatted output.
+type renderedField struct {
+	name      string
+	formatted string
+}
+
+// visibleSectionFields filters a detail section to the fields that will
+// actually render: collapse rules pass and formatting yields output. Both
+// the styled and Markdown renderers section-skip from this list, so a
+// heading never prints over zero rows.
+func visibleSectionFields(schema *EntitySchema, section DetailSection, data map[string]any, locale Locale) []renderedField {
+	var fields []renderedField
 	for _, name := range section.Fields {
 		spec := schema.Fields[name]
 		val := data[name]
@@ -175,24 +183,33 @@ func renderDetailSection(b *strings.Builder, schema *EntitySchema, section Detai
 			continue
 		}
 
-		// Body role renders as a text block, not labeled
-		if spec.Role == "body" {
-			if !isEmpty(val) {
-				visibleFields = append(visibleFields, name)
-			}
+		formatted := FormatField(spec, name, val, locale)
+		if formatted == "" {
 			continue
 		}
 
-		label := fieldLabel(name)
-		if len(label) > maxLen {
-			maxLen = len(label)
-		}
-		visibleFields = append(visibleFields, name)
+		fields = append(fields, renderedField{name: name, formatted: formatted})
 	}
+	return fields
+}
+
+func renderDetailSection(b *strings.Builder, schema *EntitySchema, section DetailSection, data map[string]any, styles Styles, locale Locale) {
+	visible := visibleSectionFields(schema, section, data, locale)
 
 	// Skip the whole section (heading included) when nothing renders.
-	if len(visibleFields) == 0 {
+	if len(visible) == 0 {
 		return
+	}
+
+	// Find max label length for alignment
+	maxLen := 0
+	for _, f := range visible {
+		if schema.Fields[f.name].Role == "body" {
+			continue
+		}
+		if label := fieldLabel(f.name); len(label) > maxLen {
+			maxLen = len(label)
+		}
 	}
 
 	if section.Heading != "" {
@@ -201,12 +218,11 @@ func renderDetailSection(b *strings.Builder, schema *EntitySchema, section Detai
 		b.WriteString("\n")
 	}
 
-	for _, name := range visibleFields {
-		spec := schema.Fields[name]
-		val := data[name]
-		formatted := FormatField(spec, name, val, locale)
+	for _, f := range visible {
+		spec := schema.Fields[f.name]
+		val := data[f.name]
 
-		style := resolveEmphasis(spec, name, val, styles)
+		style := resolveEmphasis(spec, f.name, val, styles)
 		// Fall back to Body style when no emphasis is specified for body fields
 		if spec.Role == "body" && spec.Emphasis == "" && spec.WhenOverdue == "" {
 			style = styles.Body
@@ -230,7 +246,7 @@ func renderDetailSection(b *strings.Builder, schema *EntitySchema, section Detai
 
 			// Render each line individually to prevent lipgloss from
 			// padding blank lines to the width of the longest line.
-			for _, line := range strings.Split(strings.TrimRight(formatted, "\n"), "\n") {
+			for _, line := range strings.Split(strings.TrimRight(f.formatted, "\n"), "\n") {
 				if line == "" {
 					b.WriteString("\n")
 				} else {
@@ -241,14 +257,9 @@ func renderDetailSection(b *strings.Builder, schema *EntitySchema, section Detai
 			continue
 		}
 
-		// Skip empty non-collapsed fields (collapsed empties are already filtered above)
-		if formatted == "" {
-			continue
-		}
-
-		label := fieldLabel(name)
+		label := fieldLabel(f.name)
 		b.WriteString(styles.Label.Render(fmt.Sprintf("  %-*s  ", maxLen, label)))
-		b.WriteString(style.Render(formatted))
+		b.WriteString(style.Render(f.formatted))
 		b.WriteString("\n")
 	}
 }
@@ -693,31 +704,10 @@ func extractDotPath(data map[string]any, path string) string {
 }
 
 func renderDetailSectionMarkdown(b *strings.Builder, schema *EntitySchema, section DetailSection, data map[string]any, locale Locale) {
-	// Same visible-field prepass as the styled renderDetailSection: body
-	// fields count only when non-empty, detail fields whenever present.
-	var visibleFields []string
-	for _, name := range section.Fields {
-		spec := schema.Fields[name]
-		val := data[name]
-
-		if spec.Collapse && isEmpty(val) {
-			continue
-		}
-		if spec.Role == "title" {
-			continue
-		}
-		if spec.Role == "body" {
-			if !isEmpty(val) {
-				visibleFields = append(visibleFields, name)
-			}
-			continue
-		}
-
-		visibleFields = append(visibleFields, name)
-	}
+	visible := visibleSectionFields(schema, section, data, locale)
 
 	// Skip the whole section (heading included) when nothing renders.
-	if len(visibleFields) == 0 {
+	if len(visible) == 0 {
 		return
 	}
 
@@ -725,22 +715,13 @@ func renderDetailSectionMarkdown(b *strings.Builder, schema *EntitySchema, secti
 		b.WriteString("\n#### " + section.Heading + "\n\n")
 	}
 
-	for _, name := range visibleFields {
-		spec := schema.Fields[name]
-		formatted := FormatField(spec, name, data[name], locale)
-
-		if spec.Role == "body" {
-			if formatted != "" {
-				b.WriteString("\n" + formatted + "\n")
-			}
+	for _, f := range visible {
+		if schema.Fields[f.name].Role == "body" {
+			b.WriteString("\n" + f.formatted + "\n")
 			continue
 		}
 
-		if formatted == "" {
-			continue
-		}
-
-		b.WriteString("- **" + fieldLabel(name) + ":** " + formatted + "\n")
+		b.WriteString("- **" + fieldLabel(f.name) + ":** " + f.formatted + "\n")
 	}
 }
 

--- a/internal/presenter/render.go
+++ b/internal/presenter/render.go
@@ -158,13 +158,6 @@ func RenderList(w io.Writer, schema *EntitySchema, data []map[string]any, styles
 }
 
 func renderDetailSection(b *strings.Builder, schema *EntitySchema, section DetailSection, data map[string]any, styles Styles, locale Locale) {
-	// Section heading
-	if section.Heading != "" {
-		b.WriteString("\n")
-		b.WriteString(styles.Heading.Render(section.Heading))
-		b.WriteString("\n")
-	}
-
 	// Find max label length for alignment
 	maxLen := 0
 	var visibleFields []string
@@ -195,6 +188,17 @@ func renderDetailSection(b *strings.Builder, schema *EntitySchema, section Detai
 			maxLen = len(label)
 		}
 		visibleFields = append(visibleFields, name)
+	}
+
+	// Skip the whole section (heading included) when nothing renders.
+	if len(visibleFields) == 0 {
+		return
+	}
+
+	if section.Heading != "" {
+		b.WriteString("\n")
+		b.WriteString(styles.Heading.Render(section.Heading))
+		b.WriteString("\n")
 	}
 
 	for _, name := range visibleFields {

--- a/internal/presenter/schemas/todo.yaml
+++ b/internal/presenter/schemas/todo.yaml
@@ -24,6 +24,11 @@ fields:
     format: text
     collapse: true
 
+  steps:
+    role: body
+    format: steps
+    collapse: true
+
   completed:
     role: detail
     emphasis: muted
@@ -64,6 +69,8 @@ views:
   detail:
     sections:
       - fields: [content, description]
+      - heading: Steps
+        fields: [steps]
       - heading: Status
         fields: [completed, due_on, assignees]
       - heading: Metadata

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.7.4-0.20260718061625-d15f023f64dc",
-    "revision": "d15f023f64dc",
-    "updated_at": "2026-07-18T06:16:25Z"
+    "version": "v0.7.4-0.20260722045210-81660dc101d5",
+    "revision": "81660dc101d5",
+    "updated_at": "2026-07-22T04:52:10Z"
   },
   "api": {
     "repo": "basecamp/bc3",


### PR DESCRIPTION
## Summary

The bc5-readiness stack ([basecamp-sdk #293](https://github.com/basecamp/basecamp-sdk/pull/293) + [#309](https://github.com/basecamp/basecamp-sdk/pull/309)) merged to SDK main, adding the BC5 forward-compat fields to the Go wrappers. This is the matching CLI absorption (Phase 1 of the BC5 absorption tracker): bump to the merge commit `81660dc101d5` and surface the new fields.

- **`todos show`** renders `Todo.Steps` as a checklist section via a new `steps` presenter format, with a breadcrumb pointing at the existing `cards step` mutation surface. The presenter now skips empty detail sections (heading included), so BC4 todos render exactly as before.
- **`todosets show`** adds the BC5 `todos_count` to the summary and a `todos list` breadcrumb when the todoset carries loose todos.
- **`notifications`** combines Bubble Ups + Scheduled Bubble Ups (BC5) with Memories (BC4) in the summary count — without double-counting BC5's `memories` compat alias — and `notifications read` resolves IDs across all five sections. Help text reflects the split: Bubble Ups on BC5, Memories on BC4 (permanently, per the documented contract).
- **`people show`**, todoset URLs, and notification bubble-up fields flow through JSON and generic output automatically — no schema filters in those paths.
- API-COVERAGE.md notes the BC5 field additions on the existing BC4 rows (no new endpoints in this phase).

BC4 compatibility: all new fields are `omitempty` additions; against BC4 hosts every touched command produces identical output to pre-bump.

## Testing

- `bin/ci` green (unit, e2e BATS, surface snapshot, skill drift, bare groups, provenance, tidy)
- Presenter section-skip covered by `TestSchemaViews` (todo detail sections 3 → 4) and existing render tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the CLI to the latest `github.com/basecamp/basecamp-sdk/go` with BC5 forward-compat fields and surfaces them in `todos show`, `todosets show`, and `notifications`, keeping BC4 output unchanged. Also updates `github.com/oapi-codegen/runtime` to `v1.6.0`.

- **New Features**
  - Todos: show `steps` as a checklist in `todos show` and add a breadcrumb to `cards step`.
  - Todosets: summary includes `todos_count`; add a breadcrumb to `todos list` when loose todos exist.
  - Notifications: summary counts Bubble Ups and Scheduled Bubble Ups (BC5) and Memories (BC4) without double-counting; `notifications read` resolves IDs across all sections.
  - Output passthrough: person `tagline`, todoset URLs, and bubble-up fields appear in JSON/generic output. New `steps` presenter format added.

- **Bug Fixes**
  - Detail views never show empty headings in styled or Markdown; fields are filtered after formatting and label alignment uses the visible fields.
  - Sanitize step titles in the checklist to prevent terminal injection; fix the `--json` flag mentioned in the steps breadcrumb.

<sup>Written for commit 3103e3ad54a65aba4602e74d2b7018d793fe2ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

