### PR TITLE
Produce gosec SARIF via golangci-lint for suppression parity

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,14 +116,6 @@ jobs:
           jq '.runs[].tool.driver.name = "Golang security checks by gosec"
               | .runs[].results[] |= (.ruleId = ((.message.text // "" | capture("^(?<g>G[0-9]{3}):").g) // .ruleId))' \
             gosec-results.sarif > tmp.sarif && mv tmp.sarif gosec-results.sarif
-          echo "Driver name after rewrite:"
-          jq '.runs[].tool.driver.name' gosec-results.sarif
-
-      - name: Save uploaded SARIF for inspection
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: gosec-sarif-debug
-          path: gosec-results.sarif
 
       - name: Upload gosec scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -91,18 +91,31 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Run gosec
+      # SARIF comes from golangci-lint (gosec linter only), not the standalone
+      # gosec binary, so the Security tab reflects exactly what the required
+      # Lint gate enforces: the standalone binary can't read `//nolint:gosec`
+      # suppressions or .golangci.yml gosec excludes, so it perpetually
+      # reported every accepted site and turned the code-scanning "gosec"
+      # check red on any PR touching an annotated line. One suppression
+      # convention, one source of truth. To audit accepted findings:
+      # `grep -rn 'nolint:gosec'` — justifications are inline at each site.
+      # --issues-exit-code 0 keeps this job advisory; a real escape still
+      # fails the required Lint check, and code scanning still alerts on it.
+      - name: Run gosec (via golangci-lint)
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.11.1  # keep in lockstep with test.yml Lint
+          args: --enable-only gosec --build-tags dev --issues-exit-code 0 --output.sarif.path gosec-results.sarif
+
+      - name: Keep code-scanning tool continuity
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
-          # Advisory scan: full SARIF uploaded to the Security tab for visibility
-          # (-no-fail). The enforcing gosec gate is golangci-lint (make lint),
-          # which honors the repo's //nolint:gosec suppressions per-site; the
-          # standalone binary can't read those, so making it hard-fail would
-          # require either re-annotating every accepted site or excluding rule
-          # IDs globally — and a global exclude (e.g. G101/G204) would create
-          # real blind spots for new hard-coded creds / unsafe exec, including in
-          # release scans. Keep the full advisory scan instead.
-          gosec -tags dev -no-fail -fmt sarif -out gosec-results.sarif ./...
+          # Rewrite the driver name so this upload supersedes the historical
+          # standalone-gosec analyses (first main upload closes their alerts as
+          # "fixed"), and restore per-rule identity: golangci-lint flattens every
+          # finding to ruleId "gosec", but the G### code leads each message.
+          jq '.runs[].tool.driver.name = "Golang security checks by gosec"
+              | .runs[].results[] |= (.ruleId = ((.message.text // "" | capture("^(?<g>G[0-9]{3}):").g) // .ruleId))' \
+            gosec-results.sarif > tmp.sarif && mv tmp.sarif gosec-results.sarif
 
       - name: Upload gosec scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -114,7 +114,7 @@ jobs:
           # "fixed"), and restore per-rule identity: golangci-lint flattens every
           # finding to ruleId "gosec", but the G### code leads each message.
           jq '.runs[].tool.driver.name = "Golang security checks by gosec"
-              | .runs[].results[] |= (.ruleId = ((.message.text // "" | capture("^(?<g>G[0-9]{3}):").g) // .ruleId))' \
+              | .runs[].results[]? |= (.ruleId = ((.message.text // "" | capture("^(?<g>G[0-9]{3}):").g)? // .ruleId))' \
             gosec-results.sarif > tmp.sarif && mv tmp.sarif gosec-results.sarif
 
       - name: Upload gosec scan results to GitHub Security tab

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,6 +116,14 @@ jobs:
           jq '.runs[].tool.driver.name = "Golang security checks by gosec"
               | .runs[].results[] |= (.ruleId = ((.message.text // "" | capture("^(?<g>G[0-9]{3}):").g) // .ruleId))' \
             gosec-results.sarif > tmp.sarif && mv tmp.sarif gosec-results.sarif
+          echo "Driver name after rewrite:"
+          jq '.runs[].tool.driver.name' gosec-results.sarif
+
+      - name: Save uploaded SARIF for inspection
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gosec-sarif-debug
+          path: gosec-results.sarif
 
       - name: Upload gosec scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0


### PR DESCRIPTION
## Problem

The code-scanning "gosec" check turns red on any PR whose changed lines include an annotated exec site — most recently #555 (alert #307, `refreshClaudeMarketplace`'s `exec.CommandContext`), and #294 before it. Recurring noise, zero signal.

Root cause: two scanners, one suppression convention. The enforcing gate is golangci-lint (required Lint check), which honors `//nolint:gosec` and `.golangci.yml` gosec excludes. The security workflow, however, generated its SARIF with **standalone** gosec, which can only read `#nosec` / `//gosec:disable` — `//nolint:gosec` can never match (verified in gosec source; no version bump fixes it). So the SARIF perpetually reported every accepted site (163 findings, 159 open alerts on main), and each new annotated site became a "new" alert failing the PR check.

## Fix

Generate the SARIF with the same pinned golangci-lint action + version as test.yml's Lint job, restricted to gosec via `--enable-only gosec`. The Security tab now reflects exactly what the required gate enforces — one suppression source of truth. `--issues-exit-code 0` keeps the job advisory; a real escape still fails the required Lint check, and code scanning still alerts on it.

A jq step before upload:
- rewrites the SARIF driver name to `Golang security checks by gosec`, so the upload lands in the historical tool stream (same tool + same derived category `.github/workflows/security.yml:gosec`) — the first upload on main supersedes the old analyses and closes all 159 open alerts as "fixed", no manual dismissals;
- restores per-rule `G###` identity (golangci-lint flattens every finding to `ruleId: "gosec"`; the G-code leads each message text).

Accepted tradeoff: golangci-lint's SARIF has no `driver.rules` metadata, so future findings lose gosec's rich rule descriptions in the Security tab. Per-rule identity is preserved via the jq derivation, and the expected steady state is zero findings.

## Verification

- Local run with the exact CI flags (`golangci-lint v2.11.1 run --enable-only gosec --build-tags dev --issues-exit-code 0 --output.sarif.path …`): valid SARIF, **0 results**.
- Synthetic-finding test: temporarily dropped one `//nolint:gosec`, regenerated — raw SARIF shows `ruleId: "gosec"` with message `G204: Subprocess launched…`; after the jq step, `ruleId: "G204"`. Reverted.
- Historical baseline confirmed via API: tool `Golang security checks by gosec`, category `.github/workflows/security.yml:gosec`, 163 results / 159 open alerts on `refs/heads/main`. Job name and workflow path unchanged → same derived category.
- `bin/ci` green.

Pre-merge: verify this PR's analysis landed in the same tool/category stream with `results_count == 0`. Post-merge: open standalone-gosec alerts on main drop to zero (incl. #307, closed as "fixed").

Refs #555 (alert basecamp/basecamp-cli#307), supersedes the dismiss-in-Security-tab playbook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns code scanning with the enforced linter by generating `gosec` SARIF via `golangci-lint`, so `//nolint:gosec` and `.golangci.yml` suppressions apply and noisy alerts stop. The job stays advisory; real issues still fail the required Lint check.

- **Bug Fixes**
  - Run `gosec` through `golangci/golangci-lint-action` with `version: v2.11.1`, `--enable-only gosec`, `--build-tags dev`, and `--issues-exit-code 0` to match the required Lint gate.
  - Rewrite the SARIF with `jq`: set driver name to "Golang security checks by gosec", restore per-rule `G###` `ruleId`, and make the rewrite error-resilient using `?` so missing codes or empty results don’t break the upload; then upload via `github/codeql-action/upload-sarif`. This supersedes standalone `gosec` analyses and closes false positives while keeping future alerts in sync with `golangci-lint`.

<sup>Written for commit e753df1dfed181676b45929e41d28f60f12358b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

