### PR TITLE
Deterministic, reply-ready comment context (comments thread + show)

### DIFF
--- a/.surface
+++ b/.surface
@@ -100,6 +100,7 @@ ARG basecamp comments create 01 <content>
 ARG basecamp comments list 00 <id|url>
 ARG basecamp comments restore 00 <id|url>
 ARG basecamp comments show 00 <id|url>
+ARG basecamp comments thread 00 <comment-id|comment-url>
 ARG basecamp comments trash 00 <id|url>
 ARG basecamp comments update 00 <id|url>
 ARG basecamp comments update 01 <content>
@@ -558,6 +559,7 @@ CMD basecamp comments create
 CMD basecamp comments list
 CMD basecamp comments restore
 CMD basecamp comments show
+CMD basecamp comments thread
 CMD basecamp comments trash
 CMD basecamp comments update
 CMD basecamp completion
@@ -4203,6 +4205,29 @@ FLAG basecamp comments show --stats type=bool
 FLAG basecamp comments show --styled type=bool
 FLAG basecamp comments show --todolist type=string
 FLAG basecamp comments show --verbose type=count
+FLAG basecamp comments thread --account type=string
+FLAG basecamp comments thread --agent type=bool
+FLAG basecamp comments thread --all type=bool
+FLAG basecamp comments thread --cache-dir type=string
+FLAG basecamp comments thread --count type=bool
+FLAG basecamp comments thread --help type=bool
+FLAG basecamp comments thread --hints type=bool
+FLAG basecamp comments thread --ids-only type=bool
+FLAG basecamp comments thread --in type=string
+FLAG basecamp comments thread --jq type=string
+FLAG basecamp comments thread --json type=bool
+FLAG basecamp comments thread --markdown type=bool
+FLAG basecamp comments thread --md type=bool
+FLAG basecamp comments thread --no-hints type=bool
+FLAG basecamp comments thread --no-stats type=bool
+FLAG basecamp comments thread --profile type=string
+FLAG basecamp comments thread --project type=string
+FLAG basecamp comments thread --quiet type=bool
+FLAG basecamp comments thread --stats type=bool
+FLAG basecamp comments thread --styled type=bool
+FLAG basecamp comments thread --todolist type=string
+FLAG basecamp comments thread --verbose type=count
+FLAG basecamp comments thread --window type=int
 FLAG basecamp comments trash --account type=string
 FLAG basecamp comments trash --agent type=bool
 FLAG basecamp comments trash --cache-dir type=string
@@ -16558,6 +16583,7 @@ SUB basecamp comments create
 SUB basecamp comments list
 SUB basecamp comments restore
 SUB basecamp comments show
+SUB basecamp comments thread
 SUB basecamp comments trash
 SUB basecamp comments update
 SUB basecamp completion

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -41,7 +41,7 @@ The **Since** column tags each row with the Basecamp version that introduced its
 | message_boards | 3 | `messageboards` | ✅ | BC4 | - | Container, accessed via project dock |
 | message_types | 5 | `messagetypes` | ✅ | BC4 | - | list, show, create, update, delete |
 | campfires | 14 | `chat` | ✅ | BC4 | - | list, messages, post, line show/update/delete. @mentions in content |
-| comments | 8 | `comment`, `comments` | ✅ | BC4 | - | list, show, create, update. @mentions in content |
+| comments | 8 | `comment`, `comments` | ✅ | BC4 | - | list, show, thread, create, update. @mentions in content. `thread` composes Get + parent recording (via type endpoint) + List into a deterministic reply-ready context (no new endpoints) |
 | boosts | 6 | `boost`, `react` | ✅ | BC4 | - | list (recording + event), show, create (recording + event), delete |
 | notifications | 2 | `notifications` | ✅ | BC4 | - | list, mark as read (BC5: `bubble_ups`/`scheduled_bubble_ups` sections; `memories` is BC4-only) |
 | **Cards (Kanban)** |

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -41,7 +41,7 @@ The **Since** column tags each row with the Basecamp version that introduced its
 | message_boards | 3 | `messageboards` | ✅ | BC4 | - | Container, accessed via project dock |
 | message_types | 5 | `messagetypes` | ✅ | BC4 | - | list, show, create, update, delete |
 | campfires | 14 | `chat` | ✅ | BC4 | - | list, messages, post, line show/update/delete. @mentions in content |
-| comments | 8 | `comment`, `comments` | ✅ | BC4 | - | list, show, thread, create, update. @mentions in content. `thread` composes Get + parent recording (via type endpoint) + List into a deterministic reply-ready context (no new endpoints) |
+| comments | 8 | `comment`, `comments` | ✅ | BC4 | - | list, show, thread, create, update. @mentions in content. `show` surfaces `reply_target` + paste-ready `mention` from its single Get (no new calls). `thread` composes Get + parent recording (via type endpoint) + List into a deterministic reply-ready context (no new endpoints) |
 | boosts | 6 | `boost`, `react` | ✅ | BC4 | - | list (recording + event), show, create (recording + event), delete |
 | notifications | 2 | `notifications` | ✅ | BC4 | - | list, mark as read (BC5: `bubble_ups`/`scheduled_bubble_ups` sections; `memories` is BC4-only) |
 | **Cards (Kanban)** |

--- a/e2e/comments.bats
+++ b/e2e/comments.bats
@@ -50,8 +50,8 @@ load test_helper
   run basecamp comments thread "https://3.basecamp.com/99999/buckets/1/todos/123" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "not a comment"
-  assert_output_contains "basecamp show"
+  assert_json_value '.error' 'That URL points to a recording, not a comment'
+  assert_json_value '.hint | contains("basecamp show")' 'true'
 }
 
 @test "comments thread rejects a URL whose account differs from the configured one" {
@@ -61,7 +61,7 @@ load test_helper
   run basecamp comments thread "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "does not match"
+  assert_json_value '.error' 'URL account 88888 does not match the configured account 99999'
 }
 
 @test "comments thread rejects --all with --window" {
@@ -71,7 +71,7 @@ load test_helper
   run basecamp comments thread 456 --all --window 5 --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "mutually exclusive"
+  assert_json_value '.error' '--all and --window are mutually exclusive'
 }
 
 @test "comments thread rejects a non-positive --window" {
@@ -81,7 +81,7 @@ load test_helper
   run basecamp comments thread 456 --window 0 --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "positive"
+  assert_json_value '.error' '--window must be a positive number'
 }
 
 @test "comments thread rejects a non-positive id" {
@@ -101,7 +101,7 @@ load test_helper
   run basecamp comments thread "https://evil.example/99999/buckets/1/comments/456" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "untrusted host"
+  assert_json_value '.error' 'refusing untrusted host in URL — expected a Basecamp URL'
 }
 
 
@@ -114,8 +114,8 @@ load test_helper
   run basecamp comments show "https://3.basecamp.com/99999/buckets/1/todos/123" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "not a comment"
-  assert_output_contains "basecamp show"
+  assert_json_value '.error' 'That URL points to a recording, not a comment'
+  assert_json_value '.hint | contains("basecamp show")' 'true'
 }
 
 @test "comments show rejects a URL whose account differs from the configured one" {
@@ -125,7 +125,7 @@ load test_helper
   run basecamp comments show "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "does not match"
+  assert_json_value '.error' 'URL account 88888 does not match the configured account 99999'
 }
 
 @test "comments show rejects a non-positive id" {
@@ -145,7 +145,7 @@ load test_helper
   run basecamp comments show "https://evil.example/99999/buckets/1/comments/456" --json
   assert_failure
   assert_json_value '.code' 'usage'
-  assert_output_contains "untrusted host"
+  assert_json_value '.error' 'refusing untrusted host in URL — expected a Basecamp URL'
 }
 
 

--- a/e2e/comments.bats
+++ b/e2e/comments.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# comments.bats - Test comments command error handling (thread input validation)
+
+load test_helper
+
+
+# Help
+
+@test "comments without subcommand shows help" {
+  run basecamp comments
+  assert_success
+  assert_output_contains "COMMANDS"
+}
+
+
+# thread — argument validation
+
+@test "comments thread without id shows error" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread
+  assert_failure
+  assert_output_contains "ID required"
+}
+
+@test "comments thread with surplus args is rejected" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread 456 789
+  assert_failure
+  assert_output_contains "accepts 1 arg"
+}
+
+@test "comments thread with non-numeric id shows usage error" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread abc --json
+  assert_failure
+  assert_json_value '.error' 'Invalid comment ID'
+  assert_json_value '.code' 'usage'
+}
+
+@test "comments thread rejects a plain recording URL and points at show" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread "https://3.basecamp.com/99999/buckets/1/todos/123" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "not a comment"
+  assert_output_contains "basecamp show"
+}
+
+@test "comments thread rejects a URL whose account differs from the configured one" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "does not match"
+}
+
+@test "comments thread rejects --all with --window" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread 456 --all --window 5 --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "mutually exclusive"
+}
+
+@test "comments thread rejects a non-positive --window" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread 456 --window 0 --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "positive"
+}
+
+
+# Help
+
+@test "comments thread --help shows usage" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  run basecamp comments thread --help
+  assert_success
+  assert_output_contains "reply"
+  assert_output_contains "--window"
+  assert_output_contains "--all"
+}

--- a/e2e/comments.bats
+++ b/e2e/comments.bats
@@ -84,6 +84,70 @@ load test_helper
   assert_output_contains "positive"
 }
 
+@test "comments thread rejects a non-positive id" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread 0 --json
+  assert_failure
+  assert_json_value '.error' 'Invalid comment ID'
+  assert_json_value '.code' 'usage'
+}
+
+@test "comments thread rejects an untrusted host in the URL" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments thread "https://evil.example/99999/buckets/1/comments/456" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "untrusted host"
+}
+
+
+# show — shared resolver safety (mirrors thread)
+
+@test "comments show rejects a plain recording URL and points at show" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments show "https://3.basecamp.com/99999/buckets/1/todos/123" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "not a comment"
+  assert_output_contains "basecamp show"
+}
+
+@test "comments show rejects a URL whose account differs from the configured one" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments show "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "does not match"
+}
+
+@test "comments show rejects a non-positive id" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments show 0 --json
+  assert_failure
+  assert_json_value '.error' 'Invalid comment ID'
+  assert_json_value '.code' 'usage'
+}
+
+@test "comments show rejects an untrusted host in the URL" {
+  create_credentials
+  create_global_config '{"account_id": 99999, "project_id": 123}'
+
+  run basecamp comments show "https://evil.example/99999/buckets/1/comments/456" --json
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_output_contains "untrusted host"
+}
+
 
 # Help
 

--- a/e2e/smoke/smoke_comments.bats
+++ b/e2e/smoke/smoke_comments.bats
@@ -40,6 +40,27 @@ setup_file() {
   assert_json_not_null '.data.id'
 }
 
+@test "comments thread returns reply-ready context" {
+  local id_file="$BATS_FILE_TMPDIR/comment_id"
+  [[ -f "$id_file" ]] || mark_unverifiable "No comment created in prior test"
+  local comment_id
+  comment_id=$(<"$id_file")
+
+  run_smoke basecamp comments thread "$comment_id" -p "$QA_PROJECT" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+
+  # A reply routes to the parent recording, never the comment.
+  assert_json_value '.data.recording_full' 'true'
+  assert_json_not_null '.data.focus'
+
+  local reply_target recording_id
+  reply_target=$(echo "$output" | jq -r '.data.reply_target.recording_id')
+  recording_id=$(echo "$output" | jq -r '.data.recording.id')
+  [[ "$reply_target" == "$recording_id" ]] \
+    || fail "reply_target.recording_id ($reply_target) != recording.id ($recording_id)"
+}
+
 @test "comments update updates a comment" {
   local id_file="$BATS_FILE_TMPDIR/comment_id"
   [[ -f "$id_file" ]] || mark_unverifiable "No comment created in prior test"

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -92,7 +92,7 @@ func CommandCategories() []CommandCategory {
 				{Name: "forwards", Category: "communication", Description: "Manage email forwards (inbox)", Actions: []string{"list", "show", "inbox", "replies", "reply"}},
 				{Name: "subscriptions", Category: "communication", Description: "Manage notification subscriptions", Actions: []string{"show", "subscribe", "unsubscribe", "add", "remove"}},
 				{Name: "attachments", Category: "communication", Description: "List and download attachments", Actions: []string{"list", "download"}},
-				{Name: "comments", Category: "communication", Description: "Manage comments", Actions: []string{"create", "list", "show", "update", "trash", "archive", "restore"}},
+				{Name: "comments", Category: "communication", Description: "Manage comments", Actions: []string{"create", "list", "show", "thread", "update", "trash", "archive", "restore"}},
 				{Name: "boost", Category: "communication", Description: "Manage boosts (reactions)", Actions: []string{"list", "show", "create", "delete"}},
 				{Name: "notifications", Category: "communication", Description: "View and manage notifications", Actions: []string{"list", "read"}},
 			},

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/config"
 	"github.com/basecamp/basecamp-cli/internal/editor"
 	"github.com/basecamp/basecamp-cli/internal/hostutil"
 	"github.com/basecamp/basecamp-cli/internal/output"
@@ -161,11 +162,12 @@ You can pass either a comment ID or a Basecamp URL:
 
 			app := appctx.FromContext(cmd.Context())
 
-			// Whether the account was already in persistent config (flag/env/file)
-			// before resolution. When it wasn't — adopted from the URL or resolved
-			// interactively — the advertised follow-ups must spell out --account so
-			// they remain runnable in a fresh process.
-			hadConfiguredAccount := app.Config.AccountID != ""
+			// Whether the account is persistently available (on-disk config or env)
+			// before resolution. When it isn't — adopted from the URL, resolved
+			// interactively, or passed via the process-local --account flag — the
+			// advertised follow-ups must spell out --account so they remain runnable
+			// in a fresh process.
+			persistentAccount := hasPersistentAccount(app.Config)
 
 			// Same safe front door as `thread`: classify, guard the account, and
 			// validate the ID — so a plain recording URL or wrong-account URL is
@@ -174,7 +176,7 @@ You can pass either a comment ID or a Basecamp URL:
 			if err != nil {
 				return err
 			}
-			accountArg := replyAccountArg(hadConfiguredAccount, app.Config.AccountID)
+			accountArg := replyAccountArg(persistentAccount, app.Config.AccountID)
 
 			comment, err := app.Account().Comments().Get(cmd.Context(), commentID)
 			if err != nil {
@@ -294,15 +296,16 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 	// and `comments show` are equally safe: a plain recording URL / collection is
 	// rejected toward `basecamp show`, a wrong-account URL and a non-positive ID
 	// are rejected before any API call.
-	hadConfiguredAccount := app.Config.AccountID != ""
+	persistentAccount := hasPersistentAccount(app.Config)
 	triggerID, err := resolveCommentTrigger(cmd, app, arg)
 	if err != nil {
 		return err
 	}
-	// When the account was adopted from the URL (or resolved interactively) rather
-	// than already configured, the advertised follow-ups must carry --account so
-	// they stay runnable in a fresh process.
-	accountArg := replyAccountArg(hadConfiguredAccount, app.Config.AccountID)
+	// When the account isn't persistently available (adopted from the URL,
+	// resolved interactively, or passed via the process-local --account flag), the
+	// advertised follow-ups must carry --account so they stay runnable in a fresh
+	// process.
+	accountArg := replyAccountArg(persistentAccount, app.Config.AccountID)
 
 	// Step 1 — resolve the focus comment.
 	trigger, err := app.Account().Comments().Get(cmd.Context(), triggerID)
@@ -498,13 +501,32 @@ func resolveCommentTrigger(cmd *cobra.Command, app *appctx.App, arg string) (int
 	return id, nil
 }
 
+// hasPersistentAccount reports whether the account is available to a fresh
+// process without re-specifying it — i.e. backed by an on-disk config layer or
+// an exported env var. A flag- or prompt-sourced account is process-local: it
+// lives only for this invocation, so an advertised follow-up copied into a new
+// process would fail to resolve it. Call this BEFORE resolveCommentTrigger, so a
+// URL-adopted / interactively-resolved account (AccountID empty at entry) also
+// reads as non-persistent.
+func hasPersistentAccount(cfg *config.Config) bool {
+	if cfg.AccountID == "" {
+		return false
+	}
+	switch cfg.Sources["account_id"] {
+	case string(config.SourceFlag), string(config.SourcePrompt):
+		return false
+	default:
+		return true
+	}
+}
+
 // replyAccountArg returns " --account <id>" to append to an advertised
-// follow-up command when the account was not already in persistent config
-// (adopted from the URL or resolved interactively this run), so the command
-// stays runnable in a fresh process; otherwise "". A persistent account needs no
-// echo — the follow-up inherits it.
-func replyAccountArg(hadConfiguredAccount bool, accountID string) string {
-	if hadConfiguredAccount || accountID == "" {
+// follow-up command when the account is not persistently available (adopted from
+// the URL, resolved interactively, or passed via the process-local --account
+// flag this run), so the command stays runnable in a fresh process; otherwise
+// "". A persistent account needs no echo — the follow-up inherits it.
+func replyAccountArg(persistentAccount bool, accountID string) string {
+	if persistentAccount || accountID == "" {
 		return ""
 	}
 	return " --account " + accountID

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -813,7 +813,11 @@ func threadDisplayProjection(recording map[string]any, recordingFull bool, trigg
 // recordingTitleField extracts a human title from a recording, trying the usual
 // title-bearing fields in order.
 func recordingTitleField(recording map[string]any) string {
-	for _, key := range []string{"title", "name", "subject"} {
+	// `content` is last: title/name/subject-bearing types (message, card,
+	// document) keep those, while types whose title lives in `content` — notably
+	// Todo/Todolist::Todo — fall back to it instead of rendering an empty
+	// headline. Rich-body types are unaffected because they carry a real title.
+	for _, key := range []string{"title", "name", "subject", "content"} {
 		if v := stringField(recording[key]); v != "" {
 			return v
 		}

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/editor"
+	"github.com/basecamp/basecamp-cli/internal/hostutil"
 	"github.com/basecamp/basecamp-cli/internal/output"
 	"github.com/basecamp/basecamp-cli/internal/richtext"
 	"github.com/basecamp/basecamp-cli/internal/urlarg"
@@ -159,17 +160,13 @@ You can pass either a comment ID or a Basecamp URL:
 			}
 
 			app := appctx.FromContext(cmd.Context())
-			if err := ensureAccount(cmd, app); err != nil {
-				return err
-			}
 
-			// Extract comment ID from URL if provided
-			// Uses extractCommentWithProject to prefer CommentID from URL fragments
-			commentIDStr, _ := extractCommentWithProject(args[0])
-
-			commentID, err := strconv.ParseInt(commentIDStr, 10, 64)
+			// Same safe front door as `thread`: classify, guard the account, and
+			// validate the ID — so a plain recording URL or wrong-account URL is
+			// rejected here instead of 404ing or silently targeting elsewhere.
+			commentID, err := resolveCommentTrigger(cmd, app, args[0])
 			if err != nil {
-				return output.ErrUsage("Invalid comment ID")
+				return err
 			}
 
 			comment, err := app.Account().Comments().Get(cmd.Context(), commentID)
@@ -182,16 +179,42 @@ You can pass either a comment ID or a Basecamp URL:
 				creatorName = comment.Creator.Name
 			}
 
-			return app.OK(comment,
+			// Enrich with the two cheap reply atoms — both pure functions of this
+			// single Get, no extra API call. reply_target routes to the parent
+			// recording (comments are flat); mention is a paste-ready author
+			// handle with the same escaped/round-tripping contract as `thread`.
+			// These ride in machine .data only (comment.yaml is untouched); the
+			// reply breadcrumb is the human-output affordance.
+			m, ok := output.NormalizeData(comment).(map[string]any)
+			if !ok || m == nil {
+				// Fail closed — never emit an empty "successful" comment if the
+				// normalized shape is unexpectedly not a map.
+				return &output.Error{
+					Code:    output.CodeAPI,
+					Message: fmt.Sprintf("Could not render comment #%d", commentID),
+				}
+			}
+			m["mention"] = buildFocusAuthor(comment.Creator)["mention"]
+
+			breadcrumbs := make([]output.Breadcrumb, 0, 2)
+			breadcrumbs = append(breadcrumbs, output.Breadcrumb{
+				Action:      "update",
+				Cmd:         fmt.Sprintf("basecamp comments update %d <text>", commentID),
+				Description: "Update comment",
+			})
+			if comment.Parent != nil && comment.Parent.ID != 0 {
+				m["reply_target"] = map[string]any{"recording_id": comment.Parent.ID}
+				breadcrumbs = append(breadcrumbs, output.Breadcrumb{
+					Action:      "reply",
+					Cmd:         fmt.Sprintf("basecamp comments create %d <text>", comment.Parent.ID),
+					Description: "Reply on the parent recording",
+				})
+			}
+
+			return app.OK(m,
 				output.WithEntity("comment"),
-				output.WithSummary(fmt.Sprintf("Comment #%s by %s", commentIDStr, creatorName)),
-				output.WithBreadcrumbs(
-					output.Breadcrumb{
-						Action:      "update",
-						Cmd:         fmt.Sprintf("basecamp comments update %s <text>", commentIDStr),
-						Description: "Update comment",
-					},
-				),
+				output.WithSummary(fmt.Sprintf("Comment #%d by %s", commentID, creatorName)),
+				output.WithBreadcrumbs(breadcrumbs...),
 			)
 		},
 	}
@@ -247,28 +270,13 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 		effectiveWindow = window
 	}
 
-	// Require an exact comment trigger before any API call — a plain recording
-	// URL or collection is rejected with a pointer to `basecamp show`.
-	triggerIDStr, urlAccountID, err := commentTriggerID(arg)
+	// Classify + guard + validate through the one shared front door, so `thread`
+	// and `comments show` are equally safe: a plain recording URL / collection is
+	// rejected toward `basecamp show`, a wrong-account URL and a non-positive ID
+	// are rejected before any API call.
+	triggerID, err := resolveCommentTrigger(cmd, app, arg)
 	if err != nil {
 		return err
-	}
-
-	// Guard against resolving a same-numbered comment in the wrong account: a
-	// URL names its account, and if it disagrees with the configured one the
-	// safe move is to stop rather than silently target a different account (and
-	// build a reply target that points elsewhere). Rejects before any API call.
-	if urlAccountID != "" && app.Config.AccountID != "" && urlAccountID != app.Config.AccountID {
-		return output.ErrUsage(fmt.Sprintf("URL account %s does not match the configured account %s", urlAccountID, app.Config.AccountID))
-	}
-
-	if err := ensureAccount(cmd, app); err != nil {
-		return err
-	}
-
-	triggerID, err := strconv.ParseInt(triggerIDStr, 10, 64)
-	if err != nil {
-		return output.ErrUsage("Invalid comment ID")
 	}
 
 	// Step 1 — resolve the focus comment.
@@ -311,10 +319,11 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 	author := buildFocusAuthor(trigger.Creator)
 
 	focus := map[string]any{
-		"comment_id": trigger.ID,
-		"created_at": trigger.CreatedAt.Format(time.RFC3339),
-		"content":    trigger.Content,
-		"author":     author,
+		"comment_id":          trigger.ID,
+		"created_at":          trigger.CreatedAt.Format(time.RFC3339),
+		"content":             trigger.Content,
+		"author":              author,
+		"content_attachments": trigger.ContentAttachments,
 	}
 
 	data := map[string]any{
@@ -332,22 +341,61 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 		data["recording_ref"] = recording
 	}
 
-	display := threadDisplayProjection(recording, recordingFull, trigger)
+	focusPresent := focusIdx >= 0
+	fetchComplete := !listResult.Meta.Truncated
+
+	focusMention := ""
+	if m, ok := author["mention"].(map[string]any); ok {
+		if s, ok := m["syntax"].(string); ok {
+			focusMention = s
+		}
+	}
+	display := threadDisplayProjection(recording, recordingFull, trigger, focusMention)
+
+	// Breadcrumbs: a type-safe attachment download (when the focus carries
+	// files) comes first; the reply target is always last. The typed
+	// `--type comment` form is built inline — the generic attachmentBreadcrumb
+	// omits it, and a bare recording lookup 204/404s for comments.
+	breadcrumbs := make([]output.Breadcrumb, 0, 2)
+	if len(trigger.ContentAttachments) > 0 {
+		breadcrumbs = append(breadcrumbs, output.Breadcrumb{
+			Action:      "download",
+			Cmd:         fmt.Sprintf("basecamp attachments download %d --type comment", trigger.ID),
+			Description: "Download comment attachments",
+		})
+	}
+	breadcrumbs = append(breadcrumbs, output.Breadcrumb{
+		Action:      "reply",
+		Cmd:         fmt.Sprintf("basecamp comments create %s <text>", parentIDStr),
+		Description: "Reply on the parent recording",
+	})
 
 	respOpts := []output.ResponseOption{
 		output.WithEntity("comment_thread"),
 		output.WithDisplayData(display),
-		output.WithSummary(threadSummary(trigger, author, len(selected))),
-		output.WithBreadcrumbs(output.Breadcrumb{
-			Action:      "reply",
-			Cmd:         fmt.Sprintf("basecamp comments create %s <text>", parentIDStr),
-			Description: "Reply on the parent recording",
-		}),
+		output.WithSummary(threadSummary(trigger, author, len(selected), len(fetched), selection, fetchComplete, focusPresent)),
+		output.WithBreadcrumbs(breadcrumbs...),
+	}
+
+	// One combined notice: WithNotice overwrites, so collect fragments and emit
+	// them together. States facts only — focus absence and truncation — never
+	// speculation about archived/trashed/deleted comments.
+	var notices []string
+	if !focusPresent {
+		if all {
+			notices = append(notices, fmt.Sprintf(
+				"Focus comment is not present in the fetched active discussion; showing all %d fetched comments.", len(selected)))
+		} else {
+			notices = append(notices, fmt.Sprintf(
+				"Focus comment is not present in the fetched active discussion; showing the most recent %d fetched comments.", len(selected)))
+		}
 	}
 	if listResult.Meta.Truncated {
-		respOpts = append(respOpts, output.WithNotice(
-			"Discussion truncated: more comments exist on the server than were fetched. "+
-				"\"all\"/\"most recent\" cover the fetched subset only."))
+		notices = append(notices, "Discussion truncated: more comments exist on the server than were fetched. "+
+			"\"all\"/\"most recent\" cover the fetched subset only.")
+	}
+	if len(notices) > 0 {
+		respOpts = append(respOpts, output.WithNotice(strings.Join(notices, " ")))
 	}
 
 	return app.OK(data, respOpts...)
@@ -376,6 +424,53 @@ func commentTriggerID(arg string) (id, accountID string, err error) {
 		"Pass a comment ID or a comment URL (with a #__recording_… fragment). "+
 			"For the recording itself, use: basecamp show <url>",
 	)
+}
+
+// resolveCommentTrigger is the single safe front door both `comments thread` and
+// `comments show` use to turn an argument into a validated comment ID. It
+// enforces every trust-boundary check before any API call — trusted host,
+// exact-comment classification, a positive ID, and URL/account identity — so the
+// cheaper `show` is no less trustworthy than the deep `thread`.
+func resolveCommentTrigger(cmd *cobra.Command, app *appctx.App, arg string) (int64, error) {
+	// A URL-shaped trigger must live on a trusted Basecamp host. The URL router
+	// is host-agnostic, so without this a look-alike on an attacker-controlled
+	// host (evil.example/…/comments/456) would be parsed into a fetch of an
+	// internal comment — the confused-deputy case hostutil exists to prevent.
+	// Bare IDs are not URLs and skip the check.
+	if urlarg.IsURL(arg) && !hostutil.IsTrustedBasecampHost(arg, app.Config.BaseURL) {
+		return 0, output.ErrUsage("refusing untrusted host in URL — expected a Basecamp URL")
+	}
+
+	triggerIDStr, urlAccountID, err := commentTriggerID(arg)
+	if err != nil {
+		return 0, err
+	}
+
+	// Validate the ID before any account resolution, so a bad ID fails as
+	// "Invalid comment ID" with zero requests even when no account is configured
+	// (ensureAccount would otherwise demand --account first).
+	id, err := strconv.ParseInt(triggerIDStr, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, output.ErrUsage("Invalid comment ID")
+	}
+
+	// Reconcile the URL's account with configuration before ensureAccount, so the
+	// URL's identity governs the fetch rather than an interactively-selected
+	// account: adopt it when nothing is configured, reject a configured mismatch
+	// rather than silently fetch a same-numbered comment elsewhere.
+	if urlAccountID != "" {
+		switch {
+		case app.Config.AccountID == "":
+			app.Config.AccountID = urlAccountID
+		case urlAccountID != app.Config.AccountID:
+			return 0, output.ErrUsage(fmt.Sprintf("URL account %s does not match the configured account %s", urlAccountID, app.Config.AccountID))
+		}
+	}
+
+	if err := ensureAccount(cmd, app); err != nil {
+		return 0, err
+	}
+	return id, nil
 }
 
 // fetchThreadParent loads the full parent recording using a type-derived
@@ -423,6 +518,14 @@ func fetchThreadParent(cmd *cobra.Command, app *appctx.App, parent *basecamp.Par
 		return nil, false, &output.Error{
 			Code:    output.CodeAPI,
 			Message: fmt.Sprintf("Could not decode parent recording %s: %v", parentIDStr, err),
+		}
+	}
+	// A JSON null or {} decodes to an empty map — never claim recording_full over
+	// nothing. Hard-error instead of emitting an empty recording.
+	if len(recording) == 0 {
+		return nil, false, &output.Error{
+			Code:    output.CodeAPI,
+			Message: fmt.Sprintf("Parent recording %s returned an empty body", parentIDStr),
 		}
 	}
 	return recording, true, nil
@@ -601,7 +704,7 @@ func markdownEscape(s string) string {
 // threadDisplayProjection builds the flat projection consumed by the
 // comment_thread schema. Presenter schemas read direct keys, not nested
 // recording.*/focus.*, so this is distinct from the structured .data.
-func threadDisplayProjection(recording map[string]any, recordingFull bool, trigger *basecamp.Comment) map[string]any {
+func threadDisplayProjection(recording map[string]any, recordingFull bool, trigger *basecamp.Comment, focusMention string) map[string]any {
 	authorName := ""
 	if trigger.Creator != nil {
 		authorName = trigger.Creator.Name
@@ -619,6 +722,7 @@ func threadDisplayProjection(recording map[string]any, recordingFull bool, trigg
 		"recording_full":        recordingFull,
 		"focus_comment_id":      trigger.ID,
 		"focus_author":          richtext.SanitizeSingleLine(authorName),
+		"focus_mention":         focusMention,
 		"focus_created_at":      trigger.CreatedAt.Format(time.RFC3339),
 		"focus_content":         trigger.Content,
 	}
@@ -650,13 +754,34 @@ func stringField(v any) string {
 	}
 }
 
-// threadSummary is the one-line human summary for the thread response.
-func threadSummary(trigger *basecamp.Comment, author map[string]any, returned int) string {
+// threadSummary is the one-line human summary for the thread response. It is a
+// pure function of the discussion facts (selection, returned, fetched,
+// fetch_complete, focus_present) over the full fetch_complete × focus_present ×
+// selection cube, so it never asserts a server-side total the fetch did not
+// confirm and never claims to center "around the focus" when the focus is absent.
+func threadSummary(trigger *basecamp.Comment, author map[string]any, returned, fetched int, selection string, fetchComplete, focusPresent bool) string {
 	name, _ := author["name"].(string)
 	if name == "" {
 		name = "unknown"
 	}
-	return fmt.Sprintf("Comment #%d by %s — %d in discussion", trigger.ID, name, returned)
+	prefix := fmt.Sprintf("Comment #%d by %s — ", trigger.ID, name)
+
+	var body string
+	switch {
+	case selection == "all_fetched" && fetchComplete:
+		body = fmt.Sprintf("all %d active comments", fetched)
+	case selection == "all_fetched":
+		body = fmt.Sprintf("all %d fetched active comments; fetch incomplete", fetched)
+	case focusPresent && fetchComplete:
+		body = fmt.Sprintf("showing %d of %d active comments around the focus", returned, fetched)
+	case focusPresent:
+		body = fmt.Sprintf("showing %d around the focus from %d fetched active comments; more exist on server", returned, fetched)
+	case fetchComplete:
+		body = fmt.Sprintf("showing the %d most recent of %d active comments", returned, fetched)
+	default:
+		body = fmt.Sprintf("showing the %d most recent within the fetched subset (%d fetched)", returned, fetched)
+	}
+	return prefix + body
 }
 
 func newCommentsUpdateCmd() *cobra.Command {

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -1,12 +1,17 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +21,7 @@ import (
 	"github.com/basecamp/basecamp-cli/internal/editor"
 	"github.com/basecamp/basecamp-cli/internal/output"
 	"github.com/basecamp/basecamp-cli/internal/richtext"
+	"github.com/basecamp/basecamp-cli/internal/urlarg"
 )
 
 // NewCommentsCmd creates the comments command group (list/show/update).
@@ -35,6 +41,7 @@ func NewCommentsCmd() *cobra.Command {
 	cmd.AddCommand(
 		newCommentsListCmd(),
 		newCommentsShowCmd(),
+		newCommentsThreadCmd(),
 		newCommentsCreateCmd(),
 		newCommentsUpdateCmd(),
 		newRecordableTrashCmd("comment"),
@@ -189,6 +196,467 @@ You can pass either a comment ID or a Basecamp URL:
 		},
 	}
 	return cmd
+}
+
+// defaultCommentThreadWindow is the default maximum number of comments returned
+// by `comments thread` when neither --all nor --window is given. Focus-centered:
+// (N-1)/2 older, the focus, and the remainder newer.
+const defaultCommentThreadWindow = 41
+
+func newCommentsThreadCmd() *cobra.Command {
+	var all bool
+	var window int
+
+	cmd := &cobra.Command{
+		Use:   "thread <comment-id|comment-url>",
+		Short: "Show a comment with its discussion, ready to reply",
+		Long: `Show a comment together with its parent recording and the surrounding
+discussion, plus a ready-to-use reply target and author @mention.
+
+The argument must identify a specific comment — a bare comment ID, a comment
+fragment URL (…#__recording_789), or a direct comment URL. A plain recording
+URL is rejected; use ` + "`basecamp show`" + ` for the recording itself.
+
+By default the discussion is a window of up to 41 comments centered on the
+focus. Use --window N to change the size or --all to return every fetched
+comment. Selection bounds the output, never the fetch.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCommentsThread(cmd, args[0], all, window)
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Return every fetched comment instead of a window")
+	cmd.Flags().IntVar(&window, "window", 0, "Maximum comments to return, centered on the focus (default 41)")
+
+	return cmd
+}
+
+func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) error {
+	app := appctx.FromContext(cmd.Context())
+
+	windowSet := cmd.Flags().Changed("window")
+	if all && windowSet {
+		return output.ErrUsage("--all and --window are mutually exclusive")
+	}
+	if windowSet && window <= 0 {
+		return output.ErrUsage("--window must be a positive number")
+	}
+	effectiveWindow := defaultCommentThreadWindow
+	if windowSet {
+		effectiveWindow = window
+	}
+
+	// Require an exact comment trigger before any API call — a plain recording
+	// URL or collection is rejected with a pointer to `basecamp show`.
+	triggerIDStr, urlAccountID, err := commentTriggerID(arg)
+	if err != nil {
+		return err
+	}
+
+	// Guard against resolving a same-numbered comment in the wrong account: a
+	// URL names its account, and if it disagrees with the configured one the
+	// safe move is to stop rather than silently target a different account (and
+	// build a reply target that points elsewhere). Rejects before any API call.
+	if urlAccountID != "" && app.Config.AccountID != "" && urlAccountID != app.Config.AccountID {
+		return output.ErrUsage(fmt.Sprintf("URL account %s does not match the configured account %s", urlAccountID, app.Config.AccountID))
+	}
+
+	if err := ensureAccount(cmd, app); err != nil {
+		return err
+	}
+
+	triggerID, err := strconv.ParseInt(triggerIDStr, 10, 64)
+	if err != nil {
+		return output.ErrUsage("Invalid comment ID")
+	}
+
+	// Step 1 — resolve the focus comment.
+	trigger, err := app.Account().Comments().Get(cmd.Context(), triggerID)
+	if err != nil {
+		return convertSDKError(err)
+	}
+
+	// Step 2 — reply target + parent safety. A reply routes to the parent
+	// recording, never to the comment; without a parent it cannot be built.
+	if trigger.Parent == nil || trigger.Parent.ID == 0 {
+		return &output.Error{
+			Code:    output.CodeAPI,
+			Message: fmt.Sprintf("Comment #%d has no parent recording; cannot build a reply target", triggerID),
+			Hint:    "This usually means the comment was returned without its parent. Try `basecamp comments show`.",
+		}
+	}
+	parentID := trigger.Parent.ID
+	parentIDStr := strconv.FormatInt(parentID, 10)
+
+	// Step 3 — full parent recording, via a server-derived endpoint (never the
+	// parent's URL field, which could point off-origin).
+	recording, recordingFull, err := fetchThreadParent(cmd, app, trigger.Parent)
+	if err != nil {
+		return err
+	}
+
+	// Step 4 — truthful discussion window over the active comments.
+	listResult, err := app.Account().Comments().List(cmd.Context(), parentID, &basecamp.CommentListOptions{Limit: -1})
+	if err != nil {
+		return convertSDKError(err)
+	}
+	fetched := sortCommentsChronologically(listResult.Comments)
+	focusIdx := commentIndexByID(fetched, trigger.ID)
+	selected, selection := selectCommentWindow(fetched, focusIdx, all, effectiveWindow)
+
+	meta := buildCommentsMeta(len(fetched), len(selected), selection, focusIdx >= 0, listResult.Meta)
+
+	// Step 5 — reply-ready, escaped author handle.
+	author := buildFocusAuthor(trigger.Creator)
+
+	focus := map[string]any{
+		"comment_id": trigger.ID,
+		"created_at": trigger.CreatedAt.Format(time.RFC3339),
+		"content":    trigger.Content,
+		"author":     author,
+	}
+
+	data := map[string]any{
+		"recording_full": recordingFull,
+		"focus":          focus,
+		"comments":       selected,
+		"comments_meta":  meta,
+		"reply_target":   map[string]any{"recording_id": parentID},
+	}
+	// A fully-fetched parent is `recording`; a sparse ref (unmapped type) is
+	// `recording_ref` so consumers can tell the two apart.
+	if recordingFull {
+		data["recording"] = recording
+	} else {
+		data["recording_ref"] = recording
+	}
+
+	display := threadDisplayProjection(recording, recordingFull, trigger)
+
+	respOpts := []output.ResponseOption{
+		output.WithEntity("comment_thread"),
+		output.WithDisplayData(display),
+		output.WithSummary(threadSummary(trigger, author, len(selected))),
+		output.WithBreadcrumbs(output.Breadcrumb{
+			Action:      "reply",
+			Cmd:         fmt.Sprintf("basecamp comments create %s <text>", parentIDStr),
+			Description: "Reply on the parent recording",
+		}),
+	}
+	if listResult.Meta.Truncated {
+		respOpts = append(respOpts, output.WithNotice(
+			"Discussion truncated: more comments exist on the server than were fetched. "+
+				"\"all\"/\"most recent\" cover the fetched subset only."))
+	}
+
+	return app.OK(data, respOpts...)
+}
+
+// commentTriggerID classifies the argument and returns an exact comment ID plus
+// the account named by the URL (empty for a bare ID). It accepts a bare comment
+// ID, a comment fragment URL (…#__recording_789), or a direct comment URL
+// (/comments/789). A plain recording URL or collection URL is rejected — the
+// plain-URL extractor would silently collapse it to a recording ID, which is
+// exactly the mistake this command must not make.
+func commentTriggerID(arg string) (id, accountID string, err error) {
+	parsed := urlarg.Parse(arg)
+	if parsed == nil {
+		// Not a URL — treat as a bare comment ID (validated by ParseInt later).
+		return arg, "", nil
+	}
+	if parsed.CommentID != "" {
+		return parsed.CommentID, parsed.AccountID, nil
+	}
+	if parsed.Type == "comments" && parsed.RecordingID != "" && !parsed.IsCollection {
+		return parsed.RecordingID, parsed.AccountID, nil
+	}
+	return "", "", output.ErrUsageHint(
+		"That URL points to a recording, not a comment",
+		"Pass a comment ID or a comment URL (with a #__recording_… fragment). "+
+			"For the recording itself, use: basecamp show <url>",
+	)
+}
+
+// fetchThreadParent loads the full parent recording using a type-derived
+// endpoint. A mapped type that then fails to fetch, returns 204, or fails to
+// decode is a hard error — never a silent degrade. Only an unmapped or
+// contextual-without-parent type (endpoint "") returns a sparse ref built from
+// the parent fields, with recordingFull=false.
+func fetchThreadParent(cmd *cobra.Command, app *appctx.App, parent *basecamp.Parent) (map[string]any, bool, error) {
+	parentIDStr := strconv.FormatInt(parent.ID, 10)
+	parentData := map[string]any{
+		"type": parent.Type,
+		"id":   parent.ID,
+		"url":  parent.URL,
+	}
+	endpoint := recordingTypeEndpoint(parentData, parentIDStr)
+	if endpoint == "" {
+		ref := map[string]any{
+			"id":   parent.ID,
+			"type": parent.Type,
+			"url":  parent.URL,
+		}
+		if parent.Title != "" {
+			ref["title"] = parent.Title
+		}
+		return ref, false, nil
+	}
+
+	resp, err := app.Account().Get(cmd.Context(), endpoint)
+	if err != nil {
+		return nil, false, convertSDKError(err)
+	}
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, false, &output.Error{
+			Code:       output.CodeAPI,
+			Message:    fmt.Sprintf("Parent recording %s returned no content", parentIDStr),
+			HTTPStatus: resp.StatusCode,
+		}
+	}
+
+	// UseNumber preserves int64 IDs (> 2^53) through the map round-trip.
+	var recording map[string]any
+	dec := json.NewDecoder(bytes.NewReader(resp.Data))
+	dec.UseNumber()
+	if err := dec.Decode(&recording); err != nil {
+		return nil, false, &output.Error{
+			Code:    output.CodeAPI,
+			Message: fmt.Sprintf("Could not decode parent recording %s: %v", parentIDStr, err),
+		}
+	}
+	return recording, true, nil
+}
+
+// sortCommentsChronologically returns the comments sorted by created_at
+// ascending, then id ascending. The API guarantees no order, so we never trust
+// the received sequence.
+func sortCommentsChronologically(comments []basecamp.Comment) []basecamp.Comment {
+	sorted := make([]basecamp.Comment, len(comments))
+	copy(sorted, comments)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].CreatedAt.Equal(sorted[j].CreatedAt) {
+			return sorted[i].ID < sorted[j].ID
+		}
+		return sorted[i].CreatedAt.Before(sorted[j].CreatedAt)
+	})
+	return sorted
+}
+
+// commentIndexByID returns the index of the comment with the given ID, or -1.
+func commentIndexByID(comments []basecamp.Comment, id int64) int {
+	for i := range comments {
+		if comments[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// selectCommentWindow chooses which comments to return. --all returns every
+// fetched comment. Otherwise it returns a window of at most `window` comments:
+// centered on the focus when present ((N-1)/2 older, the focus, the rest newer,
+// with unused capacity shifted toward the other side at either boundary), or the
+// most-recent N when the focus is absent from the fetched set.
+func selectCommentWindow(comments []basecamp.Comment, focusIdx int, all bool, window int) ([]basecamp.Comment, string) {
+	if all {
+		return comments, "all_fetched"
+	}
+
+	n := window
+	if n > len(comments) {
+		n = len(comments)
+	}
+	if n <= 0 {
+		return []basecamp.Comment{}, "focus_window"
+	}
+
+	// Focus absent → most-recent N (the tail of the chronological list).
+	if focusIdx < 0 {
+		return comments[len(comments)-n:], "focus_window"
+	}
+
+	before := (n - 1) / 2
+	after := n - 1 - before
+	start := focusIdx - before
+	end := focusIdx + after // inclusive
+
+	// Shift unused capacity toward the other side at each boundary.
+	if start < 0 {
+		end += -start
+		start = 0
+	}
+	if last := len(comments) - 1; end > last {
+		start -= end - last
+		end = last
+	}
+	if start < 0 {
+		start = 0
+	}
+	return comments[start : end+1], "focus_window"
+}
+
+// buildCommentsMeta assembles the facts-only comments_meta object.
+func buildCommentsMeta(fetched, returned int, selection string, focusPresent bool, meta basecamp.ListMeta) map[string]any {
+	m := map[string]any{
+		"scope":                    "active",
+		"fetched":                  fetched,
+		"returned":                 returned,
+		"selection":                selection,
+		"order":                    "created_at_asc_id_asc",
+		"focus_in_active_comments": focusPresent,
+		"fetch_complete":           !meta.Truncated,
+		"api_truncated":            meta.Truncated,
+	}
+	// TotalCount is 0 when the X-Total-Count header was absent — never treat 0
+	// as an authoritative total.
+	if meta.TotalCount > 0 {
+		m["total"] = meta.TotalCount
+		m["total_known"] = true
+	} else {
+		m["total"] = nil
+		m["total_known"] = false
+	}
+	return m
+}
+
+// buildFocusAuthor builds the reply-ready author handle. The @mention label is
+// SanitizeSingleLine'd first (drops newlines/terminal controls) then
+// Markdown-escaped, so a hostile name can neither break the terminal nor the
+// [@name](scheme:value) link syntax.
+func buildFocusAuthor(creator *basecamp.Person) map[string]any {
+	if creator == nil {
+		return map[string]any{
+			"id":      nil,
+			"name":    "",
+			"mention": unavailableMention(),
+		}
+	}
+
+	author := map[string]any{
+		"id":   creator.ID,
+		"name": creator.Name,
+	}
+
+	label := markdownEscape(richtext.SanitizeSingleLine(creator.Name))
+	switch {
+	case label == "":
+		author["mention"] = unavailableMention()
+	case creator.AttachableSGID != "":
+		author["mention"] = map[string]any{
+			"syntax":          fmt.Sprintf("[@%s](mention:%s)", label, creator.AttachableSGID),
+			"resolution":      "embedded_sgid",
+			"requires_lookup": false,
+		}
+	case creator.ID > 0:
+		// A positive person ID with no embedded SGID resolves via one lookup at
+		// reply time — not labeled non-pingable, which we don't verify here.
+		author["mention"] = map[string]any{
+			"syntax":          fmt.Sprintf("[@%s](person:%d)", label, creator.ID),
+			"resolution":      "person_lookup",
+			"requires_lookup": true,
+		}
+	default:
+		author["mention"] = unavailableMention()
+	}
+	return author
+}
+
+func unavailableMention() map[string]any {
+	return map[string]any{
+		"syntax":          nil,
+		"resolution":      "unavailable",
+		"requires_lookup": false,
+	}
+}
+
+// markdownEscape backslash-escapes Markdown metacharacters so an author name is
+// safe inside a [@name](scheme:value) mention link and cannot inject emphasis,
+// links, or raw HTML. Newlines/terminal controls are handled separately by
+// SanitizeSingleLine, which must run first.
+func markdownEscape(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"{", "\\{",
+		"}", "\\}",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+		"<", "\\<",
+		">", "\\>",
+		"#", "\\#",
+		"+", "\\+",
+		"-", "\\-",
+		"!", "\\!",
+		"|", "\\|",
+		"~", "\\~",
+	)
+	return replacer.Replace(s)
+}
+
+// threadDisplayProjection builds the flat projection consumed by the
+// comment_thread schema. Presenter schemas read direct keys, not nested
+// recording.*/focus.*, so this is distinct from the structured .data.
+func threadDisplayProjection(recording map[string]any, recordingFull bool, trigger *basecamp.Comment) map[string]any {
+	authorName := ""
+	if trigger.Creator != nil {
+		authorName = trigger.Creator.Name
+	}
+	// The projection feeds the human renderer, so single-line detail fields
+	// (author, type) are collapsed to one line here — the presenter's text
+	// format strips terminal escapes but preserves newlines, which would break
+	// the row layout. The machine contract keeps these values raw.
+	return map[string]any{
+		"recording_id":          stringField(recording["id"]),
+		"recording_type":        richtext.SanitizeSingleLine(stringField(recording["type"])),
+		"recording_title":       recordingTitleField(recording),
+		"recording_content":     stringField(recording["content"]),
+		"recording_description": stringField(recording["description"]),
+		"recording_full":        recordingFull,
+		"focus_comment_id":      trigger.ID,
+		"focus_author":          richtext.SanitizeSingleLine(authorName),
+		"focus_created_at":      trigger.CreatedAt.Format(time.RFC3339),
+		"focus_content":         trigger.Content,
+	}
+}
+
+// recordingTitleField extracts a human title from a recording, trying the usual
+// title-bearing fields in order.
+func recordingTitleField(recording map[string]any) string {
+	for _, key := range []string{"title", "name", "subject"} {
+		if v := stringField(recording[key]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// stringField renders a decoded JSON value as a string. IDs decoded with
+// UseNumber arrive as json.Number; everything else is best-effort.
+func stringField(v any) string {
+	switch val := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return val
+	case json.Number:
+		return val.String()
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+// threadSummary is the one-line human summary for the thread response.
+func threadSummary(trigger *basecamp.Comment, author map[string]any, returned int) string {
+	name, _ := author["name"].(string)
+	if name == "" {
+		name = "unknown"
+	}
+	return fmt.Sprintf("Comment #%d by %s — %d in discussion", trigger.ID, name, returned)
 }
 
 func newCommentsUpdateCmd() *cobra.Command {

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -313,6 +313,18 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 		return convertSDKError(err)
 	}
 
+	// Guard an empty/zero focus before dereferencing it — a nil or all-zero
+	// comment (empty API response or a deserialization regression) would panic on
+	// trigger.Parent or misreport the zero value as a real comment missing its
+	// parent. A real comment always has a positive ID. Mirrors `comments show`.
+	if trigger == nil || trigger.ID == 0 {
+		return &output.Error{
+			Code:    "empty_response",
+			Message: "API returned empty data",
+			Hint:    "The response contained no comment. This may indicate a deserialization issue.",
+		}
+	}
+
 	// Step 2 — reply target + parent safety. A reply routes to the parent
 	// recording, never to the comment; without a parent it cannot be built.
 	if trigger.Parent == nil || trigger.Parent.ID == 0 {

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -161,6 +161,12 @@ You can pass either a comment ID or a Basecamp URL:
 
 			app := appctx.FromContext(cmd.Context())
 
+			// Whether the account was already in persistent config (flag/env/file)
+			// before resolution. When it wasn't — adopted from the URL or resolved
+			// interactively — the advertised follow-ups must spell out --account so
+			// they remain runnable in a fresh process.
+			hadConfiguredAccount := app.Config.AccountID != ""
+
 			// Same safe front door as `thread`: classify, guard the account, and
 			// validate the ID — so a plain recording URL or wrong-account URL is
 			// rejected here instead of 404ing or silently targeting elsewhere.
@@ -168,10 +174,24 @@ You can pass either a comment ID or a Basecamp URL:
 			if err != nil {
 				return err
 			}
+			accountArg := replyAccountArg(hadConfiguredAccount, app.Config.AccountID)
 
 			comment, err := app.Account().Comments().Get(cmd.Context(), commentID)
 			if err != nil {
 				return convertSDKError(err)
+			}
+
+			// Guard an empty/zero comment before enrichment. app.OK's checkZeroData
+			// rejects an all-zero recording, but the non-empty mention map we add
+			// below would mask it — reporting a bogus success (comment #0, empty
+			// content) instead of empty_response. A real comment always has a
+			// positive ID.
+			if comment == nil || comment.ID == 0 {
+				return &output.Error{
+					Code:    "empty_response",
+					Message: "API returned empty data",
+					Hint:    "The response contained no comment. This may indicate a deserialization issue.",
+				}
 			}
 
 			creatorName := ""
@@ -199,14 +219,14 @@ You can pass either a comment ID or a Basecamp URL:
 			breadcrumbs := make([]output.Breadcrumb, 0, 2)
 			breadcrumbs = append(breadcrumbs, output.Breadcrumb{
 				Action:      "update",
-				Cmd:         fmt.Sprintf("basecamp comments update %d <text>", commentID),
+				Cmd:         fmt.Sprintf("basecamp comments update %d <text>%s", commentID, accountArg),
 				Description: "Update comment",
 			})
 			if comment.Parent != nil && comment.Parent.ID != 0 {
-				m["reply_target"] = map[string]any{"recording_id": comment.Parent.ID}
+				m["reply_target"] = replyTarget(comment.Parent.ID, app.Config.AccountID)
 				breadcrumbs = append(breadcrumbs, output.Breadcrumb{
 					Action:      "reply",
-					Cmd:         fmt.Sprintf("basecamp comments create %d <text>", comment.Parent.ID),
+					Cmd:         fmt.Sprintf("basecamp comments create %d <text>%s", comment.Parent.ID, accountArg),
 					Description: "Reply on the parent recording",
 				})
 			}
@@ -274,10 +294,15 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 	// and `comments show` are equally safe: a plain recording URL / collection is
 	// rejected toward `basecamp show`, a wrong-account URL and a non-positive ID
 	// are rejected before any API call.
+	hadConfiguredAccount := app.Config.AccountID != ""
 	triggerID, err := resolveCommentTrigger(cmd, app, arg)
 	if err != nil {
 		return err
 	}
+	// When the account was adopted from the URL (or resolved interactively) rather
+	// than already configured, the advertised follow-ups must carry --account so
+	// they stay runnable in a fresh process.
+	accountArg := replyAccountArg(hadConfiguredAccount, app.Config.AccountID)
 
 	// Step 1 — resolve the focus comment.
 	trigger, err := app.Account().Comments().Get(cmd.Context(), triggerID)
@@ -331,7 +356,7 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 		"focus":          focus,
 		"comments":       selected,
 		"comments_meta":  meta,
-		"reply_target":   map[string]any{"recording_id": parentID},
+		"reply_target":   replyTarget(parentID, app.Config.AccountID),
 	}
 	// A fully-fetched parent is `recording`; a sparse ref (unmapped type) is
 	// `recording_ref` so consumers can tell the two apart.
@@ -360,13 +385,13 @@ func runCommentsThread(cmd *cobra.Command, arg string, all bool, window int) err
 	if len(trigger.ContentAttachments) > 0 {
 		breadcrumbs = append(breadcrumbs, output.Breadcrumb{
 			Action:      "download",
-			Cmd:         fmt.Sprintf("basecamp attachments download %d --type comment", trigger.ID),
+			Cmd:         fmt.Sprintf("basecamp attachments download %d --type comment%s", trigger.ID, accountArg),
 			Description: "Download comment attachments",
 		})
 	}
 	breadcrumbs = append(breadcrumbs, output.Breadcrumb{
 		Action:      "reply",
-		Cmd:         fmt.Sprintf("basecamp comments create %s <text>", parentIDStr),
+		Cmd:         fmt.Sprintf("basecamp comments create %s <text>%s", parentIDStr, accountArg),
 		Description: "Reply on the parent recording",
 	})
 
@@ -471,6 +496,29 @@ func resolveCommentTrigger(cmd *cobra.Command, app *appctx.App, arg string) (int
 		return 0, err
 	}
 	return id, nil
+}
+
+// replyAccountArg returns " --account <id>" to append to an advertised
+// follow-up command when the account was not already in persistent config
+// (adopted from the URL or resolved interactively this run), so the command
+// stays runnable in a fresh process; otherwise "". A persistent account needs no
+// echo — the follow-up inherits it.
+func replyAccountArg(hadConfiguredAccount bool, accountID string) string {
+	if hadConfiguredAccount || accountID == "" {
+		return ""
+	}
+	return " --account " + accountID
+}
+
+// replyTarget builds the machine reply-target contract: the parent recording to
+// reply on, plus the account it belongs to so a consumer can construct a
+// fully-qualified reply regardless of its own configuration.
+func replyTarget(recordingID int64, accountID string) map[string]any {
+	rt := map[string]any{"recording_id": recordingID}
+	if accountID != "" {
+		rt["account_id"] = accountID
+	}
+	return rt
 }
 
 // fetchThreadParent loads the full parent recording using a type-derived

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -188,4 +189,212 @@ func (t *mockCommentWriteTransport) RoundTrip(req *http.Request) (*http.Response
 		Body:       io.NopCloser(strings.NewReader(`{"id":1234,"content":"ok","status":"active"}`)),
 		Header:     header,
 	}, nil
+}
+
+// --- Iteration 2: comments show reply-atom enrichment -----------------------
+
+// runCommentsShow executes `comments show` against a tracking transport and
+// returns stdout/stderr plus the run error, mirroring runThreadCmd.
+func runCommentsShow(t *testing.T, transport *showTrackingTransport, format output.Format, args ...string) (string, string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, format, stdout, stderr)
+	app.Flags.Hints = true
+	cmd := NewCommentsCmd()
+	full := append([]string{"show"}, args...)
+	cmd.SetArgs(full)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func showCommentResponder(commentJSON string) func(path string) (int, string, http.Header) {
+	return func(_ string) (int, string, http.Header) {
+		return 200, commentJSON, nil
+	}
+}
+
+func TestCommentsShowEnrichesReplyAtoms(t *testing.T) {
+	comment := map[string]any{
+		"id": 456, "type": "Comment", "content": "<p>hi</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": 123, "type": "Todo", "url": "https://x/y"},
+		"creator":    map[string]any{"id": 7, "name": "Jane Doe", "attachable_sgid": "SGID123"},
+	}
+	cb, _ := json.Marshal(comment)
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(string(cb))}
+
+	stdout, _, err := runCommentsShow(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+
+	var env threadEnvelope
+	require.NoError(t, json.Unmarshal([]byte(stdout), &env))
+
+	// reply_target.recording_id == parent.id — the smoke invariant.
+	replyTarget := env.Data["reply_target"].(map[string]any)
+	parent := env.Data["parent"].(map[string]any)
+	assert.EqualValues(t, parent["id"], replyTarget["recording_id"])
+	assert.EqualValues(t, 123, replyTarget["recording_id"])
+
+	// Paste-ready mention rides in machine .data.
+	mention := env.Data["mention"].(map[string]any)
+	assert.Equal(t, "[@Jane Doe](mention:SGID123)", mention["syntax"])
+
+	// Exactly one request — no parent or list fetch.
+	assert.Len(t, transport.getRequests(), 1)
+
+	// The reply breadcrumb is the human-output affordance: update first, reply
+	// last, targeting the parent recording.
+	require.Len(t, env.Breadcrumbs, 2)
+	assert.Equal(t, "update", env.Breadcrumbs[0].Action)
+	assert.Equal(t, "reply", env.Breadcrumbs[1].Action)
+	assert.Equal(t, "basecamp comments create 123 <text>", env.Breadcrumbs[1].Cmd)
+}
+
+func TestCommentsShowNilParentOmitsReplyTarget(t *testing.T) {
+	comment := map[string]any{
+		"id": 456, "type": "Comment", "content": "<p>hi</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"creator":    map[string]any{"id": 7, "name": "Jane Doe"},
+	}
+	cb, _ := json.Marshal(comment)
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(string(cb))}
+
+	stdout, _, err := runCommentsShow(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+
+	var env threadEnvelope
+	require.NoError(t, json.Unmarshal([]byte(stdout), &env))
+
+	_, hasReplyTarget := env.Data["reply_target"]
+	assert.False(t, hasReplyTarget, "no reply_target without a parent")
+	for _, b := range env.Breadcrumbs {
+		assert.NotEqual(t, "reply", b.Action, "no reply breadcrumb without a parent")
+	}
+	// Mention still resolves (person lookup) — enrichment is graceful, not fatal.
+	mention := env.Data["mention"].(map[string]any)
+	assert.Equal(t, "person_lookup", mention["resolution"])
+}
+
+func TestCommentsShowSharedResolverSafety(t *testing.T) {
+	comment := `{"id":456,"type":"Comment","content":"<p>hi</p>","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
+
+	t.Run("plain recording URL rejected, zero requests", func(t *testing.T) {
+		transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+		_, _, err := runCommentsShow(t, transport, output.FormatJSON, "https://3.basecamp.com/99999/buckets/1/todos/123")
+		require.Error(t, err)
+		var outErr *output.Error
+		require.True(t, errors.As(err, &outErr))
+		assert.Equal(t, output.CodeUsage, outErr.Code)
+		assert.Empty(t, transport.getRequests())
+	})
+
+	t.Run("account mismatch rejected, zero requests", func(t *testing.T) {
+		transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+		url := "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456"
+		_, _, err := runCommentsShow(t, transport, output.FormatJSON, url)
+		require.Error(t, err)
+		var outErr *output.Error
+		require.True(t, errors.As(err, &outErr))
+		assert.Equal(t, output.CodeUsage, outErr.Code)
+		assert.Contains(t, outErr.Message, "does not match")
+		assert.Empty(t, transport.getRequests())
+	})
+
+	t.Run("non-positive id rejected, zero requests", func(t *testing.T) {
+		transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+		_, _, err := runCommentsShow(t, transport, output.FormatJSON, "0")
+		require.Error(t, err)
+		var outErr *output.Error
+		require.True(t, errors.As(err, &outErr))
+		assert.Equal(t, output.CodeUsage, outErr.Code)
+		assert.Empty(t, transport.getRequests())
+	})
+
+	t.Run("three valid forms resolve the same comment", func(t *testing.T) {
+		forms := []string{
+			"456",
+			"https://3.basecamp.com/99999/buckets/1/todos/123#__recording_456",
+			"https://3.basecamp.com/99999/buckets/1/comments/456",
+		}
+		for _, form := range forms {
+			transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+			stdout, _, err := runCommentsShow(t, transport, output.FormatJSON, form)
+			require.NoError(t, err, form)
+			var env threadEnvelope
+			require.NoError(t, json.Unmarshal([]byte(stdout), &env))
+			assert.EqualValues(t, 456, env.Data["id"])
+			assert.Len(t, transport.getRequests(), 1, form)
+		}
+	})
+}
+
+// runCommentsShowAccount runs `comments show` with an explicit configured account
+// (use "" to simulate an unconfigured run).
+func runCommentsShowAccount(t *testing.T, transport *showTrackingTransport, accountID string, args ...string) (string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, output.FormatJSON, stdout, stderr)
+	app.Flags.Hints = true
+	app.Config.AccountID = accountID
+	app.Names.SetAccountID(accountID)
+	cmd := NewCommentsCmd()
+	full := append([]string{"show"}, args...)
+	cmd.SetArgs(full)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func TestCommentsShowRejectsUntrustedHostNoAPICall(t *testing.T) {
+	comment := `{"id":456,"type":"Comment","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
+	cases := map[string]string{
+		"direct comment URL": "https://evil.example/99999/buckets/1/comments/456",
+		"fragment URL":       "https://evil.example/99999/buckets/1/todos/123#__recording_456",
+	}
+	for name, url := range cases {
+		t.Run(name, func(t *testing.T) {
+			transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+			_, _, err := runCommentsShow(t, transport, output.FormatJSON, url)
+			require.Error(t, err)
+			var outErr *output.Error
+			require.True(t, errors.As(err, &outErr))
+			assert.Equal(t, output.CodeUsage, outErr.Code)
+			assert.Contains(t, outErr.Message, "untrusted host")
+			assert.Empty(t, transport.getRequests())
+		})
+	}
+}
+
+func TestCommentsShowInvalidIDBeforeAccountResolution(t *testing.T) {
+	comment := `{"id":456,"type":"Comment","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+	stdout, err := runCommentsShowAccount(t, transport, "", "0")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+	assert.Equal(t, "Invalid comment ID", outErr.Message)
+	assert.NotContains(t, stdout, "account is required")
+	assert.Empty(t, transport.getRequests())
+}
+
+func TestCommentsShowAdoptsURLAccountWhenUnconfigured(t *testing.T) {
+	comment := `{"id":456,"type":"Comment","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+	url := "https://3.basecamp.com/77777/buckets/1/comments/456"
+	_, err := runCommentsShowAccount(t, transport, "", url)
+	require.NoError(t, err)
+
+	reqs := transport.getRequests()
+	require.Len(t, reqs, 1, "one Get, no extra calls")
+	assert.Contains(t, reqs[0], "/77777/", "the fetch must target the URL's account")
 }

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/config"
 	"github.com/basecamp/basecamp-cli/internal/names"
 	"github.com/basecamp/basecamp-cli/internal/output"
 )
@@ -421,4 +422,59 @@ func TestCommentsShowRejectsZeroComment(t *testing.T) {
 	var outErr *output.Error
 	require.True(t, errors.As(err, &outErr))
 	assert.Equal(t, "empty_response", outErr.Code)
+}
+
+// --- Iteration 2: account provenance in reply breadcrumbs -------------------
+
+func TestHasPersistentAccount(t *testing.T) {
+	mk := func(id, src string) *config.Config {
+		c := &config.Config{AccountID: id, Sources: map[string]string{}}
+		if src != "" {
+			c.Sources["account_id"] = src
+		}
+		return c
+	}
+	// No account → not persistent.
+	assert.False(t, hasPersistentAccount(mk("", "")))
+	// Process-local sources → not persistent (follow-ups must echo --account).
+	assert.False(t, hasPersistentAccount(mk("99999", string(config.SourceFlag))))
+	assert.False(t, hasPersistentAccount(mk("99999", string(config.SourcePrompt))))
+	// On-disk / exported-env sources → persistent (follow-ups inherit it).
+	assert.True(t, hasPersistentAccount(mk("99999", string(config.SourceGlobal))))
+	assert.True(t, hasPersistentAccount(mk("99999", string(config.SourceLocal))))
+	assert.True(t, hasPersistentAccount(mk("99999", string(config.SourceEnv))))
+}
+
+func TestReplyAccountArg(t *testing.T) {
+	assert.Equal(t, "", replyAccountArg(true, "99999"))                  // persistent → no echo
+	assert.Equal(t, "", replyAccountArg(false, ""))                      // nothing to echo
+	assert.Equal(t, " --account 99999", replyAccountArg(false, "99999")) // process-local → echo
+}
+
+func TestCommentsShowFlagAccountEchoedInBreadcrumb(t *testing.T) {
+	// An account supplied solely via the process-local --account flag is not
+	// persistent, so the reply breadcrumb must spell out --account.
+	comment := `{"id":456,"type":"Comment","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
+	stdout := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, output.FormatJSON, stdout, &bytes.Buffer{})
+	app.Flags.Hints = true
+	app.Config.Sources = map[string]string{"account_id": string(config.SourceFlag)}
+
+	cmd := NewCommentsCmd()
+	cmd.SetArgs([]string{"show", "456"})
+	cmd.SetContext(appctx.WithApp(context.Background(), app))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Execute())
+
+	var env threadEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	var replyCmd string
+	for _, b := range env.Breadcrumbs {
+		if b.Action == "reply" {
+			replyCmd = b.Cmd
+		}
+	}
+	assert.Contains(t, replyCmd, "--account 99999")
 }

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -391,10 +391,34 @@ func TestCommentsShowAdoptsURLAccountWhenUnconfigured(t *testing.T) {
 	comment := `{"id":456,"type":"Comment","parent":{"id":123,"type":"Todo"},"creator":{"id":7,"name":"Jane"}}`
 	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(comment)}
 	url := "https://3.basecamp.com/77777/buckets/1/comments/456"
-	_, err := runCommentsShowAccount(t, transport, "", url)
+	stdout, err := runCommentsShowAccount(t, transport, "", url)
 	require.NoError(t, err)
 
 	reqs := transport.getRequests()
 	require.Len(t, reqs, 1, "one Get, no extra calls")
 	assert.Contains(t, reqs[0], "/77777/", "the fetch must target the URL's account")
+
+	// The reply contract stays runnable in a fresh process: reply_target names
+	// the adopted account, and the reply breadcrumb spells out --account.
+	var env threadEnvelope
+	require.NoError(t, json.Unmarshal([]byte(stdout), &env))
+	assert.Equal(t, "77777", env.Data["reply_target"].(map[string]any)["account_id"])
+	var replyCmd string
+	for _, b := range env.Breadcrumbs {
+		if b.Action == "reply" {
+			replyCmd = b.Cmd
+		}
+	}
+	assert.Contains(t, replyCmd, "--account 77777")
+}
+
+func TestCommentsShowRejectsZeroComment(t *testing.T) {
+	// An all-zero comment ({}) must fail as empty_response, not a bogus success
+	// masked by the non-empty enrichment mention map.
+	transport := &showTrackingTransport{responderWithHeaders: showCommentResponder(`{}`)}
+	_, _, err := runCommentsShow(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, "empty_response", outErr.Code)
 }

--- a/internal/commands/comment_thread_test.go
+++ b/internal/commands/comment_thread_test.go
@@ -1,0 +1,666 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/names"
+	"github.com/basecamp/basecamp-cli/internal/output"
+	"github.com/basecamp/basecamp-cli/internal/richtext"
+)
+
+// --- Pure helpers -----------------------------------------------------------
+
+func TestCommentTriggerID(t *testing.T) {
+	// Bare numeric ID passes through untouched, with no URL account.
+	id, acct, err := commentTriggerID("456")
+	require.NoError(t, err)
+	assert.Equal(t, "456", id)
+	assert.Equal(t, "", acct)
+
+	// Fragment URL yields the comment ID from the fragment (not the recording)
+	// and surfaces the account the URL names.
+	id, acct, err = commentTriggerID("https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479351#__recording_1069479352")
+	require.NoError(t, err)
+	assert.Equal(t, "1069479352", id)
+	assert.Equal(t, "195539477", acct)
+
+	// Direct comment URL yields the comment ID and account.
+	id, acct, err = commentTriggerID("https://3.basecamp.com/195539477/buckets/2085958499/comments/1069479352")
+	require.NoError(t, err)
+	assert.Equal(t, "1069479352", id)
+	assert.Equal(t, "195539477", acct)
+}
+
+func TestCommentTriggerIDRejectsPlainRecordingURL(t *testing.T) {
+	_, _, err := commentTriggerID("https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479351")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+	assert.Contains(t, outErr.Hint, "basecamp show")
+}
+
+func TestSortCommentsChronologically(t *testing.T) {
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	in := []basecamp.Comment{
+		{ID: 3, CreatedAt: base.Add(2 * time.Hour)},
+		{ID: 1, CreatedAt: base},
+		{ID: 5, CreatedAt: base.Add(time.Hour)}, // tie with ID 4 below
+		{ID: 4, CreatedAt: base.Add(time.Hour)},
+		{ID: 2, CreatedAt: base.Add(30 * time.Minute)},
+	}
+	out := sortCommentsChronologically(in)
+	got := make([]int64, len(out))
+	for i := range out {
+		got[i] = out[i].ID
+	}
+	// created_at asc, then id asc for ties (4 before 5).
+	assert.Equal(t, []int64{1, 2, 4, 5, 3}, got)
+	// Original slice is untouched.
+	assert.Equal(t, int64(3), in[0].ID)
+}
+
+func makeComments(n int) []basecamp.Comment {
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	out := make([]basecamp.Comment, n)
+	for i := range out {
+		out[i] = basecamp.Comment{ID: int64(i + 1), CreatedAt: base.Add(time.Duration(i) * time.Minute)}
+	}
+	return out
+}
+
+func windowIDs(comments []basecamp.Comment) []int64 {
+	ids := make([]int64, len(comments))
+	for i := range comments {
+		ids[i] = comments[i].ID
+	}
+	return ids
+}
+
+func TestSelectCommentWindowCentersOnFocus(t *testing.T) {
+	comments := makeComments(100)
+	// Focus at index 50 (ID 51), window 5 → 2 older, focus, 2 newer.
+	sel, kind := selectCommentWindow(comments, 50, false, 5)
+	assert.Equal(t, "focus_window", kind)
+	assert.Equal(t, []int64{49, 50, 51, 52, 53}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowEvenBiasesNewer(t *testing.T) {
+	comments := makeComments(100)
+	// Window 4 → before=(3)/2=1, after=2. 1 older, focus, 2 newer.
+	sel, _ := selectCommentWindow(comments, 50, false, 4)
+	assert.Equal(t, []int64{50, 51, 52, 53}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowShiftsAtStartEdge(t *testing.T) {
+	comments := makeComments(100)
+	// Focus near the start: unused older capacity shifts to newer, still N total.
+	sel, _ := selectCommentWindow(comments, 1, false, 5)
+	require.Len(t, sel, 5)
+	assert.Equal(t, []int64{1, 2, 3, 4, 5}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowShiftsAtEndEdge(t *testing.T) {
+	comments := makeComments(100)
+	sel, _ := selectCommentWindow(comments, 99, false, 5)
+	require.Len(t, sel, 5)
+	assert.Equal(t, []int64{96, 97, 98, 99, 100}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowSingle(t *testing.T) {
+	comments := makeComments(100)
+	sel, _ := selectCommentWindow(comments, 42, false, 1)
+	assert.Equal(t, []int64{43}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowFocusAbsentReturnsMostRecent(t *testing.T) {
+	comments := makeComments(10)
+	sel, kind := selectCommentWindow(comments, -1, false, 3)
+	assert.Equal(t, "focus_window", kind)
+	assert.Equal(t, []int64{8, 9, 10}, windowIDs(sel))
+}
+
+func TestSelectCommentWindowAll(t *testing.T) {
+	comments := makeComments(7)
+	sel, kind := selectCommentWindow(comments, 3, true, 3)
+	assert.Equal(t, "all_fetched", kind)
+	assert.Len(t, sel, 7)
+}
+
+func TestBuildCommentsMetaTotalCountZeroIsUnknown(t *testing.T) {
+	m := buildCommentsMeta(5, 5, "all_fetched", true, basecamp.ListMeta{TotalCount: 0})
+	assert.Nil(t, m["total"])
+	assert.Equal(t, false, m["total_known"])
+	assert.Equal(t, true, m["fetch_complete"])
+	assert.Equal(t, false, m["api_truncated"])
+	assert.Equal(t, "active", m["scope"])
+	assert.Equal(t, "created_at_asc_id_asc", m["order"])
+}
+
+func TestBuildCommentsMetaTruncated(t *testing.T) {
+	m := buildCommentsMeta(100, 41, "focus_window", false, basecamp.ListMeta{TotalCount: 250, Truncated: true})
+	assert.Equal(t, 250, m["total"])
+	assert.Equal(t, true, m["total_known"])
+	assert.Equal(t, false, m["fetch_complete"])
+	assert.Equal(t, true, m["api_truncated"])
+	assert.Equal(t, false, m["focus_in_active_comments"])
+}
+
+// --- Author mention ---------------------------------------------------------
+
+func TestBuildFocusAuthorEmbeddedSGID(t *testing.T) {
+	author := buildFocusAuthor(&basecamp.Person{ID: 7, Name: "Jane Doe", AttachableSGID: "SGID123"})
+	mention := author["mention"].(map[string]any)
+	assert.Equal(t, "[@Jane Doe](mention:SGID123)", mention["syntax"])
+	assert.Equal(t, "embedded_sgid", mention["resolution"])
+	assert.Equal(t, false, mention["requires_lookup"])
+}
+
+func TestBuildFocusAuthorPersonLookup(t *testing.T) {
+	author := buildFocusAuthor(&basecamp.Person{ID: 42, Name: "Jane Doe"})
+	mention := author["mention"].(map[string]any)
+	assert.Equal(t, "[@Jane Doe](person:42)", mention["syntax"])
+	assert.Equal(t, "person_lookup", mention["resolution"])
+	assert.Equal(t, true, mention["requires_lookup"])
+}
+
+func TestBuildFocusAuthorUnavailable(t *testing.T) {
+	// No SGID and no positive ID (system actor).
+	author := buildFocusAuthor(&basecamp.Person{ID: 0, Name: "System"})
+	mention := author["mention"].(map[string]any)
+	assert.Nil(t, mention["syntax"])
+	assert.Equal(t, "unavailable", mention["resolution"])
+}
+
+func TestBuildFocusAuthorNilCreator(t *testing.T) {
+	author := buildFocusAuthor(nil)
+	assert.Nil(t, author["id"])
+	assert.Equal(t, "", author["name"])
+	mention := author["mention"].(map[string]any)
+	assert.Equal(t, "unavailable", mention["resolution"])
+}
+
+func TestBuildFocusAuthorHostileNameEscaped(t *testing.T) {
+	// Newlines, ANSI, and markdown metachars must not survive into the syntax.
+	hostile := "Jane\n\x1b[31m](evil)[Doe"
+	author := buildFocusAuthor(&basecamp.Person{ID: 7, Name: hostile, AttachableSGID: "SGID"})
+	syntax := author["mention"].(map[string]any)["syntax"].(string)
+	assert.NotContains(t, syntax, "\n")
+	assert.NotContains(t, syntax, "\x1b")
+	// The link-breaking brackets/parens are backslash-escaped.
+	assert.NotContains(t, syntax, "](evil)")
+	assert.True(t, strings.HasPrefix(syntax, "[@"))
+	assert.True(t, strings.HasSuffix(syntax, "](mention:SGID)"))
+}
+
+func TestBuildFocusAuthorEmptySanitizedNameUnavailable(t *testing.T) {
+	// A name that sanitizes to empty (only controls) yields no mention.
+	author := buildFocusAuthor(&basecamp.Person{ID: 7, Name: "\x1b\x1b", AttachableSGID: "SGID"})
+	mention := author["mention"].(map[string]any)
+	assert.Nil(t, mention["syntax"])
+	assert.Equal(t, "unavailable", mention["resolution"])
+}
+
+func TestFocusMentionRoundTripsThroughResolveMentions(t *testing.T) {
+	cases := map[string]string{
+		"normal name":  "Jane Doe",
+		"hostile name": "Jane\n\x1b[31m](evil)[Doe",
+	}
+	for label, name := range cases {
+		t.Run(label, func(t *testing.T) {
+			author := buildFocusAuthor(&basecamp.Person{ID: 7, Name: name, AttachableSGID: "BAh7CEkiCG"})
+			syntax := author["mention"].(map[string]any)["syntax"].(string)
+
+			// Embed the produced syntax exactly as a reply body would, then run
+			// it through the same mention pipeline `comments create` uses. The
+			// embedded SGID must resolve to a mention attachment with zero
+			// lookups — even when the display label came from a hostile name.
+			html := richtext.MarkdownToHTML(syntax)
+			result, err := resolveMentions(context.Background(), nil, html)
+			require.NoError(t, err)
+			assert.Contains(t, result.HTML, "BAh7CEkiCG")
+			assert.Contains(t, result.HTML, "application/vnd.basecamp.mention")
+		})
+	}
+}
+
+// --- Integration ------------------------------------------------------------
+
+// threadFixture builds a focus comment, its parent recording, and a list of
+// active comments, and returns a responder for showTrackingTransport keyed by
+// request path.
+type threadFixture struct {
+	focusJSON     string
+	parentJSON    string
+	listJSON      string
+	listHeaders   map[string]string
+	parentStatus  int
+	commentStatus int
+}
+
+func (f threadFixture) responder() func(path string) (int, string, http.Header) {
+	return func(path string) (int, string, http.Header) {
+		switch {
+		case strings.Contains(path, "/recordings/") && strings.HasSuffix(path, "/comments.json"):
+			h := http.Header{}
+			for k, v := range f.listHeaders {
+				h.Set(k, v)
+			}
+			return 200, f.listJSON, h
+		case strings.Contains(path, "/comments/"):
+			status := f.commentStatus
+			if status == 0 {
+				status = 200
+			}
+			return status, f.focusJSON, nil
+		default:
+			// Any other path is treated as the parent recording fetch.
+			status := f.parentStatus
+			if status == 0 {
+				status = 200
+			}
+			return status, f.parentJSON, nil
+		}
+	}
+}
+
+func runThreadCmd(t *testing.T, transport *showTrackingTransport, format output.Format, args ...string) (string, string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, format, stdout, stderr)
+	app.Flags.Hints = true // root enables hints/breadcrumbs by default
+	cmd := NewCommentsCmd()
+	full := append([]string{"thread"}, args...)
+	cmd.SetArgs(full)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+// runThreadCmdMaxPages runs the thread command with an SDK client capped at
+// maxPages, so a next-page Link header on a list response makes the SDK report
+// truncation deterministically.
+func runThreadCmdMaxPages(t *testing.T, transport *showTrackingTransport, format output.Format, maxPages int, args ...string) (string, string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, format, stdout, stderr)
+	app.Flags.Hints = true
+	app.SDK = basecamp.NewClient(&basecamp.Config{BaseURL: "https://3.basecampapi.com"}, &showTestTokenProvider{},
+		basecamp.WithTransport(transport),
+		basecamp.WithMaxRetries(1),
+		basecamp.WithMaxPages(maxPages),
+	)
+	app.Names = names.NewResolver(app.SDK, app.Auth, app.Config.AccountID)
+	cmd := NewCommentsCmd()
+	full := append([]string{"thread"}, args...)
+	cmd.SetArgs(full)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func defaultThreadFixture() threadFixture {
+	focus := map[string]any{
+		"id":         456,
+		"type":       "Comment",
+		"content":    "<p>focus body</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": 123, "type": "Todo", "url": "https://3.basecampapi.com/99999/buckets/1/messages/999.json"},
+		"creator":    map[string]any{"id": 7, "name": "Jane Doe", "attachable_sgid": "SGID123"},
+	}
+	parent := map[string]any{"id": 123, "type": "Todo", "title": "Parent todo", "content": "<p>todo body</p>"}
+	// Out-of-order list including the focus (456).
+	list := []map[string]any{
+		{"id": 458, "content": "<p>c3</p>", "created_at": "2026-07-20T10:10:00Z", "creator": map[string]any{"name": "Bob"}},
+		{"id": 456, "content": "<p>focus body</p>", "created_at": "2026-07-20T10:05:00Z", "creator": map[string]any{"name": "Jane Doe"}},
+		{"id": 457, "content": "<p>c2</p>", "created_at": "2026-07-20T10:07:00Z", "creator": map[string]any{"name": "Bob"}},
+		{"id": 455, "content": "<p>c0</p>", "created_at": "2026-07-20T10:00:00Z", "creator": map[string]any{"name": "Amy"}},
+	}
+	fb, _ := json.Marshal(focus)
+	pb, _ := json.Marshal(parent)
+	lb, _ := json.Marshal(list)
+	return threadFixture{focusJSON: string(fb), parentJSON: string(pb), listJSON: string(lb)}
+}
+
+type threadEnvelope struct {
+	Summary     string              `json:"summary"`
+	Notice      string              `json:"notice"`
+	Breadcrumbs []output.Breadcrumb `json:"breadcrumbs"`
+	Data        map[string]any      `json:"data"`
+}
+
+func decodeThread(t *testing.T, stdout string) threadEnvelope {
+	t.Helper()
+	var env threadEnvelope
+	require.NoError(t, json.Unmarshal([]byte(stdout), &env))
+	return env
+}
+
+func TestThreadResolvesAndBuildsContract(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+
+	env := decodeThread(t, stdout)
+	// reply_target routes to the parent recording, never the comment.
+	replyTarget := env.Data["reply_target"].(map[string]any)
+	assert.EqualValues(t, 123, replyTarget["recording_id"])
+	assert.Equal(t, true, env.Data["recording_full"])
+
+	recording := env.Data["recording"].(map[string]any)
+	assert.EqualValues(t, 123, recording["id"])
+
+	// reply_target.recording_id == recording.id (the smoke invariant).
+	assert.EqualValues(t, recording["id"], replyTarget["recording_id"])
+
+	focus := env.Data["focus"].(map[string]any)
+	assert.EqualValues(t, 456, focus["comment_id"])
+
+	// Comments sorted created_at asc, then id asc: 455, 456, 457, 458.
+	comments := env.Data["comments"].([]any)
+	require.Len(t, comments, 4)
+	ids := make([]int, 0, len(comments))
+	for _, c := range comments {
+		ids = append(ids, int(c.(map[string]any)["id"].(float64)))
+	}
+	assert.Equal(t, []int{455, 456, 457, 458}, ids)
+
+	meta := env.Data["comments_meta"].(map[string]any)
+	assert.Equal(t, true, meta["focus_in_active_comments"])
+
+	// The reply breadcrumb targets the parent recording.
+	require.NotEmpty(t, env.Breadcrumbs)
+	last := env.Breadcrumbs[len(env.Breadcrumbs)-1]
+	assert.Equal(t, "reply", last.Action)
+	assert.Contains(t, last.Cmd, "comments create 123")
+}
+
+func TestThreadFetchesParentViaTypeEndpointNotURL(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+
+	// The parent was fetched from the type endpoint (/todos/123.json), derived
+	// from Parent.Type+ID — never from the decoy URL (which named messages/999).
+	paths := transport.getRequests()
+	assert.Contains(t, paths, "/99999/todos/123.json")
+	for _, p := range paths {
+		assert.NotContains(t, p, "messages/999")
+	}
+}
+
+func TestThreadThreeTriggerFormsResolveSameComment(t *testing.T) {
+	forms := []string{
+		"456",
+		"https://3.basecamp.com/99999/buckets/1/todos/123#__recording_456",
+		"https://3.basecamp.com/99999/buckets/1/comments/456",
+	}
+	for _, form := range forms {
+		t.Run(form, func(t *testing.T) {
+			fx := defaultThreadFixture()
+			transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+			stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, form)
+			require.NoError(t, err)
+			env := decodeThread(t, stdout)
+			assert.EqualValues(t, 456, env.Data["focus"].(map[string]any)["comment_id"])
+		})
+	}
+}
+
+func TestThreadPreservesLargeIDsWithUseNumber(t *testing.T) {
+	fx := defaultThreadFixture()
+	// Parent ID > 2^53 must survive the decode without float rounding.
+	bigID := int64(9007199254740993)
+	focus := map[string]any{
+		"id":         456,
+		"type":       "Comment",
+		"content":    "<p>x</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": bigID, "type": "Todo", "url": "https://x/y"},
+		"creator":    map[string]any{"id": 7, "name": "Jane", "attachable_sgid": "S"},
+	}
+	parent := map[string]any{"id": bigID, "type": "Todo", "title": "Big"}
+	fb, _ := json.Marshal(focus)
+	pb, _ := json.Marshal(parent)
+	fx.focusJSON = string(fb)
+	fx.parentJSON = string(pb)
+	fx.listJSON = "[]"
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	// The exact ID appears in the reply-target path and JSON (no rounding).
+	assert.Contains(t, transport.getRequests(), fmt.Sprintf("/99999/todos/%d.json", bigID))
+	assert.Contains(t, stdout, fmt.Sprintf("%d", bigID))
+}
+
+func TestThreadNilParentHardFailsBeforeList(t *testing.T) {
+	fx := defaultThreadFixture()
+	focus := map[string]any{"id": 456, "type": "Comment", "content": "x", "created_at": "2026-07-20T10:05:00Z",
+		"creator": map[string]any{"id": 7, "name": "Jane"}}
+	fb, _ := json.Marshal(focus)
+	fx.focusJSON = string(fb)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no parent recording")
+
+	// No list or parent fetch happened — only the trigger Get.
+	for _, p := range transport.getRequests() {
+		assert.NotContains(t, p, "/recordings/")
+		assert.NotContains(t, p, "/todos/")
+	}
+}
+
+func TestThreadMappedParentFetchFailureHardErrors(t *testing.T) {
+	fx := defaultThreadFixture()
+	fx.parentStatus = 500
+	fx.parentJSON = `{"error":"boom"}`
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+}
+
+func TestThreadRejectsURLAccountMismatchNoAPICall(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	// Configured account is 99999 (showTestApp); the URL names 88888.
+	url := "https://3.basecamp.com/88888/buckets/1/todos/123#__recording_456"
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, url)
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+	assert.Contains(t, outErr.Message, "does not match")
+	// The mismatch is caught before any request — no Get, no List.
+	assert.Empty(t, transport.getRequests())
+}
+
+func TestThreadMappedParent204HardErrors(t *testing.T) {
+	fx := defaultThreadFixture()
+	fx.parentStatus = 204
+	fx.parentJSON = ""
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no content")
+}
+
+func TestThreadMappedParentDecodeFailureHardErrors(t *testing.T) {
+	fx := defaultThreadFixture()
+	fx.parentJSON = `{not valid json`
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestThreadTruncationEmitsNotice(t *testing.T) {
+	fx := defaultThreadFixture()
+	// A same-origin next-page Link on the list response, combined with a
+	// MaxPages cap of 1, makes the SDK report Meta.Truncated.
+	fx.listHeaders = map[string]string{
+		"Link": `<https://3.basecampapi.com/99999/recordings/123/comments.json?page=2>; rel="next"`,
+	}
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmdMaxPages(t, transport, output.FormatJSON, 1, "456")
+	require.NoError(t, err)
+
+	env := decodeThread(t, stdout)
+	assert.NotEmpty(t, env.Notice)
+	assert.Contains(t, env.Notice, "truncated")
+	meta := env.Data["comments_meta"].(map[string]any)
+	assert.Equal(t, false, meta["fetch_complete"])
+	assert.Equal(t, true, meta["api_truncated"])
+}
+
+func TestThreadStyledSanitizesHostileMultilineAuthor(t *testing.T) {
+	fx := defaultThreadFixture()
+	focus := map[string]any{
+		"id": 456, "type": "Comment", "content": "<p>body</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": 123, "type": "Todo", "url": "https://x/y"},
+		"creator":    map[string]any{"id": 7, "name": "Evil\nInjected Line", "attachable_sgid": "S"},
+	}
+	fb, _ := json.Marshal(focus)
+	fx.focusJSON = string(fb)
+
+	for _, format := range []output.Format{output.FormatStyled, output.FormatMarkdown} {
+		transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+		stdout, _, err := runThreadCmd(t, transport, format, "456")
+		require.NoError(t, err)
+		// The Focus Author detail row stays on one line — the injected newline
+		// must not split the name across rows in either human format.
+		assert.Contains(t, stdout, "Evil Injected Line")
+		assert.NotContains(t, stdout, "Evil\nInjected Line")
+	}
+}
+
+func TestThreadUnmappedParentTypeReturnsRef(t *testing.T) {
+	fx := defaultThreadFixture()
+	focus := map[string]any{
+		"id": 456, "type": "Comment", "content": "x", "created_at": "2026-07-20T10:05:00Z",
+		"parent":  map[string]any{"id": 123, "type": "Some::New::Type", "url": "https://x/y", "title": "Ref title"},
+		"creator": map[string]any{"id": 7, "name": "Jane"},
+	}
+	fb, _ := json.Marshal(focus)
+	fx.focusJSON = string(fb)
+	fx.listJSON = "[]"
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+	assert.Equal(t, false, env.Data["recording_full"])
+	ref := env.Data["recording_ref"].(map[string]any)
+	assert.Equal(t, "Some::New::Type", ref["type"])
+	assert.Equal(t, "Ref title", ref["title"])
+	// reply_target still routes to the parent ID.
+	assert.EqualValues(t, 123, env.Data["reply_target"].(map[string]any)["recording_id"])
+}
+
+func TestThreadWindowAndAllMutuallyExclusive(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456", "--all", "--window", "5")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+}
+
+func TestThreadFocusAbsentReportsFact(t *testing.T) {
+	fx := defaultThreadFixture()
+	// List without the focus (456).
+	list := []map[string]any{
+		{"id": 455, "content": "<p>c0</p>", "created_at": "2026-07-20T10:00:00Z", "creator": map[string]any{"name": "Amy"}},
+		{"id": 457, "content": "<p>c2</p>", "created_at": "2026-07-20T10:07:00Z", "creator": map[string]any{"name": "Bob"}},
+	}
+	lb, _ := json.Marshal(list)
+	fx.listJSON = string(lb)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+	meta := env.Data["comments_meta"].(map[string]any)
+	assert.Equal(t, false, meta["focus_in_active_comments"])
+	assert.Equal(t, "focus_window", meta["selection"])
+}
+
+func TestThreadStyledRendersRecordingFocusAndComments(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+	stdout, _, err := runThreadCmd(t, transport, output.FormatStyled, "456")
+	require.NoError(t, err)
+
+	// Sections render in the fixed order: Recording → Focus → Comments → reply.
+	iRecording := strings.Index(stdout, "Recording")
+	iFocus := strings.Index(stdout, "Focus")
+	iComments := strings.Index(stdout, "Comments:")
+	iReply := strings.Index(stdout, "comments create 123")
+	require.Greater(t, iRecording, -1)
+	require.Greater(t, iFocus, iRecording)
+	require.Greater(t, iComments, iFocus)
+	require.Greater(t, iReply, iComments)
+}
+
+func TestThreadMarkdownRenders(t *testing.T) {
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+	stdout, _, err := runThreadCmd(t, transport, output.FormatMarkdown, "456")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "## Comments")
+	assert.Contains(t, stdout, "Focus")
+}
+
+func TestThreadSanitizesHostileHTMLBody(t *testing.T) {
+	fx := defaultThreadFixture()
+	focus := map[string]any{
+		"id": 456, "type": "Comment",
+		"content":    "<script>alert(1)</script><p>hi\x1b[31mred</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": 123, "type": "Todo", "url": "https://x/y"},
+		"creator":    map[string]any{"id": 7, "name": "Jane", "attachable_sgid": "S"},
+	}
+	fb, _ := json.Marshal(focus)
+	fx.focusJSON = string(fb)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatStyled, "456")
+	require.NoError(t, err)
+	// No raw escape byte and no live script tag reaches the terminal sink.
+	assert.NotContains(t, stdout, "\x1b[31m")
+	assert.NotContains(t, stdout, "<script>")
+}

--- a/internal/commands/comment_thread_test.go
+++ b/internal/commands/comment_thread_test.go
@@ -994,3 +994,27 @@ func TestThreadRejectsZeroFocusComment(t *testing.T) {
 	assert.Equal(t, "empty_response", outErr.Code)
 	assert.NotContains(t, outErr.Message, "no parent recording")
 }
+
+func TestRecordingTitleFieldFallsBackToContent(t *testing.T) {
+	// Todo-like parent: title/name/subject absent, content holds the title.
+	assert.Equal(t, "Buy milk", recordingTitleField(map[string]any{"content": "Buy milk"}))
+	// A real title still wins over content (rich-body types keep their title).
+	assert.Equal(t, "Weekly update", recordingTitleField(map[string]any{"title": "Weekly update", "content": "<p>long body</p>"}))
+	// subject (messages) beats content too.
+	assert.Equal(t, "Kickoff", recordingTitleField(map[string]any{"subject": "Kickoff", "content": "<p>body</p>"}))
+	// Nothing title-bearing → empty.
+	assert.Equal(t, "", recordingTitleField(map[string]any{"id": 1}))
+}
+
+func TestThreadTodoParentHeadlineUsesContent(t *testing.T) {
+	// A Todo parent (content-as-title) must not render an empty headline.
+	fx := defaultThreadFixture()
+	parent := map[string]any{"id": 123, "type": "Todo", "content": "Ship the release"}
+	pb, _ := json.Marshal(parent)
+	fx.parentJSON = string(pb)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatStyled, "456")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Ship the release")
+}

--- a/internal/commands/comment_thread_test.go
+++ b/internal/commands/comment_thread_test.go
@@ -979,3 +979,18 @@ func TestThreadAdoptsURLAccountWhenUnconfigured(t *testing.T) {
 	}
 	assert.Contains(t, replyCmd, "--account 77777")
 }
+
+func TestThreadRejectsZeroFocusComment(t *testing.T) {
+	// A nil/all-zero focus Get must fail as empty_response before dereferencing
+	// trigger.Parent — never panic, never misreport it as "no parent recording".
+	fx := defaultThreadFixture()
+	fx.focusJSON = `{}`
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, "empty_response", outErr.Code)
+	assert.NotContains(t, outErr.Message, "no parent recording")
+}

--- a/internal/commands/comment_thread_test.go
+++ b/internal/commands/comment_thread_test.go
@@ -966,4 +966,16 @@ func TestThreadAdoptsURLAccountWhenUnconfigured(t *testing.T) {
 
 	env := decodeThread(t, stdout)
 	assert.EqualValues(t, 456, env.Data["focus"].(map[string]any)["comment_id"])
+
+	// The reply contract stays runnable in a fresh process: reply_target names
+	// the adopted account, and the reply breadcrumb spells out --account.
+	replyTarget := env.Data["reply_target"].(map[string]any)
+	assert.Equal(t, "77777", replyTarget["account_id"])
+	var replyCmd string
+	for _, b := range env.Breadcrumbs {
+		if b.Action == "reply" {
+			replyCmd = b.Cmd
+		}
+	}
+	assert.Contains(t, replyCmd, "--account 77777")
 }

--- a/internal/commands/comment_thread_test.go
+++ b/internal/commands/comment_thread_test.go
@@ -664,3 +664,306 @@ func TestThreadSanitizesHostileHTMLBody(t *testing.T) {
 	assert.NotContains(t, stdout, "\x1b[31m")
 	assert.NotContains(t, stdout, "<script>")
 }
+
+// --- Iteration 2: trust-contract completeness -------------------------------
+
+// attachmentFocusFixture builds a focus whose Get carries a content attachment
+// but whose parent's active-comments list omits the focus entirely — proving the
+// attachment data rides on the Get, not the list.
+func attachmentFocusFixture(t *testing.T) threadFixture {
+	t.Helper()
+	fx := defaultThreadFixture()
+	focus := map[string]any{
+		"id": 456, "type": "Comment", "content": "<p>see attached</p>",
+		"created_at": "2026-07-20T10:05:00Z",
+		"parent":     map[string]any{"id": 123, "type": "Todo", "url": "https://x/y"},
+		"creator":    map[string]any{"id": 7, "name": "Jane Doe", "attachable_sgid": "SGID123"},
+		"content_attachments": []map[string]any{
+			{"id": 999, "sgid": "AT", "filename": "spec.pdf", "content_type": "application/pdf", "byte_size": 2048, "download_url": "https://x/dl"},
+		},
+	}
+	// List that does NOT contain the focus (456).
+	list := []map[string]any{
+		{"id": 455, "content": "<p>c0</p>", "created_at": "2026-07-20T10:00:00Z", "creator": map[string]any{"name": "Amy"}},
+		{"id": 457, "content": "<p>c2</p>", "created_at": "2026-07-20T10:07:00Z", "creator": map[string]any{"name": "Bob"}},
+	}
+	fb, _ := json.Marshal(focus)
+	lb, _ := json.Marshal(list)
+	fx.focusJSON = string(fb)
+	fx.listJSON = string(lb)
+	return fx
+}
+
+func TestThreadSurfacesFocusAttachmentEvenWhenAbsentFromList(t *testing.T) {
+	fx := attachmentFocusFixture(t)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+
+	// The attachment survives from the Get though the list omits the focus.
+	focusOut := env.Data["focus"].(map[string]any)
+	atts, ok := focusOut["content_attachments"].([]any)
+	require.True(t, ok, "focus.content_attachments should be a non-nil array")
+	require.Len(t, atts, 1)
+	assert.Equal(t, "spec.pdf", atts[0].(map[string]any)["filename"])
+
+	// A type-safe download breadcrumb fires even though the focus is absent.
+	dlIdx, replyIdx := -1, -1
+	for i, b := range env.Breadcrumbs {
+		if b.Action == "download" {
+			dlIdx = i
+			assert.Equal(t, "basecamp attachments download 456 --type comment", b.Cmd)
+		}
+		if b.Action == "reply" {
+			replyIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, dlIdx, 0, "download breadcrumb should be present")
+	require.GreaterOrEqual(t, replyIdx, 0, "reply breadcrumb should be present")
+	assert.Less(t, dlIdx, replyIdx, "download breadcrumb must come before reply (reply last)")
+}
+
+func TestThreadNoAttachmentBreadcrumbWhenNone(t *testing.T) {
+	fx := defaultThreadFixture() // no content_attachments on the focus
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+
+	for _, b := range env.Breadcrumbs {
+		assert.NotEqual(t, "download", b.Action, "no download breadcrumb without attachments")
+	}
+	// Reply is still the last breadcrumb.
+	last := env.Breadcrumbs[len(env.Breadcrumbs)-1]
+	assert.Equal(t, "reply", last.Action)
+}
+
+func TestThreadFocusAbsentNoticeWindowSelectionAware(t *testing.T) {
+	fx := attachmentFocusFixture(t) // list omits focus; 2 fetched
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+
+	assert.Contains(t, env.Notice, "not present in the fetched active discussion")
+	assert.Contains(t, env.Notice, "most recent 2 fetched comments")
+	assert.NotContains(t, env.Notice, "all 2 fetched")
+}
+
+func TestThreadFocusAbsentNoticeAllSelectionAware(t *testing.T) {
+	fx := attachmentFocusFixture(t)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456", "--all")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+
+	assert.Contains(t, env.Notice, "not present in the fetched active discussion")
+	assert.Contains(t, env.Notice, "all 2 fetched comments")
+	assert.NotContains(t, env.Notice, "most recent")
+}
+
+func TestThreadFocusAbsentNoticeComposesWithTruncation(t *testing.T) {
+	fx := attachmentFocusFixture(t)
+	fx.listHeaders = map[string]string{
+		"Link": `<https://3.basecampapi.com/99999/recordings/123/comments.json?page=2>; rel="next"`,
+	}
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmdMaxPages(t, transport, output.FormatJSON, 1, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+
+	// Both fragments compose into one combined notice.
+	assert.Contains(t, env.Notice, "most recent")
+	assert.Contains(t, env.Notice, "truncated")
+}
+
+func TestThreadSummaryMatrix(t *testing.T) {
+	trigger := &basecamp.Comment{ID: 123}
+	author := map[string]any{"name": "Jane"}
+	cases := []struct {
+		name              string
+		returned, fetched int
+		selection         string
+		fetchComplete     bool
+		focusPresent      bool
+		want              string
+	}{
+		{"all complete", 50, 50, "all_fetched", true, true,
+			"Comment #123 by Jane — all 50 active comments"},
+		{"all truncated", 40, 40, "all_fetched", false, true,
+			"Comment #123 by Jane — all 40 fetched active comments; fetch incomplete"},
+		{"window focus present complete", 41, 50, "focus_window", true, true,
+			"Comment #123 by Jane — showing 41 of 50 active comments around the focus"},
+		{"window focus present truncated", 41, 60, "focus_window", false, true,
+			"Comment #123 by Jane — showing 41 around the focus from 60 fetched active comments; more exist on server"},
+		{"window focus absent complete", 41, 50, "focus_window", true, false,
+			"Comment #123 by Jane — showing the 41 most recent of 50 active comments"},
+		{"window focus absent truncated", 41, 60, "focus_window", false, false,
+			"Comment #123 by Jane — showing the 41 most recent within the fetched subset (60 fetched)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := threadSummary(trigger, author, c.returned, c.fetched, c.selection, c.fetchComplete, c.focusPresent)
+			assert.Equal(t, c.want, got)
+			assert.NotContains(t, got, "in discussion")
+			if !c.focusPresent && c.selection != "all_fetched" {
+				assert.NotContains(t, got, "around the focus")
+			}
+		})
+	}
+}
+
+func TestThreadSummary41Of50Integration(t *testing.T) {
+	fx := defaultThreadFixture()
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	list := make([]map[string]any, 0, 50)
+	for i := 0; i < 50; i++ {
+		id := 1000 + i
+		if i == 25 {
+			id = 456 // focus present in the fetched set
+		}
+		list = append(list, map[string]any{
+			"id":         id,
+			"content":    "<p>c</p>",
+			"created_at": base.Add(time.Duration(i) * time.Minute).Format(time.RFC3339),
+			"creator":    map[string]any{"name": "Bob"},
+		})
+	}
+	lb, _ := json.Marshal(list)
+	fx.listJSON = string(lb)
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	stdout, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.NoError(t, err)
+	env := decodeThread(t, stdout)
+	assert.Contains(t, env.Summary, "41 of 50")
+	assert.NotContains(t, env.Summary, "in discussion")
+}
+
+func TestThreadRendersMentionInHumanOutput(t *testing.T) {
+	for _, format := range []output.Format{output.FormatStyled, output.FormatMarkdown} {
+		fx := defaultThreadFixture() // creator Jane Doe with attachable_sgid SGID123
+		transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+		stdout, _, err := runThreadCmd(t, transport, format, "456")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "[@Jane Doe](mention:SGID123)",
+			"human format %v must render the paste-ready mention", format)
+	}
+}
+
+func TestThreadParentNullBodyHardErrors(t *testing.T) {
+	fx := defaultThreadFixture()
+	fx.parentJSON = "null"
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+
+	_, _, err := runThreadCmd(t, transport, output.FormatJSON, "456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty body")
+}
+
+func TestThreadResolverRejectsBeforeAnyRequest(t *testing.T) {
+	cases := []struct{ name, arg string }{
+		{"plain recording URL", "https://3.basecamp.com/99999/buckets/1/todos/123"},
+		{"non-positive id", "0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fx := defaultThreadFixture()
+			transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+			_, _, err := runThreadCmd(t, transport, output.FormatJSON, c.arg)
+			require.Error(t, err)
+			var outErr *output.Error
+			require.True(t, errors.As(err, &outErr))
+			assert.Equal(t, output.CodeUsage, outErr.Code)
+			assert.Empty(t, transport.getRequests(), "must reject before any API call")
+		})
+	}
+}
+
+// runThreadCmdAccount runs `thread` with an explicit configured account (use ""
+// to simulate an unconfigured run), so URL-account adoption and pre-API ID
+// validation can be exercised without a configured account masking them.
+func runThreadCmdAccount(t *testing.T, transport *showTrackingTransport, accountID string, args ...string) (string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := showTestAppWithOutput(t, transport, output.FormatJSON, stdout, stderr)
+	app.Flags.Hints = true
+	app.Config.AccountID = accountID
+	app.Names.SetAccountID(accountID)
+	cmd := NewCommentsCmd()
+	full := append([]string{"thread"}, args...)
+	cmd.SetArgs(full)
+	ctx := appctx.WithApp(context.Background(), app)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func TestThreadRejectsUntrustedHostNoAPICall(t *testing.T) {
+	cases := map[string]string{
+		"direct comment URL":  "https://evil.example/99999/buckets/1/comments/456",
+		"fragment URL":        "https://evil.example/99999/buckets/1/todos/123#__recording_456",
+		"api look-alike host": "https://3.basecampapi.evil.com/99999/buckets/1/comments/456",
+	}
+	for name, url := range cases {
+		t.Run(name, func(t *testing.T) {
+			fx := defaultThreadFixture()
+			transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+			_, _, err := runThreadCmd(t, transport, output.FormatJSON, url)
+			require.Error(t, err)
+			var outErr *output.Error
+			require.True(t, errors.As(err, &outErr))
+			assert.Equal(t, output.CodeUsage, outErr.Code)
+			assert.Contains(t, outErr.Message, "untrusted host")
+			assert.Empty(t, transport.getRequests(), "untrusted host must be rejected before any API call")
+		})
+	}
+}
+
+func TestThreadInvalidIDBeforeAccountResolution(t *testing.T) {
+	// Empty configuration + non-positive id → Invalid comment ID, not
+	// "--account is required", and zero requests (no account/content fetch).
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+	stdout, err := runThreadCmdAccount(t, transport, "", "0")
+	require.Error(t, err)
+	var outErr *output.Error
+	require.True(t, errors.As(err, &outErr))
+	assert.Equal(t, output.CodeUsage, outErr.Code)
+	assert.Equal(t, "Invalid comment ID", outErr.Message)
+	assert.NotContains(t, stdout, "account is required")
+	assert.Empty(t, transport.getRequests())
+}
+
+func TestThreadAdoptsURLAccountWhenUnconfigured(t *testing.T) {
+	// Empty configuration + trusted URL → the fetch targets the URL's account,
+	// not an interactively-selected one.
+	fx := defaultThreadFixture()
+	transport := &showTrackingTransport{responderWithHeaders: fx.responder()}
+	url := "https://3.basecamp.com/77777/buckets/1/comments/456"
+	stdout, err := runThreadCmdAccount(t, transport, "", url)
+	require.NoError(t, err)
+
+	reqs := transport.getRequests()
+	require.NotEmpty(t, reqs)
+	targetedURLAccount := false
+	for _, p := range reqs {
+		assert.Contains(t, p, "/77777/", "every request must target the URL's account")
+		if strings.Contains(p, "/77777/") {
+			targetedURLAccount = true
+		}
+	}
+	assert.True(t, targetedURLAccount)
+
+	env := decodeThread(t, stdout)
+	assert.EqualValues(t, 456, env.Data["focus"].(map[string]any)["comment_id"])
+}

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -356,7 +356,25 @@ func recordingTypeEndpoint(data map[string]any, id string) string {
 		return ""
 	}
 
-	switch t {
+	// Inbox forward replies need the parent forward ID for the nested endpoint.
+	if t == "Inbox::Forward::Reply" {
+		if parentID := parentRecordingID(data); parentID != "" {
+			return fmt.Sprintf("/inbox_forwards/%s/replies/%s.json", parentID, id)
+		}
+		return ""
+	}
+
+	return canonicalEndpointForType(t, id)
+}
+
+// canonicalEndpointForType maps an ordinary recording type to its type-specific
+// endpoint path. It handles only context-free types — those whose endpoint is a
+// pure function of (type, id). Contextual types that additionally need a parent
+// ID (Chat::Lines::*, Inbox::Forward::Reply) are layered on by
+// recordingTypeEndpoint and are intentionally absent here. Returns "" for
+// unrecognized types, letting callers fall through to sparse recording data.
+func canonicalEndpointForType(recType, id string) string {
+	switch recType {
 	case "Todo", "Todolist::Todo":
 		return fmt.Sprintf("/todos/%s.json", id)
 	case "Todolist":
@@ -397,11 +415,6 @@ func recordingTypeEndpoint(data map[string]any, id string) string {
 		return fmt.Sprintf("/card_tables/columns/%s.json", id)
 	case "Kanban::Step":
 		return fmt.Sprintf("/card_tables/steps/%s.json", id)
-	case "Inbox::Forward::Reply":
-		if parentID := parentRecordingID(data); parentID != "" {
-			return fmt.Sprintf("/inbox_forwards/%s/replies/%s.json", parentID, id)
-		}
-		return ""
 	default:
 		return ""
 	}

--- a/internal/commands/show_test.go
+++ b/internal/commands/show_test.go
@@ -244,6 +244,8 @@ func (t *showTrackingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     header,
+		// Request is required by the SDK's same-origin pagination guard.
+		Request: req,
 	}, nil
 }
 

--- a/internal/presenter/schemas/comment_thread.yaml
+++ b/internal/presenter/schemas/comment_thread.yaml
@@ -1,0 +1,63 @@
+entity: comment_thread
+kind: recording
+
+# Rendered over the flat display projection built by `comments thread`
+# (recording_*/focus_* direct keys), NOT the nested structured .data. The
+# envelope appends the discussion under its built-in "Comments:" header and the
+# reply command as the last breadcrumb.
+
+identity:
+  id: recording_id
+
+headline:
+  default:
+    template: "{{.recording_title}}"
+
+fields:
+  recording_type:
+    role: detail
+    format: text
+
+  recording_id:
+    role: meta
+    emphasis: muted
+
+  recording_content:
+    role: body
+    format: text
+    collapse: true
+
+  recording_description:
+    role: body
+    format: text
+    collapse: true
+
+  recording_full:
+    role: meta
+    format: boolean
+    emphasis: muted
+
+  focus_author:
+    role: detail
+    format: text
+
+  focus_created_at:
+    role: meta
+    emphasis: muted
+    format: relative_time
+
+  focus_comment_id:
+    role: meta
+    emphasis: muted
+
+  focus_content:
+    role: body
+    format: text
+
+views:
+  detail:
+    sections:
+      - heading: Recording
+        fields: [recording_type, recording_id, recording_full, recording_content, recording_description]
+      - heading: Focus
+        fields: [focus_author, focus_created_at, focus_comment_id, focus_content]

--- a/internal/presenter/schemas/comment_thread.yaml
+++ b/internal/presenter/schemas/comment_thread.yaml
@@ -41,6 +41,11 @@ fields:
     role: detail
     format: text
 
+  focus_mention:
+    role: detail
+    format: text
+    collapse: true
+
   focus_created_at:
     role: meta
     emphasis: muted
@@ -60,4 +65,4 @@ views:
       - heading: Recording
         fields: [recording_type, recording_id, recording_full, recording_content, recording_description]
       - heading: Focus
-        fields: [focus_author, focus_created_at, focus_comment_id, focus_content]
+        fields: [focus_author, focus_mention, focus_created_at, focus_comment_id, focus_content]

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -237,6 +237,13 @@ Returns: `account_id`, `project_id`, `type`, `recording_id`, `comment_id` (from 
 basecamp url parse "https://...messages/123#__recording_456" --json
 # Returns recording_id: 123 (parent), comment_id: 456 (fragment) - comment on 123, not 456
 basecamp comments create 123 "Reply" --in <project>
+
+# Or get the whole reply-ready context deterministically in one call:
+basecamp comments thread "https://...messages/123#__recording_456" --json
+# .data.reply_target.recording_id  → where to post the reply
+# .data.focus.author.mention.syntax → paste-ready [@Name](mention:SGID)
+# .data.comments                   → surrounding discussion (default window of 41)
+# --all returns every fetched comment; --window N sets the window size
 ```
 
 ## Decision Trees
@@ -669,6 +676,9 @@ case. To change visibility on an already-created recording, use
 
 ```bash
 basecamp comments list <recording_id> --in <project> --json
+basecamp comments thread <comment-id|comment-url> --json          # Reply-ready: parent + focus + discussion + @mention
+basecamp comments thread <comment-id> --all --json                # Every fetched comment instead of a window
+basecamp comments thread <comment-id> --window 11 --json          # Focus-centered window of 11
 basecamp comments create <recording_id> "Text" --in <project>
 basecamp comments create <recording_id> "@Jane.Smith, looks good!" --in <project>  # With @mention
 basecamp comments update <id> "Updated" --in <project>

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -218,9 +218,9 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 that accepts a URL directly** (`show`, `comments show`, `comments thread`,
 `attachments …`), which extract the IDs for you. Only `comments show` and
 `comments thread` verify the URL's host and account before any fetch. For other
-URL-accepting commands, only pass URLs from a trusted Basecamp host: `basecamp url
-parse` extracts IDs but does **not** validate the URL's origin, so parsing an
-attacker-controlled path yields trusted-looking IDs.
+URL-accepting commands, only pass URLs from a trusted Basecamp host:
+`basecamp url parse` extracts IDs but does **not** validate the URL's origin, so
+parsing an attacker-controlled path yields trusted-looking IDs.
 
 ```bash
 basecamp url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598" --json

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -190,7 +190,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 | Read ping thread | `basecamp api get "/buckets/<circle_id>/chats/<chat_id>/lines.json" --agent` |
 | Post to ping thread | `basecamp api post "/buckets/<circle_id>/chats/<chat_id>/lines.json" --data '{"content":"<p>message</p>"}' --json` |
 | Add comment | `basecamp comments create <recording_id> "Text" --in <project> --json` |
-| Inspect comment / reply atoms | `basecamp comments show <url> --jq '.data \| {reply_target, mention}'` |
+| Inspect comment / reply atoms | `basecamp comments show <url> --json` → `reply_target` + `mention` in `.data` |
 | List attachments | `basecamp attachments list <id\|url> --json` |
 | Download attachments | `basecamp attachments download <id> --out /tmp/` |
 | Show + download | `basecamp todos show <id> --download-attachments --json` |

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -216,7 +216,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 
 **Parse URLs before acting on them — unless you're handing the URL to a command
 that accepts a URL directly** (`show`, `comments show`, `comments thread`,
-`attachments …`), which extract the IDs for you. Only `comments show` and
+`attachments list`/`attachments download`), which extract the IDs for you. Only `comments show` and
 `comments thread` verify the URL's host and account before any fetch. For other
 URL-accepting commands, only pass URLs from a trusted Basecamp host:
 `basecamp url parse` extracts IDs but does **not** validate the URL's origin, so

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -248,9 +248,11 @@ basecamp comments create 123 "Reply" --in <project>
 # Or get the whole reply-ready context deterministically in one call:
 basecamp comments thread "https://...messages/123#__recording_456" --json
 # .data.reply_target.recording_id  → where to post the reply
+# .data.reply_target.account_id    → the account that reply belongs to (build a fully-qualified command)
 # .data.focus.author.mention.syntax → paste-ready [@Name](mention:SGID)
 # .data.comments                   → surrounding discussion (default window of 41)
 # --all returns every fetched comment; --window N sets the window size
+# When the account came from the URL (none configured), the reply breadcrumb carries --account
 ```
 
 ## Decision Trees
@@ -699,9 +701,9 @@ basecamp comments update <id> "Updated" --in <project>
 
 **Cheap atoms vs. deep context (choose by need):**
 - `comments show <url> --jq '.data | {reply_target, mention}'` — one API call. Returns
-  `reply_target.recording_id` (where a reply is posted — comments are flat) and a
-  paste-ready author `mention` (JSON only; human output shows a reply breadcrumb). Use
-  this for the exact-comment reply atoms.
+  `reply_target` (`recording_id` — where a reply is posted, comments are flat — plus
+  `account_id`) and a paste-ready author `mention` (JSON only; human output shows a reply
+  breadcrumb). Use this for the exact-comment reply atoms.
 - `comments thread <url>` — two extra calls. Adds the full parent recording, the
   surrounding discussion (windowed, truncation-honest), and focus attachments. Use this
   when the surrounding discussion matters.

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -190,6 +190,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 | Read ping thread | `basecamp api get "/buckets/<circle_id>/chats/<chat_id>/lines.json" --agent` |
 | Post to ping thread | `basecamp api post "/buckets/<circle_id>/chats/<chat_id>/lines.json" --data '{"content":"<p>message</p>"}' --json` |
 | Add comment | `basecamp comments create <recording_id> "Text" --in <project> --json` |
+| Inspect comment / reply atoms | `basecamp comments show <url> --jq '.data \| {reply_target, mention}'` |
 | List attachments | `basecamp attachments list <id\|url> --json` |
 | Download attachments | `basecamp attachments download <id> --out /tmp/` |
 | Show + download | `basecamp todos show <id> --download-attachments --json` |
@@ -213,7 +214,13 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 
 ## URL Parsing
 
-**Always parse URLs before acting on them:**
+**Parse URLs before acting on them — unless you're handing the URL to a command
+that accepts a URL directly** (`show`, `comments show`, `comments thread`,
+`attachments …`), which extract the IDs for you. Only `comments show` and
+`comments thread` verify the URL's host and account before any fetch. For other
+URL-accepting commands, only pass URLs from a trusted Basecamp host: `basecamp url
+parse` extracts IDs but does **not** validate the URL's origin, so parsing an
+attacker-controlled path yields trusted-looking IDs.
 
 ```bash
 basecamp url parse "https://3.basecamp.com/2914079/buckets/41746046/messages/9478142982#__recording_9488783598" --json
@@ -265,6 +272,7 @@ Need to find something?
 │   Note: Defaults to active status; use --status archived for archived items
 │   ⚠ No assignee data — cannot filter by person; use reports assigned instead
 ├── Full-text search? → basecamp search "query" --json
+├── Have a comment URL, or a notification link targeting a comment? → basecamp comments thread <url> --json
 └── Have a URL? → basecamp url parse "<url>" --json
 ```
 
@@ -276,7 +284,11 @@ Want to change something?
 ├── Have ID? → basecamp <resource> update <id> --field value
 ├── Change status? → basecamp recordings trash|archive|restore <id>
 ├── Complete todo? → basecamp todos complete <id>
-└── Complete card? → basecamp cards done <id|url> --in <project>
+├── Complete card? → basecamp cards done <id|url> --in <project>
+└── Reply to a comment? → basecamp comments show <url> --jq '.data | {reply_target, mention}'
+    (one call, cheap atoms — the mention is machine-only, so use --jq/--json, not plain show)
+    or basecamp comments thread <url> when you need the surrounding discussion;
+    then basecamp comments create <reply_target.recording_id> <text>
 ```
 
 ## Common Workflows
@@ -676,6 +688,7 @@ case. To change visibility on an already-created recording, use
 
 ```bash
 basecamp comments list <recording_id> --in <project> --json
+basecamp comments show <comment-id|comment-url> --json            # Now returns reply_target + paste-ready mention (JSON)
 basecamp comments thread <comment-id|comment-url> --json          # Reply-ready: parent + focus + discussion + @mention
 basecamp comments thread <comment-id> --all --json                # Every fetched comment instead of a window
 basecamp comments thread <comment-id> --window 11 --json          # Focus-centered window of 11
@@ -683,6 +696,15 @@ basecamp comments create <recording_id> "Text" --in <project>
 basecamp comments create <recording_id> "@Jane.Smith, looks good!" --in <project>  # With @mention
 basecamp comments update <id> "Updated" --in <project>
 ```
+
+**Cheap atoms vs. deep context (choose by need):**
+- `comments show <url> --jq '.data | {reply_target, mention}'` — one API call. Returns
+  `reply_target.recording_id` (where a reply is posted — comments are flat) and a
+  paste-ready author `mention` (JSON only; human output shows a reply breadcrumb). Use
+  this for the exact-comment reply atoms.
+- `comments thread <url>` — two extra calls. Adds the full parent recording, the
+  surrounding discussion (windowed, truncation-honest), and focus attachments. Use this
+  when the surrounding discussion matters.
 
 ### Files & Documents
 


### PR DESCRIPTION
## What

Turn a pasted comment reference into context an agent can act on without second-guessing, decomposed across two commands by cost:

- **`comments thread <comment-id|url>`** (new) — composes the focus comment's `Get` + its parent recording (fetched via a type-derived endpoint, never the payload URL) + the parent's active-comment `List` into one reply-ready envelope: reply target, paste-ready author `@mention`, a truncation-honest discussion window, and focus attachments. Two extra calls, justified by full parent context.
- **`comments show <comment-id|url>`** (enriched) — surfaces the two cheap reply atoms (`reply_target` + a paste-ready `mention`) from the single `Get` it already makes. Zero extra API calls; correct-by-default at the command agents already reach for.

## Trust contract

Both commands share one resolver (`resolveCommentTrigger`) that enforces every trust-boundary check **before any API call**:

- **Trusted host only** — a URL-shaped trigger must live on a trusted Basecamp host (`hostutil.IsTrustedBasecampHost`), so a look-alike on an attacker-controlled host can't be parsed into a fetch of an internal comment (confused-deputy; mirrors `chat update`).
- **Exact-comment classification** — a plain recording URL / collection is rejected with a pointer to `basecamp show`.
- **ID validated before account resolution** — a non-positive ID fails as `Invalid comment ID` with zero requests even when no account is configured.
- **URL account governs the fetch** — adopted when nothing is configured (no interactive selection of a different account), a configured mismatch rejected rather than silently targeting elsewhere.

## thread completeness

- Focus `content_attachments` preserved + a type-safe `attachments download <id> --type comment` breadcrumb (before the reply breadcrumb) that fires even when the focus is absent from the fetched list.
- Selection-aware neutral notice when the focus is absent, composed with the truncation sentence into one notice.
- Author `@mention` rendered in human output, not just JSON.
- Summary is a pure function over the full `fetch_complete × focus_present × selection` matrix — never claims to center "around the focus" when the focus is absent, never asserts a server-side total the fetch didn't confirm.
- Empty parent-recording body hard-errors instead of claiming `recording_full`.

## show enrichment

- `reply_target` (the parent recording) + paste-ready `mention` ride in machine `.data`; a reply breadcrumb is the human-output affordance. No extra call. Fails closed if the normalized shape isn't a map; graceful when parent/creator is absent. `comment.yaml` is untouched, so `comments list/create/update` are unaffected.

## Docs & routing

- `skills/basecamp/SKILL.md`: URL invariant amended for URL-aware commands (accurately scoped — only `comments show`/`comments thread` verify host+account); Finding/Modifying decision trees, a dedicated quick-ref row, and the cheap-atoms-vs-deep-context decomposition.
- `API-COVERAGE.md`: comments row notes `show` now surfaces `reply_target`/`mention`.

## Tests

Unit + e2e cover: three trigger forms resolving the same comment; untrusted-host (direct, fragment, api look-alike), plain-recording-URL, account-mismatch, and non-positive-ID rejections with **zero requests** on both commands; empty-config URL-account adoption; focus-attachment survival when absent from the list; selection-aware notices (+ truncation composition); mention in styled + markdown; the full summary matrix (6 rows) + a `41 of 50` integration fixture; empty parent-body hard error; show enrichment invariants (`reply_target.recording_id == parent.id`, one request, reply breadcrumb ordering). `e2e/comments.bats` 15/15.

`bin/ci` green on the head commit (surface current, skill drift green, provenance OK, uncovered leaves 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `comments thread` to turn a comment link into deterministic, reply‑ready context, and enriches `comments show` with cheap reply atoms. Also polishes the SKILL quick‑ref so quick‑ref commands copy cleanly.

- **New Features**
  - `comments thread <comment-id|comment-url>` returns a reply-ready envelope: full parent recording (via type endpoint), focus (with attachments), a sorted discussion window (default 41; `--all` or `--window N`), paste‑ready `@mention`, `reply_target`, and reply/attachment-download breadcrumbs. Emits notices for truncation and when the focus isn’t in the fetched comments.
  - `comments show` adds `reply_target` and `mention` in `.data` and shows a reply breadcrumb, with no extra API calls.
  - One shared resolver (`resolveCommentTrigger`) guards both commands before any request: trusted Basecamp host only, exact comment classification (plain recording URLs are rejected with a pointer to `basecamp show`), positive ID, and URL/account agreement (adopts URL account if unconfigured; rejects mismatches).

- **Bug Fixes**
  - Reply contract is now self-contained: `reply_target` includes `account_id`, and reply breadcrumbs append `--account <id>` when the account is non‑persistent (adopted from URL, `--account` flag, or prompt) so follow‑ups work in a fresh process.
  - `comments show` guards empty/zero comment responses and returns `empty_response` instead of a bogus success.
  - `comments thread` guards an empty/zero focus comment and returns `empty_response` before any parent dereference.
  - Thread headline falls back to `content` for Todo/Todolist::Todo parents so titles never render empty.

<sup>Written for commit f189270ce3722c5f0eb6b42c8639d3234dd92ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

