### PR TITLE
Fix piped installer under nounset

### DIFF
--- a/e2e/installer.bats
+++ b/e2e/installer.bats
@@ -67,6 +67,15 @@ run_post_install_setup() {
   [[ "$output" != *"Basecamp CLI"* ]]  # banner would print if main ran
 }
 
+@test "install.sh runs main when piped to bash" {
+  # Keep PATH empty so main stops at its curl prerequisite without downloading
+  # anything or modifying the test environment.
+  run bash -c "cat '$INSTALL_SH' | PATH='$BATS_TEST_TMPDIR' /bin/bash"
+  [[ "$status" -ne 0 ]]
+  [[ "$output" == *"curl is required but not installed"* ]]
+  [[ "$output" != *"BASH_SOURCE[0]: unbound variable"* ]]
+}
+
 @test "new binary: post_install_setup dispatches to 'setup agents', never 'setup claude'" {
   run_post_install_setup
   [[ "$status" -eq 0 ]]

--- a/e2e/installer.bats
+++ b/e2e/installer.bats
@@ -70,7 +70,7 @@ run_post_install_setup() {
 @test "install.sh runs main when piped to bash" {
   # Keep PATH empty so main stops at its curl prerequisite without downloading
   # anything or modifying the test environment.
-  run bash -c "cat '$INSTALL_SH' | PATH='$BATS_TEST_TMPDIR' /bin/bash"
+  run bash -c "cat '$INSTALL_SH' | PATH='$BATS_TEST_TMPDIR' '$BASH'"
   [[ "$status" -ne 0 ]]
   [[ "$output" == *"curl is required but not installed"* ]]
   [[ "$output" != *"BASH_SOURCE[0]: unbound variable"* ]]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -542,6 +542,6 @@ post_install_setup() {
 # Guard so sourcing the script (e.g. from tests) doesn't run the installer.
 # The if-form is required: `[[ … ]] && main` returns 1 when sourced, which
 # trips `set -e` in the sourcing shell.
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   main "$@"
 fi


### PR DESCRIPTION
## What

- Make the installer source guard tolerate an unset `BASH_SOURCE[0]` when Bash reads the script from standard input.
- Add a regression test that pipes the real installer into Bash without downloading or installing anything.

## Why

The documented `curl ... | bash` installation path runs with `BASH_SOURCE[0]` unset. The source guard added in #558 dereferences that value while `set -u` is active, so the installer exits before `main` runs. Falling back to `$0` preserves direct and piped execution while still preventing `main` from running when the script is sourced.

## Testing

- [x] `bats e2e/installer.bats`
- [x] `bin/ci`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the installer so piping to `bash` works under `set -u`. The source guard now tolerates an unset `BASH_SOURCE[0]`, so `curl ... | bash` runs `main` as expected.

- **Bug Fixes**
  - Update guard to `[[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]` to handle stdin execution while still preventing execution when sourced.
  - Add e2e test that pipes the real installer to `bash`, runs with the current `$BASH`, and asserts it fails on missing `curl` (not on an unbound variable).

<sup>Written for commit 0f3b638fbc124c2a237768553ec6e8389378a023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

