### PR TITLE
Add post-deploy installer smoke canary

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,0 +1,72 @@
+name: Installer Smoke
+
+# Post-deploy canary for the published installer (#558/#568). The install
+# endpoint serves main, so merge == deploy for scripts/install.sh: the bats
+# suite gates pre-merge, and this catches a broken published installer after.
+# Runs the documented Quick Start shape (curl pipe to bash), not a checkout.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/install.sh
+
+permissions: {}
+
+concurrency:
+  group: installer-smoke-${{ github.ref }}
+
+jobs:
+  linux:
+    name: Linux (modern bash)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install from the published endpoint
+        run: |
+          # Scratch HOME + explicit BASECAMP_BIN_DIR contain the installer's
+          # writes: even with the wizard and agent connection skipped, it
+          # still edits shell config and installs the baseline skill.
+          smoke_root=$(mktemp -d)
+          mkdir -p "$smoke_root/home" "$smoke_root/bin"
+          export HOME="$smoke_root/home"
+          export BASECAMP_BIN_DIR="$smoke_root/bin"
+          export BASECAMP_SKIP_SETUP=1
+          export BASECAMP_SETUP_AGENT=none
+
+          # Cache-bust with the commit SHA: raw.githubusercontent.com serves
+          # max-age=300, so a push-triggered run could otherwise fetch the
+          # pre-push installer and falsely pass. The canonical endpoint
+          # preserves the query string on redirect, making each commit's
+          # request cache-distinct.
+          curl -fsSL "https://basecamp.com/install-cli?sha=${GITHUB_SHA}" | bash
+
+          # Assert the deterministic installed path, not ambient PATH.
+          "$BASECAMP_BIN_DIR/basecamp" version
+
+  macos:
+    name: macOS (stock bash 3.2)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install via stock /bin/bash
+        run: |
+          # Assert exactly Bash 3.2, through the same interpreter that runs
+          # the install — honest 3.2 coverage instead of silently degrading
+          # if a future runner image changes /bin/bash.
+          /bin/bash -c '[[ "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" == "3.2" ]]' \
+            || { echo "/bin/bash is not Bash 3.2:" >&2; /bin/bash --version >&2; exit 1; }
+
+          smoke_root=$(mktemp -d)
+          mkdir -p "$smoke_root/home" "$smoke_root/bin"
+          export HOME="$smoke_root/home"
+          export BASECAMP_BIN_DIR="$smoke_root/bin"
+          export BASECAMP_SKIP_SETUP=1
+          export BASECAMP_SETUP_AGENT=none
+
+          curl -fsSL "https://basecamp.com/install-cli?sha=${GITHUB_SHA}" | /bin/bash
+
+          "$BASECAMP_BIN_DIR/basecamp" version

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -18,6 +18,7 @@ permissions: {}
 
 concurrency:
   group: installer-smoke-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   linux:

--- a/e2e/installer.bats
+++ b/e2e/installer.bats
@@ -68,8 +68,8 @@ run_post_install_setup() {
 }
 
 @test "install.sh runs main when piped to bash" {
-  # Keep PATH empty so main stops at its curl prerequisite without downloading
-  # anything or modifying the test environment.
+  # PATH points at a binary-free tmpdir so main stops at its curl
+  # prerequisite without downloading anything or touching the host.
   run bash -c "cat '$INSTALL_SH' | PATH='$BATS_TEST_TMPDIR' '$BASH'"
   [[ "$status" -ne 0 ]]
   [[ "$output" == *"curl is required but not installed"* ]]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -541,7 +541,9 @@ post_install_setup() {
 
 # Guard so sourcing the script (e.g. from tests) doesn't run the installer.
 # The if-form is required: `[[ … ]] && main` returns 1 when sourced, which
-# trips `set -e` in the sourcing shell.
+# trips `set -e` in the sourcing shell. The `:-$0` fallback is also
+# required: bash executing from stdin (curl | bash) or -c leaves BASH_SOURCE
+# unset, and the bare expansion aborts under `set -u` (#568).
 if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   main "$@"
 fi


### PR DESCRIPTION
## What

A post-deploy canary for the published installer, plus two installer-scoped comment fixes from the #568 incident review.

The install endpoint serves `main`, so merging a change to `scripts/install.sh` deploys it immediately. #558 shipped a sourcing guard that broke the documented `curl … | bash` path under `set -u`; #568 fixed it and added a bats regression test that gates pre-merge. Nothing verified the *published* installer post-merge — this closes that gap.

## The canary (`.github/workflows/installer-smoke.yml`)

- **Triggers**: nightly schedule, `workflow_dispatch`, and push to `main` touching `scripts/install.sh`.
- **Endpoint**: the canonical Quick Start command from the README, cache-busted with the commit SHA (`?sha=${GITHUB_SHA}`) — raw.githubusercontent.com serves `max-age=300`, so a push-triggered run could otherwise fetch the pre-push installer and falsely pass. The canonical endpoint preserves the query on redirect, making each commit's request cache-distinct.
- **Legs**: `ubuntu-latest` (modern bash) and `macos-latest` via stock `/bin/bash`, which asserts exactly Bash 3.2 through the same interpreter that runs the install — the coverage can't silently degrade if a future runner image changes `/bin/bash`.
- **Isolation**: scratch `HOME` + explicit `BASECAMP_BIN_DIR` contain the installer's writes (it edits shell config and installs the baseline skill even with `BASECAMP_SKIP_SETUP=1` / `BASECAMP_SETUP_AGENT=none`). Asserts the deterministic installed path, not ambient PATH.
- **Hygiene**: `permissions: {}`, `timeout-minutes: 10`, concurrency group; no actions used, so nothing to pin. actionlint and zizmor clean.

## Comment fixes

- `e2e/installer.bats`: the piped-execution test's PATH comment said "Keep PATH empty"; it actually points at a binary-free tmpdir.
- `scripts/install.sh`: document why the guard's `:-$0` fallback is required (bash from stdin or `-c` leaves `BASH_SOURCE` unset, aborting under `set -u`) so a future cleanup doesn't re-break piping.

## Verification

- `bats e2e/installer.bats` — 12/12 pass.
- `bin/ci` green.
- Will `workflow_dispatch` the canary after merge to confirm both legs.

Refs #558, #568

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-deploy smoke canary that installs the published CLI via the Quick Start on Linux and macOS. Also updates installer comments and sets explicit workflow concurrency behavior.

- **New Features**
  - Adds `.github/workflows/installer-smoke.yml`: runs nightly, on demand, and when `scripts/install.sh` changes; `permissions: {}`, `timeout-minutes: 10`, concurrency group with `cancel-in-progress: false`.
  - Installs from `https://basecamp.com/install-cli?sha=${GITHUB_SHA}` to bust CDN cache; verifies the binary at the deterministic install path.
  - Runs on `ubuntu-latest` and `macos-latest`; macOS uses `/bin/bash` and asserts Bash 3.2; uses scratch `HOME` and `BASECAMP_BIN_DIR` to isolate writes.

- **Bug Fixes**
  - Corrects PATH comment in `e2e/installer.bats` to note a binary-free tmpdir.
  - Documents why `${BASH_SOURCE[0]:-$0}` is required in `scripts/install.sh` to keep `curl | bash` working with `set -u`.

<sup>Written for commit 48bd75c2e5b2191f442d61dfe0a339fedfcf26ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

