### PR TITLE
Disable keyring in installer canary

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -16,6 +16,12 @@ on:
 
 permissions: {}
 
+# The post-install skill step reaches for the OS keyring; on a headless macOS
+# runner the `security` tool blocks forever on the locked keychain (caught by
+# this canary's first run). Same escape hatch the Test workflow uses.
+env:
+  BASECAMP_NO_KEYRING: "1"
+
 concurrency:
   group: installer-smoke-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
The canary added in #569 hung on its first two macOS runs (push-triggered and dispatched) for the full 10-minute `timeout-minutes`, right after "Skipping setup wizard". The cancelled job's orphan processes were `basecamp` and `security`: the post-install skill step reaches for the OS keyring, and on a headless macOS runner the `security` tool blocks forever on the locked keychain. The Linux leg passed on both runs.

Set `BASECAMP_NO_KEYRING=1` at the workflow level — the same escape hatch `test.yml` uses. The variable reaches the installer's child `basecamp` processes through the step environment.

Verification: will dispatch the canary after merge and confirm both legs pass.

Refs #569

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable keyring usage in the installer canary workflow to stop macOS runs from hanging on headless keychain prompts. Sets `BASECAMP_NO_KEYRING=1` at the workflow level so child `basecamp` processes skip the `security` keychain call; Linux runs are unchanged.

<sup>Written for commit 8d8b5ad244fcee30c39aa18e9c4d61b696f38c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

