### PR TITLE
Sync Dependabot action pin comments via reusable workflow

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -1,0 +1,46 @@
+name: Sync Dependabot action pin comments
+
+# Thin caller: all logic lives in basecamp/.github's reusable workflow —
+# trusted default-branch code that fetches the Dependabot head branch as data
+# only, rewrites stale `# vX.Y.Z` pin comments, and pushes back behind a
+# compare-and-swap lease using the write deploy key scoped to this repo's
+# dependabot-sync environment.
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
+    workflows: [Test]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Dependabot branch to sync (dependabot/github_actions/...)
+        required: true
+        type: string
+      e2e:
+        description: "E2E proof mode: expect a draft PR authored by the dispatcher on a dependabot/github_actions/e2e-proof-* branch"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  sync:
+    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
+    # the reusable workflow re-checks this and everything else.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    with:
+      ci-workflow-name: Test
+      branch: ${{ inputs.branch || '' }}
+      e2e: ${{ inputs.e2e || false }}
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    # The deploy key is scoped to this repo's dependabot-sync environment
+    # (deployment branches: default branch only); environment secrets cannot
+    # be forwarded explicitly to a reusable workflow, so inherit is required.
+    secrets: inherit # zizmor: ignore[secrets-inherit] -- see above; the called workflow is SHA-pinned and reads only SYNC_ACTIONS_DEPLOY_KEY, gated by the dependabot-sync environment

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -10,6 +10,7 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
     workflows: [Test]
     types: [completed]
+    branches: ["dependabot/github_actions/**"]
   workflow_dispatch:
     inputs:
       branch:
@@ -26,8 +27,9 @@ permissions: {}
 
 jobs:
   sync:
-    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
-    # the reusable workflow re-checks this and everything else.
+    # Defense-in-depth behind the trigger-level branches filter (which stops
+    # runs from being created for other branches at all); the reusable
+    # workflow re-checks this and everything else.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.4.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           go-version-file: 'go.mod'
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Cache BATS
         id: cache-bats
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5.0.5 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           path: ~/.local
           key: bats-1.11.0-home
@@ -127,7 +127,7 @@ jobs:
           permission-contents: write
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.4.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
Thin caller for the `dependabot-sync-actions-comments` reusable workflow (basecamp/.github#8, merged as 95a9f7a2). After CI completes on a Dependabot `github_actions` branch, trusted default-branch code fixes any stale `# vX.Y.Z` pin comments — including compound ones with trailing `# zizmor: ignore[...]` annotations that Dependabot can't rewrite — and pushes back behind a compare-and-swap lease.

Security model (openclaw-basecamp lineage, hardened after basecamp-sdk#458 review): the Dependabot head branch is fetched as *data* and never executed; the push uses a write deploy key scoped to this repo's `dependabot-sync` environment, whose deployment branch policy allows only the default branch (App tokens can't push workflow-file changes at all). Environment + deploy key are already provisioned.

Second commit is a one-time catch-up running the updater against current workflows: 3 stale comments in release.yml (setup-go v6.4.0→v6.5.0 ×2, cache v5.0.5→v6.1.0).

Runtime validation: after merge, a `workflow_dispatch` run against a live Dependabot actions branch (basecamp-cli#566 is the standing candidate) proves the full fix→guard→push→re-CI loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow to auto-sync Dependabot Actions pin comments after CI, keeping `# vX.Y.Z` hints accurate without running untrusted code. Also updates stale comment versions in `release.yml` (`actions/setup-go` → v6.5.0; `actions/cache` → v6.1.0).

- **New Features**
  - Adds `.github/workflows/dependabot-sync-actions-comments.yml`, a thin caller for the SHA-pinned reusable workflow in `basecamp/.github`.
  - Triggers on `workflow_run` of `Test` for `dependabot/github_actions/**` only, plus manual `workflow_dispatch` (`branch`, `e2e` inputs); keeps a job-level `if` as defense-in-depth.
  - Rewrites stale pin comments, including lines with trailing `# zizmor: ignore[...]`, on Dependabot action PR branches.
  - Security: fetches the Dependabot branch as data only; pushes via a deploy key scoped to the `dependabot-sync` environment with minimal permissions and `secrets: inherit`.

<sup>Written for commit 4238cf9a005cf9163a703e7d5fe843b867214700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

