### PR TITLE
Bare pin comments: let Dependabot maintain action version comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           go-version-file: 'go.mod'
 
@@ -46,7 +47,8 @@ jobs:
 
       - name: Cache BATS
         id: cache-bats
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           path: ~/.local
           key: bats-1.11.0-home
@@ -127,7 +129,8 @@ jobs:
           permission-contents: write
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to the cache used by tag-push workflows
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           advanced-security: false
 


### PR DESCRIPTION
Dependabot rewrites *bare* `# vX.Y.Z` comments on pinned `uses:` lines natively but cannot touch compound ones carrying a trailing `# zizmor: ignore[...]`. Moving each ignore to its own line directly below the pin (reason text kept, association verified under zizmor 1.28) makes Dependabot itself the comment maintainer — no push automation required on its PRs. Same restructure basecamp-sdk shipped in basecamp-sdk#458. Part of the post-merge redesign of the comment-sync program (see basecamp/.github#10 for why in-PR pushing is unsafe: a deploy-key push flips the run actor off dependabot[bot] and lifts the Dependabot sandbox for the unreviewed bumped actions).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `zizmor` ignores to their own line under each pinned `uses:` so Dependabot can update bare `# vX.Y.Z` comments automatically. Upgrade `zizmorcore/zizmor-action` to v0.6.0 to ensure standalone ignore comments are recognized.

- **Refactors**
  - Split trailing `# zizmor: ignore[...]` off `uses:` pins in `release.yml`; reasons preserved.
  - No workflow behavior changes.

- **Dependencies**
  - Bumped `zizmorcore/zizmor-action` from v0.5.7 to v0.6.0 in `test.yml` to support standalone ignore association.

<sup>Written for commit eda3bc4a77b2447fac7a91fe79b2e1e07c4f8d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

