### PR TITLE
Bound the keyring probe on headless sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/basecamp/basecamp-sdk/go v0.9.1-0.20260727173625-bb363c847b92
-	github.com/basecamp/cli v0.2.1
+	github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/basecamp-sdk/go v0.9.1-0.20260727173625-bb363c847b92 h1:4gQJTR8e5kBvXHDHLvef+Q00XY7KzWTxnQSLWMSPcyA=
 github.com/basecamp/basecamp-sdk/go v0.9.1-0.20260727173625-bb363c847b92/go.mod h1:r83ralDQ0q9vbAby5qQ5x9hgCgUdJLDLHYpiU6jaFjE=
-github.com/basecamp/cli v0.2.1 h1:8GyehPVtsTXla0oOPu4QgXRjwwzJ99prlByvyi+0HRQ=
-github.com/basecamp/cli v0.2.1/go.mod h1:p8tt/DatJ2LAzWO6N6tNfV8x3gF5T3IxDTo+U8FfWPo=
+github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c h1:+5sQBl8sqYoD1Qhwsibn8sBCKWPyZ9NDez6mnuo9Afo=
+github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c/go.mod h1:EK1Dba6DEw8ZAilVBpf/jri3ONDV7LQkLACSDe73f/c=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/basecamp/cli/credstore"
+	"github.com/charmbracelet/x/term"
 )
 
 // Credentials holds OAuth tokens and metadata.
@@ -38,6 +40,23 @@ type Store struct {
 // newCredStore is replaceable in tests to avoid real keyring access.
 var newCredStore = credstore.NewStore
 
+// stderrIsTerminal reports whether a human is attached. Stderr, not stdout:
+// interactive use routinely pipes stdout (JSON to jq) while prompts and
+// warnings still reach the terminal. Replaceable in tests.
+var stderrIsTerminal = func() bool {
+	return term.IsTerminal(os.Stderr.Fd())
+}
+
+// headlessProbeTimeout bounds the keyring availability probe when no
+// terminal is attached. A headless session (CI, piped installers, ssh
+// without a TTY) can never answer a keychain unlock prompt, so an
+// unavailable keyring must fall back to file storage instead of hanging
+// forever in an uncancellable `security` child — the #568 incident class.
+// Interactive sessions keep the unbounded probe: a locked keychain there
+// raises an unlock prompt, and cutting it off mid-answer would silently
+// degrade the user to plaintext file storage.
+const headlessProbeTimeout = 10 * time.Second
+
 // NewStore creates a credential store. The OS keyring is not touched until
 // the first credential operation.
 func NewStore(fallbackDir string) *Store {
@@ -49,11 +68,15 @@ func NewStore(fallbackDir string) *Store {
 // sync.Once provides the synchronization.
 func (s *Store) ensure() *credstore.Store {
 	s.initOnce.Do(func() {
-		s.inner = newCredStore(credstore.StoreOptions{
+		opts := credstore.StoreOptions{
 			ServiceName:   "basecamp",
 			DisableEnvVar: "BASECAMP_NO_KEYRING",
 			FallbackDir:   s.fallbackDir,
-		})
+		}
+		if !stderrIsTerminal() {
+			opts.ProbeTimeout = headlessProbeTimeout
+		}
+		s.inner = newCredStore(opts)
 	})
 	return s.inner
 }

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -40,15 +40,18 @@ type Store struct {
 // newCredStore is replaceable in tests to avoid real keyring access.
 var newCredStore = credstore.NewStore
 
-// sessionIsHeadless reports that no human is attached: stdin, stdout, and
-// stderr are all non-terminals. Any one being a terminal counts as
-// interactive — redirecting a stream or two (`2>auth.log`, `| jq`) is
-// routine interactive use where a keychain unlock prompt can still be
-// answered, on the controlling terminal or the GUI. Replaceable in tests.
+// sessionIsHeadless reports that no human can answer a keyring unlock
+// prompt: stdin, stdout, and stderr are all non-terminals AND no GUI
+// session is available. Any attached stream counts as interactive —
+// redirecting a stream or two (`2>auth.log`, `| jq`) is routine interactive
+// use — and a GUI session (an app or IDE task runner launching the CLI with
+// all streams detached) can still present the unlock dialog. Replaceable in
+// tests.
 var sessionIsHeadless = func() bool {
 	return !term.IsTerminal(os.Stdin.Fd()) &&
 		!term.IsTerminal(os.Stdout.Fd()) &&
-		!term.IsTerminal(os.Stderr.Fd())
+		!term.IsTerminal(os.Stderr.Fd()) &&
+		!guiSessionAvailable()
 }
 
 // headlessProbeTimeout bounds the keyring availability probe when no

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -40,21 +40,25 @@ type Store struct {
 // newCredStore is replaceable in tests to avoid real keyring access.
 var newCredStore = credstore.NewStore
 
-// stderrIsTerminal reports whether a human is attached. Stderr, not stdout:
-// interactive use routinely pipes stdout (JSON to jq) while prompts and
-// warnings still reach the terminal. Replaceable in tests.
-var stderrIsTerminal = func() bool {
-	return term.IsTerminal(os.Stderr.Fd())
+// sessionIsHeadless reports that no human is attached: stdin, stdout, and
+// stderr are all non-terminals. Any one being a terminal counts as
+// interactive — redirecting a stream or two (`2>auth.log`, `| jq`) is
+// routine interactive use where a keychain unlock prompt can still be
+// answered, on the controlling terminal or the GUI. Replaceable in tests.
+var sessionIsHeadless = func() bool {
+	return !term.IsTerminal(os.Stdin.Fd()) &&
+		!term.IsTerminal(os.Stdout.Fd()) &&
+		!term.IsTerminal(os.Stderr.Fd())
 }
 
 // headlessProbeTimeout bounds the keyring availability probe when no
-// terminal is attached. A headless session (CI, piped installers, ssh
-// without a TTY) can never answer a keychain unlock prompt, so an
-// unavailable keyring must fall back to file storage instead of hanging
-// forever in an uncancellable `security` child — the #568 incident class.
-// Interactive sessions keep the unbounded probe: a locked keychain there
-// raises an unlock prompt, and cutting it off mid-answer would silently
-// degrade the user to plaintext file storage.
+// terminal is attached to any standard stream. A headless session (CI,
+// piped installers, ssh without a TTY) can never answer a keychain unlock
+// prompt, so an unavailable keyring must fall back to file storage instead
+// of hanging forever in an uncancellable `security` child — the #568
+// incident class. Interactive sessions keep the unbounded probe: a locked
+// keychain there raises an unlock prompt, and cutting it off mid-answer
+// would silently degrade the user to plaintext file storage.
 const headlessProbeTimeout = 10 * time.Second
 
 // NewStore creates a credential store. The OS keyring is not touched until
@@ -73,7 +77,7 @@ func (s *Store) ensure() *credstore.Store {
 			DisableEnvVar: "BASECAMP_NO_KEYRING",
 			FallbackDir:   s.fallbackDir,
 		}
-		if !stderrIsTerminal() {
+		if sessionIsHeadless() {
 			opts.ProbeTimeout = headlessProbeTimeout
 		}
 		s.inner = newCredStore(opts)

--- a/internal/auth/keyring_test.go
+++ b/internal/auth/keyring_test.go
@@ -45,17 +45,17 @@ func TestNewStoreIsLazy(t *testing.T) {
 	assert.Equal(t, 1, calls, "construction happens once")
 }
 
-// swapStderrIsTerminal replaces the interactivity seam for the test.
-func swapStderrIsTerminal(t *testing.T, interactive bool) {
+// swapSessionIsHeadless replaces the interactivity seam for the test.
+func swapSessionIsHeadless(t *testing.T, headless bool) {
 	t.Helper()
-	orig := stderrIsTerminal
-	stderrIsTerminal = func() bool { return interactive }
-	t.Cleanup(func() { stderrIsTerminal = orig })
+	orig := sessionIsHeadless
+	sessionIsHeadless = func() bool { return headless }
+	t.Cleanup(func() { sessionIsHeadless = orig })
 }
 
 // ensureOptions constructs a store's credstore through the seams and returns
 // the options it was built with.
-func ensureOptions(t *testing.T, interactive bool) credstore.StoreOptions {
+func ensureOptions(t *testing.T, headless bool) credstore.StoreOptions {
 	t.Helper()
 	t.Setenv("BASECAMP_NO_KEYRING", "1") // keep the delegated construction off the real keyring
 
@@ -64,7 +64,7 @@ func ensureOptions(t *testing.T, interactive bool) credstore.StoreOptions {
 		got = opts
 		return credstore.NewStore(opts)
 	})
-	swapStderrIsTerminal(t, interactive)
+	swapSessionIsHeadless(t, headless)
 
 	NewStore(t.TempDir()).UsingKeyring()
 	return got
@@ -75,6 +75,6 @@ func ensureOptions(t *testing.T, interactive bool) credstore.StoreOptions {
 // the unbounded probe so a legitimate unlock prompt is never cut off
 // mid-answer (which would silently degrade to plaintext file storage).
 func TestEnsureBoundsProbeOnlyWhenHeadless(t *testing.T) {
-	assert.Equal(t, headlessProbeTimeout, ensureOptions(t, false).ProbeTimeout)
-	assert.Zero(t, ensureOptions(t, true).ProbeTimeout)
+	assert.Equal(t, headlessProbeTimeout, ensureOptions(t, true).ProbeTimeout)
+	assert.Zero(t, ensureOptions(t, false).ProbeTimeout)
 }

--- a/internal/auth/keyring_test.go
+++ b/internal/auth/keyring_test.go
@@ -44,3 +44,37 @@ func TestNewStoreIsLazy(t *testing.T) {
 	store.UsingKeyring()
 	assert.Equal(t, 1, calls, "construction happens once")
 }
+
+// swapStderrIsTerminal replaces the interactivity seam for the test.
+func swapStderrIsTerminal(t *testing.T, interactive bool) {
+	t.Helper()
+	orig := stderrIsTerminal
+	stderrIsTerminal = func() bool { return interactive }
+	t.Cleanup(func() { stderrIsTerminal = orig })
+}
+
+// ensureOptions constructs a store's credstore through the seams and returns
+// the options it was built with.
+func ensureOptions(t *testing.T, interactive bool) credstore.StoreOptions {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1") // keep the delegated construction off the real keyring
+
+	var got credstore.StoreOptions
+	swapNewCredStore(t, func(opts credstore.StoreOptions) *credstore.Store {
+		got = opts
+		return credstore.NewStore(opts)
+	})
+	swapStderrIsTerminal(t, interactive)
+
+	NewStore(t.TempDir()).UsingKeyring()
+	return got
+}
+
+// Headless sessions can never answer a keychain unlock prompt, so the probe
+// must be bounded there — the #568 incident class. Interactive sessions keep
+// the unbounded probe so a legitimate unlock prompt is never cut off
+// mid-answer (which would silently degrade to plaintext file storage).
+func TestEnsureBoundsProbeOnlyWhenHeadless(t *testing.T) {
+	assert.Equal(t, headlessProbeTimeout, ensureOptions(t, false).ProbeTimeout)
+	assert.Zero(t, ensureOptions(t, true).ProbeTimeout)
+}

--- a/internal/auth/session_darwin.go
+++ b/internal/auth/session_darwin.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// guiSessionAvailable reports whether the process runs inside a macOS Aqua
+// (GUI) session, where the keychain unlock prompt appears as a WindowServer
+// dialog even with every standard stream detached — GUI-launched apps and
+// IDE task runners. `launchctl managername` prints "Aqua" there; ssh and CI
+// run under StandardIO or Background. launchctl only inspects the launchd
+// session — it cannot touch the keychain — but is bounded anyway, and any
+// failure counts as no GUI so genuinely headless sessions keep the bounded
+// probe.
+func guiSessionAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/bin/launchctl", "managername").Output()
+	return err == nil && strings.TrimSpace(string(out)) == "Aqua"
+}

--- a/internal/auth/session_other.go
+++ b/internal/auth/session_other.go
@@ -1,13 +1,11 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package auth
 
 import "os"
 
 // guiSessionAvailable reports a display server the keyring's unlock prompt
-// could use even with every standard stream detached. On Windows this is
-// always false: Credential Manager operates without prompting, so a bounded
-// probe cannot cut off an interaction there.
+// could use even with every standard stream detached.
 func guiSessionAvailable() bool {
 	return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
 }

--- a/internal/auth/session_other.go
+++ b/internal/auth/session_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package auth
+
+import "os"
+
+// guiSessionAvailable reports a display server the keyring's unlock prompt
+// could use even with every standard stream detached. On Windows this is
+// always false: Credential Manager operates without prompting, so a bounded
+// probe cannot cut off an interaction there.
+func guiSessionAvailable() bool {
+	return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
+}

--- a/internal/auth/session_other_test.go
+++ b/internal/auth/session_other_test.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGUISessionAvailableTracksDisplayEnv(t *testing.T) {
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	assert.False(t, guiSessionAvailable())
+
+	t.Setenv("DISPLAY", ":0")
+	assert.True(t, guiSessionAvailable())
+}

--- a/internal/auth/session_other_test.go
+++ b/internal/auth/session_other_test.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package auth
 
@@ -15,4 +15,8 @@ func TestGUISessionAvailableTracksDisplayEnv(t *testing.T) {
 
 	t.Setenv("DISPLAY", ":0")
 	assert.True(t, guiSessionAvailable())
+
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	assert.True(t, guiSessionAvailable(), "Wayland-only sessions have no DISPLAY")
 }

--- a/internal/auth/session_windows.go
+++ b/internal/auth/session_windows.go
@@ -1,0 +1,9 @@
+package auth
+
+// guiSessionAvailable is always false on Windows: Credential Manager
+// operates without prompting, so a bounded probe cannot cut off an
+// interaction, and misclassifying a GUI-launched session as headless is
+// harmless here.
+func guiSessionAvailable() bool {
+	return false
+}


### PR DESCRIPTION
Completes the #568 keychain-hang lineage: after lazy store construction (#578) fixed credential-free commands, credential-touching commands on a locked headless keychain still blocked unbounded. basecamp/cli#56 added the upstream prerequisite (`StoreOptions.ProbeTimeout` — a bounded probe whose darwin implementation actually kills the hung `security` child and falls back to file storage). This PR bumps to that credstore (pseudo-version of the merge commit; no release tag exists yet) and wires it.

## Interactivity-aware bound

- **Headless (stderr not a terminal)**: probe bounded at 10s. A headless session can never answer a keychain unlock prompt, so the only prior outcomes were an infinite hang or the manual `BASECAMP_NO_KEYRING=1` escape hatch. Now: bounded probe → file fallback with the existing plaintext warning.
- **Interactive**: unbounded probe, exactly as today. A locked keychain in an interactive session raises an unlock prompt the user may legitimately take longer than any reasonable timeout to answer — cutting it off would silently degrade them to plaintext file storage. Not a regression: interactive sessions were never the incident class.
- Stderr, not stdout, as the signal: interactive use routinely pipes stdout (`| jq`) while prompts still reach the terminal.

`ForceFile` is deliberately not wired — credstore's internal timeout-to-file fallback covers the CLI's need, and `BASECAMP_NO_KEYRING` already provides forced file mode.

## Tests

`TestEnsureBoundsProbeOnlyWhenHeadless` pins both branches through the existing `newCredStore` seam plus a new `stderrIsTerminal` seam (precedent: `stdoutIsTerminal` in update_notice.go). Existing laziness test unchanged.

## Verification

- `bin/ci` green; `go test -race ./internal/auth/...` green.
- Behavioral smoke on macOS: piped (headless-path) `auth status` probes within the bound against a healthy keychain and loads keyring credentials (`expired: false`; the file fallback holds a stale token, distinguishing the paths).
- Upstream credstore at the pinned commit: eleven-round review convergence on basecamp/cli#56, macOS `-race -count=2` proof at merge head.

Refs #568

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the keyring probe to 10s only in fully headless sessions (no TTYs and no GUI) and fall back to file storage to prevent hangs on locked keychains. Interactive or GUI-launched sessions keep the unbounded probe. Addresses #568.

- **Bug Fixes**
  - Treat sessions as headless only when stdin, stdout, and stderr are all non-terminals and no GUI is available (macOS: `launchctl managername` != Aqua; Linux/*BSD: no `DISPLAY`/`WAYLAND_DISPLAY`; Windows: GUI check is always false since Credential Manager never prompts); set `ProbeTimeout` to 10s so `credstore` falls back to file storage.
  - Keep the probe unbounded when any stdio is a terminal or a GUI is present to allow unlock prompts.

- **Dependencies**
  - Bump `github.com/basecamp/cli` to `v0.2.2-0.20260728023309-04e401b12c6c` to use `credstore.StoreOptions.ProbeTimeout`.

<sup>Written for commit 4eb07792bfe03bc6996c0f1f00ad30b39f0c65b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

