### PR TITLE
Add Nix development shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,16 @@ make build            # Build
 bin/ci                # Verify everything passes
 ```
 
+### Nix
+
+As an alternative to `bin/setup`, contributors with Nix can enter the development environment with:
+
+```bash
+nix develop
+```
+
+The development shell provides Go and the tools required by `bin/ci`.
+
 ## SDK Development
 
 When developing against a local copy of [basecamp-sdk](https://github.com/basecamp/basecamp-sdk), use Go workspaces instead of `replace` directives in go.mod:

--- a/flake.nix
+++ b/flake.nix
@@ -23,5 +23,24 @@
           default = self.packages.${system}.basecamp;
         }
       );
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              actionlint
+              bats
+              git
+              go_1_26
+              golangci-lint
+              goreleaser
+              gnumake
+              jq
+              zizmor
+            ];
+          };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
               goreleaser
               gnumake
               jq
+              ripgrep
               zizmor
             ];
           };


### PR DESCRIPTION
## What

- Add a default Nix development shell with the tools required for development and CI.
- Document `nix develop` as an optional contributor setup path.

## Why

The existing flake exposes build packages but no contributor environment. This adds an optional Nix-native development workflow alongside the existing `bin/setup` path.

## Testing

- [x] `nix flake check`
- [x] `bin/ci` inside `nix develop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a default Nix development shell and docs for `nix develop`, giving a reproducible local environment with Go and CI tools. Provides an optional Nix workflow alongside `bin/setup`.

- **New Features**
  - Add flake `devShells.default` for all systems; supports running `bin/ci` inside `nix develop`.
  - Include tools: `go_1_26`, `golangci-lint`, `goreleaser`, `actionlint`, `bats`, `git`, `gnumake`, `jq`, `ripgrep`, `zizmor`.
  - Update CONTRIBUTING with a Nix section and quick start.

<sup>Written for commit 89d3cab039b180510b5bd7de2b0f7ac7810fea82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

