### PR TITLE
Reference STYLE.md instead of importing it, and fix two wrong claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-@STYLE.md
-
 # Basecamp CLI Development Context
 
 ## Getting Started
@@ -61,10 +59,10 @@ Run it early and often — after finishing a feature, after fixing a bug, before
 pushing. If you're about to `git push` and haven't run `bin/ci` in this
 session, stop and run it first.
 
-**Skill drift**: when you change CLI commands or flags, `check-skill-drift`
-verifies that `skills/basecamp/SKILL.md` still references valid commands and
-flags from the `.surface` snapshot. If you add, rename, or remove commands/flags,
-update the skill to match.
+**Skill drift**: when you change CLI commands or flags, `make check-skill-drift`
+verifies that `skills/basecamp/SKILL.md` **and** `skills/basecamp-doctor/SKILL.md`
+still reference valid commands and flags from the `.surface` snapshot. If you add,
+rename, or remove commands/flags, update both skills to match.
 
 ```bash
 bin/ci                # The single command — run this
@@ -121,9 +119,14 @@ API revision the CLI is built against. `API-COVERAGE.md` tracks endpoint coverag
 **Completeness bar**: every new SDK service method needs:
 - Command file in `internal/commands/`
 - Catalog entry in `commands.go`
-- Registration in `root.go` + `commands_test.go`
+- Registration in `internal/cli/root.go` + `commands_test.go`
 - API-COVERAGE.md row
 
 **Andon cord**: if the SDK lacks a Go service wrapper for a generated endpoint,
 stop and open an issue on [basecamp-sdk](https://github.com/basecamp/basecamp-sdk) —
 never call the raw generated client from CLI code.
+
+## Code style
+
+See `STYLE.md` for the Go conventions used here. Read it when writing or reviewing Go;
+it is not imported, so it stays out of context for sessions that never touch Go.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,12 @@ Run it early and often — after finishing a feature, after fixing a bug, before
 pushing. If you're about to `git push` and haven't run `bin/ci` in this
 session, stop and run it first.
 
-**Skill drift**: when you change CLI commands or flags, `make check-skill-drift`
-verifies that `skills/basecamp/SKILL.md` **and** `skills/basecamp-doctor/SKILL.md`
-still reference valid commands and flags from the `.surface` snapshot. If you add,
-rename, or remove commands/flags, update both skills to match.
+**Skill drift**: `make check-skill-drift` runs over both `skills/basecamp/SKILL.md`
+and `skills/basecamp-doctor/SKILL.md`, checking that the commands and flags each one
+*references* still exist in the `.surface` snapshot. It catches stale references, not
+missing coverage — so renaming or removing a command breaks whichever skill mentioned
+it, and adding a new one breaks neither. Update the skill the change actually affects;
+basecamp-doctor deliberately covers only doctor, setup and auth remediation.
 
 ```bash
 bin/ci                # The single command — run this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,12 @@ session, stop and run it first.
 **Skill drift**: `make check-skill-drift` runs over both `skills/basecamp/SKILL.md`
 and `skills/basecamp-doctor/SKILL.md`, checking that the commands and flags each one
 *references* still exist in the `.surface` snapshot. It catches stale references, not
-missing coverage — so renaming or removing a command breaks whichever skill mentioned
-it, and adding a new one breaks neither. Update the skill the change actually affects;
+missing coverage, so adding a command breaks neither skill.
+
+Removal is only partly caught. `resolve_cmd` walks up to the nearest existing ancestor,
+so dropping a nested subcommand leaves the reference resolving against its parent and the
+check still passes — `basecamp setup <removed>` resolves as `basecamp setup`. Removing a
+top-level command is caught; removing a subcommand is not. Don't lean on CI for this. Update the skill the change actually affects;
 basecamp-doctor deliberately covers only doctor, setup and auth remediation.
 
 ```bash


### PR DESCRIPTION
@STYLE.md sat on line 1, so 2,369 bytes of Go conventions loaded into every
session regardless of what it was about -- a third of the always-on budget for
guidance most sessions never need. It is now a pointer. Because Codex reads
AGENTS.md without expanding imports, that cost fell on Claude Code alone.

Two corrections:

- The completeness bar listed "Registration in root.go" directly under
  "Command file in internal/commands/", which reads as though root.go were in
  that directory. It is internal/cli/root.go.
- Skill drift was described as checking skills/basecamp/SKILL.md. The Makefile
  target runs the script twice -- once on that default and once on
  skills/basecamp-doctor/SKILL.md -- so changing a command could leave the
  second skill stale while the doc said nothing about it.

Always-on drops from 7,285 to 5,150 bytes.


---
Checked against `main` at c863c3d312547ae337a9c957c7da50529144b0a5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the inline import of `STYLE.md` in `AGENTS.md` with a link, reducing always-on context by ~2.3 KB. Also fixed the completeness path and clarified that skill-drift checks catch stale references and do not catch subcommand removals.

- **Refactors**
  - Link to `STYLE.md` instead of importing it in `AGENTS.md` (always-on drops from 7,285 to 5,150 bytes).

- **Bug Fixes**
  - Completeness bar: registration path is `internal/cli/root.go` (plus `commands_test.go`).
  - Skill drift: `make check-skill-drift` runs over both skills and flags stale references, not missing coverage; top-level removals are caught, subcommand removals are not (CI won’t catch them).

<sup>Written for commit df317c86b5f88f5aa1c35495a9703c00453ce0ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

