### PR TITLE
Include email addresses in people list output

### DIFF
--- a/internal/commands/people.go
+++ b/internal/commands/people.go
@@ -267,20 +267,22 @@ func runPeopleList(cmd *cobra.Command, projectID string, limit, page int, all bo
 
 	// Slim output
 	type personListItem struct {
-		ID       int64  `json:"id"`
-		Name     string `json:"name"`
-		Title    string `json:"title"`
-		Employee bool   `json:"employee"`
-		Admin    bool   `json:"admin"`
+		ID           int64  `json:"id"`
+		Name         string `json:"name"`
+		EmailAddress string `json:"email_address"`
+		Title        string `json:"title"`
+		Employee     bool   `json:"employee"`
+		Admin        bool   `json:"admin"`
 	}
 	items := make([]personListItem, len(people))
 	for i, p := range people {
 		items[i] = personListItem{
-			ID:       p.ID,
-			Name:     p.Name,
-			Title:    p.Title,
-			Employee: p.Employee,
-			Admin:    p.Admin,
+			ID:           p.ID,
+			Name:         p.Name,
+			EmailAddress: p.EmailAddress,
+			Title:        p.Title,
+			Employee:     p.Employee,
+			Admin:        p.Admin,
 		}
 	}
 

--- a/internal/commands/people_test.go
+++ b/internal/commands/people_test.go
@@ -604,6 +604,49 @@ func setupPeopleMockApp(t *testing.T, server *httptest.Server) (*appctx.App, *by
 	return app, buf
 }
 
+func TestPeopleListIncludesEmailAddress(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, buf := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "list")
+	require.NoError(t, err)
+
+	var result struct {
+		Data []struct {
+			ID           int64  `json:"id"`
+			EmailAddress string `json:"email_address"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output: %s", buf.String())
+
+	emailsByID := make(map[int64]string, len(result.Data))
+	for _, person := range result.Data {
+		emailsByID[person.ID] = person.EmailAddress
+	}
+	assert.Equal(t, "alice@example.com", emailsByID[1001])
+	assert.Equal(t, "bob@example.com", emailsByID[2001])
+	assert.Equal(t, "carol@example.com", emailsByID[2002])
+}
+
+func TestPeopleListInIncludesEmailAddress(t *testing.T) {
+	server := setupPeopleMockServer(t, "99999", 55555)
+	app, buf := setupPeopleMockApp(t, server)
+
+	cmd := NewPeopleCmd()
+	err := executePeopleCommand(cmd, app, "list", "--in", "55555")
+	require.NoError(t, err)
+
+	var result struct {
+		Data []struct {
+			EmailAddress string `json:"email_address"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "output: %s", buf.String())
+	require.Len(t, result.Data, 1)
+	assert.Equal(t, "alice@example.com", result.Data[0].EmailAddress)
+}
+
 // TestPeopleListIn verifies that --in takes the project-scoped path and
 // returns project-specific people, not the account-wide list.
 func TestPeopleListIn(t *testing.T) {


### PR DESCRIPTION
## Summary
- include `email_address` in the slim output from `people list`
- cover both account-wide and project-scoped people lists
- preserve the API’s permission-aware email value for JSON and `--jq` consumers

## Validation
- added focused tests and confirmed they failed before the implementation change
- `GOWORK=off go test ./internal/commands -run 'TestPeopleList(In)?IncludesEmailAddress$' -count=1`\n- `GOWORK=off bin/ci`

## Basecamp card 

https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10146757400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `email_address` in the slim output of `people list` for both account-wide and project-scoped (`--in`) lists. Keeps the API’s permission-aware email visibility for JSON and `--jq` consumers.

<sup>Written for commit bcc5777a02281b31fddd190f27f336b6c58c14b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

