### PR TITLE
Carry an explicit project into the bare boost list usage hint

### DIFF
--- a/internal/commands/boost.go
+++ b/internal/commands/boost.go
@@ -68,6 +68,21 @@ response, so there is nothing to page through either.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if len(args) == 0 {
+				// An explicitly named project cannot stand in for the item ID,
+				// but it is a statement of intent the hint can honor: carry it
+				// forward into the corrected invocation. Otherwise the generic
+				// missing-argument path answers (help when interactive).
+				explicitProject := *project
+				if explicitProject == "" {
+					explicitProject = app.Flags.Project
+				}
+				if explicitProject != "" {
+					hint := fmt.Sprintf("Pass the item's ID or URL: basecamp boost list <id> --project %s", explicitProject)
+					if eventID != "" {
+						hint = fmt.Sprintf("%s --event %s", hint, eventID)
+					}
+					return output.ErrUsageHint("Boosts belong to an item, so listing them needs one", hint)
+				}
 				return missingArg(cmd, "<id|url>")
 			}
 			if err := ensureAccount(cmd, app); err != nil {

--- a/internal/commands/boost_test.go
+++ b/internal/commands/boost_test.go
@@ -297,6 +297,40 @@ func TestBoostListConfiguredProjectStillNeedsAnID(t *testing.T) {
 	assert.Empty(t, transport.recorded())
 }
 
+// An explicitly named project cannot stand in for the item ID either, but it
+// is a statement of intent: the hint carries it forward into the corrected
+// invocation — through --project, its --in alias, and the root-level form
+// that lands in app.Flags.Project.
+func TestBoostListExplicitProjectWithoutIDCarriesProjectIntoHint(t *testing.T) {
+	assertHintCarriesProject := func(t *testing.T, err error, transport *recordingTransport) {
+		t.Helper()
+		requireBoostUsageError(t, err, "listing them needs one")
+		var e *output.Error
+		require.True(t, errors.As(err, &e))
+		assert.Contains(t, e.Hint, "--project 123")
+		assert.Empty(t, transport.recorded(), "a usage error must not reach the API")
+	}
+
+	cmd, app, transport := setupBoostListTest(t, nil)
+	assertHintCarriesProject(t, executeBoostCommand(cmd, app, "list", "--project", "123"), transport)
+
+	cmd, app, transport = setupBoostListTest(t, nil)
+	assertHintCarriesProject(t, executeBoostCommand(cmd, app, "list", "--in", "123"), transport)
+
+	cmd, app, transport = setupBoostListTest(t, nil)
+	app.Flags.Project = "123"
+	assertHintCarriesProject(t, executeBoostCommand(cmd, app, "list"), transport)
+
+	// --event is explicit intent too: when the structured hint fires, it
+	// rides along rather than being silently dropped from the correction.
+	cmd, app, transport = setupBoostListTest(t, nil)
+	err := executeBoostCommand(cmd, app, "list", "--project", "123", "--event", "5")
+	assertHintCarriesProject(t, err, transport)
+	var e *output.Error
+	require.True(t, errors.As(err, &e))
+	assert.Contains(t, e.Hint, "--event 5")
+}
+
 // The pagination flags existed only for the account-wide feed. With that gone
 // they must not linger: an item's boosts arrive in one unpaginated response,
 // and the SDK documents BoostListOptions.Page as not honoring a page number.


### PR DESCRIPTION
## Why

This PR set out to withdraw the CLI's account-wide boost listing ahead of BC5 removing `GET /:account/boosts.json` (basecamp/bc3#12464; diagnosis basecamp/bc3#12458). While it was in flight, #590 landed the same withdrawal as part of bounding all the account-wide listings — item-ID-required `boost list`, `--all-projects` gone, `.surface`/`.surface-breaking` acknowledgments, docs, and the guard tests — and #594 adopted SDK v0.11.0, which dropped `Everything().Boosts()` entirely (basecamp/basecamp-sdk#504). The original body's premise that the SDK method stays is obsolete.

Rebased onto post-#590/#594 main, one refinement from this branch survives that #590 did not pick up: the missing-ID error for `boost list` is project-aware.

## What

- A bare `boost list` that names a project explicitly — via `--project`, its `--in` alias, or the root-level flag that lands in `app.Flags.Project` — now gets a usage hint that carries the project forward into the corrected invocation (`Pass the item's ID or URL: basecamp boost list <id> --project my-project`) instead of the generic missing-argument path. An explicit `--event` rides along in the same hint rather than being silently dropped from the correction. A config-supplied project still takes the generic path: only an explicit flag is a statement of intent worth echoing back.
- Everything else this PR originally carried was absorbed: the flag removal, account-wide code deletion, `.surface-breaking` entries (already present on main at lines 136–137), ACCOUNT-WIDE-LISTINGS.md/API-COVERAGE.md/SKILL.md updates, and the bare/configured-project/`--event` guard tests all resolve to main's versions with no residual delta.

## Tests

- New `TestBoostListExplicitProjectWithoutIDCarriesProjectIntoHint` pins the contract across all three flag forms plus the `--event` combination, and asserts no request reaches the API. Shown red against pre-change main, where a bare interactive invocation answered with help and a nil error rather than a structured usage error.
- `make check` (fmt, vet, lint, unit, e2e, surface, skill-drift, smoke-coverage, provenance, tidy) and `make check-surface-compat` both pass.
