### PR TITLE
Adopt basecamp-sdk v0.11.0

### DIFF
--- a/ACCOUNT-WIDE-LISTINGS.md
+++ b/ACCOUNT-WIDE-LISTINGS.md
@@ -14,7 +14,9 @@ group's existing leaf list command.
 
 ## Method matrix
 
-All 17 methods, and the invocation that reaches each.
+All 16 methods, and the invocation that reaches each. The family was 17 through
+SDK v0.10.0; `Boosts` was removed in v0.11.0, for the reasons under
+"`boost list` — withdrawn" below.
 
 | Command | SDK method | Payload | Paginated |
 |---|---|---|---|

--- a/ACCOUNT-WIDE-LISTINGS.md
+++ b/ACCOUNT-WIDE-LISTINGS.md
@@ -89,7 +89,7 @@ project scope": for these two commands a configured project is not a scope that
 can be honored, so it is ignored rather than turned into an error.
 
 `boost list` is per-item in the same way but has **no account-wide row at all**
-— the aggregate behind it is being withdrawn server-side. Every absent-ID case
+— the aggregate behind it was withdrawn server-side. Every absent-ID case
 asks for an ID, and it carries no `--all-projects`. See "`boost list` —
 withdrawn" under I5.
 
@@ -273,9 +273,10 @@ There is **no account-wide boost listing.** `boost list` requires an item ID.
 
 The `/boosts.json` aggregate this section used to document was an easter egg —
 unlinked from the Basecamp web UI, ~2,250 requests per 30 days globally, and
-this CLI its only known consumer. BC5 has **withdrawn it** (bc3#12464); the
-path 404s on both the web and API hosts once that deploys, so the CLI stops
-calling it.
+this CLI its only known consumer. BC5 **withdrew it** (bc3#12464), and the path
+now 404s on both the web and API hosts, so the CLI no longer calls it. The SDK
+dropped `Everything().Boosts()` to match in v0.11.0 (basecamp/basecamp-sdk#504),
+so the operation is not merely unused here — it no longer exists.
 
 The cause, from BC3's own diagnosis rather than inference: the query's cost is
 proportional to the account's **accessible recordings, not its boosts**. That

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -77,7 +77,7 @@ API date 2026-07-28.
 ## Account-wide aggregates
 
 `EverythingService` answers, across every accessible project, the same questions
-the project-scoped listings answer within one. All 17 methods are reachable.
+the project-scoped listings answer within one. All 16 methods are reachable.
 
 These rows are **not** added to the totals above. They are not new endpoints in
 the tracked matrix — they are the account-wide variant of listings already

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -20,20 +20,25 @@ Out-of-scope sections are excluded from parity totals and scripts: chatbots (dif
 
 > Note: the per-row `Endpoints` column in the Coverage by Section table sums higher than the Summary totals above. The discrepancy predates the BC5 baseline; the row count (48 sections) is authoritative for the `Since` column. Reconciling endpoint counts is pre-existing maintenance, tracked separately.
 
-**SDK version:** v0.10.0 — adds `EverythingService` (`AccountClient.Everything()`,
-basecamp/basecamp-sdk#435 and #438), a 17-method account-wide aggregate family
-covering cross-project messages, comments, checkins, forwards, boosts, files, and
-the open/completed/unassigned/overdue/no-due-date todo and card rollups. **16 of
-the 17 are reached from the CLI** — see [Account-wide
-aggregates](#account-wide-aggregates). `Everything().Boosts()` is not called:
-BC5 has withdrawn the `/boosts.json` aggregate behind it (basecamp/bc3#12464),
-because its cost was proportional to the account's accessible recordings rather
-than its boosts (~44s per page — basecamp/bc3#12458). The feed is expected back
-later on a boost-proportional query (basecamp/bc3#12463), but the endpoint is
-genuinely gone server-side in the meantime, so **the SDK is dropping the
-operation as well**. The CLI holds no references to it, so that SDK removal
-lands here as a no-op. Once the CLI pins an SDK without it, this line becomes
-16 of 16. They are not a new command group and add
+**SDK version:** v0.11.0 — carries `EverythingService`
+(`AccountClient.Everything()`, basecamp/basecamp-sdk#435 and #438), a
+16-method account-wide aggregate family covering cross-project messages,
+comments, checkins, forwards, files, and the
+open/completed/unassigned/overdue/no-due-date todo and card rollups. **All 16
+are reached from the CLI** — see [Account-wide
+aggregates](#account-wide-aggregates).
+
+The family was 17 methods through v0.10.0. `Everything().Boosts()` is gone as
+of v0.11.0 (basecamp/basecamp-sdk#504): BC5 withdrew the `/boosts.json`
+aggregate behind it (basecamp/bc3#12464), because its cost was proportional to
+the account's accessible recordings rather than its boosts (~44s per page —
+basecamp/bc3#12458). The feed is expected back later on a boost-proportional
+query (basecamp/bc3#12463), but the endpoint is genuinely gone server-side in
+the meantime, so the SDK dropped the operation rather than ship one that cannot
+work. The CLI had already stopped calling it, so the removal landed here as a
+no-op.
+
+The aggregates are not a new command group and add
 no endpoints to the tracked totals above: each aggregate is the account-wide
 variant of a listing the CLI already owned, reached through that group's
 existing leaf command. The contract is `ACCOUNT-WIDE-LISTINGS.md`.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
-	github.com/basecamp/basecamp-sdk/go v0.10.1-0.20260729233651-9480aa4c84b8
+	github.com/basecamp/basecamp-sdk/go v0.11.0
 	github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.10.1-0.20260729233651-9480aa4c84b8 h1:M4vBBDNYkS8XtwZ4q8TIhR4c8F8h/4Lk2QIqx2s/A5w=
-github.com/basecamp/basecamp-sdk/go v0.10.1-0.20260729233651-9480aa4c84b8/go.mod h1:r83ralDQ0q9vbAby5qQ5x9hgCgUdJLDLHYpiU6jaFjE=
+github.com/basecamp/basecamp-sdk/go v0.11.0 h1:bjbwcjEZIAUh93PF/Mr/+KSnQStmhL5yB903OBTVBoM=
+github.com/basecamp/basecamp-sdk/go v0.11.0/go.mod h1:r83ralDQ0q9vbAby5qQ5x9hgCgUdJLDLHYpiU6jaFjE=
 github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c h1:+5sQBl8sqYoD1Qhwsibn8sBCKWPyZ9NDez6mnuo9Afo=
 github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c/go.mod h1:EK1Dba6DEw8ZAilVBpf/jri3ONDV7LQkLACSDe73f/c=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/commands/boost.go
+++ b/internal/commands/boost.go
@@ -90,9 +90,9 @@ func runBoostList(cmd *cobra.Command, app *appctx.App, recording, project, event
 	//
 	// The feed is expected back later on a boost-proportional query
 	// (basecamp/bc3#12463), but the endpoint is genuinely gone in the meantime
-	// and the SDK is dropping Everything().Boosts() with it. When it returns,
-	// this is where the account-wide branch goes back, along with
-	// --all-projects.
+	// and the SDK dropped Everything().Boosts() with it in v0.11.0
+	// (basecamp/basecamp-sdk#504). When it returns, this is where the
+	// account-wide branch goes back, along with --all-projects.
 	recordingID, urlProjectID := extractWithProject(recording)
 
 	projectID := project

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,13 +1,13 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.10.1-0.20260729233651-9480aa4c84b8",
-    "revision": "9480aa4c84b8",
-    "updated_at": "2026-07-29T23:36:51Z"
+    "version": "v0.11.0",
+    "revision": "b7124ca6a62a",
+    "updated_at": "2026-07-31T09:00:51Z"
   },
   "api": {
     "repo": "basecamp/bc3",
-    "revision": "dffa7e11b3337b17454d9a82301be3e94226a858",
-    "synced_at": "2026-07-28"
+    "revision": "e83b273363891ff060f0c818f542916c681f1bfd",
+    "synced_at": "2026-07-30"
   }
 }


### PR DESCRIPTION
Retires the pseudo-version pin left by #582 (`v0.10.1-0.20260729233651-9480aa4c84b8`) and puts the CLI back on a release tag.

## What's in the range

| SDK PR | Effect on Go | Effect here |
|---|---|---|
| [#504](https://github.com/basecamp/basecamp-sdk/pull/504) | Removes `Everything().Boosts()` | **The only breaking change.** No-op — #590 already removed the last call site |
| [#518](https://github.com/basecamp/basecamp-sdk/pull/518) | Deletes an unreachable pre-fetch check in `TimelineService.PersonProgress` | None — `Meta.Truncated` semantics unchanged |
| [#514](https://github.com/basecamp/basecamp-sdk/pull/514) | `Subscribe` + `EnableCardColumnOnHold` flagged naturally idempotent | Those two POSTs become retry-eligible |
| [#500](https://github.com/basecamp/basecamp-sdk/pull/500), [#507](https://github.com/basecamp/basecamp-sdk/pull/507) | Retry status-set copy; README fixes | None |

Two of those deserve a note, because the titles suggest more than they deliver here.

**#518** fixes a genuine boundary false positive — a cap landing exactly on the final item of a Link-less last page reported `truncated: true` — but only in the TypeScript, Kotlin, Swift, and Python SDKs. The Go half is a deletion of dead code, argued unreachable and pinned by tests that are green before *and* after. This matters because the CLI reads `Meta.Truncated` in three places (`comment.go:540,588`, `todos.go:372`, `cards.go:346`), so a semantics change there would have needed real work. It doesn't.

**#504** completes the boost withdrawal. The account-wide aggregate family is now **16 of 16** reached from the CLI rather than 16 of 17 — not because coverage improved, but because the unreachable one stopped existing.

## Docs

`API-COVERAGE.md` had pre-committed to this edit (*"Once the CLI pins an SDK without it, this line becomes 16 of 16"*). Along with it, the boost withdrawal notes in `API-COVERAGE.md`, `ACCOUNT-WIDE-LISTINGS.md`, and `boost.go` were written in the future tense while the SDK still carried the operation; they're now past tense with the SDK PR cited.

## Verification

`bin/ci` exit 0 — 361 e2e tests, surface snapshot current, skill drift clean, `SDK provenance OK (v0.11.0)`. No `replace` directive in `go.mod`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the CLI to `github.com/basecamp/basecamp-sdk/go` v0.11.0, replacing the temporary pseudo-version pin. No CLI behavior changes; the SDK’s removed boosts aggregate was already unused, and two POSTs are now retryable.

- **Dependencies**
  - Bump to `github.com/basecamp/basecamp-sdk/go` v0.11.0.
  - Removal of Everything().Boosts() aligns with prior CLI changes; no break.
  - `Subscribe` and `EnableCardColumnOnHold` marked idempotent; retries enabled.
  - `Meta.Truncated` semantics unchanged.

- **Docs**
  - `API-COVERAGE.md`: 16/16 aggregates, corrected remaining “17” references, and noted the v0.11.0 drop of boosts.
  - `ACCOUNT-WIDE-LISTINGS.md` and `boost.go`: past-tense boost withdrawal, 16-method wording; matrix unchanged.

<sup>Written for commit 4b6404ab0e3343374f07b26f61af8e3bd8ba97f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

