### PR TITLE
Stage the PowerShell installer as ASCII+CRLF before signing it

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,8 +12,11 @@ before:
     # the release as basecamp_installer.ps1. Staged outside dist/ because
     # goreleaser requires dist to be empty after before-hooks run. Unsigned
     # copy when the SM_* env is absent (forks, make test-release). Raw-main
-    # install.ps1 stays unsigned.
-    - sh -c 'mkdir -p .release-extra && cp scripts/install.ps1 .release-extra/basecamp_installer.ps1 && scripts/sign-windows.sh windows .release-extra/basecamp_installer.ps1'
+    # install.ps1 stays unsigned and LF -- that is the `irm | iex` path,
+    # which needs neither. The staging step converts to CRLF and rejects
+    # non-ASCII, without which PowerShell reports HashMismatch (see the
+    # script for why both invariants are load-bearing).
+    - sh -c 'scripts/stage-installer-ps1.sh scripts/install.ps1 .release-extra/basecamp_installer.ps1 && scripts/sign-windows.sh windows .release-extra/basecamp_installer.ps1'
 
 builds:
   - id: basecamp

--- a/e2e/installer_signing.bats
+++ b/e2e/installer_signing.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# installer_signing.bats - Tests for the shape the PowerShell installer must
+# have before Authenticode signing.
+#
+# v0.8.0-rc.2 shipped a basecamp_installer.ps1 that PowerShell rejected as
+# HashMismatch, so the installer would not run under AllSigned/RemoteSigned.
+# Cause: jsign digests the script as UTF-16LE of the content with NO
+# line-ending normalization, while PowerShell's script SIP normalizes to CRLF
+# first. An LF file therefore yields two different digests.
+#
+# A second, latent cause would have survived a CRLF-only fix: the file carries
+# no BOM, jsign assumes UTF-8, and Windows PowerShell 5.1 assumes ANSI
+# (Windows-1252). Any byte above 0x7F decodes differently on each side. Within
+# ASCII the encodings are identical, so staging rejects non-ASCII outright.
+
+setup() {
+  STAGE="${BATS_TEST_DIRNAME}/../scripts/stage-installer-ps1.sh"
+  INSTALL_PS1="${BATS_TEST_DIRNAME}/../scripts/install.ps1"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  [[ -n "${WORK:-}" ]] && rm -rf "$WORK"
+}
+
+@test "install.ps1 is pure ASCII so staging can succeed at release time" {
+  # Guards the source, not just the staged copy: a stray em-dash here fails
+  # the release, and this is where it is cheap to catch.
+  run env LC_ALL=C grep -n '[^[:print:][:space:]]' "$INSTALL_PS1"
+  [ "$status" -ne 0 ]
+}
+
+@test "staging converts LF to CRLF" {
+  run "$STAGE" "$INSTALL_PS1" "$WORK/out.ps1"
+  [ "$status" -eq 0 ]
+  # Every line ends CRLF; none is bare LF.
+  total=$(wc -l < "$WORK/out.ps1")
+  crlf=$(grep -c $'\r$' "$WORK/out.ps1")
+  [ "$total" -eq "$crlf" ]
+}
+
+@test "staging is idempotent (no CR CR LF on a second pass)" {
+  "$STAGE" "$INSTALL_PS1" "$WORK/once.ps1"
+  "$STAGE" "$WORK/once.ps1" "$WORK/twice.ps1"
+  run cmp -s "$WORK/once.ps1" "$WORK/twice.ps1"
+  [ "$status" -eq 0 ]
+  run grep -c $'\r\r' "$WORK/twice.ps1"
+  [ "$status" -ne 0 ]
+}
+
+@test "staging rejects non-ASCII rather than signing an unverifiable file" {
+  printf '# dash \xe2\x80\x94 here\nWrite-Host x\n' > "$WORK/bad.ps1"
+  run "$STAGE" "$WORK/bad.ps1" "$WORK/bad-out.ps1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"non-ASCII"* ]]
+  [ ! -f "$WORK/bad-out.ps1" ]
+}
+
+@test "staged file makes jsign's digest and PowerShell's agree" {
+  # The actual property under test. jsign hashes UTF-16LE of the content as-is;
+  # PowerShell hashes UTF-16LE after normalizing to CRLF. On a correctly staged
+  # file those are the same bytes, so the digests match and the signature
+  # verifies. This reproduces both sides rather than trusting the shape.
+  "$STAGE" "$INSTALL_PS1" "$WORK/out.ps1"
+  run python3 -c '
+import hashlib, sys
+raw = open(sys.argv[1], "rb").read()
+txt = raw.decode("utf-8")
+jsign = hashlib.sha256(txt.encode("utf-16-le")).hexdigest()
+ps = hashlib.sha256(txt.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-16-le")).hexdigest()
+print("MATCH" if jsign == ps else f"DIFFER jsign={jsign} powershell={ps}")
+' "$WORK/out.ps1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "MATCH" ]
+}
+
+@test "an unstaged LF copy would NOT verify (the rc.2 regression)" {
+  # Negative control: without staging, the two digests diverge. If this ever
+  # passes, the digest model above has stopped reflecting reality and the
+  # positive test is no longer evidence of anything.
+  run python3 -c '
+import hashlib, sys
+raw = open(sys.argv[1], "rb").read()
+txt = raw.decode("utf-8")
+jsign = hashlib.sha256(txt.encode("utf-16-le")).hexdigest()
+ps = hashlib.sha256(txt.replace("\r\n", "\n").replace("\n", "\r\n").encode("utf-16-le")).hexdigest()
+print("MATCH" if jsign == ps else "DIFFER")
+' "$INSTALL_PS1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "DIFFER" ]
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,7 +88,7 @@ function Get-LatestVersion {
 
 function Download-File([string]$Url, [string]$Destination) {
   # -UseBasicParsing avoids initializing IE's MSHTML parser on Windows
-  # PowerShell 5.1 — required on Server Core and locked-down installs.
+  # PowerShell 5.1 -- required on Server Core and locked-down installs.
   # No-op on PowerShell 6+, where basic parsing is the only mode.
   Invoke-WebRequest -UseBasicParsing -ErrorAction Stop `
     -Headers @{ 'User-Agent' = 'basecamp-cli-installer' } `
@@ -130,7 +130,7 @@ function Verify-CosignSignature([string]$Version, [string]$BaseUrl, [string]$Tmp
   Download-File -Url "$BaseUrl/checksums.txt.bundle" -Destination $bundlePath
 
   # Native exits don't trigger ErrorActionPreference=Stop on Windows PowerShell 5.1,
-  # so check $LASTEXITCODE explicitly — otherwise a verify failure would false-green.
+  # so check $LASTEXITCODE explicitly -- otherwise a verify failure would false-green.
   & cosign verify-blob `
     --bundle $bundlePath `
     --certificate-identity "https://github.com/basecamp/basecamp-cli/.github/workflows/release.yml@refs/tags/v$Version" `
@@ -268,7 +268,7 @@ function Test-InteractiveSession {
 #
 # Cross-version: newer binaries expose the intent-neutral `setup agents`. Older
 # release binaries (the hosted install.ps1 from main can outrun the latest
-# release) fall back WITHOUT reintroducing the Claude-first bug — only an
+# release) fall back WITHOUT reintroducing the Claude-first bug -- only an
 # *explicitly* selected agent is connected. `all` runs every per-agent setup the
 # binary supports; unset/auto/ambiguous installs the shared skill only. Each
 # native call is individually guarded so a nonzero exit never aborts the install.
@@ -300,7 +300,7 @@ function Invoke-PostInstallSetup([string]$Binary) {
       $ranAgent = $false
       foreach ($agent in @('claude', 'codex')) {
         if ($help -match "(?m)^\s+$agent\s") {
-          # Mark attempted (not succeeded) — matches install.sh's `ran_agent=1`,
+          # Mark attempted (not succeeded) -- matches install.sh's `ran_agent=1`,
           # which is set regardless of the setup call's exit status.
           $ranAgent = $true
           try { & $Binary setup $agent } catch { }
@@ -359,7 +359,7 @@ function Main {
 
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
     # Windows holds an exclusive lock on running PE files; -Force doesn't help.
-    # Generic catch — typed catches miss ActionPreferenceStopException wrapping.
+    # Generic catch -- typed catches miss ActionPreferenceStopException wrapping.
     try {
       Copy-Item -Force $binaryPath $installedBinary -ErrorAction Stop
     } catch {

--- a/scripts/stage-installer-ps1.sh
+++ b/scripts/stage-installer-ps1.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# Usage: scripts/stage-installer-ps1.sh SOURCE DEST
+#
+# Stage a copy of the PowerShell installer for Authenticode signing, in the
+# only shape where jsign's digest and PowerShell's agree.
+#
+# jsign computes the script digest as UTF-16LE of the file content with the
+# signature block stripped, and applies NO line-ending normalization
+# (SignableScript.computeDigest). PowerShell's script SIP normalizes to CRLF
+# before hashing. Sign an LF file and the two digests differ, so
+# Get-AuthenticodeSignature reports HashMismatch and the installer is refused
+# under AllSigned/RemoteSigned. That is what shipped in v0.8.0-rc.2.
+#
+# Two invariants make the digests agree:
+#
+#   CRLF        removes the normalization disagreement above.
+#
+#   pure ASCII  removes an encoding disagreement that CRLF alone would not
+#               fix. The file has no BOM; jsign assumes UTF-8, but Windows
+#               PowerShell 5.1 assumes ANSI (Windows-1252) for BOM-less files.
+#               Any byte above 0x7F therefore decodes to different characters
+#               on each side and the digests diverge again. Within ASCII the
+#               two encodings are identical byte-for-byte, so the question
+#               never arises. Adding a BOM would be the other way out, but it
+#               trades a known-good invariant for jsign's
+#               isByteOrderMarkSigned() matching Microsoft's undocumented
+#               treatment of the BOM in the hash — untestable without a
+#               signing round-trip.
+#
+# The source file is left alone: raw-main install.ps1 stays LF and unsigned,
+# which is the `irm | iex` path and needs neither.
+
+set -eu
+
+SRC="${1:?usage: stage-installer-ps1.sh SOURCE DEST}"
+DEST="${2:?usage: stage-installer-ps1.sh SOURCE DEST}"
+
+[ -f "$SRC" ] || { echo "stage-installer-ps1: source not found: $SRC" >&2; exit 1; }
+
+# Reject non-ASCII before signing rather than after. Under LC_ALL=C every byte
+# above 0x7F is non-printable, so this matches exactly the bytes that would
+# make jsign and PowerShell 5.1 disagree.
+if LC_ALL=C grep -n '[^[:print:][:space:]]' "$SRC" >/dev/null 2>&1; then
+  echo "stage-installer-ps1: $SRC contains non-ASCII bytes, which would produce" >&2
+  echo "  a signature PowerShell 5.1 rejects as HashMismatch (it decodes BOM-less" >&2
+  echo "  files as Windows-1252 while jsign assumes UTF-8). Offending lines:" >&2
+  LC_ALL=C grep -n '[^[:print:][:space:]]' "$SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DEST")"
+
+# LF -> CRLF, idempotent: strip any existing CR first so a CRLF source does
+# not become CR CR LF.
+awk '{ sub(/\r$/, ""); printf "%s\r\n", $0 }' "$SRC" > "$DEST"
+
+echo "stage-installer-ps1: staged $DEST (pure ASCII, CRLF)"


### PR DESCRIPTION
`v0.8.0-rc.2` published a `basecamp_installer.ps1` that PowerShell rejects:

```
Installer status (pwsh): HashMismatch - the hash of the file does not match
the hash stored in the digital signature.
```

Under `AllSigned`/`RemoteSigned` the installer won't run. A signature that looks tampered-with is worse than no signature — it reads as a supply-chain compromise rather than an unsigned file.

**Only the `.ps1` is affected.** Both `.exe` signatures verified Valid on both arches, so DigiCert KeyLocker and jsign are fine for PE. The arch asymmetry was an illusion: all three installer steps are `if: matrix.arch == 'amd64'`, so arm64 never checked it.

## Two independent causes, both proven

**1. Line endings.** jsign digests a script as UTF-16LE of the content with the signature block stripped, applying **no** line-ending normalization (`SignableScript.computeDigest`). PowerShell's script SIP normalizes to CRLF first.

Confirmed by extracting the `SpcIndirectData` digest from the published asset and reproducing it exactly:

| | digest |
|---|---|
| embedded by jsign | `eb73e59e…5c7487` |
| `sha256(utf-16-le(content as-is, LF))` | `eb73e59e…5c7487` ✅ |
| `sha256(utf-16-le(content CRLF-normalized))` | `d7a8f223…91eb29` ❌ |

**2. Encoding — which a CRLF-only fix would not have caught.** The file has no BOM. jsign assumes UTF-8; **Windows PowerShell 5.1 assumes ANSI (Windows-1252)** for BOM-less files. `install.ps1` contained five em-dashes, so the two sides decoded different characters and would still have failed the 5.1 verification step:

```
jsign          (UTF-8)  : 1a4f213c…
PowerShell 5.1 (cp1252) : 8df922aa…   still HashMismatch
```

Within ASCII the encodings are byte-identical, so the question disappears. The em-dashes are now `--`, and staging **rejects** any future non-ASCII rather than signing something unverifiable.

Adding a BOM was the other way out. Rejected: it trades a known-good invariant for jsign's `isByteOrderMarkSigned()` matching Microsoft's undocumented treatment of the BOM in the hash — untestable without a signing round-trip.

## The fix

`scripts/stage-installer-ps1.sh` replaces the plain `cp` in the goreleaser hook: assert pure ASCII, convert LF→CRLF (idempotently), then sign.

The source file is untouched in shape — raw-main `install.ps1` stays LF and unsigned, which is the `irm | iex` path and needs neither.

## Verification without signing credentials

Both digests are reproduced directly. On the staged file they are now **identical** — and that value is exactly what PowerShell was computing all along:

```
BEFORE  jsign aa03…?  no: fa32ed8e…   powershell aa030635…   DIFFER
AFTER   jsign aa030635…               powershell aa030635…   AGREE
```

`e2e/installer_signing.bats` pins this in 6 tests, including a **negative control** that fails if an unstaged LF copy ever starts appearing to verify. Without it the positive test would stop being evidence of anything.

`bin/ci` green. `goreleaser check` valid.

## Remaining risk

The definitive proof is a real signing round-trip, which needs the DigiCert credentials and therefore a tag. **rc.3 is the test.** If it fails again, the proportionate response is to stop signing the `.ps1` rather than burn more release candidates — the signature only matters for users who save the file and run it under a restrictive execution policy, and `irm | iex` (the documented path) executes a string, where script signature policy doesn't apply.

Refs #592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PowerShell installer signature failures by staging the `.ps1` as pure ASCII with CRLF line endings before signing. This aligns `jsign`’s digest with PowerShell’s and allows execution under AllSigned/RemoteSigned.

- **Bug Fixes**
  - Added `scripts/stage-installer-ps1.sh` to assert ASCII, convert LF→CRLF idempotently, and stage a copy for signing.
  - Updated `goreleaser` before-hook to run staging; source `install.ps1` stays LF/unsigned for `irm | iex`.
  - Replaced em-dashes with `--` in `scripts/install.ps1` to keep the file ASCII.
  - Added `e2e/installer_signing.bats` to prove `jsign` and PowerShell digests match and to catch regressions (includes a negative control).

<sup>Written for commit 29be55ceff6799ba14e4de0cf9881db0aec80844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

