### PR TITLE
Diff stable release notes against the last stable tag, not the last rc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,21 @@ jobs:
           version: 'v2.15.4'
           install-only: true
 
+      - name: Resolve the previous stable tag for release notes
+        run: |
+          # Stable releases must diff against the last STABLE tag, not the last
+          # rc, or the notes come out empty. Mirrors update-nix-flake.sh:32.
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            echo "prerelease — leaving previous-tag detection to goreleaser"
+            exit 0
+          fi
+          PREV=$(git tag --merged "$GITHUB_SHA" --sort=-version:refname \
+                   --list 'v[0-9]*.[0-9]*.[0-9]*' \
+                 | awk -v cur="$GITHUB_REF_NAME" '!/-/ && $0 != cur { print; exit }')
+          [ -n "$PREV" ] || { echo "::error::no previous stable tag resolved"; exit 1; }
+          echo "Release notes will diff against $PREV"
+          echo "GORELEASER_PREVIOUS_TAG=$PREV" >> "$GITHUB_ENV"
+
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The trap

`.goreleaser.yaml` sets `changelog.use: github-native`, which asks GitHub to generate
release notes **relative to the previous tag**. goreleaser resolves "previous tag" to
whatever tag came last — for `v0.8.0` that is `v0.8.0-rc.3`.

Measured against the real API:

| Previous tag | Generated notes |
|---|---|
| `v0.8.0-rc.3` (what goreleaser picks) | 5 lines — effectively empty, just a compare link |
| `v0.7.2` (what it should be) | 113 lines, including all 6 breaking changes |

`main` is 122 PRs ahead of `v0.7.2`. Left alone, the first stable release since
2026-03-26 would ship with none of it — everything stays stranded across
rc.1/rc.2/rc.3.

## Why it is only springing now

`v0.8.0-rc.{1,2,3}` are the only prerelease tags this repo has ever had; rc publishing
landed in #492. **v0.8.0 is the first stable-after-rc we have ever cut**, and the trap
will spring on every future one, hence a permanent fix rather than a one-off env var on
the release run.

## The fix

Resolve the previous *stable* tag ourselves and hand it to goreleaser via
`GORELEASER_PREVIOUS_TAG`. The selector mirrors the idiom already in
`scripts/update-nix-flake.sh:32`, plus a `$0 != cur` guard — `v0.8.0` is itself stable
and sorts first, so without it the tag would diff against itself.

Prereleases return early, so rc notes keep diffing against the preceding rc.

## Alternatives considered

- **`git.ignore_tags: ['*-rc*']`** — no. It suppresses matching tags as *current* as well
  as previous, which breaks rc releases outright.
- **Native goreleaser support** — goreleaser#2764 asked for exactly this and was closed
  wontfix. The environment variable is the sanctioned route.

## Verification

- Env var name read from the pinned `goreleaser v2.15.4` binary itself, not from docs —
  it is `GORELEASER_PREVIOUS_TAG`, *not* `..._TAGNAME`.
- Selector run against the real tag list at `7aefeafd` with `cur=v0.8.0` → resolves
  `v0.7.2`. Self-guard exercised by simulating a tag list that already contains `v0.8.0`
  → still `v0.7.2`.
- `bin/ci` green, `actionlint` clean, `zizmor` reports no findings.
- The `release` job already checks out with `fetch-depth: 0`, so tags are present.

Must land before `v0.8.0` is tagged — `release.yml` is read from the tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release notes for stable tags by diffing against the last stable tag instead of the last `-rc`. This prevents empty notes on stable releases and captures all changes since the prior stable.

- **Bug Fixes**
  - For stable tags, resolve the previous stable tag and set `GORELEASER_PREVIOUS_TAG` for `goreleaser`.
  - Keep prereleases unchanged; they still diff against the preceding `-rc`.
  - Add a guard to avoid self-diffing and fail if no previous stable tag is found.

<sup>Written for commit 39da8efebbd8dde5cf5cf9addaf773817298e287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

