### PR TITLE
Fix the deprecated app-id input, and track failed AUR recoveries

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -56,6 +56,7 @@ jobs:
           echo "Publishing v${VERSION} to the AUR"
 
       - name: Refuse to downgrade the AUR package
+        id: aur-state
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -67,6 +68,8 @@ jobs:
                         'https://aur.archlinux.org/rpc/v5/info/basecamp-cli'); then
             # Fail closed: proceeding blind here risks a silent downgrade, and a
             # dispatch is cheap to repeat once the AUR is reachable again.
+            # Flag it so the notify step can tell an outage from a bad input.
+            echo "unreachable=true" >> "$GITHUB_OUTPUT"
             echo "::error::Could not reach the AUR to check the published version. Retry when it is reachable."
             exit 1
           fi
@@ -119,6 +122,7 @@ jobs:
           fi
 
       - name: Publish to AUR
+        id: publish
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
           VERSION: ${{ inputs.version }}
@@ -145,8 +149,17 @@ jobs:
       # run is dispatched by hand and then forgotten, and its whole reason for
       # existing is that the AUR was unreachable — which is exactly the outage
       # likely to still be going when the retries run out.
+      #
+      # Scoped to the two failures that actually mean "the AUR is unreachable":
+      # retries exhausted, or the RPC reachability check. A bare failure() would
+      # also catch a mistyped version, a version with no release, a refused
+      # downgrade and a missing AUR_KEY — none of which the issue's "retry once
+      # the AUR accepts pushes again" advice fits. Those are operator mistakes,
+      # visible in the run they just dispatched by hand, and because the issue
+      # dedupes on title they would otherwise land as misleading comments on the
+      # genuine outage issue.
       - name: Notify on AUR publish failure
-        if: failure()
+        if: failure() && (steps.publish.outcome == 'failure' || steps.aur-state.outputs.unreachable == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -32,6 +32,7 @@ jobs:
     environment: release
     permissions:
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -139,3 +140,25 @@ jobs:
           done
           echo "::error::AUR publish failed after 3 attempts"
           exit 1
+
+      # The recovery path needs this more than the release job does: a recovery
+      # run is dispatched by hand and then forgotten, and its whole reason for
+      # existing is that the AUR was unreachable — which is exactly the outage
+      # likely to still be going when the retries run out.
+      - name: Notify on AUR publish failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          TITLE="AUR publish failure"
+          BODY="Recovery publish of \`${VERSION}\` to the AUR [failed](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}). The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${VERSION}\` once the AUR accepts pushes again."
+
+          # Check for existing open issue before creating a new one
+          existing=$(gh issue list --repo ${{ github.repository }} --state open --search "in:title $TITLE" --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number // empty' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh issue comment --repo ${{ github.repository }} "$existing" --body "$BODY" || true
+          else
+            gh issue create --repo ${{ github.repository }} --title "$TITLE" --body "$BODY" || true
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         id: sdk-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_CLIENT_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: basecamp
           repositories: homebrew-tap
@@ -543,7 +543,7 @@ jobs:
         id: skills-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_CLIENT_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: basecamp
           repositories: skills

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -77,7 +77,7 @@ jobs:
         id: skills-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_CLIENT_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: basecamp
           repositories: skills


### PR DESCRIPTION
Two small fixes found by actually running the v0.8.0 recovery paths.

## `app-id` → `client-id`

`create-github-app-token` marks `app-id` deprecated in favour of `client-id`, and
every skills-sync run now emits the warning twice.

This is not only warning cleanup. `RELEASE_CLIENT_ID` holds
`Iv23li…` — a **client ID**, which was being passed through the `app-id` input.
GitHub accepts either as the JWT issuer, which is why it has worked, but the input
now says what the value actually is.

Three call sites: `release.yml` ×2 (Homebrew tap token, skills token) and
`sync-skills.yml` ×1.

## Notify when a recovery publish fails

`release.yml`'s `aur-publish` job opens an issue on failure. The standalone
recovery workflow did not — so today's 0.8.0 recovery run failed and left
**nothing tracking it**.

The recovery path needs this more than the release job does. A recovery run is
dispatched by hand and then forgotten, and its whole reason for existing is that
the AUR was unreachable — which is exactly the outage still likely to be going
when three retries run out.

That is precisely what happened here: the AUR has [disabled pushes entirely since
2026-07-30](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/YPJ3FQYJTJXXY3RUXCYLMHUKHLIUNVFF/)
while Arch handles a wave of malicious package adoptions. Not a maintenance
window — retries cannot help, and 0.8.0 stays unpublished there until pushes are
re-enabled.

## Verification

`bin/ci` exit 0, `actionlint` clean, `zizmor` reports no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch GitHub App auth to `client-id` and add outage-only issue notifications for AUR recovery publishes. This removes warnings and files an issue only when the AUR is unreachable.

- **Bug Fixes**
  - Use `client-id` with `actions/create-github-app-token` in `release.yml` (both tokens) and `sync-skills.yml`, matching `RELEASE_CLIENT_ID`.
  - In `aur-publish.yml`, notify only when the AUR is unreachable (RPC check fails or retries are exhausted); include run link and version; dedupe by title and comment if open; add `issues: write`.

<sup>Written for commit d309b607f7309d2f16e819bc5f1d02f03dd261ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

