### PR TITLE
Fix the Nix flake, and stop the hash check reporting false success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,11 +498,14 @@ jobs:
           Write-Host "Installer status (powershell): $($sig.Status) - $($sig.StatusMessage)"
           if ($sig.Status -ne 'Valid') { exit 1 }
 
+  # Not continue-on-error. It was, and that is half of why v0.8.0 published a
+  # flake that could not build: the job could not fail the run, and the AUR
+  # outage skipped it outright. A broken flake is a broken release artifact, so
+  # it should colour the run even though it lands after publication.
   nix-verify:
     name: Verify Nix flake
     needs: [release]
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
-    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -472,3 +472,41 @@ jobs:
           name: benchmarks
           path: benchmarks.txt
           retention-days: 30
+
+  # The flake broke on 2026-07-13 when #533 raised go.mod to 1.26.5 while
+  # flake.lock still pinned a nixpkgs carrying 1.26.4, and nothing noticed for
+  # three weeks: nix-verify only runs on tags, and the release-time hash check
+  # was reporting success on a failed build. Catch the drift where it is
+  # introduced instead — a Go bump that outpaces the lock now fails its own PR.
+  nix-build:
+    name: Nix flake builds
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Check for flake-relevant changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            nix:
+              - 'go.mod'
+              - 'go.sum'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'nix/**'
+
+      - name: Install Nix
+        if: steps.filter.outputs.nix == 'true'
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: Build the flake
+        if: steps.filter.outputs.nix == 'true'
+        run: |
+          STORE_PATH=$(nix build --no-link --print-out-paths)
+          "$STORE_PATH/bin/basecamp" --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -483,6 +483,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read  # dorny/paths-filter enumerates PR files via the REST API
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -212,8 +212,12 @@ bump-sdk:
 # Recompute Nix vendorHash via Docker and update nix/package.nix
 .PHONY: update-nix-hash
 update-nix-hash:
-	@VERSION=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1) && \
-	scripts/update-nix-flake.sh "$$VERSION" || true
+	@VERSION=$$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' nix/package.nix | head -1); \
+	scripts/update-nix-flake.sh "$$VERSION"; RC=$$?; \
+	if [ $$RC -ne 0 ] && [ $$RC -ne 2 ]; then exit $$RC; fi
+	@# 0 = updated, 2 = nothing to do. Anything else is a real failure and must
+	@# propagate: a blanket `|| true` here silently undid the script's own
+	@# fail-closed check, which is how v0.8.0 shipped a flake that cannot build.
 
 # Verify sdk-provenance.json matches go.mod
 # Skips when a replace directive is active (local dev with go.work or go.mod replace)

--- a/e2e/update_nix_flake.bats
+++ b/e2e/update_nix_flake.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+#
+# Exit-status classification for scripts/update-nix-flake.sh.
+#
+# The PR-time flake build proves the *current* flake compiles; it says nothing
+# about whether this script correctly tells a passing build from a failing one.
+# That distinction is the actual defect that shipped: v0.8.0's flake could not
+# build, and the script reported "vendorHash: verified (build succeeded)".
+#
+# `docker` is stubbed so these run anywhere, in milliseconds, and can reproduce
+# failure modes that are otherwise awkward to stage.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR" "$WORK/repo/nix" "$WORK/repo/scripts"
+
+  cp "$REPO_ROOT/scripts/update-nix-flake.sh" "$WORK/repo/scripts/"
+  cat > "$WORK/repo/nix/package.nix" <<'NIXPKG'
+{
+  version = "0.8.0";
+  vendorHash = "sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=";
+}
+NIXPKG
+
+  cd "$WORK/repo"
+  git init -q .
+  git config user.email t@t && git config user.name t
+  git add -A && git commit -qm init
+  # A stable tag at HEAD keeps go.mod/go.sum unchanged, so DEPS_CHANGED=false.
+  git tag v0.8.0
+
+  PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# Emits a canned nix log plus the sentinel the script reads for exit status.
+stub_docker() {
+  cat > "$STUB_DIR/docker" <<STUB
+#!/usr/bin/env bash
+cat <<'OUT'
+$1
+OUT
+STUB
+  chmod +x "$STUB_DIR/docker"
+}
+
+@test "succeeds when the nix build succeeds" {
+  stub_docker "building '/nix/store/abc-basecamp-0.8.0-go-modules.drv'...
+NIX_BUILD_EXIT=0"
+
+  run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 2 ]   # 2 = no changes needed
+  [[ "$output" == *"verified (build succeeded)"* ]]
+}
+
+@test "fails closed when the build fails without a hash mismatch" {
+  # The exact v0.8.0 shape: nix logs that it is *building* basecamp, then dies
+  # on the Go toolchain. The old heuristic matched that line and reported
+  # success.
+  stub_docker "building '/nix/store/abc-basecamp-0.8.0-go-modules.drv'...
+       > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+  [[ "$output" != *"verified (build succeeded)"* ]]
+}
+
+@test "records a corrected hash only after a rebuild proves it" {
+  # First call reports the mismatch, second call succeeds.
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+STATE="${NIX_STUB_STATE:?}"
+if [ -f "$STATE" ]; then
+  echo "NIX_BUILD_EXIT=0"
+else
+  touch "$STATE"
+  echo "error: hash mismatch in fixed-output derivation"
+  echo "         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA="
+  echo "            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="
+  echo "NIX_BUILD_EXIT=1"
+fi
+STUB
+  chmod +x "$STUB_DIR/docker"
+
+  NIX_STUB_STATE="$WORK/called" run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 0 ]   # 0 = changes written
+  [[ "$output" == *"vendorHash: updated"* ]]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+  grep -q 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=' nix/package.nix
+}
+
+@test "fails when the corrected hash still does not build" {
+  # Every call reports a mismatch — the rebuild never converges, so the script
+  # must not claim success just because it wrote a new hash.
+  stub_docker "error: hash mismatch in fixed-output derivation
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"still fails after updating the vendorHash"* ]]
+}
+
+@test "verifies the build even when dependencies did not change" {
+  # DEPS_CHANGED=false must not skip the build: the Go-toolchain drift that
+  # broke v0.8.0 touches neither go.mod nor go.sum.
+  stub_docker "NIX_BUILD_EXIT=0"
+
+  run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"dependencies unchanged — verifying the Nix build anyway"* ]]
+  [[ "$output" == *"verified (build succeeded)"* ]]
+}

--- a/e2e/update_nix_flake.bats
+++ b/e2e/update_nix_flake.bats
@@ -110,6 +110,26 @@ NIX_BUILD_EXIT=1"
   [[ "$output" == *"still fails after updating the vendorHash"* ]]
 }
 
+@test "does not mistake an unrelated 'got:' line for a hash mismatch" {
+  # A failing build whose log happens to contain `got:` — a Go test assertion,
+  # say — must take the non-hash failure path. Matching a bare `got:` would
+  # capture "42" and write it into vendorHash, corrupting a tracked file while
+  # reporting the wrong kind of failure.
+  stub_docker "--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+    thing_test.go:43: want: 7
+error: builder failed with exit code 1
+NIX_BUILD_EXIT=1"
+
+  run scripts/update-nix-flake.sh 0.8.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not because of the vendorHash"* ]]
+  [[ "$output" != *"vendorHash: updated"* ]]
+  # The tracked file must be untouched.
+  grep -q 'sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=' nix/package.nix
+  ! grep -q '"42"' nix/package.nix
+}
+
 @test "verifies the build even when dependencies did not change" {
   # DEPS_CHANGED=false must not skip the build: the Go-toolchain drift that
   # broke v0.8.0 touches neither go.mod nor go.sum.

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782636521,
-        "narHash": "sha256-OG8laCOGtkxlB1JH3XqOnXxnkGJme4mQdXo5hkhCQIY=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1c1b84752fb0897897380a3cae9dc7fcab91ca3",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-hG1eymlnBAhRDtOqi078uVwMwEFC9+8ilft1LOW7SzY=";
+  vendorHash = "sha256-DmCW1Ms9TmcvEzvNIcqutf1bxtOpN+MjpPO0XP1VaZQ=";
 
   subPackages = [ "cmd/basecamp" ];
 

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -47,35 +47,62 @@ if [[ "$NEED_HASH" == "true" ]]; then
     # Pin image digest for supply-chain integrity. Update periodically:
     #   docker pull nixos/nix && docker inspect nixos/nix:latest --format '{{index .RepoDigests 0}}'
     NIX_IMAGE="nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dcaf85212e47845112caf3adeea"
-    BUILD_OUTPUT=$(docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
-      cp -a /src /build && cd /build
-      rm -rf .git
-      git config --global --add safe.directory /build
-      git init -q && git add -A && \
-        GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
-        GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
-        git commit -q -m init
-      nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1 || true
-    ' 2>&1)
 
-    NEW_HASH=$(echo "$BUILD_OUTPUT" | grep "got:" | awk '{print $2}' || true)
+    # Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real
+    # exit status survives command substitution. Nothing here may swallow a
+    # failure: a `|| true` plus a "did it print 'building basecamp'" heuristic
+    # is what let v0.8.0 ship a flake that could not build at all — the log
+    # says `building '...basecamp-0.8.0-go-modules.drv'` while *starting* the
+    # build it then fails, so the heuristic reported success on a hard failure.
+    run_nix_build() {
+      docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
+        cp -a /src /build && cd /build
+        rm -rf .git
+        git config --global --add safe.directory /build
+        git init -q && git add -A && \
+          GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
+          GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
+          git commit -q -m init
+        nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
+        echo "NIX_BUILD_EXIT=$?"
+      ' 2>&1
+    }
 
-    if [[ -n "$NEW_HASH" ]]; then
-      CURRENT_HASH=$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
-      if [[ "$CURRENT_HASH" != "$NEW_HASH" ]]; then
-        sed -i.bak "s|vendorHash = \"${CURRENT_HASH}\"|vendorHash = \"${NEW_HASH}\"|" "$NIX_PKG"
-        rm -f "${NIX_PKG}.bak"
-        CHANGED=true
-        echo "  vendorHash: updated"
-      else
-        echo "  vendorHash: unchanged"
+    nix_build_failed() {
+      [[ "$(echo "$1" | grep -c 'NIX_BUILD_EXIT=0')" -eq 0 ]]
+    }
+
+    BUILD_OUTPUT=$(run_nix_build)
+
+    if nix_build_failed "$BUILD_OUTPUT"; then
+      NEW_HASH=$(echo "$BUILD_OUTPUT" | grep "got:" | awk '{print $2}' || true)
+      if [[ -z "$NEW_HASH" ]]; then
+        # No hash mismatch, so the build broke for some other reason — a stale
+        # flake.lock whose Go is older than go.mod's directive is the one that
+        # has actually bitten us. Never continue from here.
+        echo "ERROR: nix build failed, and not because of the vendorHash"
+        echo "$BUILD_OUTPUT" | tail -25
+        exit 1
       fi
-    elif echo "$BUILD_OUTPUT" | grep -q "building.*basecamp" ; then
+
+      CURRENT_HASH=$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
+      sed -i.bak "s|vendorHash = \"${CURRENT_HASH}\"|vendorHash = \"${NEW_HASH}\"|" "$NIX_PKG"
+      rm -f "${NIX_PKG}.bak"
+      CHANGED=true
+      echo "  vendorHash: updated"
+
+      # Prove the corrected hash actually builds. The old code trusted the
+      # hash it had just written without ever rebuilding.
+      echo "  verifying the updated vendorHash builds..."
+      BUILD_OUTPUT=$(run_nix_build)
+      if nix_build_failed "$BUILD_OUTPUT"; then
+        echo "ERROR: nix build still fails after updating the vendorHash"
+        echo "$BUILD_OUTPUT" | tail -25
+        exit 1
+      fi
       echo "  vendorHash: verified (build succeeded)"
     else
-      echo "ERROR: Could not determine vendorHash from nix build output"
-      echo "$BUILD_OUTPUT" | tail -20
-      exit 1
+      echo "  vendorHash: verified (build succeeded)"
     fi
   fi
 else

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -85,11 +85,22 @@ nix_build_failed() {
 BUILD_OUTPUT=$(run_nix_build)
 
 if nix_build_failed "$BUILD_OUTPUT"; then
-  NEW_HASH=$(grep "got:" <<<"$BUILD_OUTPUT" | awk '{print $2}' || true)
+  # Two independent conditions before touching the tracked file: nix must have
+  # actually reported a fixed-output hash mismatch, and the captured value must
+  # look like an SRI hash. Matching a bare `got:` is far too loose — any failing
+  # build whose log contains one (a Go test assertion printing `got: 42`, say)
+  # would otherwise write that value straight into vendorHash and misreport the
+  # failure as a hash problem.
+  NEW_HASH=""
+  if grep -q 'hash mismatch in fixed-output derivation' <<<"$BUILD_OUTPUT"; then
+    NEW_HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/]+=*' <<<"$BUILD_OUTPUT" \
+                 | awk '{print $2}' | head -1)
+  fi
+
   if [[ -z "$NEW_HASH" ]]; then
-    # No hash mismatch, so the build broke for some other reason — a stale
-    # flake.lock whose Go is older than go.mod's directive is the one that has
-    # actually bitten us. Never continue from here.
+    # The build broke for some other reason — a stale flake.lock whose Go is
+    # older than go.mod's directive is the one that has actually bitten us.
+    # Never continue from here, and never write to nix/package.nix.
     echo "ERROR: nix build failed, and not because of the vendorHash"
     tail -25 <<<"$BUILD_OUTPUT"
     exit 1

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -26,88 +26,93 @@ if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
   echo "  nix version: ${CURRENT_VERSION} → ${VERSION}"
 fi
 
-# --- Check if vendorHash needs recomputing ---
+# --- Report whether dependencies moved ---
 # Prerelease tags skip Nix metadata updates, so compare dependency changes
 # against the latest stable tag instead of an intervening RC tag.
+#
+# This no longer decides *whether* to build — only what to say about it. The
+# build is unconditional: v0.8.0's flake was broken by a Go toolchain bump
+# outpacing flake.lock, which changes neither go.mod nor go.sum, so a
+# deps-changed gate would have skipped the very check that catches it.
 PREV_TAG=$(git tag --merged HEAD --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' | awk '!/-/ { print; exit }')
-NEED_HASH=false
+DEPS_CHANGED=false
 if [[ -z "$PREV_TAG" ]]; then
-  NEED_HASH=true
+  DEPS_CHANGED=true
 elif ! git diff --quiet "$PREV_TAG"..HEAD -- go.mod go.sum 2>/dev/null; then
-  NEED_HASH=true
+  DEPS_CHANGED=true
 fi
 
-if [[ "$NEED_HASH" == "true" ]]; then
-  if ! command -v docker &>/dev/null; then
-    echo "ERROR: Docker unavailable — cannot recompute vendorHash"
-    echo "Install Docker or run 'make update-nix-hash' manually."
-    exit 1
-  else
-    echo "  go.mod changed — computing vendorHash via Docker..."
-    # Pin image digest for supply-chain integrity. Update periodically:
-    #   docker pull nixos/nix && docker inspect nixos/nix:latest --format '{{index .RepoDigests 0}}'
-    NIX_IMAGE="nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dcaf85212e47845112caf3adeea"
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: Docker unavailable — cannot verify the Nix build"
+  echo "Install Docker and re-run; a release must not ship an unverified flake."
+  exit 1
+fi
 
-    # Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real
-    # exit status survives command substitution. Nothing here may swallow a
-    # failure: a `|| true` plus a "did it print 'building basecamp'" heuristic
-    # is what let v0.8.0 ship a flake that could not build at all — the log
-    # says `building '...basecamp-0.8.0-go-modules.drv'` while *starting* the
-    # build it then fails, so the heuristic reported success on a hard failure.
-    run_nix_build() {
-      docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
-        cp -a /src /build && cd /build
-        rm -rf .git
-        git config --global --add safe.directory /build
-        git init -q && git add -A && \
-          GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
-          GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
-          git commit -q -m init
-        nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
-        echo "NIX_BUILD_EXIT=$?"
-      ' 2>&1
-    }
-
-    nix_build_failed() {
-      [[ "$(echo "$1" | grep -c 'NIX_BUILD_EXIT=0')" -eq 0 ]]
-    }
-
-    BUILD_OUTPUT=$(run_nix_build)
-
-    if nix_build_failed "$BUILD_OUTPUT"; then
-      NEW_HASH=$(echo "$BUILD_OUTPUT" | grep "got:" | awk '{print $2}' || true)
-      if [[ -z "$NEW_HASH" ]]; then
-        # No hash mismatch, so the build broke for some other reason — a stale
-        # flake.lock whose Go is older than go.mod's directive is the one that
-        # has actually bitten us. Never continue from here.
-        echo "ERROR: nix build failed, and not because of the vendorHash"
-        echo "$BUILD_OUTPUT" | tail -25
-        exit 1
-      fi
-
-      CURRENT_HASH=$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
-      sed -i.bak "s|vendorHash = \"${CURRENT_HASH}\"|vendorHash = \"${NEW_HASH}\"|" "$NIX_PKG"
-      rm -f "${NIX_PKG}.bak"
-      CHANGED=true
-      echo "  vendorHash: updated"
-
-      # Prove the corrected hash actually builds. The old code trusted the
-      # hash it had just written without ever rebuilding.
-      echo "  verifying the updated vendorHash builds..."
-      BUILD_OUTPUT=$(run_nix_build)
-      if nix_build_failed "$BUILD_OUTPUT"; then
-        echo "ERROR: nix build still fails after updating the vendorHash"
-        echo "$BUILD_OUTPUT" | tail -25
-        exit 1
-      fi
-      echo "  vendorHash: verified (build succeeded)"
-    else
-      echo "  vendorHash: verified (build succeeded)"
-    fi
-  fi
+if [[ "$DEPS_CHANGED" == "true" ]]; then
+  echo "  dependencies changed — verifying the Nix build via Docker..."
 else
-  echo "  vendorHash: go.mod unchanged, skipping"
+  echo "  dependencies unchanged — verifying the Nix build anyway..."
 fi
+
+# Pin image digest for supply-chain integrity. Update periodically:
+#   docker pull nixos/nix && docker inspect nixos/nix:latest --format '{{index .RepoDigests 0}}'
+NIX_IMAGE="${NIX_IMAGE:-nixos/nix@sha256:b9c9611c8530fa8049a1215b20638536e1e71dcaf85212e47845112caf3adeea}"
+
+# Runs `nix build` and echoes a trailing NIX_BUILD_EXIT= line so the real exit
+# status survives command substitution. Nothing here may swallow a failure: a
+# `|| true` plus a "did it print 'building basecamp'" heuristic is what let
+# v0.8.0 ship a flake that could not build at all — nix logs
+# `building '...basecamp-0.8.0-go-modules.drv'` when it *starts* the build it
+# then fails, so the heuristic reported success on a hard failure.
+run_nix_build() {
+  docker run --rm -v "$(pwd):/src:ro" "$NIX_IMAGE" bash -c '
+    cp -a /src /build && cd /build
+    rm -rf .git
+    git config --global --add safe.directory /build
+    git init -q && git add -A && \
+      GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@ci \
+      GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@ci \
+      git commit -q -m init
+    nix --extra-experimental-features "nix-command flakes" build --no-link 2>&1
+    echo "NIX_BUILD_EXIT=$?"
+  ' 2>&1
+}
+
+nix_build_failed() {
+  ! grep -q 'NIX_BUILD_EXIT=0' <<<"$1"
+}
+
+BUILD_OUTPUT=$(run_nix_build)
+
+if nix_build_failed "$BUILD_OUTPUT"; then
+  NEW_HASH=$(grep "got:" <<<"$BUILD_OUTPUT" | awk '{print $2}' || true)
+  if [[ -z "$NEW_HASH" ]]; then
+    # No hash mismatch, so the build broke for some other reason — a stale
+    # flake.lock whose Go is older than go.mod's directive is the one that has
+    # actually bitten us. Never continue from here.
+    echo "ERROR: nix build failed, and not because of the vendorHash"
+    tail -25 <<<"$BUILD_OUTPUT"
+    exit 1
+  fi
+
+  CURRENT_HASH=$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' "$NIX_PKG" | head -1)
+  sed -i.bak "s|vendorHash = \"${CURRENT_HASH}\"|vendorHash = \"${NEW_HASH}\"|" "$NIX_PKG"
+  rm -f "${NIX_PKG}.bak"
+  CHANGED=true
+  echo "  vendorHash: updated"
+
+  # Prove the corrected hash actually builds. The old code trusted the hash it
+  # had just written without ever rebuilding.
+  echo "  verifying the updated vendorHash builds..."
+  BUILD_OUTPUT=$(run_nix_build)
+  if nix_build_failed "$BUILD_OUTPUT"; then
+    echo "ERROR: nix build still fails after updating the vendorHash"
+    tail -25 <<<"$BUILD_OUTPUT"
+    exit 1
+  fi
+fi
+
+echo "  vendorHash: verified (build succeeded)"
 
 if [[ "$CHANGED" == "true" ]]; then
   exit 0


### PR DESCRIPTION
## v0.8.0 shipped a flake that cannot build

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

#533 raised `go.mod` to 1.26.5 on **2026-07-13**. `flake.lock` still pinned a
nixpkgs from **2026-06-28** carrying 1.26.4, and release prep never updates the
lock. Every `nix build` user has been broken since, across two releases.

## Why nothing caught it

Both safeguards were blind, independently:

- **`update-nix-flake.sh` reported success on failure.** It ran
  `nix build ... || true`, then treated the presence of
  `building '...basecamp-0.8.0-go-modules.drv'` as proof of success. Nix prints that
  when the build *starts* — so a hard failure printed
  `vendorHash: verified (build succeeded)`. It said exactly that during the v0.8.0
  release, which is how a broken flake got through a pre-tag check that existed to
  prevent this.
- **`nix-verify` could not fail the run.** `continue-on-error: true`, and it only runs
  on tags — weeks after the drift is introduced. For v0.8.0 it never ran at all,
  because the AUR outage reddened `release` and skipped every `needs: [release]` job.

## The fix

**Lock + hash.** Updating nixpkgs to one carrying 1.26.5 surfaced a *second* defect the
Go error had been masking — the recorded `vendorHash` was stale as well:

```
specified: sha256-hG1eymlnBAhRDtOqi078uVwMwEFC9+8ilft1LOW7SzY=
got:       sha256-DmCW1Ms9TmcvEzvNIcqutf1bxtOpN+MjpPO0XP1VaZQ=
```

Both corrected. `nix build` now exits 0 and the resulting binary reports
`basecamp version 0.8.0`.

**Fail closed.** The release-time check now reads the real exit status. A failure that
is not a hash mismatch is fatal instead of shrugged off, and when it *does* update a
hash it rebuilds to prove the new one works — which the old code never did.

**Catch it at the source.** `nix-verify` is no longer `continue-on-error`, and a
path-filtered `nix-build` job runs on PRs touching `go.mod`, `go.sum`, `flake.*` or
`nix/**`, so a Go bump that outpaces the lock fails its own PR.

## Verification

Run against the real Docker path, not reasoned about:

| Scenario | Before | After |
|---|---|---|
| Stale lock (the v0.8.0 condition) | `vendorHash: verified (build succeeded)`, exit 0 | **exit 1**, prints the Go version error |
| Fixed lock + hash | — | `vendorHash: verified (build succeeded)`, exit 2 |
| `nix build` on this branch | fails | **exit 0**, binary runs |

`bin/ci` exit 0, `actionlint` clean, `zizmor` no findings.

## Consequence for the queue

0.8.1 cannot be a bare manifest bump — it has to carry this first, or it repeats the
broken Nix release. Let `release.sh` stamp both plugin manifests as part of that
release rather than bumping them standalone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Nix flake by updating `flake.lock` to a `nixpkgs` with Go 1.26.5 and correcting the Go `vendorHash`. Makes the hash check accurate and fail-closed so a flake that can’t build can’t ship again.

- **Bug Fixes**
  - Update `flake.lock` to a revision with Go 1.26.5.
  - Update `nix/package.nix` `vendorHash`.
  - Only rewrite `vendorHash` when `nix` reports a fixed-output hash mismatch and the captured value is SRI-shaped; then rebuild to verify.

- **CI**
  - Make release `nix-verify` blocking (remove `continue-on-error`).
  - Fail closed end-to-end: use the real `nix build` exit code, build unconditionally, update the hash only on mismatch, and `make update-nix-hash` now propagates real failures (RC 0=updated, 2=no-op).
  - Add a path-filtered `nix-build` job in PR CI for changes to `go.mod`, `go.sum`, `flake.*`, and `nix/**`.
  - Add regression tests for the hash-check script (stubbed Docker), including a case that rejects unrelated “got:” logs.

<sup>Written for commit e508d3d3ad5c515039d5f376489a1eaef64ed138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

