### PR TITLE
Share the AUR notifier and the Nix hash classifier between their callers

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -162,16 +162,25 @@ jobs:
         if: failure() && (steps.publish.outcome == 'failure' || steps.aur-state.outputs.unreachable == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          TITLE="AUR publish failure"
-          BODY="Recovery publish of \`${VERSION}\` to the AUR [failed](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}). The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${VERSION}\` once the AUR accepts pushes again."
+          RUN_URL="https://github.com/${REPO_SLUG}/actions/runs/${RUN_ID}"
+          BODY="Recovery publish of \`${VERSION}\` to the AUR [failed](${RUN_URL}). The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${VERSION}\` once the AUR accepts pushes again."
 
-          # Check for existing open issue before creating a new one
-          existing=$(gh issue list --repo ${{ github.repository }} --state open --search "in:title $TITLE" --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number // empty' 2>/dev/null || true)
-          if [ -n "$existing" ]; then
-            gh issue comment --repo ${{ github.repository }} "$existing" --body "$BODY" || true
-          else
-            gh issue create --repo ${{ github.repository }} --title "$TITLE" --body "$BODY" || true
-          fi
+          # Dedup lives in notify-issue.sh, shared with release.yml, and keys on
+          # the aur-publish label rather than the title. A title lookup misses
+          # the moment someone retitles the issue while triaging it — which is
+          # the normal fate of an issue that stays open across an outage.
+          notify_status=0
+          scripts/notify-issue.sh \
+            --repo "$REPO_SLUG" \
+            --label aur-publish \
+            --title "AUR publish failure" \
+            --body "$BODY" || notify_status=$?
+
+          # The notifier fails closed, so on a lookup failure the annotation is
+          # the only record that this dispatch went nowhere.
+          echo "::error::AUR publish failed for ${VERSION}. See ${RUN_URL}"
+          exit "$notify_status"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,22 +350,29 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_SLUG: ${{ github.repository }}
           REF_NAME: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          TITLE="AUR publish failure"
-          BODY="Publishing [${REF_NAME}](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}) to the AUR failed. The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${REF_NAME#v}\` once the AUR is reachable."
+          RUN_URL="https://github.com/${REPO_SLUG}/actions/runs/${RUN_ID}"
+          BODY="Publishing [${REF_NAME}](${RUN_URL}) to the AUR failed. The GitHub release is unaffected — only the Arch package is stale. Re-run the \`Publish to AUR\` workflow with version \`${REF_NAME#v}\` once the AUR is reachable."
 
-          # Check for existing open issue before creating a new one
-          existing=$(gh issue list --repo ${{ github.repository }} --state open --search "in:title $TITLE" --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number // empty' 2>/dev/null || true)
-          if [ -n "$existing" ]; then
-            gh issue comment --repo ${{ github.repository }} "$existing" --body "$BODY" || true
-          else
-            gh issue create --repo ${{ github.repository }} --title "$TITLE" --body "$BODY" || true
-          fi
+          # Dedup lives in notify-issue.sh, shared with aur-publish.yml. Both
+          # files used to carry their own title-based lookup; when the canonical
+          # issue was retitled, the release path opened a duplicate and fixing
+          # only the recovery path would have left this one broken.
+          notify_status=0
+          scripts/notify-issue.sh \
+            --repo "$REPO_SLUG" \
+            --label aur-publish \
+            --title "AUR publish failure" \
+            --body "$BODY" || notify_status=$?
 
-          # Always emit annotation so the failure is visible in the workflow summary
-          echo "::error::AUR publish failed for ${REF_NAME}. See https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+          # Always emit the annotation, whatever the notifier did. It now fails
+          # closed rather than filing a duplicate, so on a lookup failure this
+          # is the only signal left.
+          echo "::error::AUR publish failed for ${REF_NAME}. See ${RUN_URL}"
+          exit "$notify_status"
 
   macos-verify:
     name: Verify macOS signing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -478,6 +478,15 @@ jobs:
   # three weeks: nix-verify only runs on tags, and the release-time hash check
   # was reporting success on a failed build. Catch the drift where it is
   # introduced instead — a Go bump that outpaces the lock now fails its own PR.
+  #
+  # This job is *meant* to fail on a dependency bump: any go.mod or go.sum
+  # change invalidates vendorHash, and dependabot does not update it, so every
+  # weekly `gomod` PR lands here red. That is the check working. nix-build-check.sh
+  # exists so it lands red with the correct hash and `make update-nix-hash`
+  # attached, instead of a raw nix dump.
+  #
+  # The filter includes this file: a PR that changes only the job would
+  # otherwise skip the job it changed.
   nix-build:
     name: Nix flake builds
     runs-on: ubuntu-latest
@@ -501,6 +510,9 @@ jobs:
               - 'flake.nix'
               - 'flake.lock'
               - 'nix/**'
+              - 'scripts/nix-build-check.sh'
+              - 'scripts/extract-nix-vendor-hash.sh'
+              - '.github/workflows/test.yml'
 
       - name: Install Nix
         if: steps.filter.outputs.nix == 'true'
@@ -508,6 +520,4 @@ jobs:
 
       - name: Build the flake
         if: steps.filter.outputs.nix == 'true'
-        run: |
-          STORE_PATH=$(nix build --no-link --print-out-paths)
-          "$STORE_PATH/bin/basecamp" --version
+        run: scripts/nix-build-check.sh

--- a/e2e/extract_nix_vendor_hash.bats
+++ b/e2e/extract_nix_vendor_hash.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+#
+# Fixtures for scripts/extract-nix-vendor-hash.sh — the single classifier that
+# decides whether a failing nix build failed *because of the vendorHash*.
+#
+# Both production callers depend on this answer, and they depend on it for
+# different reasons: update-nix-flake.sh writes the returned value into a
+# tracked file, and nix-build-check.sh puts it in front of a contributor as a
+# remedy. A loose parse corrupts nix/package.nix in one and misdirects a human
+# in the other, which is why the guard is tested here rather than twice at the
+# call sites.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  EXTRACT="$REPO_ROOT/scripts/extract-nix-vendor-hash.sh"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+@test "extracts the SRI hash from a fixed-output mismatch" {
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-basecamp-0.8.1-go-modules.drv':
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+error: 1 dependencies of derivation '/nix/store/xyz-basecamp-0.8.1.drv' failed to build
+LOG
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=" ]
+}
+
+@test "reads from a file argument as well as stdin" {
+  cat > "$WORK/nix.log" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+LOG
+  run "$EXTRACT" "$WORK/nix.log"
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=" ]
+}
+
+@test "rejects a bare 'got:' with no mismatch diagnostic" {
+  # A Go test assertion printing `got: 42`. Matching a bare `got:` would return
+  # "42" — which update-nix-flake.sh would then write into vendorHash.
+  run "$EXTRACT" <<'LOG'
+--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+    thing_test.go:43: want: 7
+error: builder for '/nix/store/xyz.drv' failed with exit code 1
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects a mismatch diagnostic whose value is not SRI-shaped" {
+  # Both guards are load-bearing independently: the diagnostic is present here,
+  # so a diagnostic-only check would accept "not-a-hash".
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    not-a-hash
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects an md5-style hash that is not sha256 SRI" {
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+            got:    md5-d41d8cd98f00b204e9800998ecf8427e
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects the Go toolchain drift that broke v0.8.0" {
+  # The failure this whole lineage exists for. It reports no hash mismatch, so
+  # it must never be classified as one — the fix is flake.lock, not vendorHash.
+  run "$EXTRACT" <<'LOG'
+building '/nix/store/abc-basecamp-0.8.0-go-modules.drv'...
+     > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency
+LOG
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "rejects an empty log" {
+  run "$EXTRACT" </dev/null
+  [ "$status" -ne 0 ]
+  [ -z "$output" ]
+}
+
+@test "returns the first hash when nix reports several mismatches" {
+  # Deterministic rather than arbitrary: update-nix-flake.sh rebuilds after
+  # writing, so it converges across repeated runs. Picking a different one each
+  # time would not.
+  run "$EXTRACT" <<'LOG'
+error: hash mismatch in fixed-output derivation '/nix/store/one-go-modules.drv':
+            got:    sha256-1111111111111111111111111111111111111111111=
+error: hash mismatch in fixed-output derivation '/nix/store/two-go-modules.drv':
+            got:    sha256-2222222222222222222222222222222222222222222=
+LOG
+  [ "$status" -eq 0 ]
+  [ "$output" = "sha256-1111111111111111111111111111111111111111111=" ]
+}

--- a/e2e/nix_build_check.bats
+++ b/e2e/nix_build_check.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+#
+# Wrapper behaviour for scripts/nix-build-check.sh — CI's flake gate.
+#
+# The classifier itself is covered by extract_nix_vendor_hash.bats. What is
+# tested here is everything wrapped around it: that the build's real exit status
+# survives, that nix's own diagnostics are always replayed, that the `::error::`
+# remedy appears only when the classifier agrees, and that a successful build is
+# not trusted until the binary it produced actually runs.
+#
+# `nix` is stubbed via PATH, so these run anywhere in milliseconds and can stage
+# failures that are otherwise awkward to reproduce.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  CHECK="$REPO_ROOT/scripts/nix-build-check.sh"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR"
+  PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# Stubs `nix build`: $1 is the store path echoed on stdout, $2 the log written
+# to stderr, $3 the exit status.
+stub_nix() {
+  cat > "$STUB_DIR/nix" <<STUB
+#!/usr/bin/env bash
+printf '%s' '$1'
+[ -n '$1' ] && echo
+cat >&2 <<'NIXLOG'
+$2
+NIXLOG
+exit $3
+STUB
+  chmod +x "$STUB_DIR/nix"
+}
+
+# Stubs the built binary at STORE/bin/basecamp.
+stub_store_binary() {
+  local store="$WORK/store"
+  mkdir -p "$store/bin"
+  cat > "$store/bin/basecamp" <<STUB
+#!/usr/bin/env bash
+echo "basecamp version ${1:-0.8.1}"
+exit ${2:-0}
+STUB
+  chmod +x "$store/bin/basecamp"
+  echo "$store"
+}
+
+@test "succeeds and runs the built binary" {
+  store="$(stub_store_binary 0.8.1 0)"
+  stub_nix "$store" "building '/nix/store/abc-basecamp.drv'..." 0
+
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"basecamp version 0.8.1"* ]]
+}
+
+@test "fails when the flake builds but the binary does not run" {
+  # A store path that exists proves nix succeeded, not that the result works.
+  store="$(stub_store_binary 0.8.1 1)"
+  stub_nix "$store" "" 0
+
+  run "$CHECK"
+  [ "$status" -ne 0 ]
+}
+
+@test "propagates the build's exit status rather than masking it" {
+  stub_nix "" "error: builder failed" 7
+
+  run "$CHECK"
+  [ "$status" -eq 7 ]
+}
+
+@test "replays nix diagnostics on failure" {
+  stub_nix "" "error: attribute 'basecamp' missing
+       at /nix/store/flake.nix:12:5" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"attribute 'basecamp' missing"* ]]
+  [[ "$output" == *"flake.nix:12:5"* ]]
+}
+
+@test "replays nix diagnostics on success too" {
+  store="$(stub_store_binary)"
+  stub_nix "$store" "warning: Git tree '/src' is dirty" 0
+
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Git tree '/src' is dirty"* ]]
+}
+
+@test "annotates a stale vendorHash with the correct hash and the remedy" {
+  # The dependabot case: a go.mod bump invalidates vendorHash, so the job fails
+  # by design. It must fail with instructions, not a raw nix dump.
+  stub_nix "" "error: hash mismatch in fixed-output derivation '/nix/store/abc-go-modules.drv':
+         specified: sha256-OLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDOLDA=
+            got:    sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB=
+error: 1 dependencies of derivation '/nix/store/xyz.drv' failed to build" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWB="* ]]
+  [[ "$output" == *"make update-nix-hash"* ]]
+  # The remedy is layered on top of the diagnostics, never a replacement.
+  [[ "$output" == *"hash mismatch in fixed-output derivation"* ]]
+}
+
+@test "emits no hash remedy for an unrelated build failure" {
+  # The v0.8.0 shape: the fix is flake.lock, and pointing at
+  # `make update-nix-hash` would send a contributor down the wrong path.
+  stub_nix "" "building '/nix/store/abc-basecamp-0.8.0-go-modules.drv'...
+     > go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
+error: Build failed due to failed dependency" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"make update-nix-hash"* ]]
+  [[ "$output" == *"GOTOOLCHAIN=local"* ]]
+}
+
+@test "emits no hash remedy for a bare 'got:' in a failing build" {
+  stub_nix "" "--- FAIL: TestSomething
+    thing_test.go:42: got: 42
+error: builder failed with exit code 1" 1
+
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"make update-nix-hash"* ]]
+}
+
+@test "fails when nix reports success but prints no store path" {
+  stub_nix "" "" 0
+
+  run "$CHECK"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no store path"* ]]
+}

--- a/e2e/notify_issue.bats
+++ b/e2e/notify_issue.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+#
+# Dedup behaviour for scripts/notify-issue.sh, shared by release.yml and
+# aur-publish.yml.
+#
+# Two defects are pinned here. The first shipped: the old inline lookup matched
+# on *title*, so retitling the canonical issue while triaging it — the normal
+# fate of an issue that stays open across an outage — made the next failure open
+# a duplicate. The second was latent: the lookup was wrapped in
+# `2>/dev/null || true`, which makes a rate limit, a permissions gap and a
+# GitHub outage indistinguishable from "no open issue", and the very next line
+# files one.
+#
+# `gh` is stubbed via PATH. Its four possible answers each get a branch, because
+# the failure mode of guessing wrong is a public issue nobody asked for.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  NOTIFY="$REPO_ROOT/scripts/notify-issue.sh"
+  WORK="$(mktemp -d)"
+  STUB_DIR="$WORK/bin"
+  mkdir -p "$STUB_DIR"
+  GH_CALLS="$WORK/gh-calls"
+  : > "$GH_CALLS"
+  PATH="$STUB_DIR:$PATH"
+  export GH_CALLS
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# Stubs `gh`. $1 is what `gh issue list` prints (one issue number per line),
+# $2 its exit status. Every invocation is recorded to $GH_CALLS so the tests can
+# assert on what was *not* called as well as what was.
+stub_gh() {
+  local list_output="$1" list_status="${2:-0}"
+
+  printf '%s\n' "$list_output" > "$WORK/list-output"
+
+  cat > "$STUB_DIR/gh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "\$GH_CALLS"
+if [ "\$2" = "list" ]; then
+  cat "$WORK/list-output"
+  exit $list_status
+fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/gh"
+}
+
+run_notify() {
+  run "$NOTIFY" \
+    --repo basecamp/basecamp-cli \
+    --label aur-publish \
+    --title "AUR publish failure" \
+    --body "The AUR publish failed."
+}
+
+@test "comments on the single labelled issue" {
+  stub_gh "602" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue comment .* 602" "$GH_CALLS"
+  ! grep -q "issue create" "$GH_CALLS"
+}
+
+@test "files one issue, carrying the label, when none is open" {
+  stub_gh "" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue create" "$GH_CALLS"
+  # Without the label the issue it just filed would not be found next time, and
+  # the run after that would file a third.
+  grep -q -- "--label aur-publish" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+}
+
+@test "fails closed when the lookup errors, filing nothing" {
+  # The regression that matters. `|| true` here reads an API failure as "no
+  # match" and opens a duplicate on every subsequent failed run.
+  stub_gh "" 1
+
+  run_notify
+  [ "$status" -eq 2 ]
+  ! grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+  [[ "$output" == *"Could not list"* ]]
+}
+
+@test "fails closed when several issues carry the label" {
+  # Two open issues means a human split them on purpose. Commenting on whichever
+  # sorts first scatters one outage's history across both.
+  stub_gh "602
+607" 0
+
+  run_notify
+  [ "$status" -eq 3 ]
+  ! grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+  [[ "$output" == *"602"* ]]
+  [[ "$output" == *"607"* ]]
+}
+
+@test "looks up by label, never by title" {
+  # #607 was opened alongside a retitled #602 because the lookup searched
+  # `in:title`. A label survives retitling.
+  stub_gh "602" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q -- "issue list .*--label aur-publish" "$GH_CALLS"
+  ! grep -q -- "--search" "$GH_CALLS"
+  ! grep -q "in:title" "$GH_CALLS"
+}
+
+@test "ignores blank lines in the lookup output" {
+  # `--jq '.[].number'` prints nothing for an empty list, which arrives here as
+  # a single empty line. Counting it would make "none open" look like "one open"
+  # and send a comment to issue "".
+  stub_gh "
+" 0
+
+  run_notify
+  [ "$status" -eq 0 ]
+  grep -q "issue create" "$GH_CALLS"
+  ! grep -q "issue comment" "$GH_CALLS"
+}
+
+@test "propagates a failure to comment rather than reporting success" {
+  cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_CALLS"
+if [ "$2" = "list" ]; then
+  echo 602
+  exit 0
+fi
+echo "HTTP 403" >&2
+exit 1
+STUB
+  chmod +x "$STUB_DIR/gh"
+
+  run_notify
+  [ "$status" -ne 0 ]
+}
+
+@test "rejects a missing required argument" {
+  stub_gh "602" 0
+
+  run "$NOTIFY" --repo basecamp/basecamp-cli --label aur-publish --title "t"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--body"* ]]
+  [ ! -s "$GH_CALLS" ]
+}

--- a/e2e/update_nix_flake.bats
+++ b/e2e/update_nix_flake.bats
@@ -16,7 +16,10 @@ setup() {
   STUB_DIR="$WORK/bin"
   mkdir -p "$STUB_DIR" "$WORK/repo/nix" "$WORK/repo/scripts"
 
-  cp "$REPO_ROOT/scripts/update-nix-flake.sh" "$WORK/repo/scripts/"
+  # The classifier travels with it — update-nix-flake.sh resolves it relative to
+  # its own directory, and shares it with CI's nix-build-check.sh.
+  cp "$REPO_ROOT/scripts/update-nix-flake.sh" \
+     "$REPO_ROOT/scripts/extract-nix-vendor-hash.sh" "$WORK/repo/scripts/"
   cat > "$WORK/repo/nix/package.nix" <<'NIXPKG'
 {
   version = "0.8.0";

--- a/scripts/extract-nix-vendor-hash.sh
+++ b/scripts/extract-nix-vendor-hash.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Extracts the corrected vendorHash from a nix build log.
+#
+# Usage: scripts/extract-nix-vendor-hash.sh [LOGFILE]   (reads stdin when omitted)
+#
+# The single classifier for "did this build fail because of the vendorHash?".
+# Both production callers use it — update-nix-flake.sh, which writes the value
+# into nix/package.nix, and nix-build-check.sh, which reports it in CI. They
+# each carried their own copy of this parse once; two classifiers that can
+# drift is one classifier too many, because the one that drifts is the one
+# that writes to a tracked file.
+#
+# Two independent conditions must hold before a hash comes back. Nix must have
+# actually reported a fixed-output hash mismatch, and the captured value must
+# look like an SRI hash. Matching a bare `got:` is far too loose: any failing
+# build whose log happens to contain one — a Go test assertion printing
+# `got: 42`, say — would otherwise yield "42" as a vendorHash and misreport an
+# unrelated failure as a hash problem.
+#
+# Exit codes:
+#   0 — a fixed-output hash mismatch was reported; the SRI hash is on stdout
+#   1 — the log reports no vendorHash mismatch; nothing on stdout
+
+set -euo pipefail
+
+LOG=$(cat -- "${1:--}")
+
+if ! grep -q 'hash mismatch in fixed-output derivation' <<<"$LOG"; then
+  exit 1
+fi
+
+HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/]+=*' <<<"$LOG" \
+         | awk '{print $2}' | head -1 || true)
+
+if [[ -z "$HASH" ]]; then
+  exit 1
+fi
+
+printf '%s\n' "$HASH"

--- a/scripts/nix-build-check.sh
+++ b/scripts/nix-build-check.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Builds the Nix flake, runs the resulting binary, and turns a stale vendorHash
+# into an actionable annotation instead of a raw nix dump.
+#
+# Usage: scripts/nix-build-check.sh
+#
+# This exists because the nix-build job is *supposed* to fail on a dependency
+# bump: changing go.mod or go.sum invalidates vendorHash, and dependabot will
+# not update it, so every weekly `gomod` PR fails here. The failure is correct.
+# What was wrong is that it arrived as an unexplained nix log with no remedy.
+#
+# Lives in a script rather than inline in the workflow so the classification is
+# reachable from tests — an inline `run:` block can only be exercised by
+# breaking main.
+#
+# Exit status is the nix build's own. Nothing here may swallow a failure: a
+# `|| true` plus a "did it look like it built" heuristic is what let v0.8.0
+# ship a flake that could not build at all.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+STATUS=0
+STORE_PATH="$(nix build --no-link --print-out-paths 2>"$LOG")" || STATUS=$?
+
+# Always replay what nix said, whichever way this goes. The annotation below is
+# a hint layered on top of the diagnostics, never a replacement for them.
+cat "$LOG" >&2
+
+if [[ "$STATUS" -ne 0 ]]; then
+  # Only claim this is a hash problem when the shared classifier agrees, which
+  # requires both the fixed-output diagnostic and an SRI-shaped value. Every
+  # other failure — a stale flake.lock whose Go is older than go.mod's
+  # directive, say — falls through with nix's own output and no false remedy.
+  if HASH="$("$SCRIPT_DIR/extract-nix-vendor-hash.sh" "$LOG")"; then
+    echo "::error::Stale Nix vendorHash. Expected ${HASH}. A go.mod or go.sum change invalidates it and dependabot does not update it — run 'make update-nix-hash' and commit nix/package.nix."
+  fi
+  exit "$STATUS"
+fi
+
+if [[ -z "$STORE_PATH" ]]; then
+  echo "::error::nix build reported success but printed no store path"
+  exit 1
+fi
+
+"$STORE_PATH/bin/basecamp" --version

--- a/scripts/notify-issue.sh
+++ b/scripts/notify-issue.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Files or updates the single open issue tracking a recurring failure.
+#
+# Usage:
+#   scripts/notify-issue.sh --repo OWNER/NAME --label LABEL --title TITLE --body BODY
+#
+# Dedupes by *label*, not by title. Titles get edited the moment a human triages
+# the issue, and a title-based lookup then misses and opens a duplicate — which
+# is exactly how #607 landed alongside the retitled #602. A label survives
+# retitling, reassignment and rewording.
+#
+# Fails closed. The lookup's failure and its empty result must never be the same
+# thing: `2>/dev/null || true` around the search turned a rate limit, a
+# permissions gap or a GitHub outage into "no match found", and the very next
+# line creates a duplicate. If we cannot see the issue list, we file nothing and
+# say so — the workflow annotation still makes the underlying failure visible.
+#
+# Shared by release.yml and aur-publish.yml. They kept two inline copies of this
+# logic, which is how only one of them would have been fixed.
+#
+# Exit codes:
+#   0 — commented on the existing issue, or created a new one
+#   1 — usage error, or the comment/create itself failed
+#   2 — the lookup failed; nothing was created
+#   3 — more than one open issue carries the label; nothing was created
+
+set -euo pipefail
+
+REPO=""
+LABEL=""
+TITLE=""
+BODY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)  REPO="${2:-}";  shift 2 ;;
+    --label) LABEL="${2:-}"; shift 2 ;;
+    --title) TITLE="${2:-}"; shift 2 ;;
+    --body)  BODY="${2:-}";  shift 2 ;;
+    *)
+      echo "notify-issue.sh: unknown argument '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+missing=""
+[[ -n "$REPO"  ]] || missing="$missing --repo"
+[[ -n "$LABEL" ]] || missing="$missing --label"
+[[ -n "$TITLE" ]] || missing="$missing --title"
+[[ -n "$BODY"  ]] || missing="$missing --body"
+if [[ -n "$missing" ]]; then
+  echo "notify-issue.sh: missing required argument(s):$missing" >&2
+  exit 1
+fi
+
+if ! matches=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+                 --json number --jq '.[].number'); then
+  echo "::error::Could not list open '${LABEL}' issues in ${REPO}. Filing nothing rather than risk a duplicate — the failure is still annotated on this run."
+  exit 2
+fi
+
+issues=()
+while IFS= read -r number; do
+  if [[ "$number" =~ ^[0-9]+$ ]]; then
+    issues+=("$number")
+  fi
+done <<<"$matches"
+
+case "${#issues[@]}" in
+  0)
+    echo "No open '${LABEL}' issue; filing one."
+    gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "$LABEL"
+    ;;
+  1)
+    echo "Commenting on existing '${LABEL}' issue #${issues[0]}."
+    gh issue comment --repo "$REPO" "${issues[0]}" --body "$BODY"
+    ;;
+  *)
+    # Picking one arbitrarily would scatter the history of a single outage
+    # across issues that a human already decided to keep separate.
+    echo "::error::${#issues[@]} open issues carry the '${LABEL}' label (${issues[*]}). Refusing to guess which one to update — consolidate them, then re-run."
+    exit 3
+    ;;
+esac

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
   echo "Usage: scripts/update-nix-flake.sh VERSION"
@@ -85,17 +87,11 @@ nix_build_failed() {
 BUILD_OUTPUT=$(run_nix_build)
 
 if nix_build_failed "$BUILD_OUTPUT"; then
-  # Two independent conditions before touching the tracked file: nix must have
-  # actually reported a fixed-output hash mismatch, and the captured value must
-  # look like an SRI hash. Matching a bare `got:` is far too loose — any failing
-  # build whose log contains one (a Go test assertion printing `got: 42`, say)
-  # would otherwise write that value straight into vendorHash and misreport the
-  # failure as a hash problem.
-  NEW_HASH=""
-  if grep -q 'hash mismatch in fixed-output derivation' <<<"$BUILD_OUTPUT"; then
-    NEW_HASH=$(grep -oE 'got:[[:space:]]+sha256-[A-Za-z0-9+/]+=*' <<<"$BUILD_OUTPUT" \
-                 | awk '{print $2}' | head -1)
-  fi
+  # Classification lives in extract-nix-vendor-hash.sh, shared with CI's
+  # nix-build-check.sh. It requires both a fixed-output mismatch diagnostic and
+  # an SRI-shaped value before yielding anything — deliberately, because this
+  # caller writes the result into a tracked file.
+  NEW_HASH=$("$SCRIPT_DIR/extract-nix-vendor-hash.sh" <<<"$BUILD_OUTPUT" || true)
 
   if [[ -z "$NEW_HASH" ]]; then
     # The build broke for some other reason — a stale flake.lock whose Go is


### PR DESCRIPTION
Two pieces of logic each existed twice, and in both cases only one copy would
have been fixed. Both are consequences of my own earlier changes.

## Label-based dedup, in both AUR paths

#607 was opened by `release.yml`, not the manual recovery workflow — its body
("Publishing [v0.8.1]…") is release.yml's wording, not aur-publish.yml's
("Recovery publish of…"). The canonical #602 was already open; I had retitled it,
and **both** files dedupe with `--search "in:title $TITLE"`, so the lookup missed
and filed a duplicate. Fixing only the manual workflow leaves the automatic
release path opening another one on the next failure.

`scripts/notify-issue.sh` now searches open issues **by the `aur-publish`
label** — which survives retitling, reassignment and rewording — comments on the
match, or creates *with* the label. Both workflows call it.

### It fails closed

The old lookup was `... 2>/dev/null || true`. That makes a rate limit, a
permissions gap and a GitHub outage indistinguishable from "no open issue", and
the very next line files one. Four branches, each pinned by a test:

| Lookup result | Behaviour |
|---|---|
| errors | file nothing, exit 2, annotation retained |
| zero matches | create one issue, carrying the label |
| exactly one | comment on it |
| more than one | refuse to guess, exit 3, file nothing |

Both workflows emit their `::error::` annotation regardless of what the notifier
did, so when it fails closed the failure is still visible on the run.

## Extract the Nix classifier so tests can reach it

The `nix-build` job from #606 triggers on `go.mod`/`go.sum`, so **every weekly
dependabot Go bump will fail it** — a dependency change invalidates `vendorHash`
and dependabot will not update it. The job *should* fail. The defect is that it
failed as a raw nix dump with no remedy, and being an inline `run:` block, no
test could reach it. Its path filter also omitted `.github/workflows/test.yml`,
so a PR editing the job would skip the job it edited.

`scripts/nix-build-check.sh` runs the build, replays nix's diagnostics either
way, propagates the build's **real** exit status (no `|| true`), and emits the
corrected `sha256-…` plus `make update-nix-hash` — but only when both the
fixed-output diagnostic and an SRI-shaped value are present.

That guard is `scripts/extract-nix-vendor-hash.sh`, **shared with
`update-nix-flake.sh`** rather than copied into it. Two production classifiers
that can drift is one too many when the one that drifts is the one that writes
into `nix/package.nix`. Fixture tests pin the helper; separate wrapper tests pin
exit propagation, diagnostic replay, annotation rendering, and that a successful
build is not trusted until the binary it produced actually runs.

Considered and rejected: narrowing the filter to drop `go.sum`. It would still
have caught v0.8.0's Go-toolchain drift (go.mod's `go` directive plus
`flake.lock`) but would stop catching a stale `vendorHash` — the *second* v0.8.0
defect.

## Verification

- `bin/ci` exit 0; `make lint-actions` clean (actionlint + zizmor).
- 31 BATS tests green across the three new suites and the existing
  `update_nix_flake.bats`, which now routes through the shared classifier.
- **Mutation-checked**, not just green: reverting the lookup to `|| true` fails
  exactly the fail-closed test, and loosening the SRI pattern to `[^[:space:]]+`
  fails exactly the two shape tests. Nothing else moved.
- The live notify path was dry-run against real GitHub with writes stubbed — it
  resolves to labelled **#602** and takes the comment branch, so it will not open
  a third issue.
- This PR changes `test.yml`, so the `nix-build` job running here is itself the
  proof that the widened path filter works.
- A temporary wrong-`vendorHash` commit will demonstrate the `::error::`
  rendering once, then be removed before review.

The `aur-publish` label has been created and applied to #602, so the label path
is live before this merges.

Refs #602, #607

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the AUR failure notifier and the Nix vendorHash classifier across workflows to remove duplicate logic, prevent duplicate issues, and make CI failures actionable with the correct hash and remedy.

- **Bug Fixes**
  - AUR issue dedup now keys on the `aur-publish` label via `scripts/notify-issue.sh`.
  - Notifier fails closed on lookup errors or multiple matches (files nothing; exits non‑zero). Both workflows still emit their `::error::` annotation and propagate the notifier’s status.

- **Refactors**
  - Extracted vendorHash classifier to `scripts/extract-nix-vendor-hash.sh` and wired it into `scripts/nix-build-check.sh` and `scripts/update-nix-flake.sh`.
  - `nix-build` job now runs `scripts/nix-build-check.sh`: replays nix logs, preserves real exit status, annotates with the corrected `sha256-…` and `make update-nix-hash` only on a fixed‑output mismatch with an SRI hash, verifies the built binary runs, and errors if nix prints no store path.
  - Widened `test.yml` path filter to include Nix and script paths (incl. this file). Added BATS tests for the notifier, classifier, and build wrapper.

<sup>Written for commit 7a5f2782e5ae853243f3b3155330783686fba2f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

