### PR TITLE
Adopt basecamp-sdk v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
-	github.com/basecamp/basecamp-sdk/go v0.11.0
+	github.com/basecamp/basecamp-sdk/go v0.12.0
 	github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.11.0 h1:bjbwcjEZIAUh93PF/Mr/+KSnQStmhL5yB903OBTVBoM=
-github.com/basecamp/basecamp-sdk/go v0.11.0/go.mod h1:r83ralDQ0q9vbAby5qQ5x9hgCgUdJLDLHYpiU6jaFjE=
+github.com/basecamp/basecamp-sdk/go v0.12.0 h1:N+sdsz109J5PUu8AZM5UT7vS00Z76s+zG4ItFDeKXkM=
+github.com/basecamp/basecamp-sdk/go v0.12.0/go.mod h1:r83ralDQ0q9vbAby5qQ5x9hgCgUdJLDLHYpiU6jaFjE=
 github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c h1:+5sQBl8sqYoD1Qhwsibn8sBCKWPyZ9NDez6mnuo9Afo=
 github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c/go.mod h1:EK1Dba6DEw8ZAilVBpf/jri3ONDV7LQkLACSDe73f/c=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/commands/cards.go
+++ b/internal/commands/cards.go
@@ -313,15 +313,15 @@ func runCardsListAccountWide(cmd *cobra.Command, app *appctx.App, opts cardsList
 		)
 		switch selector {
 		case cardsSelectorCompleted:
-			groupsPage, err = everything.CompletedCards(cmd.Context(), page)
+			groupsPage, err = everything.CompletedCards(cmd.Context(), page, nil)
 		case cardsSelectorUnassigned:
-			groupsPage, err = everything.UnassignedCards(cmd.Context(), page)
+			groupsPage, err = everything.UnassignedCards(cmd.Context(), page, nil)
 		case cardsSelectorNoDueDate:
-			groupsPage, err = everything.NoDueDateCards(cmd.Context(), page)
+			groupsPage, err = everything.NoDueDateCards(cmd.Context(), page, nil)
 		case cardsSelectorNotNow:
-			groupsPage, err = everything.NotNowCards(cmd.Context(), page)
+			groupsPage, err = everything.NotNowCards(cmd.Context(), page, nil)
 		default:
-			groupsPage, err = everything.OpenCards(cmd.Context(), page)
+			groupsPage, err = everything.OpenCards(cmd.Context(), page, nil)
 		}
 		if err != nil {
 			return nil, basecamp.ListMeta{}, convertSDKError(err)
@@ -388,7 +388,7 @@ func runCardsListOverdue(cmd *cobra.Command, app *appctx.App, opts cardsListOpti
 		return output.ErrUsage("--sort position requires --column (position is per-column)")
 	}
 
-	cards, err := app.Account().Everything().OverdueCards(cmd.Context())
+	cards, err := app.Account().Everything().OverdueCards(cmd.Context(), nil)
 	if err != nil {
 		return convertSDKError(err)
 	}

--- a/internal/commands/todos.go
+++ b/internal/commands/todos.go
@@ -427,7 +427,7 @@ func listOverdueTodosAcrossProjects(cmd *cobra.Command, app *appctx.App, flags t
 		return output.ErrUsage("--sort position requires --list (position is per-todolist)")
 	}
 
-	todos, err := app.Account().Everything().OverdueTodos(cmd.Context())
+	todos, err := app.Account().Everything().OverdueTodos(cmd.Context(), nil)
 	if err != nil {
 		return convertSDKError(err)
 	}
@@ -502,13 +502,13 @@ func fetchAccountWideTodoGroups(ctx context.Context, app *appctx.App, filter tod
 	everything := app.Account().Everything()
 	switch filter {
 	case todosFilterCompleted:
-		return everything.CompletedTodos(ctx, page)
+		return everything.CompletedTodos(ctx, page, nil)
 	case todosFilterUnassigned:
-		return everything.UnassignedTodos(ctx, page)
+		return everything.UnassignedTodos(ctx, page, nil)
 	case todosFilterNoDueDate:
-		return everything.NoDueDateTodos(ctx, page)
+		return everything.NoDueDateTodos(ctx, page, nil)
 	default:
-		return everything.OpenTodos(ctx, page)
+		return everything.OpenTodos(ctx, page, nil)
 	}
 }
 

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,13 +1,13 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.11.0",
-    "revision": "b7124ca6a62a",
-    "updated_at": "2026-07-31T09:00:51Z"
+    "version": "v0.12.0",
+    "revision": "7e2925d25078",
+    "updated_at": "2026-08-01T00:57:46Z"
   },
   "api": {
     "repo": "basecamp/bc3",
-    "revision": "e83b273363891ff060f0c818f542916c681f1bfd",
-    "synced_at": "2026-07-30"
+    "revision": "d0edc1283b231c58b7c88b014df5f8d231b1f7c8",
+    "synced_at": "2026-07-31"
   }
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-DmCW1Ms9TmcvEzvNIcqutf1bxtOpN+MjpPO0XP1VaZQ=";
+  vendorHash = "sha256-+j9bY0gSONYBIYZG9uaKgyISp6QUqNl9n8WRZWIPUKI=";
 
   subPackages = [ "cmd/basecamp" ];
 


### PR DESCRIPTION
**PR 1 of 3.** Bump only — no new commands. B (`bc5-command-surface`) and C
(`account-wide-task-filters`) stack on top.

## What changed

`Everything()` gained a parameter in v0.12.0. Eleven call sites across
`cards.go` and `todos.go` pass `nil`, preserving today's behaviour exactly.

`internal/version/sdk-provenance.json` moves to v0.12.0.

## vendorHash

`nix/package.nix` is updated to `sha256-+j9bY0gS…` via `make update-nix-hash`.
A go.mod change invalidates it and the `nix-build` job gates on it, so the bump
cannot land without this. Recomputed and re-verified by rebuild — through the
shared classifier that #609 just extracted, which is a nice first real exercise
of it.

## Rebase provenance

Rebased from `1bf961f2` onto `ec979fc8`. `git range-diff` against
`backup/sdk-0.12.0-pre-rebase` shows the only intra-commit change is the
`vendorHash` line; everything else is byte-identical.

go.mod resolved cleanly because the two moves are disjoint — main bumped goldmark
1.8.4 → 1.8.5 and left the SDK alone; this branch bumps the SDK and leaves
goldmark alone. Result is SDK v0.12.0 + goldmark v1.8.5, which is the intended
resolution. No `replace` directive.

## Verification

- `bin/ci` exit 0 at this head.
- **goldmark renderer re-smoked, and this is the interesting one.** The stack
  carried goldmark 1.8.4, main carries 1.8.5, and `internal/commands/notes.go`
  renders through `richtext.MarkdownToHTML` — so the renderer under that path
  changed on rebase. Rendering one corpus (headings, nested lists, tables, fenced
  code, footnotes, emoji, raw HTML, hard breaks, entities) under both versions
  produces **byte-identical** output.
- Live round-trip against production as well: `notes set --file` → `notes show`
  returns correct HTML for headings, emphasis, lists, links (`target`/`rel`),
  blockquote and entity escaping. Test note restored to its prior content
  byte-for-byte afterwards.

Backup branch: `backup/sdk-0.12.0-pre-rebase`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade to `github.com/basecamp/basecamp-sdk/go` v0.12.0 and update `Everything()` selectors to accept the new filters param, passing `nil` to keep behavior unchanged. No user-facing changes; sets up future account-wide filtering.

- **Dependencies**
  - Bumped SDK to v0.12.0 in `go.mod`/`go.sum`.
  - Updated `nix/package.nix` `vendorHash`.
  - Refreshed `internal/version/sdk-provenance.json`.

<sup>Written for commit 4e232e9e303d8f327a3fdb1c6e93a9857137a349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

