### PR TITLE
Stop a losing rm -rf race from failing a passing test

### DIFF
--- a/e2e/update_nix_flake.bats
+++ b/e2e/update_nix_flake.bats
@@ -38,7 +38,23 @@ NIXPKG
 }
 
 teardown() {
-  rm -rf "$WORK"
+  # Cleanup must not decide whether the test passed. Under `bats -j` these tests
+  # each build a throwaway git repo in $TMPDIR, and on macOS `rm -rf`
+  # intermittently fails with ENOTEMPTY on .git/objects. bats treats a failing
+  # teardown as a failing test, so a green assertion was reported red — twice in
+  # six local runs, landing on a different test name each time.
+  #
+  # ENOTEMPTY says the directory was not empty when rm reached it; it does not
+  # say what refilled it, and that has not been established. Hence a fix at the
+  # teardown rather than at a presumed cause: retry briefly, then give up
+  # quietly. A leftover directory under $TMPDIR is worth less than a trustworthy
+  # signal, and the assertions have already run either way.
+  for _ in 1 2 3; do
+    rm -rf "$WORK" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  rm -rf "$WORK" 2>/dev/null || true
+  return 0
 }
 
 # Emits a canned nix log plus the sentinel the script reads for exit status.


### PR DESCRIPTION
Not part of the SDK stack — a flake I kept hitting while running `bin/ci`
against it, in a file #609 last touched.

## What is observed

`e2e/update_nix_flake.bats` builds a throwaway git repo per test. Under
`bats -j` (which `e2e/run.sh` uses by default), teardown's `rm -rf "$WORK"`
intermittently fails with ENOTEMPTY:

```
not ok 365 records a corrected hash only after a rebuild proves it
# (from function `teardown' in test file update_nix_flake.bats, line 41)
#   `rm -rf "$WORK"' failed
# rm: /var/folders/.../repo/.git/objects: Directory not empty
# rm: /var/folders/.../repo/.git: Directory not empty
```

bats counts a failing teardown as a failing test, so the assertion passed and
the test was reported red. The test name it lands on varies between runs — I saw
it on two different tests, which is itself the tell.

It hit **twice in six local `bin/ci` runs**, so it is frequent enough to cost
real CI runs and, worse, to train people to re-run on red.

## What is not claimed

ENOTEMPTY says only that the directory was not empty when `rm` reached it during
parallel execution. It does not identify what put entries back, and I have not
established that. An earlier revision of this description asserted that something
"still holds `.git/objects`" — that was a guess dressed as a finding, and it is
withdrawn. The evidence supports "cleanup lost a race under `-j`", nothing
narrower.

That uncertainty is exactly why the fix is at the teardown rather than at a
presumed cause.

## Fix

Retry briefly, then give up quietly. Cleanup should not decide whether a test
passed, and a leftover directory under `$TMPDIR` is worth less than a signal
people trust. This is a policy choice about teardown, and it holds regardless of
which actor wins the race.

## Verification

- 6 serial runs and 3 parallel (`-j 10`) runs of that file: 0 failures.
- `bin/ci` exit 0.
- Full remote suite on the exact head: 22 success / 2 skipped / 1 neutral /
  0 failures.