### PR TITLE
Point two comments at functions that exist

### DIFF
--- a/internal/commands/accountwide.go
+++ b/internal/commands/accountwide.go
@@ -191,15 +191,17 @@ func accountWideCapNotice(capped bool, meta basecamp.ListMeta, count int, plural
 // algorithm untouched; the number of requests it takes is a property of the
 // result, not of the filter.
 //
-// Project-scoped --assignee is a different animal — see the note on
-// filterTodosByAssignees.
+// Project-scoped --assignee is a different animal: that endpoint has no
+// assignee parameter, so the flag is applied client-side over an unlimited
+// fetch. See the note in listTodosInList (internal/commands/todos.go).
 
 // dueFilterValues are the tokens --due accepts. These are categories, not
 // dates: internal/dateparse is deliberately not involved, since "overdue" is
 // not a date and "with" is not a date range.
 var dueFilterValues = []string{"with", "without", "overdue"}
 
-// rejectEmptyTaskFilterValues refuses an explicitly empty --due or --assignee.
+// validateTaskFilterValues refuses an explicitly empty --due or --assignee, and
+// an unknown --due token.
 //
 // Every other check in this file tests the flag's *value*, which makes `--due=`
 // indistinguishable from never passing --due: the project-scoped guard stops


### PR DESCRIPTION
Comment-only. Both were flagged by Copilot on #612 and judged real but
non-blocking, so I did not move that PR's reviewed head for them. Follow-up now
that #612 has merged.

**`filterTodosByAssignees` does not exist** in this repository. The
project-scoped assignee note it points at lives in `listTodosInList`
(`internal/commands/todos.go`). Redirected there, and the reference now states
what the note says — the endpoint has no assignee parameter, so the flag is
applied client-side over an unlimited fetch — so it is useful without following
it.

**The second is mine, from #612.** I renamed `rejectEmptyTaskFilterValues` to
`validateTaskFilterValues` when it took on the `--due` token check, and left its
doc comment naming the old function. The comment also now mentions the token
check it gained.

`bin/ci` exit 0. No behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two doc comments: project-scoped `--assignee` now points to `listTodosInList` with a note on client-side filtering, and `validateTaskFilterValues` mentions the `--due` token check. No behavior change.

<sup>Written for commit b8550951a40b3165ba3eb3a29d51d0193bfbff5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

