### PR TITLE
Tell agents the truth about card column moves

### DIFF
--- a/internal/commands/events.go
+++ b/internal/commands/events.go
@@ -29,7 +29,8 @@ You can pass either an ID or a Basecamp URL:
 
 Events track all changes to an item. Common event actions:
 - created - Item was created
-- completed/uncompleted - Todo completion state changed
+- completed/uncompleted - Todo or card completion state changed
+- adopted - A card moved to another column
 - assignment_changed - Assignees were added/removed
 - content_changed - Content was edited
 - archived/unarchived - Status changed

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -221,6 +221,7 @@ basecamp <cmd> --page 1     # First page only, no auto-pagination
 | Download attachments | `basecamp attachments download <id> --out /tmp/` |
 | Show + download | `basecamp todos show <id> --download-attachments --json` |
 | Stream attachment to stdout | `basecamp attachments download <id> --file <name> --out -` |
+| Change history for an item | `basecamp events <id\|url> --json` (when a card moved columns, when a todo was completed) |
 | Search | `basecamp search "query" --json` |
 | Parse URL | `basecamp url parse "<url>" --json` |
 | Upload file | `basecamp files uploads create <file> [--vault <folder_id>] --in <project> --json` |
@@ -659,7 +660,11 @@ against the source table's wormholes.
 
 **Identifying completed cards:** Cards in Done columns have `parent.type: "Kanban::DoneColumn"` and `completed: true`. Use this to identify completed cards that haven't been archived.
 
-**Limitation:** Basecamp does not track when cards are moved between columns. The `updated_at` field updates on any modification and cannot reliably indicate when a card was completed.
+**When a card moved columns:** don't read `updated_at` — it changes on any
+modification. Use the event history instead: `basecamp events <card_id> --json`
+records an `adopted` event for every column move, and a card crossing into or
+out of a Done column pairs that with `completed`/`uncompleted`. See
+[Events](#events-change-history).
 
 **Card Steps (checklists):**
 ```bash
@@ -856,6 +861,27 @@ basecamp timeline --watch --interval 60           # Poll every 60 seconds
 ```
 
 Use `--limit N` to cap results or `--all` to fetch everything (default: 100 events). `--all` and `--page` cannot be combined with `--watch`.
+
+### Events (change history)
+
+`basecamp timeline` reports activity across a project or account. For the audit
+trail of one specific item — todo, card, message, document — use `basecamp
+events`:
+
+```bash
+basecamp events <id|url> --json                   # Change history for one item
+basecamp events <id> --limit 25 --json            # Cap results (default 100)
+basecamp events <id> --all --json                 # Fetch everything
+```
+
+Common `action` values: `created`, `completed`/`uncompleted`,
+`assignment_changed`, `content_changed`, `archived`/`unarchived`,
+`commented_on`, and — for cards — `adopted`, which is recorded every time a card
+moves to another column. That makes `events` the way to answer "when did this
+card move?" or "when was this actually finished?", neither of which `updated_at`
+can tell you.
+
+`--page` accepts only `1`; use `--all` to walk every page.
 
 ### Recordings (Cross-project)
 


### PR DESCRIPTION
`skills/basecamp/SKILL.md` claimed:

> **Limitation:** Basecamp does not track when cards are moved between columns.

It does. `basecamp events <card_id>` records an `adopted` event on every column
move, and a card crossing into or out of a Done column pairs that with
`completed`/`uncompleted`. This file installs to `~/.agents/skills/`, so the
claim was actively misinforming agents — telling them to give up on a question
the CLI already answers.

Two gaps let it survive:

- **`basecamp events` appeared nowhere in SKILL.md** — zero grep hits. An agent
  reading the skill never learned the command exists, so nothing contradicted
  the limitation.
- **`internal/commands/events.go` omitted `adopted`** from the common actions in
  its `Long` help, so `--help` didn't fill the gap either.

All three are fixed here: the false limitation becomes the events recipe,
`events` gets its own section next to Timeline plus a Quick Reference row, and
`adopted` joins the command's own list of common actions.

`.surface` is unchanged — it doesn't capture `Long` help text — so
`make check-skill-drift` and `make check-surface` both pass, and `bin/ci` is
green.

Closes #595

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reflects that Basecamp cards record column moves via `adopted` events and documents how to use `basecamp events` to answer when a card moved or was completed, addressing #595. Adds `adopted` to `events --help`, replaces the false limitation in `skills/basecamp/SKILL.md`, and adds an Events section plus a Quick Reference entry.

<sup>Written for commit 068f3f6659e098b5dae2094f2ce5e2a39eca06ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

