### PR TITLE
Install the skill where opencode actually looks

### DIFF
--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -30,8 +30,8 @@ var skillLocations = []skillLocation{
 	{Name: "Agents (Shared)", Path: "~/.agents/skills/basecamp/SKILL.md"},
 	{Name: "Claude Code (Global)", Path: "~/.claude/skills/basecamp/SKILL.md"},
 	{Name: "Claude Code (Project)", Path: ".claude/skills/basecamp/SKILL.md"},
-	{Name: "OpenCode (Global)", Path: "~/.config/opencode/skill/basecamp/SKILL.md"},
-	{Name: "OpenCode (Project)", Path: ".opencode/skill/basecamp/SKILL.md"},
+	{Name: "OpenCode (Global)", Path: "~/.config/opencode/skills/basecamp/SKILL.md"},
+	{Name: "OpenCode (Project)", Path: ".opencode/skills/basecamp/SKILL.md"},
 	{Name: "Codex (Global)", Path: codexGlobalSkillPath()},
 }
 

--- a/internal/commands/skill_test.go
+++ b/internal/commands/skill_test.go
@@ -222,6 +222,30 @@ func TestCopySkillFilesRejectsSubdirs(t *testing.T) {
 	}
 }
 
+// skillLocations is both the wizard's install targets and the refresh set, so a
+// path an agent doesn't read is a silent no-op in either direction. Pin the
+// literals rather than deriving them, so a test can't mirror the same typo the
+// code has. OpenCode's search paths: https://opencode.ai/docs/skills/. Codex's
+// entry is computed by codexGlobalSkillPath and covered separately.
+func TestSkillLocationsMatchAgentSearchPaths(t *testing.T) {
+	want := map[string]string{
+		"Agents (Shared)":       "~/.agents/skills/basecamp/SKILL.md",
+		"Claude Code (Global)":  "~/.claude/skills/basecamp/SKILL.md",
+		"Claude Code (Project)": ".claude/skills/basecamp/SKILL.md",
+		"OpenCode (Global)":     "~/.config/opencode/skills/basecamp/SKILL.md",
+		"OpenCode (Project)":    ".opencode/skills/basecamp/SKILL.md",
+	}
+
+	got := make(map[string]string, len(skillLocations))
+	for _, loc := range skillLocations {
+		got[loc.Name] = loc.Path
+	}
+
+	for name, path := range want {
+		assert.Equal(t, path, got[name], "install target for %s", name)
+	}
+}
+
 func TestNormalizeSkillPath(t *testing.T) {
 	tests := []struct {
 		input, want string
@@ -494,7 +518,7 @@ func TestRefreshAllInstalledSkills_MultipleLocations(t *testing.T) {
 	require.NoError(t, os.MkdirAll(claudeSkill, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(claudeSkill, "SKILL.md"), []byte("old"), 0o644))
 
-	opencode := filepath.Join(home, ".config", "opencode", "skill", "basecamp")
+	opencode := filepath.Join(home, ".config", "opencode", "skills", "basecamp")
 	require.NoError(t, os.MkdirAll(opencode, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(opencode, "SKILL.md"), []byte("old"), 0o644))
 


### PR DESCRIPTION
Closes part of #617.

`skillLocations` offered OpenCode targets at `skill/`, singular. opencode reads `skills/`, plural — it has never read either path we wrote.

```go
{Name: "OpenCode (Global)",  Path: "~/.config/opencode/skill/basecamp/SKILL.md"},
{Name: "OpenCode (Project)", Path: ".opencode/skill/basecamp/SKILL.md"},
```

## Why this failed silently, twice

That list is both the wizard's install targets *and* the refresh set, so one typo broke two things:

- **The wizard.** Picking "OpenCode (Global)" in `basecamp skill` wrote a file opencode would never load, then reported success.
- **The refresh loop.** `refreshAllInstalledSkills` only visits paths in this list and skips ones that don't exist. An opencode user who put the skill at the plural path by hand never got it refreshed on upgrade.

## Verification

Real binaries, temp `HOME`, stale `SKILL.md` pre-placed at `~/.config/opencode/skills/basecamp/`:

| Build | That file after a run |
|---|---|
| `origin/main` | still reads `STALE` |
| this branch | byte-identical to the embedded skill |

`~/.agents/skills/basecamp/SKILL.md` is refreshed by both, which is the next point.

## The skill already worked in opencode

opencode also searches `~/.agents/skills/<name>/SKILL.md` — the canonical target `installSkillFiles` has always written. So this fixes the **wizard and the refresh loop**, not first-run coverage. Nobody was unable to use the skill in opencode; some people were told they'd installed it somewhere it wasn't.

## About the test

The existing refresh test built its opencode path from the same wrong spelling the code used, so it asserted the bug was working. The new `TestSkillLocationsMatchAgentSearchPaths` pins the literals instead of deriving them, so a test can't mirror the typo again.

## Not in this PR

#617 also raises opencode **plugin** parity with what Codex got in #550 — hooks, not just a skill. opencode plugins are JS/TS modules in `.opencode/plugins/` or npm packages named in `opencode.json`: a different mechanism from both existing manifests, and a new artifact for this repo to build, version-stamp and ship. That wants a decision before it wants code, so it stays out of here. The path fix may well be all #617 actually needs.

Frontmatter needs no change — opencode wants `name` + `description` with `name` matching the directory, which `skills/basecamp/SKILL.md` already satisfies.

Search paths confirmed at https://opencode.ai/docs/skills/. `bin/ci` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenCode skill install and refresh paths to use `skills/` so OpenCode actually loads the file; the wizard and refresh loop now work as expected. Part of #617.

- **Bug Fixes**
  - Update `skillLocations` for OpenCode (Global/Project) from `skill/` to `skills/`.
  - Add `TestSkillLocationsMatchAgentSearchPaths` to pin literal paths.
  - Update the refresh test to use the plural OpenCode path.

<sup>Written for commit 3176e945b463fe6efca91655898e6571c339f1a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

