### PR TITLE
Lint the release the same way we lint everything else

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.9.0
+          version: v2.11.1  # keep in lockstep with test.yml Lint
           install-only: true
 
       - name: Cache BATS
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run release quality gate
         run: |
-          make fmt-check vet lint test test-e2e provenance-check check-naming check-surface
+          make check-lint-lockstep fmt-check vet lint test test-e2e provenance-check check-naming check-surface
           go test -tags dev -race -count=1 ./...
 
       - name: Run govulncheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      # Runs before the linter: if the pins have drifted, say so plainly rather
+      # than letting the odd job out fail later on a version-specific finding.
+      - name: Check golangci-lint pins are in lockstep
+        run: make check-lint-lockstep
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ check-smoke-coverage: build
 
 # Run all checks (local CI gate)
 .PHONY: check
-check: fmt-check vet lint lint-actions test test-e2e check-naming check-surface check-skill-drift check-bare-groups check-smoke-coverage provenance-check tidy-check
+check: fmt-check vet lint lint-actions test test-e2e check-naming check-surface check-skill-drift check-bare-groups check-lint-lockstep check-smoke-coverage provenance-check tidy-check
 
 # Lint GitHub Actions workflows (requires actionlint + zizmor)
 .PHONY: lint-actions
@@ -412,6 +412,11 @@ check-skill-drift:
 .PHONY: check-bare-groups
 check-bare-groups:
 	@scripts/check-bare-groups.sh
+
+# Verify every workflow lints with the same golangci-lint version
+.PHONY: check-lint-lockstep
+check-lint-lockstep:
+	@scripts/check-lint-lockstep.sh
 
 # Guard against bcq/BCQ creeping back (allowlist in .naming-allowlist)
 .PHONY: check-naming

--- a/scripts/check-lint-lockstep.sh
+++ b/scripts/check-lint-lockstep.sh
@@ -6,32 +6,52 @@
 # security.yml moved to v2.11.1, and the drift surfaced as a gosec G115 false
 # positive that blocked a release tag after every PR check had gone green. The
 # "keep in lockstep" comments were already there; comments do not enforce.
+#
+# Every golangci-lint-action step must carry a version, not just agree with the
+# others. An unpinned step resolves to whatever the action defaults to, which
+# drifts on its own schedule and would rebuild exactly the release-only mismatch
+# this exists to prevent — so a missing pin is a failure, not a skip.
 set -euo pipefail
 
 WORKFLOW_DIR=".github/workflows"
 
-# name:version, in the order found
+# One line per golangci-lint-action step: "<file>:<version>", or
+# "<file>:UNPINNED" when the step declares no version.
 mapfile -t pins < <(
   for f in "$WORKFLOW_DIR"/*.yml; do
-    # Only the version: line belonging to a golangci-lint-action step. Track the
-    # most recent `uses:` so an unrelated `version:` elsewhere is not picked up.
     awk -v file="$f" '
+      function close_step() {
+        if (in_step) { print file ":UNPINNED"; in_step = 0 }
+      }
+      # A new list item ends the previous step, pinned or not.
+      /^[[:space:]]*-[[:space:]]/ { close_step() }
       /uses:.*golangci-lint-action/ { in_step = 1; next }
-      in_step && /version:[[:space:]]*v[0-9]/ {
+      in_step && /^[[:space:]]*version:[[:space:]]*v[0-9]/ {
         match($0, /v[0-9]+\.[0-9]+\.[0-9]+/)
         print file ":" substr($0, RSTART, RLENGTH)
         in_step = 0
         next
       }
-      # A new step or job resets the window.
-      in_step && /^[[:space:]]*-[[:space:]]*(name|uses):/ { in_step = 0 }
+      # Dedenting to a new job or top-level key also ends the step.
+      in_step && /^[[:space:]]{0,4}[A-Za-z_-]+:/ { close_step() }
+      END { close_step() }
     ' "$f"
   done
 )
 
 if [[ "${#pins[@]}" -eq 0 ]]; then
-  echo "FAIL: found no golangci-lint-action version pins under $WORKFLOW_DIR"
+  echo "FAIL: found no golangci-lint-action steps under $WORKFLOW_DIR"
   echo "If the linter moved to a different action, update $0 to match."
+  exit 1
+fi
+
+unpinned=$(printf '%s\n' "${pins[@]}" | grep ':UNPINNED$' || true)
+if [[ -n "$unpinned" ]]; then
+  echo "FAIL: golangci-lint-action step with no version pin:"
+  printf '%s\n' "$unpinned" | sed 's/:UNPINNED$//; s/^/  /'
+  echo ""
+  echo "An unpinned step takes whatever the action defaults to and drifts on"
+  echo "its own schedule, which is the mismatch this check exists to prevent."
   exit 1
 fi
 
@@ -48,4 +68,4 @@ if [[ "$count" -ne 1 ]]; then
   exit 1
 fi
 
-echo "golangci-lint lockstep check passed (${#pins[@]} workflows pinned at $versions)"
+echo "golangci-lint lockstep check passed (${#pins[@]} steps pinned at $versions)"

--- a/scripts/check-lint-lockstep.sh
+++ b/scripts/check-lint-lockstep.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Verify every workflow lints with the same golangci-lint version.
+#
+# A stale pin here does not fail a PR — it fails whichever job is the odd one
+# out, at the moment that job runs. release.yml sat on v2.9.0 while test.yml and
+# security.yml moved to v2.11.1, and the drift surfaced as a gosec G115 false
+# positive that blocked a release tag after every PR check had gone green. The
+# "keep in lockstep" comments were already there; comments do not enforce.
+set -euo pipefail
+
+WORKFLOW_DIR=".github/workflows"
+
+# name:version, in the order found
+mapfile -t pins < <(
+  for f in "$WORKFLOW_DIR"/*.yml; do
+    # Only the version: line belonging to a golangci-lint-action step. Track the
+    # most recent `uses:` so an unrelated `version:` elsewhere is not picked up.
+    awk -v file="$f" '
+      /uses:.*golangci-lint-action/ { in_step = 1; next }
+      in_step && /version:[[:space:]]*v[0-9]/ {
+        match($0, /v[0-9]+\.[0-9]+\.[0-9]+/)
+        print file ":" substr($0, RSTART, RLENGTH)
+        in_step = 0
+        next
+      }
+      # A new step or job resets the window.
+      in_step && /^[[:space:]]*-[[:space:]]*(name|uses):/ { in_step = 0 }
+    ' "$f"
+  done
+)
+
+if [[ "${#pins[@]}" -eq 0 ]]; then
+  echo "FAIL: found no golangci-lint-action version pins under $WORKFLOW_DIR"
+  echo "If the linter moved to a different action, update $0 to match."
+  exit 1
+fi
+
+versions=$(printf '%s\n' "${pins[@]}" | sed 's/.*://' | sort -u)
+count=$(printf '%s\n' "$versions" | wc -l | tr -d ' ')
+
+if [[ "$count" -ne 1 ]]; then
+  echo "FAIL: golangci-lint pins disagree across workflows:"
+  printf '  %s\n' "${pins[@]}"
+  echo ""
+  echo "Every workflow that lints must pin the same version. Otherwise a job"
+  echo "that is not run on PRs — the release gate especially — can fail on a"
+  echo "finding no PR check would ever have surfaced."
+  exit 1
+fi
+
+echo "golangci-lint lockstep check passed (${#pins[@]} workflows pinned at $versions)"


### PR DESCRIPTION
`v0.9.0-rc.1` failed. Nothing was wrong with the code.

## What happened

`release.yml` pinned golangci-lint at **v2.9.0**. `test.yml` and `security.yml` are on **v2.11.1** — with a `# keep in lockstep with test.yml Lint` comment on the latter. `release.yml` drifted and nothing noticed, because the release gate is the one job no pull request ever runs.

It surfaced as:

```
internal/commands/assignments.go:142:85: G115: integer overflow conversion int -> int32 (gosec)
```

That conversion is guarded, two lines above it:

```go
if position < 1 || position > math.MaxInt32 {
    return output.ErrUsage("--position must be 1 or greater (positions are 1-based)")
}
...
MyAssignments().Reorder(cmd.Context(), recordingID, int32(position))
```

gosec at v2.11.1 follows that bound and stays quiet. At v2.9.0 it does not. So a false positive that every PR check had already passed took down a release tag, and `assignments.go` needs no change — it was already correct.

## The fix

Pin matched, plus `scripts/check-lint-lockstep.sh` to enforce it. The lockstep comments already existed and already failed; comments don't enforce.

It reads the version off every `golangci-lint-action` step and fails naming the files:

```
FAIL: golangci-lint pins disagree across workflows:
  .github/workflows/release.yml:v2.9.0
  .github/workflows/security.yml:v2.11.1
  .github/workflows/test.yml:v2.11.1
```

Verified both directions: passes on this branch (3 workflows at v2.11.1), and fails as above when `release.yml` is reverted to v2.9.0.

Wired into three places:

- `make check` — local `bin/ci`
- the release quality gate — so a future drift fails *as drift*, ahead of the linter
- `test.yml`, before the linter step — so PRs catch it, which is the whole point

## Next

Once this lands, `v0.9.0-rc.1` gets re-cut as `v0.9.0-rc.2`. rc.1 published no release and no artifacts — every job after the gate was skipped — so nothing needs unpublishing. I'd rather leave the dead tag than retag it.

`bin/ci` green (EXIT=0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `golangci-lint` versions across CI and enforce lockstep to prevent release failures from version drift. `release.yml` now pins `v2.11.1`, and the check fails if any workflow drifts or has an unpinned step.

- **Bug Fixes**
  - Pin `golangci-lint` to `v2.11.1` in `.github/workflows/release.yml` (matching `test.yml`/`security.yml`).
  - Add `scripts/check-lint-lockstep.sh` to ensure all `golangci/golangci-lint-action` steps are pinned and use the same version; report mismatches and missing pins.
  - Run the check in `make check`, the release quality gate, and in `test.yml` before linting.

<sup>Written for commit 66e998067f521649ca7bcb4680d858ffe699af96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

