### PR TITLE
Keep refreshing opencode's other spelling

### DIFF
--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -35,6 +35,20 @@ var skillLocations = []skillLocation{
 	{Name: "Codex (Global)", Path: codexGlobalSkillPath()},
 }
 
+// legacySkillLocations are paths an agent still reads but that we no longer
+// offer as install targets. They are refreshed, never suggested.
+//
+// opencode accepts both spellings — its own docs table reads
+// `~/.config/opencode/skill(s)/<name>/SKILL.md`, the same `agent(s)`/`command(s)`
+// optional plural it uses elsewhere. #624 moved the install targets to the
+// plural form and dropped the singular entirely, which left anyone who had
+// picked OpenCode in the wizard with a file opencode still loads but that
+// nothing updates: working, and silently frozen at the version that wrote it.
+var legacySkillLocations = []skillLocation{
+	{Name: "OpenCode (Global, legacy path)", Path: "~/.config/opencode/skill/basecamp/SKILL.md"},
+	{Name: "OpenCode (Project, legacy path)", Path: ".opencode/skill/basecamp/SKILL.md"},
+}
+
 // NewSkillCmd creates the skill command.
 func NewSkillCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -360,7 +374,7 @@ func refreshAllInstalledSkills() bool {
 
 	updated := 0
 	failed := 0
-	for _, loc := range skillLocations {
+	for _, loc := range append(append([]skillLocation{}, skillLocations...), legacySkillLocations...) {
 		// Skip project-relative paths — no reliable project root in PostRunE.
 		if !strings.HasPrefix(loc.Path, "~") && !filepath.IsAbs(loc.Path) {
 			continue

--- a/internal/commands/skill_test.go
+++ b/internal/commands/skill_test.go
@@ -222,11 +222,14 @@ func TestCopySkillFilesRejectsSubdirs(t *testing.T) {
 	}
 }
 
-// skillLocations is both the wizard's install targets and the refresh set, so a
-// path an agent doesn't read is a silent no-op in either direction. Pin the
-// literals rather than deriving them, so a test can't mirror the same typo the
-// code has. OpenCode's search paths: https://opencode.ai/docs/skills/. Codex's
-// entry is computed by codexGlobalSkillPath and covered separately.
+// Pin the literals rather than deriving them, so a test can't mirror a typo the
+// code has. Codex's entry is computed by codexGlobalSkillPath and covered
+// separately.
+//
+// These are install targets, not the full set of paths an agent reads. opencode
+// takes an optional plural throughout — its own table reads
+// `~/.config/opencode/skill(s)/<name>/SKILL.md` — so the singular form works too
+// and is kept alive for refresh in legacySkillLocations.
 func TestSkillLocationsMatchAgentSearchPaths(t *testing.T) {
 	want := map[string]string{
 		"Agents (Shared)":       "~/.agents/skills/basecamp/SKILL.md",
@@ -244,6 +247,43 @@ func TestSkillLocationsMatchAgentSearchPaths(t *testing.T) {
 	for name, path := range want {
 		assert.Equal(t, path, got[name], "install target for %s", name)
 	}
+}
+
+// A wizard install written before #624 sits at opencode's singular path.
+// opencode still loads it, so dropping it from the refresh set does not break
+// the skill — it freezes it at the version that wrote it, which is worse than
+// breaking because nothing reports it.
+func TestRefreshAllInstalledSkills_LegacyOpenCodePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", home) // no claude binary
+
+	origVersion := version.Version
+	version.Version = "5.0.0"
+	defer func() { version.Version = origVersion }()
+
+	embedded, err := skills.FS.ReadFile("basecamp/SKILL.md")
+	require.NoError(t, err)
+
+	baseline := filepath.Join(home, ".agents", "skills", "basecamp")
+	require.NoError(t, os.MkdirAll(baseline, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "SKILL.md"), []byte("old"), 0o644))
+
+	// Singular — what the wizard wrote before #624.
+	legacy := filepath.Join(home, ".config", "opencode", "skill", "basecamp")
+	require.NoError(t, os.MkdirAll(legacy, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "SKILL.md"), []byte("old"), 0o644))
+
+	require.True(t, refreshAllInstalledSkills())
+
+	got, readErr := os.ReadFile(filepath.Join(legacy, "SKILL.md"))
+	require.NoError(t, readErr)
+	assert.Equal(t, string(embedded), string(got),
+		"a pre-#624 opencode install must keep getting refreshed")
+
+	// Refreshing a legacy install must not conjure the new path.
+	_, statErr := os.Stat(filepath.Join(home, ".config", "opencode", "skills", "basecamp", "SKILL.md"))
+	assert.True(t, os.IsNotExist(statErr), "refresh updates in place; it does not install elsewhere")
 }
 
 func TestNormalizeSkillPath(t *testing.T) {


### PR DESCRIPTION
**#624's central claim was wrong, and I shipped it.** This corrects the record and the regression it introduced.

## What #624 said

> opencode reads `skills/`, plural — it has never read either path we wrote.

## What opencode actually does

From the shipped 1.18.4 binary's own docs table — not the docs site:

```
| Global skills  | `~/.config/opencode/skill(s)/<name>/SKILL.md` |
| Project skills | `.opencode/skill(s)/<name>/SKILL.md`          |
| Project agents | `.opencode/agent/<name>.md` or `.opencode/agents/<name>.md` |
```

`skill(s)` — the same optional plural opencode uses for `agent(s)` and `command(s)`. **Both spellings work.** The singular paths were fine.

I asserted that negative from a summarizing fetch of <https://opencode.ai/docs/skills/>, which rendered the parenthetical as plain `skills`. A negative claim deserved a primary source, and the binary was available the whole time.

## The regression

`skillLocations` is both the wizard's install targets and the refresh set. #624 moved it wholly to plural, so anyone who picked OpenCode in `basecamp skill` **before** #624 now has a file that:

- opencode still loads — it works
- the refresh loop no longer visits — it never updates again

Working and silently frozen at the version that installed it. That is worse than broken, because nothing reports it, and it is the exact failure mode #624 claimed to be fixing.

## The fix

Separate the two roles the list was playing:

- `skillLocations` — wizard install targets. Unchanged, still plural.
- `legacySkillLocations` — paths an agent still reads that we no longer suggest. Refreshed, never offered.

`refreshAllInstalledSkills` walks both. Refresh updates **in place** and does not create the new path, so nobody ends up with two copies drifting apart — asserted in the test.

## Verification

`TestRefreshAllInstalledSkills_LegacyOpenCodePath` fails against the pre-fix loop:

```
-- API coverage: See API-COVERAGE.md in the CLI repo
+old
a pre-#624 opencode install must keep getting refreshed
```

and passes after it. `bin/ci` green (EXIT=0).

## What from #624 still holds

- `~/.agents/skills/<name>/SKILL.md` is auto-loaded by opencode — confirmed in the same table — so the skill has always worked there regardless of the wizard. That claim was right.
- Plural install targets are valid, so the new default is fine; this is additive.
- Pinning path literals in a test rather than deriving them was right, and that test's comment is corrected here too.

#617 gets a correction as well, since I told the requester the wizard was broken for them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores refresh for OpenCode skills installed at the singular `skill` path so pre-#624 installs keep updating. Keeps plural install targets and updates legacy installs in place without creating duplicates.

- **Bug Fixes**
  - Added `legacySkillLocations` for OpenCode `skill` paths (global and project).
  - `refreshAllInstalledSkills` now walks both install and legacy paths; no new files are created.
  - Confirmed OpenCode accepts `skill(s)`; added regression test to ensure legacy paths keep refreshing.

<sup>Written for commit 6cc509f42edb1620db8e6801aa21d61d05386570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

