### PR TITLE
Make the lockstep check catch stale agreement and .yaml workflows

### DIFF
--- a/scripts/check-lint-lockstep.sh
+++ b/scripts/check-lint-lockstep.sh
@@ -11,14 +11,43 @@
 # others. An unpinned step resolves to whatever the action defaults to, which
 # drifts on its own schedule and would rebuild exactly the release-only mismatch
 # this exists to prevent — so a missing pin is a failure, not a skip.
+#
+# Agreement alone is not enough either: three workflows uniformly pinned back at
+# v2.9.0 would pass this check and reproduce the release failure that motivated
+# it. Hence a floor as well as a lockstep.
 set -euo pipefail
 
 WORKFLOW_DIR=".github/workflows"
 
+# The oldest golangci-lint every workflow may pin. Raising this is a deliberate
+# act, not housekeeping: move it in the same commit that moves the workflow
+# pins, so the floor and the pins never disagree in a merged tree.
+MIN_VERSION="v2.11.1"
+
+# Compare with sort -V, never lexically or arithmetically. As strings v2.9.0
+# sorts *above* v2.11.1 — 9 > 1 — so a lexical test would wave through the exact
+# version that failed the release tag. `[ -gt ]` cannot parse either one.
+version_gte() {
+  printf '%s\n%s\n' "$2" "$1" | sort -V | head -1 | grep -qx -- "$2"
+}
+
+# Both spellings: every workflow here is .yml today, but GitHub honours .yaml
+# just as well, and a .yaml workflow that ran a linter this check never opened
+# would be exactly the invisible drift it exists to catch.
+shopt -s nullglob
+workflows=("$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml)
+shopt -u nullglob
+
+if [[ "${#workflows[@]}" -eq 0 ]]; then
+  echo "FAIL: no workflow files found under $WORKFLOW_DIR"
+  echo "An empty scan is a broken check, not a clean tree."
+  exit 1
+fi
+
 # One line per golangci-lint-action step: "<file>:<version>", or
 # "<file>:UNPINNED" when the step declares no version.
 mapfile -t pins < <(
-  for f in "$WORKFLOW_DIR"/*.yml; do
+  for f in "${workflows[@]}"; do
     awk -v file="$f" '
       function close_step() {
         if (in_step) { print file ":UNPINNED"; in_step = 0 }
@@ -68,4 +97,15 @@ if [[ "$count" -ne 1 ]]; then
   exit 1
 fi
 
-echo "golangci-lint lockstep check passed (${#pins[@]} steps pinned at $versions)"
+if ! version_gte "$versions" "$MIN_VERSION"; then
+  echo "FAIL: golangci-lint pinned at $versions, below the floor $MIN_VERSION:"
+  printf '  %s\n' "${pins[@]}"
+  echo ""
+  echo "Agreeing on a stale version is still stale. v2.9.0 in lockstep would"
+  echo "pass the check above and fail the release on the same gosec G115 false"
+  echo "positive it was written to prevent. Raise the pins, then raise"
+  echo "MIN_VERSION in $0 in the same commit."
+  exit 1
+fi
+
+echo "golangci-lint lockstep check passed (${#pins[@]} steps across ${#workflows[@]} workflows pinned at $versions, floor $MIN_VERSION)"


### PR DESCRIPTION
Two holes in the check that shipped in #625. Neither is a live failure — all 15 workflows are `.yml` and all three linting steps sit at `v2.11.1` — but both are the same shape as the drift the check exists to catch.

**It globbed `*.yml` only.** GitHub honours `.yaml` just as well, and a `.yaml` workflow running a linter this check never opened is precisely the invisible drift it was written for. Now scans both, and fails on an empty scan rather than passing a check that opened no files.

**It enforced agreement, not currency.** Verified: setting all three workflows to `v2.9.0` passes cleanly and reproduces the release failure that motivated #625 — a gosec G115 false positive that blocked a tag after every PR check had gone green. So there is now a floor, `MIN_VERSION`, next to `WORKFLOW_DIR`, commented to say that raising it is deliberate and must happen in the same commit as the pins it constrains.

**Compared with `sort -V`, and that is the point, not a detail.** As strings `v2.9.0` sorts *above* `v2.11.1` because `9` > `1`, so a lexical test would wave through the exact version that broke the release tag; `[ -gt ]` parses neither. `aur-publish.yml`'s pkgrel guard carries the same note for the same reason.

Existing shape is untouched: the `awk` step-window parser, the `UNPINNED` failure mode added after the bot's find on #625, and the error output that names offending files.

## Verification

Ran the script directly in each state, asserting exit codes and restoring the tree between:

| State | Expect | Got |
|---|---|---|
| uniform `v2.11.1` (today's tree) | pass | 0 — "3 steps across 15 workflows" |
| uniform `v2.9.0` | fail, floor | 1 — floor message |
| uniform `v2.12.0` | pass | 0 — sort -V sanity above the floor |
| drift (one workflow differs) | fail | 1 — disagree message |
| step with no `version:` | fail | 1 — `UNPINNED` |
| `.yaml` fixture with a matching pin | counted | 0 — **4 steps across 16 workflows** |
| `.yaml` fixture with a drifted pin | fail | 1 — names the `.yaml` file |
| `.yaml` fixture unpinned | fail | 1 — `UNPINNED` on the `.yaml` file |
| empty workflow dir | fail | 1 — empty-scan message |

The `.yaml` case is asserted as *counted* (3 → 4 steps, 15 → 16 workflows), not merely as a run that happened to pass; 5b and 5c confirm it is actually parsed, not just globbed.

`bin/ci` green (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the golangci-lint lockstep check to catch stale pins and include `.yaml` workflows, preventing invisible drift and release breakage. It now scans both `.yml` and `.yaml` files and enforces a version floor.

- **Bug Fixes**
  - Scan `*.yml` and `*.yaml`; fail on an empty workflow scan.
  - Enforce a `MIN_VERSION` floor for the pinned golangci-lint; fail if below.
  - Compare versions with `sort -V` to avoid incorrect lexical ordering.
  - Preserve disagreement and `UNPINNED` checks; output now includes step and workflow counts.

<sup>Written for commit 6dc91637039169188cc89345efe6c32c781a688a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

