### PR TITLE
Make the Codex probe's timeout actually bound doctor

### DIFF
--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -22,12 +22,27 @@ const (
 	CodexMarketplaceName = "37signals"
 	// CodexExpectedPluginKey is the fully qualified Basecamp plugin ID.
 	CodexExpectedPluginKey = CodexPluginName + "@" + CodexMarketplaceName
+
+	// codexQueryTimeout bounds how long the Codex probe may run.
+	codexQueryTimeout = 5 * time.Second
+	// codexWaitDelay is the grace period after the kill before Wait gives up on
+	// output pipes a surviving grandchild still holds open.
+	codexWaitDelay = time.Second
 )
 
 var (
 	codexLookPath   = exec.LookPath
 	runCodexCommand = func(ctx context.Context, path string, args ...string) ([]byte, error) {
-		return exec.CommandContext(ctx, path, args...).Output() //nolint:gosec // path comes from exec.LookPath
+		cmd := exec.CommandContext(ctx, path, args...) //nolint:gosec // path comes from exec.LookPath
+		// Bound Wait, not just the process. Cancelling the context kills the
+		// child, but it does not close output pipes a *grandchild* inherited,
+		// and Wait blocks on those copies until they do — so the 5s timeout in
+		// queryCodexPlugin buys nothing on its own. `codex` is routinely a
+		// wrapper that shells out (an npm exec launcher, a mise shim), and one
+		// of those left `basecamp doctor` hanging for ten minutes rather than
+		// five seconds. WaitDelay is what makes the deadline real.
+		cmd.WaitDelay = codexWaitDelay
+		return cmd.Output()
 	}
 )
 
@@ -189,7 +204,7 @@ func queryCodexPlugin(parent context.Context) (codexPluginState, bool, error) {
 	if path == "" {
 		return codexPluginState{}, false, errCodexBinaryMissing
 	}
-	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	ctx, cancel := context.WithTimeout(parent, codexQueryTimeout)
 	defer cancel()
 	data, err := runCodexCommand(ctx, path, "plugin", "list", "--available", "--json")
 	if err != nil {

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -34,7 +34,7 @@ var (
 	codexLookPath   = exec.LookPath
 	runCodexCommand = func(ctx context.Context, path string, args ...string) ([]byte, error) {
 		cmd := exec.CommandContext(ctx, path, args...) //nolint:gosec // path comes from exec.LookPath
-		// Bound Wait, not just the process. Cancelling the context kills the
+		// Bound Wait, not just the process. Canceling the context kills the
 		// child, but it does not close output pipes a *grandchild* inherited,
 		// and Wait blocks on those copies until they do — so the 5s timeout in
 		// queryCodexPlugin buys nothing on its own. `codex` is routinely a

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -209,7 +209,7 @@ func boolJSON(value bool) string {
 // The stub above replaces runCodexCommand, so nothing else here exercises the
 // real one. This does. It stands in for the shape codex actually ships as on
 // some machines — a wrapper script that backgrounds a longer-lived process —
-// where cancelling the context kills the wrapper but the grandchild keeps the
+// where canceling the context kills the wrapper but the grandchild keeps the
 // inherited stdout pipe open. Without cmd.WaitDelay, Wait blocks on that pipe
 // for as long as the grandchild lives, and the query timeout means nothing.
 func TestRunCodexCommandOutlivingGrandchild(t *testing.T) {

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -213,12 +215,32 @@ func boolJSON(value bool) string {
 // inherited stdout pipe open. Without cmd.WaitDelay, Wait blocks on that pipe
 // for as long as the grandchild lives, and the query timeout means nothing.
 func TestRunCodexCommandOutlivingGrandchild(t *testing.T) {
-	if _, err := exec.LookPath("sh"); err != nil {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
 		t.Skip("sh not available")
 	}
 
-	// Exits immediately, leaving a child holding stdout well past any deadline.
-	script := "sleep 120 & exit 0"
+	// The grandchild has to outlive the deadline by a wide margin, or the test
+	// passes on the sleep ending rather than on WaitDelay working. That makes
+	// it our job to reap it: WaitDelay closes the inherited pipe, it does not
+	// kill the process, which is reparented to init and would otherwise sit
+	// there for two minutes accumulating one orphan per `bin/ci`.
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	script := "sleep 120 & echo $! > " + pidFile + "; exit 0"
+
+	t.Cleanup(func() {
+		raw, readErr := os.ReadFile(pidFile) //nolint:gosec // G304: path is this test's own TempDir
+		if readErr != nil {
+			return
+		}
+		pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+		if convErr != nil {
+			return
+		}
+		if proc, findErr := os.FindProcess(pid); findErr == nil {
+			_ = proc.Kill()
+		}
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
@@ -227,7 +249,7 @@ func TestRunCodexCommandOutlivingGrandchild(t *testing.T) {
 	start := time.Now()
 	go func() {
 		defer close(done)
-		_, _ = runCodexCommand(ctx, "/bin/sh", "-c", script)
+		_, _ = runCodexCommand(ctx, sh, "-c", script)
 	}()
 
 	select {

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -200,4 +201,41 @@ func boolJSON(value bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+// TestRunCodexCommandOutlivingGrandchild pins the deadline that ten minutes of
+// a hung `basecamp doctor` proved was not being enforced.
+//
+// The stub above replaces runCodexCommand, so nothing else here exercises the
+// real one. This does. It stands in for the shape codex actually ships as on
+// some machines — a wrapper script that backgrounds a longer-lived process —
+// where cancelling the context kills the wrapper but the grandchild keeps the
+// inherited stdout pipe open. Without cmd.WaitDelay, Wait blocks on that pipe
+// for as long as the grandchild lives, and the query timeout means nothing.
+func TestRunCodexCommandOutlivingGrandchild(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	// Exits immediately, leaving a child holding stdout well past any deadline.
+	script := "sleep 120 & exit 0"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		_, _ = runCodexCommand(ctx, "/bin/sh", "-c", script)
+	}()
+
+	select {
+	case <-done:
+		// The call must return on its own deadline, not the grandchild's.
+		assert.Less(t, time.Since(start), 30*time.Second,
+			"runCodexCommand blocked on a pipe held open by a surviving grandchild")
+	case <-time.After(30 * time.Second):
+		t.Fatal("runCodexCommand did not return: WaitDelay is not bounding Wait")
+	}
 }

--- a/scripts/check-lint-lockstep.sh
+++ b/scripts/check-lint-lockstep.sh
@@ -11,14 +11,43 @@
 # others. An unpinned step resolves to whatever the action defaults to, which
 # drifts on its own schedule and would rebuild exactly the release-only mismatch
 # this exists to prevent — so a missing pin is a failure, not a skip.
+#
+# Agreement alone is not enough either: three workflows uniformly pinned back at
+# v2.9.0 would pass this check and reproduce the release failure that motivated
+# it. Hence a floor as well as a lockstep.
 set -euo pipefail
 
 WORKFLOW_DIR=".github/workflows"
 
+# The oldest golangci-lint every workflow may pin. Raising this is a deliberate
+# act, not housekeeping: move it in the same commit that moves the workflow
+# pins, so the floor and the pins never disagree in a merged tree.
+MIN_VERSION="v2.11.1"
+
+# Compare with sort -V, never lexically or arithmetically. As strings v2.9.0
+# sorts *above* v2.11.1 — 9 > 1 — so a lexical test would wave through the exact
+# version that failed the release tag. `[ -gt ]` cannot parse either one.
+version_gte() {
+  printf '%s\n%s\n' "$2" "$1" | sort -V | head -1 | grep -qx -- "$2"
+}
+
+# Both spellings: every workflow here is .yml today, but GitHub honours .yaml
+# just as well, and a .yaml workflow that ran a linter this check never opened
+# would be exactly the invisible drift it exists to catch.
+shopt -s nullglob
+workflows=("$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml)
+shopt -u nullglob
+
+if [[ "${#workflows[@]}" -eq 0 ]]; then
+  echo "FAIL: no workflow files found under $WORKFLOW_DIR"
+  echo "An empty scan is a broken check, not a clean tree."
+  exit 1
+fi
+
 # One line per golangci-lint-action step: "<file>:<version>", or
 # "<file>:UNPINNED" when the step declares no version.
 mapfile -t pins < <(
-  for f in "$WORKFLOW_DIR"/*.yml; do
+  for f in "${workflows[@]}"; do
     awk -v file="$f" '
       function close_step() {
         if (in_step) { print file ":UNPINNED"; in_step = 0 }
@@ -68,4 +97,15 @@ if [[ "$count" -ne 1 ]]; then
   exit 1
 fi
 
-echo "golangci-lint lockstep check passed (${#pins[@]} steps pinned at $versions)"
+if ! version_gte "$versions" "$MIN_VERSION"; then
+  echo "FAIL: golangci-lint pinned at $versions, below the floor $MIN_VERSION:"
+  printf '  %s\n' "${pins[@]}"
+  echo ""
+  echo "Agreeing on a stale version is still stale. v2.9.0 in lockstep would"
+  echo "pass the check above and fail the release on the same gosec G115 false"
+  echo "positive it was written to prevent. Raise the pins, then raise"
+  echo "MIN_VERSION in $0 in the same commit."
+  exit 1
+fi
+
+echo "golangci-lint lockstep check passed (${#pins[@]} steps across ${#workflows[@]} workflows pinned at $versions, floor $MIN_VERSION)"


### PR DESCRIPTION
Found while cutting v0.9.0: `make release VERSION=0.9.0 DRY_RUN=1` failed `race-test` with

```
panic: test timed out after 10m0s
	running tests:
		TestDoctorCommandWithNoAuth (9m47s)
```

Not a flake, and not a test bug. `basecamp doctor` really does hang.

## What happens

`queryCodexPlugin` has had a 5s context timeout since it was written. The timeout was doing nothing.

Canceling the context kills the child. It does **not** close output pipes a *grandchild* inherited, and `Wait` blocks on those copies until they close. The stack shows exactly that — one goroutine parked in `io.Copy` on the pipe, another in `exec.(*Cmd).awaitGoroutines`, both nine minutes in:

```
os/exec.(*Cmd).awaitGoroutines
os/exec.(*Cmd).Wait
os/exec.(*Cmd).Output
harness.init.func1  (internal/harness/codex.go:30)
harness.queryCodexPlugin
harness.CheckCodexPluginDiagnosticsContext
commands.runDoctorChecks
```

On the machine that caught it, `codex` is a wrapper script rather than a binary. The processes were still there afterwards:

```
2236158  13:56  /bin/bash ~/.local/bin/codex plugin list --available --json
2236159  13:56  npm exec which @openai/codex
```

The kill reached the wrapper. `npm exec` kept the inherited stdout pipe open, so `Wait` waited on it. The deadline expired on schedule and the call returned whenever the grandchild felt like it.

This is not specific to that launcher — an npm-exec shim, a mise shim, anything that shells out has the shape. It never reproduces in CI, where `codex` is absent and `FindCodexBinary` returns early.

## The fix

`cmd.WaitDelay` bounds `Wait` itself, not just the process — the one piece that was missing. A codex that will not answer inside the deadline is now a failed check, which is what a diagnostic probe should report.

Both durations are named constants now; the timeout and the grace period after the kill belong next to each other.

`internal/harness/codex.go:30` is the only `exec` on the doctor's probe path — the Claude probe reads files — so this is the whole exposure there. Nothing else in the repo sets `WaitDelay`; the other 24 call sites are interactive setup and upgrade paths, and widening to them is a separate change with its own tests, not something to fold into a release fix.

## Verification

Every existing test in this file stubs `runCodexCommand`, so none of them ever touched the real one. The new test does, against a script that backgrounds a longer-lived child:

| | Result |
|---|---|
| without `WaitDelay` | **FAIL at 30.00s** — "did not return: WaitDelay is not bounding Wait" |
| with `WaitDelay` | ok, 1.3s |

Verified by reverting the one line and re-running, not by inspection.

And the test that actually hung, re-run on the same machine with the same wrapper still installed:

```
$ go test -tags dev -race -run 'TestDoctorCommandWithNoAuth|TestRunCodexCommandOutlivingGrandchild' ./internal/commands/ ./internal/harness/
ok  	.../internal/commands	2.015s
ok  	.../internal/harness	2.012s
```

9m47s and a timeout, to 2s. `bin/ci` green (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang in `basecamp doctor` by making the Codex probe truly time out using `cmd.WaitDelay`, and strengthens the linter lockstep check to prevent stale or missed pins.

- **Bug Fixes**
  - Doctor Codex probe now respects its deadline: set `cmd.WaitDelay` (1s) and use `codexQueryTimeout` (5s) so `Wait` can’t block on a grandchild’s stdout pipe.
  - Added a test that simulates a wrapper spawning a long-lived child; it fails without `WaitDelay` and passes with it. The test now records the grandchild PID and reaps it in `t.Cleanup`, and uses `sh` found via `exec.LookPath`.
  - Updated `scripts/check-lint-lockstep.sh` to scan both `.yml` and `.yaml` workflows, fail on empty scans, and enforce a minimum `golangci-lint` version using version-aware comparison.

<sup>Written for commit 6995cd6b29ec9ef5a29599d2cc608e604fe29e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

