### PR TITLE
Add basecamp files replace: publish a new version of an uploaded file

### DIFF
--- a/.surface
+++ b/.surface
@@ -138,6 +138,10 @@ ARG basecamp docs documents create 01 [content]
 ARG basecamp docs download 00 <upload-id|url>
 ARG basecamp docs folder create 00 <name>
 ARG basecamp docs folders create 00 <name>
+ARG basecamp docs new-version 00 <upload-id|url>
+ARG basecamp docs new-version 01 <file>
+ARG basecamp docs replace 00 <upload-id|url>
+ARG basecamp docs replace 01 <file>
 ARG basecamp docs restore 00 <id|url>
 ARG basecamp docs show 00 <id|url>
 ARG basecamp docs trash 00 <id|url>
@@ -157,6 +161,10 @@ ARG basecamp documents documents create 01 [content]
 ARG basecamp documents download 00 <upload-id|url>
 ARG basecamp documents folder create 00 <name>
 ARG basecamp documents folders create 00 <name>
+ARG basecamp documents new-version 00 <upload-id|url>
+ARG basecamp documents new-version 01 <file>
+ARG basecamp documents replace 00 <upload-id|url>
+ARG basecamp documents replace 01 <file>
 ARG basecamp documents restore 00 <id|url>
 ARG basecamp documents show 00 <id|url>
 ARG basecamp documents trash 00 <id|url>
@@ -177,6 +185,10 @@ ARG basecamp file documents create 01 [content]
 ARG basecamp file download 00 <upload-id|url>
 ARG basecamp file folder create 00 <name>
 ARG basecamp file folders create 00 <name>
+ARG basecamp file new-version 00 <upload-id|url>
+ARG basecamp file new-version 01 <file>
+ARG basecamp file replace 00 <upload-id|url>
+ARG basecamp file replace 01 <file>
 ARG basecamp file restore 00 <id|url>
 ARG basecamp file show 00 <id|url>
 ARG basecamp file trash 00 <id|url>
@@ -196,6 +208,10 @@ ARG basecamp files documents create 01 [content]
 ARG basecamp files download 00 <upload-id|url>
 ARG basecamp files folder create 00 <name>
 ARG basecamp files folders create 00 <name>
+ARG basecamp files new-version 00 <upload-id|url>
+ARG basecamp files new-version 01 <file>
+ARG basecamp files replace 00 <upload-id|url>
+ARG basecamp files replace 01 <file>
 ARG basecamp files restore 00 <id|url>
 ARG basecamp files show 00 <id|url>
 ARG basecamp files trash 00 <id|url>
@@ -215,6 +231,10 @@ ARG basecamp folders documents create 01 [content]
 ARG basecamp folders download 00 <upload-id|url>
 ARG basecamp folders folder create 00 <name>
 ARG basecamp folders folders create 00 <name>
+ARG basecamp folders new-version 00 <upload-id|url>
+ARG basecamp folders new-version 01 <file>
+ARG basecamp folders replace 00 <upload-id|url>
+ARG basecamp folders replace 01 <file>
 ARG basecamp folders restore 00 <id|url>
 ARG basecamp folders show 00 <id|url>
 ARG basecamp folders trash 00 <id|url>
@@ -411,6 +431,10 @@ ARG basecamp vault documents create 01 [content]
 ARG basecamp vault download 00 <upload-id|url>
 ARG basecamp vault folder create 00 <name>
 ARG basecamp vault folders create 00 <name>
+ARG basecamp vault new-version 00 <upload-id|url>
+ARG basecamp vault new-version 01 <file>
+ARG basecamp vault replace 00 <upload-id|url>
+ARG basecamp vault replace 01 <file>
 ARG basecamp vault restore 00 <id|url>
 ARG basecamp vault show 00 <id|url>
 ARG basecamp vault trash 00 <id|url>
@@ -430,6 +454,10 @@ ARG basecamp vaults documents create 01 [content]
 ARG basecamp vaults download 00 <upload-id|url>
 ARG basecamp vaults folder create 00 <name>
 ARG basecamp vaults folders create 00 <name>
+ARG basecamp vaults new-version 00 <upload-id|url>
+ARG basecamp vaults new-version 01 <file>
+ARG basecamp vaults replace 00 <upload-id|url>
+ARG basecamp vaults replace 01 <file>
 ARG basecamp vaults restore 00 <id|url>
 ARG basecamp vaults show 00 <id|url>
 ARG basecamp vaults trash 00 <id|url>
@@ -643,6 +671,8 @@ CMD basecamp docs folders
 CMD basecamp docs folders create
 CMD basecamp docs folders list
 CMD basecamp docs list
+CMD basecamp docs new-version
+CMD basecamp docs replace
 CMD basecamp docs restore
 CMD basecamp docs show
 CMD basecamp docs trash
@@ -680,6 +710,8 @@ CMD basecamp documents folders
 CMD basecamp documents folders create
 CMD basecamp documents folders list
 CMD basecamp documents list
+CMD basecamp documents new-version
+CMD basecamp documents replace
 CMD basecamp documents restore
 CMD basecamp documents show
 CMD basecamp documents trash
@@ -719,6 +751,8 @@ CMD basecamp file folders
 CMD basecamp file folders create
 CMD basecamp file folders list
 CMD basecamp file list
+CMD basecamp file new-version
+CMD basecamp file replace
 CMD basecamp file restore
 CMD basecamp file show
 CMD basecamp file trash
@@ -755,6 +789,8 @@ CMD basecamp files folders
 CMD basecamp files folders create
 CMD basecamp files folders list
 CMD basecamp files list
+CMD basecamp files new-version
+CMD basecamp files replace
 CMD basecamp files restore
 CMD basecamp files show
 CMD basecamp files trash
@@ -791,6 +827,8 @@ CMD basecamp folders folders
 CMD basecamp folders folders create
 CMD basecamp folders folders list
 CMD basecamp folders list
+CMD basecamp folders new-version
+CMD basecamp folders replace
 CMD basecamp folders restore
 CMD basecamp folders show
 CMD basecamp folders trash
@@ -1064,6 +1102,8 @@ CMD basecamp vault folders
 CMD basecamp vault folders create
 CMD basecamp vault folders list
 CMD basecamp vault list
+CMD basecamp vault new-version
+CMD basecamp vault replace
 CMD basecamp vault restore
 CMD basecamp vault show
 CMD basecamp vault trash
@@ -1100,6 +1140,8 @@ CMD basecamp vaults folders
 CMD basecamp vaults folders create
 CMD basecamp vaults folders list
 CMD basecamp vaults list
+CMD basecamp vaults new-version
+CMD basecamp vaults replace
 CMD basecamp vaults restore
 CMD basecamp vaults show
 CMD basecamp vaults trash
@@ -5616,6 +5658,56 @@ FLAG basecamp docs list --styled type=bool
 FLAG basecamp docs list --todolist type=string
 FLAG basecamp docs list --vault type=string
 FLAG basecamp docs list --verbose type=count
+FLAG basecamp docs new-version --account type=string
+FLAG basecamp docs new-version --agent type=bool
+FLAG basecamp docs new-version --base-name type=string
+FLAG basecamp docs new-version --cache-dir type=string
+FLAG basecamp docs new-version --count type=bool
+FLAG basecamp docs new-version --description type=string
+FLAG basecamp docs new-version --folder type=string
+FLAG basecamp docs new-version --help type=bool
+FLAG basecamp docs new-version --hints type=bool
+FLAG basecamp docs new-version --ids-only type=bool
+FLAG basecamp docs new-version --in type=string
+FLAG basecamp docs new-version --jq type=string
+FLAG basecamp docs new-version --json type=bool
+FLAG basecamp docs new-version --markdown type=bool
+FLAG basecamp docs new-version --md type=bool
+FLAG basecamp docs new-version --no-hints type=bool
+FLAG basecamp docs new-version --no-stats type=bool
+FLAG basecamp docs new-version --profile type=string
+FLAG basecamp docs new-version --project type=string
+FLAG basecamp docs new-version --quiet type=bool
+FLAG basecamp docs new-version --stats type=bool
+FLAG basecamp docs new-version --styled type=bool
+FLAG basecamp docs new-version --todolist type=string
+FLAG basecamp docs new-version --vault type=string
+FLAG basecamp docs new-version --verbose type=count
+FLAG basecamp docs replace --account type=string
+FLAG basecamp docs replace --agent type=bool
+FLAG basecamp docs replace --base-name type=string
+FLAG basecamp docs replace --cache-dir type=string
+FLAG basecamp docs replace --count type=bool
+FLAG basecamp docs replace --description type=string
+FLAG basecamp docs replace --folder type=string
+FLAG basecamp docs replace --help type=bool
+FLAG basecamp docs replace --hints type=bool
+FLAG basecamp docs replace --ids-only type=bool
+FLAG basecamp docs replace --in type=string
+FLAG basecamp docs replace --jq type=string
+FLAG basecamp docs replace --json type=bool
+FLAG basecamp docs replace --markdown type=bool
+FLAG basecamp docs replace --md type=bool
+FLAG basecamp docs replace --no-hints type=bool
+FLAG basecamp docs replace --no-stats type=bool
+FLAG basecamp docs replace --profile type=string
+FLAG basecamp docs replace --project type=string
+FLAG basecamp docs replace --quiet type=bool
+FLAG basecamp docs replace --stats type=bool
+FLAG basecamp docs replace --styled type=bool
+FLAG basecamp docs replace --todolist type=string
+FLAG basecamp docs replace --vault type=string
+FLAG basecamp docs replace --verbose type=count
 FLAG basecamp docs restore --account type=string
 FLAG basecamp docs restore --agent type=bool
 FLAG basecamp docs restore --cache-dir type=string
@@ -6556,6 +6648,56 @@ FLAG basecamp documents list --styled type=bool
 FLAG basecamp documents list --todolist type=string
 FLAG basecamp documents list --vault type=string
 FLAG basecamp documents list --verbose type=count
+FLAG basecamp documents new-version --account type=string
+FLAG basecamp documents new-version --agent type=bool
+FLAG basecamp documents new-version --base-name type=string
+FLAG basecamp documents new-version --cache-dir type=string
+FLAG basecamp documents new-version --count type=bool
+FLAG basecamp documents new-version --description type=string
+FLAG basecamp documents new-version --folder type=string
+FLAG basecamp documents new-version --help type=bool
+FLAG basecamp documents new-version --hints type=bool
+FLAG basecamp documents new-version --ids-only type=bool
+FLAG basecamp documents new-version --in type=string
+FLAG basecamp documents new-version --jq type=string
+FLAG basecamp documents new-version --json type=bool
+FLAG basecamp documents new-version --markdown type=bool
+FLAG basecamp documents new-version --md type=bool
+FLAG basecamp documents new-version --no-hints type=bool
+FLAG basecamp documents new-version --no-stats type=bool
+FLAG basecamp documents new-version --profile type=string
+FLAG basecamp documents new-version --project type=string
+FLAG basecamp documents new-version --quiet type=bool
+FLAG basecamp documents new-version --stats type=bool
+FLAG basecamp documents new-version --styled type=bool
+FLAG basecamp documents new-version --todolist type=string
+FLAG basecamp documents new-version --vault type=string
+FLAG basecamp documents new-version --verbose type=count
+FLAG basecamp documents replace --account type=string
+FLAG basecamp documents replace --agent type=bool
+FLAG basecamp documents replace --base-name type=string
+FLAG basecamp documents replace --cache-dir type=string
+FLAG basecamp documents replace --count type=bool
+FLAG basecamp documents replace --description type=string
+FLAG basecamp documents replace --folder type=string
+FLAG basecamp documents replace --help type=bool
+FLAG basecamp documents replace --hints type=bool
+FLAG basecamp documents replace --ids-only type=bool
+FLAG basecamp documents replace --in type=string
+FLAG basecamp documents replace --jq type=string
+FLAG basecamp documents replace --json type=bool
+FLAG basecamp documents replace --markdown type=bool
+FLAG basecamp documents replace --md type=bool
+FLAG basecamp documents replace --no-hints type=bool
+FLAG basecamp documents replace --no-stats type=bool
+FLAG basecamp documents replace --profile type=string
+FLAG basecamp documents replace --project type=string
+FLAG basecamp documents replace --quiet type=bool
+FLAG basecamp documents replace --stats type=bool
+FLAG basecamp documents replace --styled type=bool
+FLAG basecamp documents replace --todolist type=string
+FLAG basecamp documents replace --vault type=string
+FLAG basecamp documents replace --verbose type=count
 FLAG basecamp documents restore --account type=string
 FLAG basecamp documents restore --agent type=bool
 FLAG basecamp documents restore --cache-dir type=string
@@ -7544,6 +7686,56 @@ FLAG basecamp file list --styled type=bool
 FLAG basecamp file list --todolist type=string
 FLAG basecamp file list --vault type=string
 FLAG basecamp file list --verbose type=count
+FLAG basecamp file new-version --account type=string
+FLAG basecamp file new-version --agent type=bool
+FLAG basecamp file new-version --base-name type=string
+FLAG basecamp file new-version --cache-dir type=string
+FLAG basecamp file new-version --count type=bool
+FLAG basecamp file new-version --description type=string
+FLAG basecamp file new-version --folder type=string
+FLAG basecamp file new-version --help type=bool
+FLAG basecamp file new-version --hints type=bool
+FLAG basecamp file new-version --ids-only type=bool
+FLAG basecamp file new-version --in type=string
+FLAG basecamp file new-version --jq type=string
+FLAG basecamp file new-version --json type=bool
+FLAG basecamp file new-version --markdown type=bool
+FLAG basecamp file new-version --md type=bool
+FLAG basecamp file new-version --no-hints type=bool
+FLAG basecamp file new-version --no-stats type=bool
+FLAG basecamp file new-version --profile type=string
+FLAG basecamp file new-version --project type=string
+FLAG basecamp file new-version --quiet type=bool
+FLAG basecamp file new-version --stats type=bool
+FLAG basecamp file new-version --styled type=bool
+FLAG basecamp file new-version --todolist type=string
+FLAG basecamp file new-version --vault type=string
+FLAG basecamp file new-version --verbose type=count
+FLAG basecamp file replace --account type=string
+FLAG basecamp file replace --agent type=bool
+FLAG basecamp file replace --base-name type=string
+FLAG basecamp file replace --cache-dir type=string
+FLAG basecamp file replace --count type=bool
+FLAG basecamp file replace --description type=string
+FLAG basecamp file replace --folder type=string
+FLAG basecamp file replace --help type=bool
+FLAG basecamp file replace --hints type=bool
+FLAG basecamp file replace --ids-only type=bool
+FLAG basecamp file replace --in type=string
+FLAG basecamp file replace --jq type=string
+FLAG basecamp file replace --json type=bool
+FLAG basecamp file replace --markdown type=bool
+FLAG basecamp file replace --md type=bool
+FLAG basecamp file replace --no-hints type=bool
+FLAG basecamp file replace --no-stats type=bool
+FLAG basecamp file replace --profile type=string
+FLAG basecamp file replace --project type=string
+FLAG basecamp file replace --quiet type=bool
+FLAG basecamp file replace --stats type=bool
+FLAG basecamp file replace --styled type=bool
+FLAG basecamp file replace --todolist type=string
+FLAG basecamp file replace --vault type=string
+FLAG basecamp file replace --verbose type=count
 FLAG basecamp file restore --account type=string
 FLAG basecamp file restore --agent type=bool
 FLAG basecamp file restore --cache-dir type=string
@@ -8463,6 +8655,56 @@ FLAG basecamp files list --styled type=bool
 FLAG basecamp files list --todolist type=string
 FLAG basecamp files list --vault type=string
 FLAG basecamp files list --verbose type=count
+FLAG basecamp files new-version --account type=string
+FLAG basecamp files new-version --agent type=bool
+FLAG basecamp files new-version --base-name type=string
+FLAG basecamp files new-version --cache-dir type=string
+FLAG basecamp files new-version --count type=bool
+FLAG basecamp files new-version --description type=string
+FLAG basecamp files new-version --folder type=string
+FLAG basecamp files new-version --help type=bool
+FLAG basecamp files new-version --hints type=bool
+FLAG basecamp files new-version --ids-only type=bool
+FLAG basecamp files new-version --in type=string
+FLAG basecamp files new-version --jq type=string
+FLAG basecamp files new-version --json type=bool
+FLAG basecamp files new-version --markdown type=bool
+FLAG basecamp files new-version --md type=bool
+FLAG basecamp files new-version --no-hints type=bool
+FLAG basecamp files new-version --no-stats type=bool
+FLAG basecamp files new-version --profile type=string
+FLAG basecamp files new-version --project type=string
+FLAG basecamp files new-version --quiet type=bool
+FLAG basecamp files new-version --stats type=bool
+FLAG basecamp files new-version --styled type=bool
+FLAG basecamp files new-version --todolist type=string
+FLAG basecamp files new-version --vault type=string
+FLAG basecamp files new-version --verbose type=count
+FLAG basecamp files replace --account type=string
+FLAG basecamp files replace --agent type=bool
+FLAG basecamp files replace --base-name type=string
+FLAG basecamp files replace --cache-dir type=string
+FLAG basecamp files replace --count type=bool
+FLAG basecamp files replace --description type=string
+FLAG basecamp files replace --folder type=string
+FLAG basecamp files replace --help type=bool
+FLAG basecamp files replace --hints type=bool
+FLAG basecamp files replace --ids-only type=bool
+FLAG basecamp files replace --in type=string
+FLAG basecamp files replace --jq type=string
+FLAG basecamp files replace --json type=bool
+FLAG basecamp files replace --markdown type=bool
+FLAG basecamp files replace --md type=bool
+FLAG basecamp files replace --no-hints type=bool
+FLAG basecamp files replace --no-stats type=bool
+FLAG basecamp files replace --profile type=string
+FLAG basecamp files replace --project type=string
+FLAG basecamp files replace --quiet type=bool
+FLAG basecamp files replace --stats type=bool
+FLAG basecamp files replace --styled type=bool
+FLAG basecamp files replace --todolist type=string
+FLAG basecamp files replace --vault type=string
+FLAG basecamp files replace --verbose type=count
 FLAG basecamp files restore --account type=string
 FLAG basecamp files restore --agent type=bool
 FLAG basecamp files restore --cache-dir type=string
@@ -9382,6 +9624,56 @@ FLAG basecamp folders list --styled type=bool
 FLAG basecamp folders list --todolist type=string
 FLAG basecamp folders list --vault type=string
 FLAG basecamp folders list --verbose type=count
+FLAG basecamp folders new-version --account type=string
+FLAG basecamp folders new-version --agent type=bool
+FLAG basecamp folders new-version --base-name type=string
+FLAG basecamp folders new-version --cache-dir type=string
+FLAG basecamp folders new-version --count type=bool
+FLAG basecamp folders new-version --description type=string
+FLAG basecamp folders new-version --folder type=string
+FLAG basecamp folders new-version --help type=bool
+FLAG basecamp folders new-version --hints type=bool
+FLAG basecamp folders new-version --ids-only type=bool
+FLAG basecamp folders new-version --in type=string
+FLAG basecamp folders new-version --jq type=string
+FLAG basecamp folders new-version --json type=bool
+FLAG basecamp folders new-version --markdown type=bool
+FLAG basecamp folders new-version --md type=bool
+FLAG basecamp folders new-version --no-hints type=bool
+FLAG basecamp folders new-version --no-stats type=bool
+FLAG basecamp folders new-version --profile type=string
+FLAG basecamp folders new-version --project type=string
+FLAG basecamp folders new-version --quiet type=bool
+FLAG basecamp folders new-version --stats type=bool
+FLAG basecamp folders new-version --styled type=bool
+FLAG basecamp folders new-version --todolist type=string
+FLAG basecamp folders new-version --vault type=string
+FLAG basecamp folders new-version --verbose type=count
+FLAG basecamp folders replace --account type=string
+FLAG basecamp folders replace --agent type=bool
+FLAG basecamp folders replace --base-name type=string
+FLAG basecamp folders replace --cache-dir type=string
+FLAG basecamp folders replace --count type=bool
+FLAG basecamp folders replace --description type=string
+FLAG basecamp folders replace --folder type=string
+FLAG basecamp folders replace --help type=bool
+FLAG basecamp folders replace --hints type=bool
+FLAG basecamp folders replace --ids-only type=bool
+FLAG basecamp folders replace --in type=string
+FLAG basecamp folders replace --jq type=string
+FLAG basecamp folders replace --json type=bool
+FLAG basecamp folders replace --markdown type=bool
+FLAG basecamp folders replace --md type=bool
+FLAG basecamp folders replace --no-hints type=bool
+FLAG basecamp folders replace --no-stats type=bool
+FLAG basecamp folders replace --profile type=string
+FLAG basecamp folders replace --project type=string
+FLAG basecamp folders replace --quiet type=bool
+FLAG basecamp folders replace --stats type=bool
+FLAG basecamp folders replace --styled type=bool
+FLAG basecamp folders replace --todolist type=string
+FLAG basecamp folders replace --vault type=string
+FLAG basecamp folders replace --verbose type=count
 FLAG basecamp folders restore --account type=string
 FLAG basecamp folders restore --agent type=bool
 FLAG basecamp folders restore --cache-dir type=string
@@ -15718,6 +16010,56 @@ FLAG basecamp vault list --styled type=bool
 FLAG basecamp vault list --todolist type=string
 FLAG basecamp vault list --vault type=string
 FLAG basecamp vault list --verbose type=count
+FLAG basecamp vault new-version --account type=string
+FLAG basecamp vault new-version --agent type=bool
+FLAG basecamp vault new-version --base-name type=string
+FLAG basecamp vault new-version --cache-dir type=string
+FLAG basecamp vault new-version --count type=bool
+FLAG basecamp vault new-version --description type=string
+FLAG basecamp vault new-version --folder type=string
+FLAG basecamp vault new-version --help type=bool
+FLAG basecamp vault new-version --hints type=bool
+FLAG basecamp vault new-version --ids-only type=bool
+FLAG basecamp vault new-version --in type=string
+FLAG basecamp vault new-version --jq type=string
+FLAG basecamp vault new-version --json type=bool
+FLAG basecamp vault new-version --markdown type=bool
+FLAG basecamp vault new-version --md type=bool
+FLAG basecamp vault new-version --no-hints type=bool
+FLAG basecamp vault new-version --no-stats type=bool
+FLAG basecamp vault new-version --profile type=string
+FLAG basecamp vault new-version --project type=string
+FLAG basecamp vault new-version --quiet type=bool
+FLAG basecamp vault new-version --stats type=bool
+FLAG basecamp vault new-version --styled type=bool
+FLAG basecamp vault new-version --todolist type=string
+FLAG basecamp vault new-version --vault type=string
+FLAG basecamp vault new-version --verbose type=count
+FLAG basecamp vault replace --account type=string
+FLAG basecamp vault replace --agent type=bool
+FLAG basecamp vault replace --base-name type=string
+FLAG basecamp vault replace --cache-dir type=string
+FLAG basecamp vault replace --count type=bool
+FLAG basecamp vault replace --description type=string
+FLAG basecamp vault replace --folder type=string
+FLAG basecamp vault replace --help type=bool
+FLAG basecamp vault replace --hints type=bool
+FLAG basecamp vault replace --ids-only type=bool
+FLAG basecamp vault replace --in type=string
+FLAG basecamp vault replace --jq type=string
+FLAG basecamp vault replace --json type=bool
+FLAG basecamp vault replace --markdown type=bool
+FLAG basecamp vault replace --md type=bool
+FLAG basecamp vault replace --no-hints type=bool
+FLAG basecamp vault replace --no-stats type=bool
+FLAG basecamp vault replace --profile type=string
+FLAG basecamp vault replace --project type=string
+FLAG basecamp vault replace --quiet type=bool
+FLAG basecamp vault replace --stats type=bool
+FLAG basecamp vault replace --styled type=bool
+FLAG basecamp vault replace --todolist type=string
+FLAG basecamp vault replace --vault type=string
+FLAG basecamp vault replace --verbose type=count
 FLAG basecamp vault restore --account type=string
 FLAG basecamp vault restore --agent type=bool
 FLAG basecamp vault restore --cache-dir type=string
@@ -16637,6 +16979,56 @@ FLAG basecamp vaults list --styled type=bool
 FLAG basecamp vaults list --todolist type=string
 FLAG basecamp vaults list --vault type=string
 FLAG basecamp vaults list --verbose type=count
+FLAG basecamp vaults new-version --account type=string
+FLAG basecamp vaults new-version --agent type=bool
+FLAG basecamp vaults new-version --base-name type=string
+FLAG basecamp vaults new-version --cache-dir type=string
+FLAG basecamp vaults new-version --count type=bool
+FLAG basecamp vaults new-version --description type=string
+FLAG basecamp vaults new-version --folder type=string
+FLAG basecamp vaults new-version --help type=bool
+FLAG basecamp vaults new-version --hints type=bool
+FLAG basecamp vaults new-version --ids-only type=bool
+FLAG basecamp vaults new-version --in type=string
+FLAG basecamp vaults new-version --jq type=string
+FLAG basecamp vaults new-version --json type=bool
+FLAG basecamp vaults new-version --markdown type=bool
+FLAG basecamp vaults new-version --md type=bool
+FLAG basecamp vaults new-version --no-hints type=bool
+FLAG basecamp vaults new-version --no-stats type=bool
+FLAG basecamp vaults new-version --profile type=string
+FLAG basecamp vaults new-version --project type=string
+FLAG basecamp vaults new-version --quiet type=bool
+FLAG basecamp vaults new-version --stats type=bool
+FLAG basecamp vaults new-version --styled type=bool
+FLAG basecamp vaults new-version --todolist type=string
+FLAG basecamp vaults new-version --vault type=string
+FLAG basecamp vaults new-version --verbose type=count
+FLAG basecamp vaults replace --account type=string
+FLAG basecamp vaults replace --agent type=bool
+FLAG basecamp vaults replace --base-name type=string
+FLAG basecamp vaults replace --cache-dir type=string
+FLAG basecamp vaults replace --count type=bool
+FLAG basecamp vaults replace --description type=string
+FLAG basecamp vaults replace --folder type=string
+FLAG basecamp vaults replace --help type=bool
+FLAG basecamp vaults replace --hints type=bool
+FLAG basecamp vaults replace --ids-only type=bool
+FLAG basecamp vaults replace --in type=string
+FLAG basecamp vaults replace --jq type=string
+FLAG basecamp vaults replace --json type=bool
+FLAG basecamp vaults replace --markdown type=bool
+FLAG basecamp vaults replace --md type=bool
+FLAG basecamp vaults replace --no-hints type=bool
+FLAG basecamp vaults replace --no-stats type=bool
+FLAG basecamp vaults replace --profile type=string
+FLAG basecamp vaults replace --project type=string
+FLAG basecamp vaults replace --quiet type=bool
+FLAG basecamp vaults replace --stats type=bool
+FLAG basecamp vaults replace --styled type=bool
+FLAG basecamp vaults replace --todolist type=string
+FLAG basecamp vaults replace --vault type=string
+FLAG basecamp vaults replace --verbose type=count
 FLAG basecamp vaults restore --account type=string
 FLAG basecamp vaults restore --agent type=bool
 FLAG basecamp vaults restore --cache-dir type=string
@@ -17545,6 +17937,8 @@ SUB basecamp docs folders
 SUB basecamp docs folders create
 SUB basecamp docs folders list
 SUB basecamp docs list
+SUB basecamp docs new-version
+SUB basecamp docs replace
 SUB basecamp docs restore
 SUB basecamp docs show
 SUB basecamp docs trash
@@ -17582,6 +17976,8 @@ SUB basecamp documents folders
 SUB basecamp documents folders create
 SUB basecamp documents folders list
 SUB basecamp documents list
+SUB basecamp documents new-version
+SUB basecamp documents replace
 SUB basecamp documents restore
 SUB basecamp documents show
 SUB basecamp documents trash
@@ -17621,6 +18017,8 @@ SUB basecamp file folders
 SUB basecamp file folders create
 SUB basecamp file folders list
 SUB basecamp file list
+SUB basecamp file new-version
+SUB basecamp file replace
 SUB basecamp file restore
 SUB basecamp file show
 SUB basecamp file trash
@@ -17657,6 +18055,8 @@ SUB basecamp files folders
 SUB basecamp files folders create
 SUB basecamp files folders list
 SUB basecamp files list
+SUB basecamp files new-version
+SUB basecamp files replace
 SUB basecamp files restore
 SUB basecamp files show
 SUB basecamp files trash
@@ -17693,6 +18093,8 @@ SUB basecamp folders folders
 SUB basecamp folders folders create
 SUB basecamp folders folders list
 SUB basecamp folders list
+SUB basecamp folders new-version
+SUB basecamp folders replace
 SUB basecamp folders restore
 SUB basecamp folders show
 SUB basecamp folders trash
@@ -17966,6 +18368,8 @@ SUB basecamp vault folders
 SUB basecamp vault folders create
 SUB basecamp vault folders list
 SUB basecamp vault list
+SUB basecamp vault new-version
+SUB basecamp vault replace
 SUB basecamp vault restore
 SUB basecamp vault show
 SUB basecamp vault trash
@@ -18002,6 +18406,8 @@ SUB basecamp vaults folders
 SUB basecamp vaults folders create
 SUB basecamp vaults folders list
 SUB basecamp vaults list
+SUB basecamp vaults new-version
+SUB basecamp vaults replace
 SUB basecamp vaults restore
 SUB basecamp vaults show
 SUB basecamp vaults trash

--- a/API-COVERAGE.md
+++ b/API-COVERAGE.md
@@ -212,7 +212,7 @@ cannot faithfully cover at least one endpoint for a reason outside the CLI. A
 | search | 2 | `search` | ✅ | BC4 | - | Full-text search + metadata. Filters: `--project`/`--in`, `--type`, `--creator`, `--since` (BC5-only), `--file-type`, `--exclude-chat`. Metadata lists recording/file search types |
 | recordings | 4 | `recordings` | ✅ | BC4 | - | Browse by type/status, trash/archive/restore |
 | **Files & Documents** |
-| uploads | 8 | `files`, `uploads` | ✅ | BC4 | - | list, show, create, update, download, versions (`files versions <id>`); trash/archive/restore go through `recordings`. Create supports `--visible-to-clients` (root vault only) |
+| uploads | 8 | `files`, `uploads` | ✅ | BC4 | - | list, show, create, update, download, versions (`files versions <id>`), replace (`files replace <id> <file>`); trash/archive/restore go through `recordings`. Create supports `--visible-to-clients` (root vault only) |
 | vaults | 8 | `files`, `vaults` | ✅ | BC4 | - | list, show, create |
 | documents | 8 | `files`, `docs` | ✅ | BC4 | - | list, show, create, update. Create supports `--subscribe`/`--no-subscribe`, `--visible-to-clients` (root vault only) |
 | attachments | 1 | `uploads`, `attachments` | ✅ | BC4 | - | Upload via `attach`; list embedded attachments via `attachments list` (parses `<bc-attachment>` from content) |

--- a/e2e/smoke/smoke_files_write.bats
+++ b/e2e/smoke/smoke_files_write.bats
@@ -49,6 +49,28 @@ setup_file() {
   echo "$output" | jq -r '.data.id' > "$BATS_FILE_TMPDIR/uploads_create_id"
 }
 
+@test "files replace uploads a new version of an upload" {
+  local id_file="$BATS_FILE_TMPDIR/uploads_create_id"
+  [[ -f "$id_file" ]] || mark_unverifiable "No upload created in prior test"
+  local upload_id
+  upload_id=$(<"$id_file")
+
+  local tmpfile="$BATS_FILE_TMPDIR/smoke_files_replace.txt"
+  echo "smoke files replace content $(date +%s)" > "$tmpfile"
+
+  run_smoke basecamp files replace "$upload_id" "$tmpfile" --json
+  assert_success
+  assert_json_value '.ok' 'true'
+  assert_json_value '.data.id' "$upload_id"
+  assert_json_value '.data.filename' 'smoke_files_replace.txt'
+
+  # The replaced file surfaces as the single current version.
+  run_smoke basecamp files versions "$upload_id" --json
+  assert_success
+  run bash -c "echo '$output' | jq '[.data[] | select(.current == true)] | length'"
+  assert_output "1"
+}
+
 @test "uploads show returns upload detail" {
   local id_file="$BATS_FILE_TMPDIR/uploads_create_id"
   [[ -f "$id_file" ]] || mark_unverifiable "No upload created in prior test"

--- a/e2e/smoke/smoke_files_write.bats
+++ b/e2e/smoke/smoke_files_write.bats
@@ -67,8 +67,7 @@ setup_file() {
   # The replaced file surfaces as the single current version.
   run_smoke basecamp files versions "$upload_id" --json
   assert_success
-  run bash -c "echo '$output' | jq '[.data[] | select(.current == true)] | length'"
-  assert_output "1"
+  assert_json_value '[.data[] | select(.current == true)] | length' '1'
 }
 
 @test "uploads show returns upload detail" {

--- a/e2e/smoke/smoke_lifecycle.bats
+++ b/e2e/smoke/smoke_lifecycle.bats
@@ -163,6 +163,18 @@ load smoke_helper
   mark_out_of_scope "Shares implementation with files group (tested)"
 }
 
+@test "docs replace is out of scope" {
+  mark_out_of_scope "Shares implementation with files group (tested)"
+}
+
+@test "docs new-version is out of scope" {
+  mark_out_of_scope "Alias of files replace (tested)"
+}
+
+@test "files new-version is out of scope" {
+  mark_out_of_scope "Alias of files replace (tested)"
+}
+
 @test "docs uploads create is out of scope" {
   mark_out_of_scope "Shares implementation with files group (tested)"
 }
@@ -207,6 +219,14 @@ load smoke_helper
 
 @test "vaults versions is out of scope" {
   mark_out_of_scope "Shares implementation with files group (tested)"
+}
+
+@test "vaults replace is out of scope" {
+  mark_out_of_scope "Shares implementation with files group (tested)"
+}
+
+@test "vaults new-version is out of scope" {
+  mark_out_of_scope "Alias of files replace (tested)"
 }
 
 @test "vaults uploads create is out of scope" {

--- a/internal/commands/attach.go
+++ b/internal/commands/attach.go
@@ -137,6 +137,27 @@ func resolveLocalImages(cmd *cobra.Command, app *appctx.App, htmlStr string) (st
 		return htmlStr, nil
 	}
 
+	// Preflight every reference before uploading any: a deterministic local
+	// failure (a missing file) must not strand already-uploaded attachments
+	// from earlier in the loop.
+	for _, m := range matches {
+		src := html.UnescapeString(htmlStr[m[2]:m[3]])
+		alt := ""
+		if m[4] >= 0 {
+			alt = htmlStr[m[4]:m[5]]
+		}
+		action, classErr := classifyImageSrc(src, alt)
+		if classErr != nil {
+			return "", classErr
+		}
+		if action == imgSkip {
+			continue
+		}
+		if err := richtext.ValidateFile(richtext.NormalizeDragPath(src)); err != nil {
+			return "", fmt.Errorf("%s: %w", src, err)
+		}
+	}
+
 	// Process in reverse order so replacements don't shift indices
 	result := htmlStr
 	for i := len(matches) - 1; i >= 0; i-- {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -44,7 +44,7 @@ func CommandCategories() []CommandCategory {
 				{Name: "messages", Category: "core", Description: "Manage messages", Actions: []string{"list", "show", "create", "update", "publish", "pin", "unpin", "trash", "archive", "restore"}},
 				{Name: "chat", Category: "core", Description: "Chat in real-time", Actions: []string{"list", "messages", "post", "upload", "line", "update", "delete"}},
 				{Name: "cards", Category: "core", Description: "Manage Kanban cards", Actions: []string{"list", "show", "create", "update", "move", "done", "columns", "wormholes", "steps", "trash", "archive", "restore"}},
-				{Name: "files", Category: "core", Description: "Manage files, documents, and folders", Actions: []string{"list", "show", "versions", "download", "update", "trash", "archive", "restore"}},
+				{Name: "files", Category: "core", Description: "Manage files, documents, and folders", Actions: []string{"list", "show", "versions", "replace", "download", "update", "trash", "archive", "restore"}},
 				{Name: "checkins", Category: "core", Description: "View automatic check-ins", Actions: []string{"questions", "question", "answers", "answer", "reminders"}},
 				{Name: "schedule", Category: "core", Description: "Manage schedule entries", Actions: []string{"show", "entries", "create", "update"}},
 			},

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -46,7 +46,7 @@ Each project has a root folder containing documents, uploads, and subfolders.`,
 		newDocsCmd(&project, &vaultID),
 		newFilesShowCmd(&project),
 		newFilesVersionsCmd(&project),
-		newFilesReplaceCmd(),
+		newFilesReplaceCmd(&project),
 		newFilesUpdateCmd(&project),
 		newFilesDownloadCmd(&project),
 		newRecordableTrashCmd("file"),
@@ -1669,7 +1669,7 @@ func flattenUploadVersions(versions []basecamp.UploadVersion) []map[string]any {
 	return rows
 }
 
-func newFilesReplaceCmd() *cobra.Command {
+func newFilesReplaceCmd(project *string) *cobra.Command {
 	var description string
 	var baseName string
 
@@ -1746,17 +1746,26 @@ You can pass either an upload ID or a Basecamp URL:
 				return convertSDKError(err)
 			}
 
+			// Breadcrumbs reuse the caller's own reference and carry an
+			// explicit --project: download resolves a project before fetching,
+			// so a bare ID without the scope could prompt or fail headless.
+			ref := args[0]
+			scope := ""
+			if *project != "" {
+				scope = fmt.Sprintf(" --project %s", *project)
+			}
+
 			return app.OK(upload,
 				output.WithSummary(fmt.Sprintf("Replaced upload #%d's file with %s", upload.ID, upload.Filename)),
 				output.WithBreadcrumbs(
 					output.Breadcrumb{
 						Action:      "versions",
-						Cmd:         fmt.Sprintf("basecamp files versions %s", args[0]),
+						Cmd:         fmt.Sprintf("basecamp files versions %s%s", ref, scope),
 						Description: "List versions",
 					},
 					output.Breadcrumb{
 						Action:      "download",
-						Cmd:         fmt.Sprintf("basecamp files download %s", args[0]),
+						Cmd:         fmt.Sprintf("basecamp files download %s%s", ref, scope),
 						Description: "Download the new version",
 					},
 				),

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/hostutil"
 	"github.com/basecamp/basecamp-cli/internal/output"
 	"github.com/basecamp/basecamp-cli/internal/richtext"
 	"github.com/basecamp/basecamp-cli/internal/urlarg"
@@ -1700,6 +1701,15 @@ You can pass either an upload ID or a Basecamp URL:
 			// session's before anything is staged — extractID keeps only the
 			// numeric ID, which would silently retarget the configured
 			// account's same-numbered upload on a mutating request.
+			// A URL-shaped argument must live on a trusted Basecamp host:
+			// the URL router is host-agnostic, so a look-alike on an
+			// attacker-controlled host would otherwise pass the identity
+			// checks below and retarget the configured account's upload —
+			// the confused-deputy case hostutil exists to prevent.
+			if urlarg.IsURL(args[0]) && !hostutil.IsTrustedBasecampHost(args[0], app.Config.BaseURL) {
+				return output.ErrUsage("refusing untrusted host in URL — expected a Basecamp URL")
+			}
+
 			if parsed := urlarg.Parse(args[0]); parsed != nil {
 				if parsed.AccountID != "" && parsed.AccountID != app.Config.AccountID {
 					return output.ErrUsage(fmt.Sprintf("URL is for account %s, but this session uses account %s", parsed.AccountID, app.Config.AccountID))

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1707,6 +1707,13 @@ You can pass either an upload ID or a Basecamp URL:
 				if parsed.Type != "uploads" {
 					return output.ErrUsage(fmt.Sprintf("URL identifies a %s recording, not an upload", parsed.Type))
 				}
+				// A collection URL (/vaults/456/uploads, /buckets/456/uploads)
+				// also parses as type "uploads", but its extracted ID is the
+				// PARENT's — the identity predicate needs the recording half
+				// too, or extractID retargets a same-numbered upload.
+				if parsed.IsCollection || parsed.RecordingID == "" {
+					return output.ErrUsage("URL identifies an uploads listing, not a single upload")
+				}
 			}
 
 			uploadIDStr := extractID(args[0])

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -1606,7 +1606,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// unlike versions, both follow-up commands resolve a project
 			// before fetching, so a bare ID could prompt or fail headless.
 			ref := shellQuote(args[0])
-			scope := breadcrumbScope(*project)
+			scope := breadcrumbScope(scopeProject(app, *project))
 
 			respOpts := []output.ResponseOption{
 				output.WithSummary(fmt.Sprintf("%d versions of upload #%s", len(versions), uploadIDStr)),
@@ -1775,7 +1775,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// explicit --project: download resolves a project before fetching,
 			// so a bare ID without the scope could prompt or fail headless.
 			ref := shellQuote(args[0])
-			scope := breadcrumbScope(*project)
+			scope := breadcrumbScope(scopeProject(app, *project))
 
 			return app.OK(upload,
 				output.WithSummary(fmt.Sprintf("Replaced upload #%d's file with %s", upload.ID, upload.Filename)),
@@ -1817,6 +1817,17 @@ func shellQuote(s string) string {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// scopeProject resolves the project value a breadcrumb should carry: the
+// group-level flag, else the root-level --project (app.Flags.Project) — the
+// same precedence the fetch paths use, minus the config default, which a
+// copier's own config supplies.
+func scopeProject(app *appctx.App, project string) string {
+	if project != "" {
+		return project
+	}
+	return app.Flags.Project
 }
 
 // breadcrumbScope renders the --project suffix for a breadcrumb command.

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -17,6 +17,7 @@ import (
 	"github.com/basecamp/basecamp-cli/internal/appctx"
 	"github.com/basecamp/basecamp-cli/internal/output"
 	"github.com/basecamp/basecamp-cli/internal/richtext"
+	"github.com/basecamp/basecamp-cli/internal/urlarg"
 )
 
 // NewFilesCmd creates the files command group.
@@ -1604,10 +1605,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// unlike versions, both follow-up commands resolve a project
 			// before fetching, so a bare ID could prompt or fail headless.
 			ref := args[0]
-			scope := ""
-			if *project != "" {
-				scope = fmt.Sprintf(" --project %s", *project)
-			}
+			scope := breadcrumbScope(*project)
 
 			respOpts := []output.ResponseOption{
 				output.WithSummary(fmt.Sprintf("%d versions of upload #%s", len(versions), uploadIDStr)),
@@ -1697,15 +1695,39 @@ You can pass either an upload ID or a Basecamp URL:
 				return err
 			}
 
+			// A pasted URL names its own account; refuse one that isn't the
+			// session's before anything is staged — extractID keeps only the
+			// numeric ID, which would silently retarget the configured
+			// account's same-numbered upload on a mutating request.
+			if parsed := urlarg.Parse(args[0]); parsed != nil && parsed.AccountID != "" && parsed.AccountID != app.Config.AccountID {
+				return output.ErrUsage(fmt.Sprintf("URL is for account %s, but this session uses account %s", parsed.AccountID, app.Config.AccountID))
+			}
+
 			uploadIDStr := extractID(args[0])
 			uploadID, err := strconv.ParseInt(uploadIDStr, 10, 64)
-			if err != nil {
+			if err != nil || uploadID <= 0 {
 				return output.ErrUsage("Invalid upload ID")
 			}
 
 			filePath := richtext.NormalizeDragPath(args[1])
 			if err := richtext.ValidateFile(filePath); err != nil {
 				return fmt.Errorf("%s: %w", filePath, err)
+			}
+
+			// Resolve the description first: its local-image references can
+			// fail deterministically, and staging a large replacement before
+			// finding that out wastes the whole transfer. A nil Description
+			// carries the previous version's forward; --description "" clears.
+			var descPtr *string
+			if cmd.Flags().Changed("description") {
+				descHTML := ""
+				if description != "" {
+					descHTML = richtext.MarkdownToHTML(description)
+					if descHTML, err = resolveLocalImages(cmd, app, descHTML); err != nil {
+						return err
+					}
+				}
+				descPtr = basecamp.Ptr(descHTML)
 			}
 
 			// Step 1: stage the new file as an attachment (same two-step flow
@@ -1724,21 +1746,11 @@ You can pass either an upload ID or a Basecamp URL:
 				return convertSDKError(err)
 			}
 
-			// Step 2: replace the upload's file. A nil Description carries the
-			// previous version's forward; --description "" clears it.
+			// Step 2: replace the upload's file.
 			req := &basecamp.CreateUploadVersionRequest{
 				AttachableSGID: resp.AttachableSGID,
 				BaseName:       baseName,
-			}
-			if cmd.Flags().Changed("description") {
-				descHTML := ""
-				if description != "" {
-					descHTML = richtext.MarkdownToHTML(description)
-					if descHTML, err = resolveLocalImages(cmd, app, descHTML); err != nil {
-						return err
-					}
-				}
-				req.Description = basecamp.Ptr(descHTML)
+				Description:    descPtr,
 			}
 
 			upload, err := app.Account().Uploads().CreateVersion(cmd.Context(), uploadID, req)
@@ -1750,10 +1762,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// explicit --project: download resolves a project before fetching,
 			// so a bare ID without the scope could prompt or fail headless.
 			ref := args[0]
-			scope := ""
-			if *project != "" {
-				scope = fmt.Sprintf(" --project %s", *project)
-			}
+			scope := breadcrumbScope(*project)
 
 			return app.OK(upload,
 				output.WithSummary(fmt.Sprintf("Replaced upload #%d's file with %s", upload.ID, upload.Filename)),
@@ -1777,6 +1786,19 @@ You can pass either an upload ID or a Basecamp URL:
 	cmd.Flags().StringVar(&baseName, "base-name", "", "Rename the file (without extension); omit to keep the uploaded file's name")
 
 	return cmd
+}
+
+// breadcrumbScope renders the --project suffix for a breadcrumb command,
+// quoting names that contain whitespace so the emitted command round-trips
+// through a shell instead of splitting into stray positional arguments.
+func breadcrumbScope(project string) string {
+	if project == "" {
+		return ""
+	}
+	if strings.ContainsAny(project, " \t") {
+		return fmt.Sprintf(" --project %q", project)
+	}
+	return " --project " + project
 }
 
 func newFilesUpdateCmd(project *string) *cobra.Command {

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -46,6 +46,7 @@ Each project has a root folder containing documents, uploads, and subfolders.`,
 		newDocsCmd(&project, &vaultID),
 		newFilesShowCmd(&project),
 		newFilesVersionsCmd(&project),
+		newFilesReplaceCmd(),
 		newFilesUpdateCmd(&project),
 		newFilesDownloadCmd(&project),
 		newRecordableTrashCmd("file"),
@@ -1666,6 +1667,107 @@ func flattenUploadVersions(versions []basecamp.UploadVersion) []map[string]any {
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func newFilesReplaceCmd() *cobra.Command {
+	var description string
+	var baseName string
+
+	cmd := &cobra.Command{
+		Use:     "replace <upload-id|url> <file>",
+		Aliases: []string{"new-version"},
+		Short:   "Replace an upload's file with a new version",
+		Long: `Replace an uploaded file with a new version.
+
+The upload keeps its ID, URL and comments; the previous file becomes a past
+version (see 'basecamp files versions'). Use this instead of a fresh upload
+when publishing a new build of the same file, so its published link keeps
+working.
+
+Nobody is notified, and the description carries forward unless --description
+is given.
+
+You can pass either an upload ID or a Basecamp URL:
+  basecamp files replace 789 ./build-v2.exe
+  basecamp files replace https://3.basecamp.com/123/buckets/456/uploads/789 ./build-v2.exe`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if err := ensureAccount(cmd, app); err != nil {
+				return err
+			}
+
+			uploadIDStr := extractID(args[0])
+			uploadID, err := strconv.ParseInt(uploadIDStr, 10, 64)
+			if err != nil {
+				return output.ErrUsage("Invalid upload ID")
+			}
+
+			filePath := richtext.NormalizeDragPath(args[1])
+			if err := richtext.ValidateFile(filePath); err != nil {
+				return fmt.Errorf("%s: %w", filePath, err)
+			}
+
+			// Step 1: stage the new file as an attachment (same two-step flow
+			// as uploads create).
+			contentType := richtext.DetectMIME(filePath)
+			filename := filepath.Base(filePath)
+
+			f, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf("%s: %w", filePath, err)
+			}
+			defer f.Close()
+
+			resp, err := app.Account().Attachments().Create(cmd.Context(), filename, contentType, f)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			// Step 2: replace the upload's file. A nil Description carries the
+			// previous version's forward; --description "" clears it.
+			req := &basecamp.CreateUploadVersionRequest{
+				AttachableSGID: resp.AttachableSGID,
+				BaseName:       baseName,
+			}
+			if cmd.Flags().Changed("description") {
+				descHTML := ""
+				if description != "" {
+					descHTML = richtext.MarkdownToHTML(description)
+					if descHTML, err = resolveLocalImages(cmd, app, descHTML); err != nil {
+						return err
+					}
+				}
+				req.Description = basecamp.Ptr(descHTML)
+			}
+
+			upload, err := app.Account().Uploads().CreateVersion(cmd.Context(), uploadID, req)
+			if err != nil {
+				return convertSDKError(err)
+			}
+
+			return app.OK(upload,
+				output.WithSummary(fmt.Sprintf("Replaced upload #%d's file with %s", upload.ID, upload.Filename)),
+				output.WithBreadcrumbs(
+					output.Breadcrumb{
+						Action:      "versions",
+						Cmd:         fmt.Sprintf("basecamp files versions %s", args[0]),
+						Description: "List versions",
+					},
+					output.Breadcrumb{
+						Action:      "download",
+						Cmd:         fmt.Sprintf("basecamp files download %s", args[0]),
+						Description: "Download the new version",
+					},
+				),
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&description, "description", "", "New description (Markdown); omit to carry the current one forward")
+	cmd.Flags().StringVar(&baseName, "base-name", "", "Rename the file (without extension); omit to keep the uploaded file's name")
+
+	return cmd
 }
 
 func newFilesUpdateCmd(project *string) *cobra.Command {

--- a/internal/commands/files.go
+++ b/internal/commands/files.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -1604,7 +1605,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// its project scope, and an explicit --project carries over —
 			// unlike versions, both follow-up commands resolve a project
 			// before fetching, so a bare ID could prompt or fail headless.
-			ref := args[0]
+			ref := shellQuote(args[0])
 			scope := breadcrumbScope(*project)
 
 			respOpts := []output.ResponseOption{
@@ -1699,8 +1700,13 @@ You can pass either an upload ID or a Basecamp URL:
 			// session's before anything is staged — extractID keeps only the
 			// numeric ID, which would silently retarget the configured
 			// account's same-numbered upload on a mutating request.
-			if parsed := urlarg.Parse(args[0]); parsed != nil && parsed.AccountID != "" && parsed.AccountID != app.Config.AccountID {
-				return output.ErrUsage(fmt.Sprintf("URL is for account %s, but this session uses account %s", parsed.AccountID, app.Config.AccountID))
+			if parsed := urlarg.Parse(args[0]); parsed != nil {
+				if parsed.AccountID != "" && parsed.AccountID != app.Config.AccountID {
+					return output.ErrUsage(fmt.Sprintf("URL is for account %s, but this session uses account %s", parsed.AccountID, app.Config.AccountID))
+				}
+				if parsed.Type != "uploads" {
+					return output.ErrUsage(fmt.Sprintf("URL identifies a %s recording, not an upload", parsed.Type))
+				}
 			}
 
 			uploadIDStr := extractID(args[0])
@@ -1761,7 +1767,7 @@ You can pass either an upload ID or a Basecamp URL:
 			// Breadcrumbs reuse the caller's own reference and carry an
 			// explicit --project: download resolves a project before fetching,
 			// so a bare ID without the scope could prompt or fail headless.
-			ref := args[0]
+			ref := shellQuote(args[0])
 			scope := breadcrumbScope(*project)
 
 			return app.OK(upload,
@@ -1788,17 +1794,30 @@ You can pass either an upload ID or a Basecamp URL:
 	return cmd
 }
 
-// breadcrumbScope renders the --project suffix for a breadcrumb command,
-// quoting names that contain whitespace so the emitted command round-trips
-// through a shell instead of splitting into stray positional arguments.
+// shellSafeRe matches strings that need no quoting in an emitted shell
+// command: IDs, plain Basecamp URLs, and simple names. Everything else gets
+// single-quoted.
+var shellSafeRe = regexp.MustCompile(`^[A-Za-z0-9_./:@%+=-]+$`)
+
+// shellQuote renders s safe to embed in an emitted shell command. Clearly
+// inert strings pass through bare; anything else is single-quoted — the one
+// POSIX form in which nothing substitutes — with embedded single quotes
+// spelled '\”. This is an encoding applied to every embedded value, not a
+// metacharacter list: breadcrumbs interpolate user- and API-controlled text,
+// and escaping cases one at a time is how quoting bugs recur.
+func shellQuote(s string) string {
+	if s != "" && shellSafeRe.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// breadcrumbScope renders the --project suffix for a breadcrumb command.
 func breadcrumbScope(project string) string {
 	if project == "" {
 		return ""
 	}
-	if strings.ContainsAny(project, " \t") {
-		return fmt.Sprintf(" --project %q", project)
-	}
-	return " --project " + project
+	return " --project " + shellQuote(project)
 }
 
 func newFilesUpdateCmd(project *string) *cobra.Command {

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1467,6 +1467,17 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 	}
 }
 
+// TestScopeProject pins breadcrumb scope sourcing: the group flag wins, the
+// root-level --project (app.Flags.Project) fills in behind it, and the config
+// default is deliberately absent — a copier's own config supplies that one.
+func TestScopeProject(t *testing.T) {
+	app := &appctx.App{Flags: appctx.GlobalFlags{Project: "root-flag"}}
+	assert.Equal(t, "group-flag", scopeProject(app, "group-flag"))
+	assert.Equal(t, "root-flag", scopeProject(app, ""))
+	app.Flags.Project = ""
+	assert.Equal(t, "", scopeProject(app, ""))
+}
+
 // TestShellQuote pins the breadcrumb encoding: inert strings (IDs, plain
 // Basecamp URLs) pass bare, and everything else is single-quoted so no shell
 // syntax survives — quoting is an encoding, not a metacharacter list.

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1353,6 +1353,118 @@ func TestFlattenUploadVersionsCarriesTheRecordedFile(t *testing.T) {
 	assert.NotContains(t, rows[2], "current", "an upload-less event gets no file columns")
 }
 
+// mockFilesReplaceTransport serves the two-step replace flow: staging the
+// attachment, then POSTing the new version to upload 789. Any other request
+// fails the test.
+type mockFilesReplaceTransport struct {
+	postPaths   []string
+	versionBody []byte
+}
+
+func (t *mockFilesReplaceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	respond := func(status int, body string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     header,
+		}, nil
+	}
+
+	path := req.URL.Path
+	switch {
+	case req.Method == http.MethodPost && strings.Contains(path, "/attachments.json"):
+		t.postPaths = append(t.postPaths, path)
+		return respond(201, `{"attachable_sgid":"sgid-v2"}`)
+	case req.Method == http.MethodPost && strings.HasSuffix(path, "/uploads/789/versions.json"):
+		t.postPaths = append(t.postPaths, path)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading version body: %w", err)
+		}
+		t.versionBody = body
+		return respond(201, `{"id":789,"title":"report","filename":"report-v2.pdf","byte_size":9}`)
+	default:
+		return nil, fmt.Errorf("unexpected request: %s %s", req.Method, path)
+	}
+}
+
+// TestFilesReplaceStagesAndCreatesVersion pins the two-step flow and the
+// carry-forward default: no --description means no description key on the
+// wire, which the server reads as "keep the current one".
+func TestFilesReplaceStagesAndCreatesVersion(t *testing.T) {
+	transport := &mockFilesReplaceTransport{}
+	app := showTestApp(t, transport)
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "replace", "789", writeTempUpload(t))
+	require.NoError(t, err)
+
+	require.Len(t, transport.postPaths, 2)
+	assert.Contains(t, transport.postPaths[0], "/attachments.json")
+	assert.Contains(t, transport.postPaths[1], "/uploads/789/versions.json")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.versionBody, &body))
+	assert.Equal(t, "sgid-v2", body["attachable_sgid"])
+	_, hasDescription := body["description"]
+	assert.False(t, hasDescription, "omitted --description must not reach the wire")
+	_, hasNotify := body["notify"]
+	assert.False(t, hasNotify, "no notify field means notify nobody")
+}
+
+// TestFilesReplaceAcceptsURL verifies a pasted upload URL resolves to the
+// same versions endpoint as the bare ID.
+func TestFilesReplaceAcceptsURL(t *testing.T) {
+	transport := &mockFilesReplaceTransport{}
+	app := showTestApp(t, transport)
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "replace", "https://3.basecamp.com/99999/buckets/456/uploads/789", writeTempUpload(t))
+	require.NoError(t, err)
+	require.Len(t, transport.postPaths, 2)
+	assert.Contains(t, transport.postPaths[1], "/uploads/789/versions.json")
+}
+
+// TestFilesReplaceDescriptionTriState pins the presence-aware description:
+// a provided value is sent as HTML, an explicit empty string is sent (and
+// clears server-side), and omission stays off the wire (covered above).
+func TestFilesReplaceDescriptionTriState(t *testing.T) {
+	for name, tc := range map[string]struct {
+		flagValue string
+		expect    func(t *testing.T, desc any)
+	}{
+		"markdown value becomes HTML": {
+			flagValue: "New **build**",
+			expect: func(t *testing.T, desc any) {
+				assert.Contains(t, desc, "<strong>build</strong>")
+			},
+		},
+		"explicit empty clears": {
+			flagValue: "",
+			expect: func(t *testing.T, desc any) {
+				assert.Equal(t, "", desc)
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			transport := &mockFilesReplaceTransport{}
+			app := showTestApp(t, transport)
+
+			cmd := NewFilesCmd()
+			err := executeMessagesCommand(cmd, app, "replace", "789", writeTempUpload(t), "--description", tc.flagValue)
+			require.NoError(t, err)
+
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(transport.versionBody, &body))
+			desc, hasDescription := body["description"]
+			require.True(t, hasDescription, "--description must reach the wire")
+			tc.expect(t, desc)
+		})
+	}
+}
+
 // TestFilesVersionsRejectsConflictingPagination pins the same pagination
 // contract the other bounded listings use: --page disables the walk, so it
 // cannot be combined with --all or --limit, and only page 1 is reachable.

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1429,6 +1429,38 @@ func TestFilesReplaceAcceptsURL(t *testing.T) {
 	assert.Contains(t, transport.postPaths[1], "/uploads/789/versions.json")
 }
 
+// TestFilesReplaceRejectsBeforeStaging pins that every locally-detectable
+// problem — a URL for a different account, a non-positive ID, a description
+// whose local image reference doesn't resolve — fails before ANY request is
+// made, so a large replacement is never transferred toward a doomed call.
+func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
+	for name, tc := range map[string]struct {
+		args []string
+	}{
+		"foreign-account URL": {
+			args: []string{"replace", "https://3.basecamp.com/12345/buckets/456/uploads/789", ""},
+		},
+		"zero upload ID": {
+			args: []string{"replace", "0", ""},
+		},
+		"unresolvable description image": {
+			args: []string{"replace", "789", "", "--description", "![preview](missing-image-file.png)"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			transport := &mockFilesReplaceTransport{}
+			app := showTestApp(t, transport)
+
+			args := tc.args
+			args[2] = writeTempUpload(t)
+			cmd := NewFilesCmd()
+			err := executeMessagesCommand(cmd, app, args...)
+			require.Error(t, err)
+			assert.Empty(t, transport.postPaths, "nothing may be staged or mutated")
+		})
+	}
+}
+
 // TestFilesReplaceBaseNameReachesTheWire pins --base-name: the rename travels
 // as base_name (the server keeps the staged file's extension), and omitting
 // the flag keeps the field off the wire so the uploaded name stands.

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1412,6 +1412,8 @@ func TestFilesReplaceStagesAndCreatesVersion(t *testing.T) {
 	assert.False(t, hasDescription, "omitted --description must not reach the wire")
 	_, hasNotify := body["notify"]
 	assert.False(t, hasNotify, "no notify field means notify nobody")
+	_, hasBaseName := body["base_name"]
+	assert.False(t, hasBaseName, "omitted --base-name keeps the uploaded filename")
 }
 
 // TestFilesReplaceAcceptsURL verifies a pasted upload URL resolves to the
@@ -1425,6 +1427,22 @@ func TestFilesReplaceAcceptsURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, transport.postPaths, 2)
 	assert.Contains(t, transport.postPaths[1], "/uploads/789/versions.json")
+}
+
+// TestFilesReplaceBaseNameReachesTheWire pins --base-name: the rename travels
+// as base_name (the server keeps the staged file's extension), and omitting
+// the flag keeps the field off the wire so the uploaded name stands.
+func TestFilesReplaceBaseNameReachesTheWire(t *testing.T) {
+	transport := &mockFilesReplaceTransport{}
+	app := showTestApp(t, transport)
+
+	cmd := NewFilesCmd()
+	err := executeMessagesCommand(cmd, app, "replace", "789", writeTempUpload(t), "--base-name", "build-v2")
+	require.NoError(t, err)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(transport.versionBody, &body))
+	assert.Equal(t, "build-v2", body["base_name"])
 }
 
 // TestFilesReplaceDescriptionTriState pins the presence-aware description:

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1452,6 +1452,14 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 		"uploads collection URL (vault-scoped)": {
 			args: []string{"replace", "https://3.basecamp.com/99999/buckets/456/vaults/555/uploads", ""},
 		},
+		"untrusted host with matching account and path": {
+			args: []string{"replace", "https://evil.example/99999/buckets/456/uploads/789", ""},
+		},
+		"description mixing a valid and a missing image": {
+			// The valid image must NOT upload before the missing one is
+			// discovered — resolveLocalImages preflights every reference.
+			args: []string{"replace", "789", "", "--description", "![gone](missing-image-file.png) and ![ok](VALID_IMAGE)"},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			transport := &mockFilesReplaceTransport{}
@@ -1459,6 +1467,13 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 
 			args := tc.args
 			args[2] = writeTempUpload(t)
+			for i, a := range args {
+				if strings.Contains(a, "VALID_IMAGE") {
+					img := filepath.Join(t.TempDir(), "ok.png")
+					require.NoError(t, os.WriteFile(img, []byte("png-bytes"), 0o644))
+					args[i] = strings.ReplaceAll(a, "VALID_IMAGE", img)
+				}
+			}
 			cmd := NewFilesCmd()
 			err := executeMessagesCommand(cmd, app, args...)
 			require.Error(t, err)

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1449,6 +1449,9 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 		"same-account URL of another recording type": {
 			args: []string{"replace", "https://3.basecamp.com/99999/buckets/456/todos/789", ""},
 		},
+		"uploads collection URL (vault-scoped)": {
+			args: []string{"replace", "https://3.basecamp.com/99999/buckets/456/vaults/555/uploads", ""},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			transport := &mockFilesReplaceTransport{}
@@ -1470,7 +1473,7 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 func TestShellQuote(t *testing.T) {
 	for input, want := range map[string]string{
 		"789": "789",
-		"https://3.basecamp.com/99999/buckets/456/uploads/789": "https://3.basecamp.com/99999/buckets/456/uploads/789",
+		"https://3.basecamp.com/99999/buckets/456/uploads/789":                  "https://3.basecamp.com/99999/buckets/456/uploads/789",
 		"https://3.basecamp.com/99999/buckets/456/uploads/789?x=$(touch pwned)": `'https://3.basecamp.com/99999/buckets/456/uploads/789?x=$(touch pwned)'`,
 		"release;id":         `'release;id'`,
 		"$(command) project": `'$(command) project'`,

--- a/internal/commands/files_test.go
+++ b/internal/commands/files_test.go
@@ -1446,6 +1446,9 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 		"unresolvable description image": {
 			args: []string{"replace", "789", "", "--description", "![preview](missing-image-file.png)"},
 		},
+		"same-account URL of another recording type": {
+			args: []string{"replace", "https://3.basecamp.com/99999/buckets/456/todos/789", ""},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			transport := &mockFilesReplaceTransport{}
@@ -1458,6 +1461,24 @@ func TestFilesReplaceRejectsBeforeStaging(t *testing.T) {
 			require.Error(t, err)
 			assert.Empty(t, transport.postPaths, "nothing may be staged or mutated")
 		})
+	}
+}
+
+// TestShellQuote pins the breadcrumb encoding: inert strings (IDs, plain
+// Basecamp URLs) pass bare, and everything else is single-quoted so no shell
+// syntax survives — quoting is an encoding, not a metacharacter list.
+func TestShellQuote(t *testing.T) {
+	for input, want := range map[string]string{
+		"789": "789",
+		"https://3.basecamp.com/99999/buckets/456/uploads/789": "https://3.basecamp.com/99999/buckets/456/uploads/789",
+		"https://3.basecamp.com/99999/buckets/456/uploads/789?x=$(touch pwned)": `'https://3.basecamp.com/99999/buckets/456/uploads/789?x=$(touch pwned)'`,
+		"release;id":         `'release;id'`,
+		"$(command) project": `'$(command) project'`,
+		"My Project":         `'My Project'`,
+		"O'Brien's":          `'O'\''Brien'\''s'`,
+		"":                   `''`,
+	} {
+		assert.Equal(t, want, shellQuote(input), "shellQuote(%q)", input)
 	}
 }
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -764,6 +764,8 @@ basecamp files list --all-projects --all                # Every page (slow on bi
 basecamp files show <id> --in <project>                 # Show item (auto-detects type)
 basecamp files versions <upload_id> --json              # Every version of an uploaded file
 basecamp files versions <upload_id> --limit 5 --json    # Cap results (default: all)
+basecamp files replace <upload_id> <file>               # Replace the file, keep the ID/URL/comments
+basecamp files replace <upload_id> <file> --description "v2 notes"  # Also set a new description
 basecamp files download <id> --in <project>             # Download file
 basecamp files download <id> --out ./dir                # Download to specific dir
 basecamp files download "https://storage.../download/f" # Download from storage URL
@@ -798,6 +800,10 @@ remediation for nested docs/uploads.
 upload ID, so `basecamp files versions <upload_id>` is how you see the history of
 one file. A file that was never replaced returns its single current version, not
 an error. Only `--page 1` is accepted; use `--all` to walk every page.
+`basecamp files replace <upload_id> <file>` publishes a new version in place —
+the upload keeps its ID, URL and comments, nobody is notified, and the
+description carries forward unless `--description` is given. Use it instead of
+`uploads create` when shipping a new build of the same file.
 
 **Subcommands:** `folders`, `uploads`, `documents` (each with pagination flags)
 


### PR DESCRIPTION
Closes #404 — the write half of the upload-versions story. #622's `files
versions` reads the history; `files replace <upload-id|url> <file>` writes to
it, over SDK v0.14.0's `UploadsService.CreateVersion`: stage the file as an
attachment (the same two-step flow as `uploads create`), then POST it to the
upload's versions endpoint.

The upload keeps its id, URL and comments; the previous file becomes a past
version. That's the issue's use case verbatim: a release script ships each
build to the same published link instead of minting duplicates. (#404
proposed PUT-with-sgid on the upload itself — bc3 has since shipped the
dedicated versions endpoint, which is what this rides.)

Semantics follow the endpoint's presence rules:
- nobody is notified (no `notify` on the wire)
- the description carries forward unless `--description` is given; an
  explicit `--description ""` clears it (tri-state pinned by
  `TestFilesReplaceDescriptionTriState`, including that omission stays off
  the wire)
- `--base-name` renames without touching the extension
- alias: `files new-version`

Completeness bar: catalog action, API-COVERAGE row, SKILL.md examples +
semantics note, `.surface` regenerated (406 lines — command + alias across
the tree), unit tests (two-step flow order, URL acceptance, tri-state), a
real write smoke (`files replace` on the suite's own created upload, then
`files versions` asserting exactly one current) plus out-of-scope markers for
the alias leaves.

**Live-verified against production**: `uploads create` → `files replace` →
`files versions` shows both filenames with exactly one `current: true`, same
upload id throughout. Verification upload trashed after.

`bin/ci` green at the head (real exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `basecamp files replace` to publish a new version of an uploaded file while keeping the same upload ID/URL and comments. This delivers the write half of #404 and pairs with `files versions` to support stable links for new builds.

- New Features
  - Command: `basecamp files replace <upload-id|url> <file>` (alias: `new-version`) via SDK `UploadsService.CreateVersion` (stage attachment, then POST to versions).
  - Behavior: no notifications; description carries forward unless `--description` is set (empty clears); `--base-name` renames without changing the extension.
  - Accepts an upload ID or full Basecamp URL; returns the same upload with the new current version.
  - Updated command catalog/help; unit and e2e smoke tests; API coverage docs include replace.

- Bug Fixes
  - Pre-flight validation: reject URLs on untrusted hosts, URLs for a different account, non-positive upload IDs, wrong recording types, uploads collection/listing URLs (must target a single upload), and unresolved local images in `--description` before staging any data.
  - Breadcrumbs: reuse the caller’s reference; include `--project` with fallback to the root-level `--project` when the group flag is unset; shell-quote all embedded values (both `files replace` and `files versions`) so emitted commands are safe and round-trip through a shell.
  - Smoke test: read JSON from `$output` directly; tests pin `--base-name` presence/omission behavior.

<sup>Written for commit a0a5ec2c25920530e046cb6b677cffa21deec0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

