### PR TITLE
Add hey-cli Windows signing secrets to the release env manifest

### DIFF
--- a/scripts/manage-release-env.sh
+++ b/scripts/manage-release-env.sh
@@ -44,6 +44,9 @@ SECRETS_MANIFEST=(
   "basecamp/hey-cli|MACOS_NOTARY_KEY_ID|macOS Notarization/key-id"
   "basecamp/hey-cli|MACOS_NOTARY_ISSUER_ID|macOS Notarization/issuer-id"
   "basecamp/hey-cli|AUR_KEY|AUR SSH Key/private-key"
+  "basecamp/hey-cli|SM_API_KEY|DigiCert CodeSigning Cert/SM_API_KEY"
+  "basecamp/hey-cli|SM_CLIENT_CERT_FILE_B64|DigiCert CodeSigning Cert/SM_CLIENT_CERT_FILE_B64"
+  "basecamp/hey-cli|SM_CLIENT_CERT_PASSWORD|DigiCert CodeSigning Cert/SM_CLIENT_CERT_PASSWORD"
   "basecamp/fizzy-cli|RELEASE_APP_PRIVATE_KEY|Release GitHub App/private-key"
   "basecamp/fizzy-cli|MACOS_SIGN_P12|macOS Code Signing/p12-base64"
   "basecamp/fizzy-cli|MACOS_SIGN_PASSWORD|macOS Code Signing/password"
@@ -57,7 +60,7 @@ SECRETS_MANIFEST=(
 # Vars to migrate per repo (repo|var_name)
 VARS_MANIFEST=(
   "basecamp/basecamp-cli|RELEASE_CLIENT_ID"
-  "basecamp/hey-cli|RELEASE_APP_ID"
+  "basecamp/hey-cli|RELEASE_CLIENT_ID"
   "basecamp/fizzy-cli|RELEASE_CLIENT_ID"
   "basecamp/cli|SKILLS_APP_ID"
 )


### PR DESCRIPTION
hey-cli is adopting the DigiCert KeyLocker Authenticode pipeline (basecamp/hey-cli PR "Sign Windows binaries and the PowerShell installer via DigiCert KeyLocker"), so its `release` environment needs the three `SM_*` secrets from the shared **DigiCert CodeSigning Cert** 1Password item. Its app token step now uses `client-id` (the `app-id` input is deprecated), so the var to migrate is `RELEASE_CLIENT_ID`, in line with basecamp-cli and fizzy-cli.

After merging: `scripts/manage-release-env.sh migrate-secrets --op-vault <vault>` for `basecamp/hey-cli`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DigiCert KeyLocker Authenticode secrets to the `basecamp/hey-cli` release environment and migrate its app token var to `RELEASE_CLIENT_ID`. Previously the env lacked the `SM_*` secrets and used the deprecated `RELEASE_APP_ID`; now Windows binaries and the PowerShell installer can be signed and the workflow uses `client-id`.

- Add `SM_API_KEY`, `SM_CLIENT_CERT_FILE_B64`, and `SM_CLIENT_CERT_PASSWORD` from the “DigiCert CodeSigning Cert” 1Password item.
- Replace `RELEASE_APP_ID` with `RELEASE_CLIENT_ID` for `basecamp/hey-cli` to match other CLIs.
- Required: run `scripts/manage-release-env.sh migrate-secrets --op-vault <vault>` for `basecamp/hey-cli`.

<sup>Written for commit b6537b8f5edab2a66c4b90196b29f6b35054551d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

