### PR TITLE
Bound stdin (and the --file twin) at 1 MiB

### DIFF
--- a/internal/commands/notes.go
+++ b/internal/commands/notes.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -196,11 +197,11 @@ func notesContent(cmd *cobra.Command, args []string, file string) (string, error
 		}
 		return notesRequireContent(content)
 	case file != "":
-		data, err := os.ReadFile(file)
+		content, err := notesFileContent(file)
 		if err != nil {
-			return "", output.ErrUsage(fmt.Sprintf("failed to read %s: %v", file, err))
+			return "", err
 		}
-		return notesRequireContent(string(data))
+		return notesRequireContent(content)
 	case positional != "":
 		content, err := resolveContentValue(cmd, positional, 0, "[content]")
 		if err != nil {
@@ -213,6 +214,25 @@ func notesContent(cmd *cobra.Command, args []string, file string) (string, error
 		"note content is required",
 		`Pass it as an argument, with --file, or pipe it and pass "-": basecamp notes set -`,
 	)
+}
+
+// notesFileContent reads --file under the same cap as --file -, so which side
+// of the "-" the bytes arrive on never changes whether they are accepted.
+func notesFileContent(file string) (string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return "", output.ErrUsage(fmt.Sprintf("failed to read %s: %v", file, err))
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, maxStdinContent+1))
+	if err != nil {
+		return "", output.ErrUsage(fmt.Sprintf("failed to read %s: %v", file, err))
+	}
+	if len(data) > maxStdinContent {
+		return "", output.ErrUsage(fmt.Sprintf("--file %s exceeds %d bytes", file, maxStdinContent))
+	}
+	return string(data), nil
 }
 
 // notesRequireContent refuses to blank the note by accident.

--- a/internal/commands/notes_test.go
+++ b/internal/commands/notes_test.go
@@ -124,6 +124,26 @@ func TestNotesSetReadsFromAFile(t *testing.T) {
 	assert.NotContains(t, body.Note.Content, "# Heading", "raw Markdown must not reach the wire")
 }
 
+// --file and --file - are the same read, so they agree on the boundary: a file
+// of exactly maxStdinContent is content, one byte past it is a usage error.
+func TestNotesSetBoundsFileAtTheStdinCap(t *testing.T) {
+	dir := t.TempDir()
+	atCap := filepath.Join(dir, "at-cap.md")
+	require.NoError(t, os.WriteFile(atCap, []byte(strings.Repeat("a", maxStdinContent)), 0o600))
+	overCap := filepath.Join(dir, "over-cap.md")
+	require.NoError(t, os.WriteFile(overCap, []byte(strings.Repeat("a", maxStdinContent+1)), 0o600))
+
+	app, transport, _ := setupPersonalFeedApp(t, notesUpdateRoute())
+	require.NoError(t, executeRecordingCommand(NewNotesCmd(), app, "set", "--file", atCap))
+	assert.NotEmpty(t, transport.recorded())
+
+	app, transport, _ = setupPersonalFeedApp(t, notesUpdateRoute())
+	err := executeRecordingCommand(NewNotesCmd(), app, "set", "--file", overCap)
+	outErr := requireBookmarksUsageError(t, err)
+	assert.Contains(t, outErr.Message, "exceeds 1048576 bytes")
+	assert.Empty(t, transport.recorded(), "a rejected write must not reach the server")
+}
+
 func TestNotesSetReadsDashFromStdin(t *testing.T) {
 	app, transport, _ := setupPersonalFeedApp(t, notesUpdateRoute())
 

--- a/internal/commands/stdin.go
+++ b/internal/commands/stdin.go
@@ -37,6 +37,13 @@ func allowDash(cmd *cobra.Command, tokens ...string) {
 	cmd.Annotations[stdinarg.AnnotationAllowDash] = merged
 }
 
+// maxStdinContent caps how much a "-" placeholder — and the --file twin that
+// shares its refusals — will read. It matches maxAgentHookInput by coincidence
+// of scale, not by kinship: that one bounds a JSON envelope an agent harness
+// writes, this one bounds prose a person pipes, and the two should stay free
+// to move apart.
+const maxStdinContent = 1 << 20
+
 // readStdinContent reads content for a "-" placeholder from piped stdin.
 //
 // Nothing piped (a TTY) is a usage error rather than a silent read: waiting on
@@ -44,6 +51,15 @@ func allowDash(cmd *cobra.Command, tokens ...string) {
 // hatches instead. A piped-but-blank stdin is also refused — blank content is
 // never an intentional write, and for update-style commands it would be an
 // implicit clear.
+//
+// A stream over maxStdinContent is refused as well, and refused rather than
+// truncated: `yes | basecamp api post /valid --data -` is a perfectly valid
+// invocation that would otherwise read until the process dies, and silently
+// posting the first megabyte would write partial content to Basecamp and
+// report success — unrecoverable once saved. The cap counts bytes read, so it
+// lands before the trim below rather than on the trimmed result: telling an
+// overflow that is only a trailing newline from any other would mean reading
+// past the cap, which is the thing being prevented.
 //
 // Trailing newlines — LF and CRLF alike — are trimmed: Markdown bodies don't
 // care, but titles and boosts (16-rune limit) do, and virtually every pipe
@@ -55,9 +71,12 @@ func readStdinContent(cmd *cobra.Command, what string) (string, error) {
 			stdinEscapeHint(cmd, what),
 		)
 	}
-	data, err := io.ReadAll(cmd.InOrStdin())
+	data, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), maxStdinContent+1))
 	if err != nil {
 		return "", output.ErrUsage(fmt.Sprintf("failed to read %s from stdin: %v", what, err))
+	}
+	if len(data) > maxStdinContent {
+		return "", output.ErrUsage(fmt.Sprintf("stdin for %s exceeds %d bytes", what, maxStdinContent))
 	}
 	content := strings.TrimRight(string(data), "\r\n")
 	if strings.TrimSpace(content) == "" {

--- a/internal/commands/stdin_test.go
+++ b/internal/commands/stdin_test.go
@@ -95,6 +95,39 @@ func TestReadStdinContentBlankPipeIsUsageError(t *testing.T) {
 	assert.Contains(t, outErr.Message, "empty")
 }
 
+// The cap is a read bound, so it is checked against the bytes read rather than
+// the trimmed content: exactly maxStdinContent is content, one byte past it is
+// a refusal — including when that byte is the trailing newline every pipe ends
+// with, which is the only way to stop reading at the cap at all.
+func TestReadStdinContentAtTheCapIsAccepted(t *testing.T) {
+	body := strings.Repeat("a", maxStdinContent)
+	cmd := &cobra.Command{Use: "x"}
+	cmd.SetIn(strings.NewReader(body))
+
+	content, err := readStdinContent(cmd, "<content>")
+	require.NoError(t, err)
+	assert.Equal(t, body, content)
+}
+
+func TestReadStdinContentOverTheCapIsUsageError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"one byte over", strings.Repeat("a", maxStdinContent+1)},
+		{"the cap plus a trailing newline", strings.Repeat("a", maxStdinContent) + "\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "x"}
+			cmd.SetIn(strings.NewReader(tc.body))
+
+			_, err := readStdinContent(cmd, "<content>")
+			outErr := requireUsageErr(t, err)
+			assert.Contains(t, outErr.Message, "exceeds 1048576 bytes")
+		})
+	}
+}
+
 func TestResolveContentArgJoinsLiteralArgs(t *testing.T) {
 	cmd := &cobra.Command{Use: "x"}
 	content, err := resolveContentArg(cmd, []string{"hello", "world"}, 1)


### PR DESCRIPTION
## What

Caps `readStdinContent` at `maxStdinContent = 1 << 20`, using the
`io.LimitReader(r, cap+1)`-then-compare idiom already in this package
(`agent_hook.go:238`, `upgrade_selfupdate.go:339`/`:359`). All 36 `-`-accepting
call sites funnel through it, so they all inherit the bound.

`notes set --file <path>` was the file twin of the same read — a bare
`os.ReadFile` — so it gets the same bound and the same error shape via a small
`notesFileContent` helper. Which side of the `-` the bytes arrive on no longer
changes whether they're accepted.

## Why

`readStdinContent` was a bare `io.ReadAll` with no cap.
`yes | basecamp api post /valid --data -` is a **perfectly valid** invocation
that read until the process died. That's why the recent pre-read ordering work
(#641, #645) didn't touch it: nothing here is a doomed invocation to reject
early — the read itself was unbounded.

The sharpest illustration: `boost create -` read the entire stream, copied it to
a string, and *then* rejected it for exceeding 16 characters
(`boost.go:307`). It now stops at 1 MiB before the 16-rune check.

**Refuse, don't truncate.** Silently posting the first megabyte would write
partial content to Basecamp and report success — unrecoverable once saved.

`maxStdinContent` is declared alongside the stdin machinery rather than reusing
`maxAgentHookInput`. Same value today, different purpose — one bounds a JSON
envelope an agent harness writes, the other bounds prose a person pipes — and
they should stay free to move apart.

Left alone deliberately: `internal/editor/editor.go:49` and the TUI composer at
`widget/composer.go:719`. Both read back what the user's own `$EDITOR` just
wrote, which is not a streaming source.

### The trailing-newline edge

The cap counts **bytes read**, so it lands before the trailing-newline trim: a
body of exactly 1 MiB *plus* a trailing `\n` is a refusal. That's the only
implementable answer — telling "the overflow is just a newline" apart from any
other overflow requires reading past the cap, which is the thing being
prevented. Documented in the doc comment and pinned by a subtest so a future
reader doesn't "fix" it.

## Testing

- [x] `make check` passes (via `bin/ci`), including the AST ordering backstop
      `TestSyntacticArgChecksPrecedeStdinReads`

Boundary pairs, not just rejection cases — `stdin_test.go` asserts exactly
`maxStdinContent` is accepted and one byte over is a usage error;
`notes_test.go` does the same for `--file` (the file helper's `+1`/compare is
written separately and could be off by one in the accept direction). The
boundary was verified by **mutation**: bumping the const to `1<<20 + 1` fails
all three assertions, so an off-by-one in either direction is caught.

Smoke (against a dead endpoint, so a proceeding read fails at the network and a
capped read fails before it):

```
1048576 (at cap)   → proceeds to the request  exit=6
1048577 (over cap) → "stdin for <content> exceeds 1048576 bytes"  exit=1
printf 'hello'     → unaffected, proceeds     exit=6
notes set --file <2 MiB>  → "--file /…/big.md exceeds 1048576 bytes"  exit=1
boost create 999 - (over) → "stdin for <content> exceeds 1048576 bytes"  exit=1
yes | api post --data -   → "stdin for --data exceeds 1048576 bytes", terminates <1s
```

The `--file` message names the flag and path rather than mirroring
`stdin for %s` verbatim — parallel shape, but it says what the caller can act
on.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound stdin and `notes --file` reads at 1 MiB to prevent unbounded reads and make file vs stdin behave the same. Previously we read all input; now we refuse inputs over the cap rather than truncating.

- All `-` placeholders now go through capped `readStdinContent`; on overflow we return a usage error: "stdin for <content> exceeds 1048576 bytes".
- `notes set --file <path>` now reads via `notesFileContent` with the same cap; overflow error: "--file <path> exceeds 1048576 bytes".
- The cap applies before trimming the trailing newline. Exactly 1 MiB is accepted; 1 MiB plus newline is refused.
- No changes to `internal/editor/editor.go` or the TUI composer; they read back from `$EDITOR`, not a stream.
- Tests cover the acceptance/refusal boundary in `internal/commands/stdin_test.go` and `internal/commands/notes_test.go`.

Migration: If you pipe more than 1 MiB, the command now fails with a usage error. Reduce the input size or split content before invoking the command.

<sup>Written for commit 35ee36507d35db093bf0bc4a48abf369c9ce8433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

