### PR TITLE
Pin bin/ci's tool versions in .mise.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
+          # The action's default version floats to the latest zizmor release.
+          # Keep in sync with the .mise.toml zizmor pin.
+          version: "1.29.0"
           advanced-security: false
 
   security:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,10 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          # The action's default version floats to the latest zizmor release.
-          # Keep in sync with the .mise.toml zizmor pin.
+          # The action resolves `version` (default "latest") through the digest
+          # map checked in at its pinned SHA, so this stays stable either way —
+          # the explicit pin keeps the release from shifting when the action SHA
+          # is bumped, and matches the .mise.toml zizmor pin for local parity.
           version: "1.29.0"
           advanced-security: false
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,5 +11,5 @@ shellcheck = "0.11.0"
 # tests run locally instead of skipping.
 powershell = "7.6.5"
 # Keep in sync with the zizmor-action `version:` input in
-# .github/workflows/test.yml (the action's default floats to latest).
+# .github/workflows/test.yml so local bin/ci runs the same release CI does.
 zizmor = "1.29.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,14 @@
 go = "1.26"
 # Keep in sync with .github/workflows/release.yml GoReleaser CLI version pin.
 goreleaser = "2.15.4"
+# Keep in sync with .github/workflows/test.yml rhysd/actionlint version pin.
+actionlint = "1.7.12"
+# Not invoked directly; actionlint shells out to it to lint workflow `run:`
+# scripts (CI uses the runner's preinstalled shellcheck).
+shellcheck = "0.11.0"
+# No CI pin to match; runners preinstall pwsh. Lets e2e/installer.bats pwsh
+# tests run locally instead of skipping.
+powershell = "7.6.5"
+# Keep in sync with the zizmor-action `version:` input in
+# .github/workflows/test.yml (the action's default floats to latest).
+zizmor = "1.29.0"


### PR DESCRIPTION
`bin/ci` fails cold in a fresh worktree. mise shims for actionlint, shellcheck, and pwsh exist machine-wide but the project pins no versions, so each shim dies with "No version is set for shim". shellcheck isn't even a repo tool — actionlint shells out to it to lint workflow `run:` blocks, so its broken shim takes actionlint down with it. And zizmor is a fourth gap: `make lint-actions` hard-fails without it, and `make tools` can't install it (brew/pacman only).

This pins all four in `[tools]` so `mise install` makes `bin/ci` self-sufficient:

| Tool | Pin | Sync note |
|---|---|---|
| actionlint | 1.7.12 | matches the `rhysd/actionlint` pin in `.github/workflows/test.yml` |
| shellcheck | 0.11.0 | actionlint's dependency; CI uses the runner's preinstall |
| powershell | 7.6.5 | no CI pin to mirror (runners preinstall pwsh); the three fail-closed-in-CI `installer.bats` pwsh tests now run locally instead of skipping |
| zizmor | 1.29.0 | also pinned via the action's `version:` input in the workflow — its default floats to latest, so the SHA-pinned action still selected a floating zizmor release |

Each pin carries a sync comment mirroring the existing goreleaser convention. No Makefile changes. The workflow's zizmor step gains `version: "1.29.0"` so CI and local runs use the same binary.

Verified: `mise install` then a full `bin/ci` run in a fresh worktree, green with **no** `MISE_*_VERSION` env workaround — actionlint and zizmor 1.29.0 ran, and the pwsh installer tests executed rather than skipping.
