### PR TITLE
Read tables back as Markdown instead of smearing their cells

### DIFF
--- a/internal/richtext/richtext.go
+++ b/internal/richtext/richtext.go
@@ -708,7 +708,27 @@ func HTMLToMarkdown(html string) string {
 	})
 
 	// Lists — use balanced-tag replacement to handle nesting correctly.
+	// Runs before the parked table pass below: list items convert their
+	// tables inline (see formatListItem) so each pipe row picks up the item
+	// indent a parked one-line placeholder would deny it.
 	html = replaceBalancedListBlocks(html)
+
+	// Tables — convert to GFM pipe tables while row and cell tags are still
+	// intact. Must run before the paragraph, line-break, and tag-stripping
+	// passes below, which would otherwise smear cell text together. The
+	// emitted Markdown is parked behind placeholders until every later pass
+	// has run: cell text is fully entity-decoded and escaped, so the
+	// document-level unescape would double-decode it (and could conjure
+	// unescaped pipes out of encoded ones).
+	var tables []string
+	html = reTableBlock.ReplaceAllStringFunc(html, func(s string) string {
+		md := convertTableHTML(s)
+		if md == "" {
+			return "\n\n"
+		}
+		tables = append(tables, md)
+		return "\x00tbl" + strconv.Itoa(len(tables)-1) + "\x00\n\n"
+	})
 
 	// Paragraphs
 	html = reP.ReplaceAllString(html, "$1\n\n")
@@ -745,32 +765,7 @@ func HTMLToMarkdown(html string) string {
 	html = reHTMLStrike.ReplaceAllString(html, "~~$1~~")
 
 	// @-mentions: extract display text, render as bold (must fire before general attachment regex)
-	html = reMentionAttachment.ReplaceAllStringFunc(html, func(s string) string {
-		inner := ""
-		if match := reMentionAttachment.FindStringSubmatch(s); len(match) >= 2 {
-			inner = match[1]
-		}
-
-		name := ""
-		if match := reMentionFigcaption.FindStringSubmatch(inner); len(match) >= 2 {
-			name = strings.TrimSpace(unescapeHTML(reStripTags.ReplaceAllString(match[1], "")))
-		}
-		if name == "" {
-			if match := reMentionImgAlt.FindStringSubmatch(inner); len(match) >= 2 {
-				name = strings.TrimSpace(unescapeHTML(match[1]))
-			}
-		}
-		if name == "" {
-			name = strings.TrimSpace(unescapeHTML(reStripTags.ReplaceAllString(inner, "")))
-		}
-		if name == "" {
-			name = "mention"
-		}
-		if !strings.HasPrefix(name, "@") {
-			name = "@" + name
-		}
-		return "**" + name + "**"
-	})
+	html = reMentionAttachment.ReplaceAllStringFunc(html, mentionMarkdown)
 
 	// Basecamp attachments: <bc-attachment ... filename="report.pdf"> → 📎 report.pdf
 	html = reAttachment.ReplaceAllString(html, "\n📎 $1\n")
@@ -788,7 +783,240 @@ func HTMLToMarkdown(html string) string {
 	// Clean up multiple newlines
 	html = reMultiNewline.ReplaceAllString(html, "\n\n")
 
+	// Restore the parked tables now that no pass can touch their content.
+	for i, table := range tables {
+		html = strings.Replace(html, "\x00tbl"+strconv.Itoa(i)+"\x00", table, 1)
+	}
+
 	return strings.TrimSpace(html)
+}
+
+// mentionMarkdown converts one <bc-attachment> mention element to bold
+// Markdown, extracting the display name from the figcaption, the image alt,
+// or the remaining text, in that order.
+func mentionMarkdown(s string) string {
+	inner := ""
+	if match := reMentionAttachment.FindStringSubmatch(s); len(match) >= 2 {
+		inner = match[1]
+	}
+
+	name := ""
+	if match := reMentionFigcaption.FindStringSubmatch(inner); len(match) >= 2 {
+		name = strings.TrimSpace(unescapeHTML(reStripTags.ReplaceAllString(match[1], "")))
+	}
+	if name == "" {
+		if match := reMentionImgAlt.FindStringSubmatch(inner); len(match) >= 2 {
+			name = strings.TrimSpace(unescapeHTML(match[1]))
+		}
+	}
+	if name == "" {
+		name = strings.TrimSpace(unescapeHTML(reStripTags.ReplaceAllString(inner, "")))
+	}
+	if name == "" {
+		name = "mention"
+	}
+	if !strings.HasPrefix(name, "@") {
+		name = "@" + name
+	}
+	return "**" + name + "**"
+}
+
+// Pre-compiled regexes for HTML table conversion. BC3 rich text is sanitized
+// editor output, not arbitrary email HTML: tables are always flat
+// editor-authored grids (no nesting, no layout tables), so a non-greedy block
+// match is safe and every <table> converts — none are skipped.
+var (
+	reTableBlock     = regexp.MustCompile(`(?is)<table(?:\s[^>]*)?>.*?</table\s*>`)
+	reTableRowHTML   = regexp.MustCompile(`(?is)<tr(?:\s[^>]*)?>(.*?)</tr\s*>`)
+	reTableCellHTML  = regexp.MustCompile(`(?is)<t[hd]((?:\s[^>]*)?)>(.*?)</t[hd]\s*>`)
+	reTableCellAlign = regexp.MustCompile(`(?i)\balign="(left|center|right)"`)
+	reTableCaption   = regexp.MustCompile(`(?is)<caption(?:\s[^>]*)?>(.*?)</caption\s*>`)
+	reWhitespaceRun  = regexp.MustCompile(`\s+`)
+)
+
+// convertTableHTML converts one <table> block to a GFM pipe table. The first
+// row is the header whether its cells are <th> or <td> (GFM has no headerless
+// tables), with its align attributes — what MarkdownToHTML emits for GFM
+// column alignment — mapped back to :--- / :---: / ---: markers. The widest
+// row sizes the table and narrower rows are padded with empty cells. Cells
+// carrying colspan/rowspan emit as ordinary cells: a merged grid displays
+// better flattened than smeared, and editing such tables stays guarded by
+// HasComplexTableHTML.
+func convertTableHTML(table string) string {
+	caption := ""
+	if m := reTableCaption.FindStringSubmatch(table); m != nil {
+		caption = cellMarkdown(m[1])
+	}
+
+	var rows [][]string
+	var aligns []string
+	for _, row := range reTableRowHTML.FindAllStringSubmatch(table, -1) {
+		cells := reTableCellHTML.FindAllStringSubmatch(row[1], -1)
+		if len(cells) == 0 {
+			continue
+		}
+		texts := make([]string, 0, len(cells))
+		for _, cell := range cells {
+			texts = append(texts, cellMarkdown(cell[2]))
+		}
+		if rows == nil {
+			aligns = make([]string, 0, len(cells))
+			for _, cell := range cells {
+				aligns = append(aligns, cellAlign(cell[1]))
+			}
+		}
+		rows = append(rows, texts)
+	}
+	if rows == nil {
+		return caption
+	}
+
+	// Size the table to its widest row, not just the header: truncating a
+	// wider later row would silently drop cell data.
+	width := 0
+	for _, row := range rows {
+		width = max(width, len(row))
+	}
+	separators := make([]string, width)
+	for i := range separators {
+		switch {
+		case i < len(aligns) && aligns[i] == "left":
+			separators[i] = ":---"
+		case i < len(aligns) && aligns[i] == "center":
+			separators[i] = ":---:"
+		case i < len(aligns) && aligns[i] == "right":
+			separators[i] = "---:"
+		default:
+			separators[i] = "---"
+		}
+	}
+
+	pipeRow := func(cells []string) string {
+		for len(cells) < width {
+			cells = append(cells, "")
+		}
+		return "| " + strings.Join(cells, " | ") + " |"
+	}
+	lines := make([]string, 0, len(rows)+1)
+	lines = append(lines, pipeRow(rows[0]), pipeRow(separators))
+	for _, row := range rows[1:] {
+		lines = append(lines, pipeRow(row))
+	}
+	out := strings.Join(lines, "\n")
+	// GFM has no table captions; emit the text as a paragraph above the grid
+	// rather than dropping user-visible content. Caption-bearing tables stay
+	// display-only (HasComplexTableHTML), so this never has to round-trip.
+	if caption != "" {
+		out = caption + "\n\n" + out
+	}
+	return out
+}
+
+// cellAlign extracts the whitelisted align attribute value from a cell's
+// open-tag attributes, or "" when unaligned.
+func cellAlign(attrs string) string {
+	if m := reTableCellAlign.FindStringSubmatch(attrs); m != nil {
+		return strings.ToLower(m[1])
+	}
+	return ""
+}
+
+// reCellEscape matches the characters that must be backslash-escaped in cell
+// text. Pipes would split the row. Backslashes must double: GFM processes
+// escapes left to right, so a lone literal `\` before an escaped pipe would
+// swallow its backslash and turn the pipe back into a delimiter. Ampersands
+// would let decoded text that still looks like an entity (say a literal
+// &#124;) be decoded a second time by goldmark on the next render.
+var reCellEscape = regexp.MustCompile(`[\\|&]`)
+
+// reCodeNonSpaceWS matches whitespace other than plain spaces. Code-span cell
+// content must be one line, but interior spaces are significant in GFM code
+// spans, so only these collapse.
+var reCodeNonSpaceWS = regexp.MustCompile(`[\t\n\r\f\v]+`)
+
+// reAdjacentCode matches the boundary between two code elements with nothing
+// separating them.
+var reAdjacentCode = regexp.MustCompile(`(?i)</code><code(?:\s[^>]*)?>`)
+
+// codeSpanMarkdown wraps code content in a backtick fence long enough to
+// survive backticks in the content, with CommonMark's space padding when the
+// content begins or ends with a backtick — or with a space, since the parser
+// strips exactly one leading/trailing space pair from padded spans and would
+// otherwise eat a significant edge space. All-space content needs no padding:
+// the strip rule exempts it.
+func codeSpanMarkdown(content string) string {
+	longest, run := 0, 0
+	for _, r := range content {
+		if r == '`' {
+			run++
+			longest = max(longest, run)
+		} else {
+			run = 0
+		}
+	}
+	delim := strings.Repeat("`", longest+1)
+	pad := ""
+	edgeSpace := (strings.HasPrefix(content, " ") || strings.HasSuffix(content, " ")) &&
+		strings.TrimSpace(content) != ""
+	if strings.HasPrefix(content, "`") || strings.HasSuffix(content, "`") || edgeSpace {
+		pad = " "
+	}
+	return delim + pad + content + pad + delim
+}
+
+// cellMarkdown converts a table cell's inner HTML to single-line Markdown:
+// inline elements convert as usual, block boundaries (<p>, <br>, and any
+// other leftover tag) collapse to spaces, and backslashes and pipes are
+// escaped so cell text can't break the row. Code spans pass through as
+// placeholders: backslashes are literal inside code, so only their pipes are
+// escaped (GFM's row splitting honors `\|` inside code spans). Entities are
+// fully decoded here, after tags are gone and before escaping — escaping
+// must see the real characters (an encoded pipe is still a pipe, and
+// goldmark would decode it on the next render) — which is why HTMLToMarkdown
+// parks the emitted table out of reach of its document-level unescape pass.
+func cellMarkdown(inner string) string {
+	s := reMentionAttachment.ReplaceAllStringFunc(inner, mentionMarkdown)
+
+	// Adjacent code elements with no gap coalesce into one span: GFM cannot
+	// express them separately (`a``b` pairs the outer fences instead), and
+	// the rendered output of one span is identical.
+	s = reAdjacentCode.ReplaceAllString(s, "")
+
+	var codes []string
+	s = reHTMLCode.ReplaceAllStringFunc(s, func(m string) string {
+		codes = append(codes, reHTMLCode.FindStringSubmatch(m)[1])
+		return "\x00" + strconv.Itoa(len(codes)-1) + "\x00"
+	})
+
+	s = reHTMLStrong.ReplaceAllString(s, "**$1**")
+	s = reHTMLB.ReplaceAllString(s, "**$1**")
+	s = reHTMLEm.ReplaceAllString(s, "*$1*")
+	s = reHTMLI.ReplaceAllString(s, "*$1*")
+	s = reHTMLLink.ReplaceAllString(s, "[$2]($1)")
+	s = reHTMLImgSA.ReplaceAllString(s, "![$2]($1)")
+	s = reHTMLImgAS.ReplaceAllString(s, "![$1]($2)")
+	s = reHTMLImgS.ReplaceAllString(s, "![]($1)")
+	s = reHTMLDel.ReplaceAllString(s, "~~$1~~")
+	s = reHTMLS.ReplaceAllString(s, "~~$1~~")
+	s = reHTMLStrike.ReplaceAllString(s, "~~$1~~")
+	s = reAttachment.ReplaceAllString(s, "📎 $1")
+	s = reAttachClose.ReplaceAllString(s, "")
+	s = reAttachNoFile.ReplaceAllString(s, "📎 attachment")
+	s = reStripTags.ReplaceAllString(s, " ")
+	s = strings.ReplaceAll(html.UnescapeString(s), "\u00a0", " ")
+	s = reCellEscape.ReplaceAllString(s, `\${0}`)
+	s = strings.TrimSpace(reWhitespaceRun.ReplaceAllString(s, " "))
+
+	for i, code := range codes {
+		// Decode before collapsing so entity-encoded newlines (&#10;) can't
+		// slip through and split the row. No TrimSpace: edge spaces are
+		// significant in code spans — codeSpanMarkdown pads so the parser's
+		// strip restores them.
+		code = reCodeNonSpaceWS.ReplaceAllString(html.UnescapeString(code), " ")
+		code = strings.ReplaceAll(code, "|", `\|`)
+		s = strings.Replace(s, "\x00"+strconv.Itoa(i)+"\x00", codeSpanMarkdown(code), 1)
+	}
+	return s
 }
 
 // reBRLine matches a <br> tag followed by an optional newline, collapsing
@@ -799,6 +1027,16 @@ var reBRLine = regexp.MustCompile(`(?i)<br\s*/?\s*>\n?`)
 // formatListItem converts a list item's HTML content to Markdown, handling
 // <br> tags as indented continuation lines.
 func formatListItem(prefix, indent, content string) string {
+	// Tables inside list items convert here, like quoted tables convert in
+	// the blockquote pass: the indentation below applies per line, so the
+	// pipe rows must already be in place. Editing stays blocked by
+	// HasComplexTableHTML.
+	content = reTableBlock.ReplaceAllStringFunc(content, func(s string) string {
+		if md := convertTableHTML(s); md != "" {
+			return "\n" + md + "\n"
+		}
+		return ""
+	})
 	content = strings.TrimSpace(content)
 	content = reBRLine.ReplaceAllString(content, "\n")
 	lines := strings.Split(content, "\n")
@@ -1005,6 +1243,19 @@ func blockquoteInnerToMarkdown(inner string) string {
 	content := strings.TrimSpace(inner)
 	content = reCodeBlock.ReplaceAllStringFunc(content, func(s string) string {
 		return convertCodeBlockHTML(s) + "\n\n"
+	})
+	// Quoted tables convert here, not in HTMLToMarkdown's parked table pass:
+	// the quote prefixes each line below, so the pipe rows must already be in
+	// place. The emitted cells then pass through the document-level unescape,
+	// which is inert for them — cell text is decoded once here and its
+	// ampersands are escaped, so no entity survives to decode again. Editing
+	// quoted tables stays blocked by HasComplexTableHTML regardless.
+	content = reTableBlock.ReplaceAllStringFunc(content, func(s string) string {
+		md := convertTableHTML(s)
+		if md == "" {
+			return "\n\n"
+		}
+		return md + "\n\n"
 	})
 	content = replaceBalancedListBlocks(content)
 	// Replace </p> with double newline (paragraph break) to separate adjacent blocks,
@@ -1506,15 +1757,152 @@ func IsHTML(s string) bool {
 // reTableHTML matches a real <table> tag — with attributes (`<table …>`), bare
 // (`<table>`), or self-closing (`<table/>`) — distinct from the Markdown table
 // detector. The trailing class requires a boundary after the name so longer
-// tags like <tablefoo> don't match. Used to gate the fail-closed TUI edit paths.
+// tags like <tablefoo> don't match.
 var reTableHTML = regexp.MustCompile(`(?i)<table[\s/>]`)
 
-// HasTableHTML reports whether s contains an HTML table element. The TUI in-place
-// editors use this to refuse table-bearing content: HTMLToMarkdown has no table
-// handling and would strip the structure, so those edits fail closed rather than
-// silently flatten the table on resubmit.
-func HasTableHTML(s string) bool {
-	return reTableHTML.MatchString(s)
+// reTableClose matches a closing </table> tag.
+var reTableClose = regexp.MustCompile(`(?i)</table\s*>`)
+
+// Complexity markers within a table block: merged cells (matched against a
+// cell's open-tag attributes, so prose that merely mentions colspan= stays
+// simple); block elements, captions, attachments, and images anywhere inside
+// the table; header cells beyond the first row (GFM has exactly one header
+// row); and cells whose content spans multiple paragraphs, divs, or lines.
+// All are shapes a GFM pipe table cannot represent — cellMarkdown flattens
+// them to single-line text for display, so resubmitting would lose the
+// structure.
+var (
+	reTableMergedCell   = regexp.MustCompile(`(?i)\b(?:colspan|rowspan)\s*=`)
+	reTableComplexInner = regexp.MustCompile(`(?i)<(?:ul|ol|pre|blockquote|h[1-6]|hr|caption|figure|img|bc-attachment)[\s/>]`)
+	reTableTH           = regexp.MustCompile(`(?i)<th[\s/>]`)
+	reOpeningDiv        = regexp.MustCompile(`(?i)<div(?:\s[^>]*)?>`)
+	// BC3's sanitizer preserves color/background-color styles; conversion
+	// strips them, so a styled tag anywhere in the table is data an edit
+	// would lose.
+	reTableStyledTag = regexp.MustCompile(`(?i)<[^>]*\bstyle\s*=`)
+)
+
+// reWholeCellWrapper matches cell content that is exactly one <p> or <div>
+// element wrapping everything — the shape whose boundary costs nothing to
+// flatten.
+var reWholeCellWrapper = regexp.MustCompile(`(?is)^(?:<p(?:\s[^>]*)?>.*</p\s*>|<div(?:\s[^>]*)?>.*</div\s*>)$`)
+
+// cellFlattensLineStructure reports whether a cell's inner HTML carries line
+// structure cellMarkdown would flatten to spaces: any <br>, more than one
+// block wrapper, or a single <p>/<div> that doesn't wrap the entire cell.
+func cellFlattensLineStructure(inner string) bool {
+	if reBR.MatchString(inner) {
+		return true
+	}
+	blocks := len(reOpeningP.FindAllString(inner, -1)) + len(reOpeningDiv.FindAllString(inner, -1))
+	if blocks > 1 {
+		return true
+	}
+	return blocks == 1 && !reWholeCellWrapper.MatchString(strings.TrimSpace(inner))
+}
+
+// reTableContext matches the tags whose nesting decides whether a table sits
+// inside another block container (a blockquote or a list item). GFM pipe
+// tables are top-level only, so a table nested in either cannot round-trip.
+var reTableContext = regexp.MustCompile(`(?i)<(/?)(blockquote|li|table)[\s/>]`)
+
+// tableHasGrid reports whether a table block contains at least one row with
+// at least one cell — the minimum structure convertTableHTML can emit.
+func tableHasGrid(block string) bool {
+	for _, row := range reTableRowHTML.FindAllStringSubmatch(block, -1) {
+		if reTableCellHTML.MatchString(row[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasComplexTableHTML reports whether s contains a table that HTMLToMarkdown
+// cannot round-trip as a GFM pipe table: merged cells (colspan/rowspan), a
+// nested table, block content inside a cell, or the table itself nested in a
+// blockquote or list. The TUI in-place editors use this to gate edits —
+// HTMLToMarkdown still converts such tables for display, best-effort, but an
+// edit-and-resubmit would flatten the structure, so those edits fail closed.
+// Simple grids round-trip cleanly and stay editable.
+func HasComplexTableHTML(s string) bool {
+	depth := 0
+	for _, m := range reTableContext.FindAllStringSubmatch(s, -1) {
+		closing := m[1] == "/"
+		if strings.EqualFold(m[2], "table") {
+			if !closing && depth > 0 {
+				return true
+			}
+		} else if closing {
+			if depth > 0 {
+				depth--
+			}
+		} else {
+			depth++
+		}
+	}
+
+	for {
+		open := reTableHTML.FindStringIndex(s)
+		if open == nil {
+			return false
+		}
+		rest := s[open[1]:]
+		closeTag := reTableClose.FindStringIndex(rest)
+		// No closing tag: the converter can't parse the table, so nothing
+		// about the edit loop is safe. Fail closed.
+		if closeTag == nil {
+			return true
+		}
+		block := rest[:closeTag[0]]
+		if reTableHTML.MatchString(block) {
+			return true
+		}
+		// A table the converter can't extract a grid from vanishes from the
+		// Markdown; if it holds any text, that vanishing is data loss.
+		if !tableHasGrid(block) && strings.TrimSpace(reStripTags.ReplaceAllString(block, "")) != "" {
+			return true
+		}
+		// Mentions are the one rich element cells may keep: they convert to
+		// **@Name** exactly as they do in body text. Strip them before
+		// scanning for content the conversion would lose.
+		stripped := reMentionAttachment.ReplaceAllString(block, "")
+		if reTableComplexInner.MatchString(stripped) || reTableStyledTag.MatchString(stripped) {
+			return true
+		}
+		var headerAligns []string
+		for ri, row := range reTableRowHTML.FindAllStringSubmatch(block, -1) {
+			// convertTableHTML promotes only the first row to the GFM header;
+			// a <th> in any later row would be demoted to a plain cell.
+			if ri > 0 && reTableTH.MatchString(row[1]) {
+				return true
+			}
+			for ci, cell := range reTableCellHTML.FindAllStringSubmatch(row[1], -1) {
+				if reTableMergedCell.MatchString(cell[1]) {
+					return true
+				}
+				if cellFlattensLineStructure(cell[2]) {
+					return true
+				}
+				// GFM alignment is a column property declared by the header
+				// row; a later cell whose align differs from its column's
+				// cannot round-trip. Our own MarkdownToHTML output aligns
+				// every cell with its column, so real CLI tables pass.
+				align := cellAlign(cell[1])
+				if ri == 0 {
+					headerAligns = append(headerAligns, align)
+				} else {
+					want := ""
+					if ci < len(headerAligns) {
+						want = headerAligns[ci]
+					}
+					if align != want {
+						return true
+					}
+				}
+			}
+		}
+		s = rest[closeTag[1]:]
+	}
 }
 
 func isEscapedAt(s string, pos int) bool {

--- a/internal/richtext/richtext_test.go
+++ b/internal/richtext/richtext_test.go
@@ -922,6 +922,48 @@ func TestEditLoopRoundTrip(t *testing.T) {
 			markdown: "# Title\n\nSome **bold** text.\n\n- Item 1\n- Item 2\n\n> A quote\n\n```\ncode\n```",
 			expected: "# Title\n\nSome **bold** text.\n\n- Item 1\n- Item 2\n\n> A quote\n\n```\ncode\n```",
 		},
+		{
+			name:     "table",
+			markdown: "| Foo | Bar |\n| --- | --- |\n| Baz | Qux |",
+			expected: "| Foo | Bar |\n| --- | --- |\n| Baz | Qux |",
+		},
+		{
+			name:     "table with alignment",
+			markdown: "| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |",
+			expected: "| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |",
+		},
+		{
+			// The #648 separator (<p><br></p>) before the table must come back
+			// as the blank line it encodes.
+			name:     "paragraph then table",
+			markdown: "Intro.\n\n| a | b |\n| --- | --- |\n| c | d |",
+			expected: "Intro.\n\n| a | b |\n| --- | --- |\n| c | d |",
+		},
+		{
+			name:     "table cell with escaped pipe after backslash",
+			markdown: "| h |\n| --- |\n| a\\\\\\|b |",
+			expected: "| h |\n| --- |\n| a\\\\\\|b |",
+		},
+		{
+			name:     "table cell with code span containing a pipe",
+			markdown: "| h |\n| --- |\n| `a\\|b` |",
+			expected: "| h |\n| --- |\n| `a\\|b` |",
+		},
+		{
+			name:     "table cell with ampersand",
+			markdown: "| h |\n| --- |\n| AT\\&T |",
+			expected: "| h |\n| --- |\n| AT\\&T |",
+		},
+		{
+			name:     "table cell with code span containing a backtick",
+			markdown: "| h |\n| --- |\n| ``a`b`` |",
+			expected: "| h |\n| --- |\n| ``a`b`` |",
+		},
+		{
+			name:     "table cell with space-padded code span",
+			markdown: "| h |\n| --- |\n| `  a  ` |",
+			expected: "| h |\n| --- |\n| `  a  ` |",
+		},
 	}
 
 	for _, tt := range tests {
@@ -930,6 +972,279 @@ func TestEditLoopRoundTrip(t *testing.T) {
 			back := HTMLToMarkdown(html)
 			if back != tt.expected {
 				t.Errorf("round-trip mismatch\nmarkdown: %q\nhtml:     %q\ngot:      %q\nwant:     %q", tt.markdown, html, back, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHTMLToMarkdownTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "thead th and tbody td",
+			input:    "<table>\n<thead>\n<tr>\n<th>Foo</th>\n<th>Bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Baz</td>\n<td>Qux</td>\n</tr>\n</tbody>\n</table>",
+			expected: "| Foo | Bar |\n| --- | --- |\n| Baz | Qux |",
+		},
+		{
+			// Trix-style grid with no <thead>: the first row is promoted to
+			// the header — GFM has no headerless tables.
+			name:     "td-only table",
+			input:    "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>",
+			expected: "| a | b |\n| --- | --- |\n| c | d |",
+		},
+		{
+			name:     "alignment attributes",
+			input:    `<table><thead><tr><th align="left">L</th><th align="center">C</th><th align="right">R</th></tr></thead><tbody><tr><td align="left">a</td><td align="center">b</td><td align="right">c</td></tr></tbody></table>`,
+			expected: "| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |",
+		},
+		{
+			name:     "pipe in cell text is escaped",
+			input:    "<table><tr><td>a|b</td><td>c</td></tr></table>",
+			expected: "| a\\|b | c |\n| --- | --- |",
+		},
+		{
+			name:     "inline formatting in cells",
+			input:    `<table><tr><th>Who</th><th>What</th></tr><tr><td><strong>bold</strong> and <em>italic</em></td><td><code>code</code> and <a href="https://example.com">link</a></td></tr></table>`,
+			expected: "| Who | What |\n| --- | --- |\n| **bold** and *italic* | `code` and [link](https://example.com) |",
+		},
+		{
+			name:     "mention in cell",
+			input:    `<table><tr><th>Owner</th></tr><tr><td><bc-attachment content-type="application/vnd.basecamp.mention"><figure><img alt="Jane Doe"><figcaption>Jane Doe</figcaption></figure></bc-attachment></td></tr></table>`,
+			expected: "| Owner |\n| --- |\n| **@Jane Doe** |",
+		},
+		{
+			name:     "multi-paragraph cell joins with spaces",
+			input:    "<table><tr><th>Notes</th></tr><tr><td><p>one</p><p>two</p></td></tr></table>",
+			expected: "| Notes |\n| --- |\n| one two |",
+		},
+		{
+			name:     "br in cell joins with spaces",
+			input:    "<table><tr><th>Notes</th></tr><tr><td>one<br>two</td></tr></table>",
+			expected: "| Notes |\n| --- |\n| one two |",
+		},
+		{
+			name:     "ragged row padded to header width",
+			input:    "<table><tr><th>a</th><th>b</th></tr><tr><td>c</td></tr></table>",
+			expected: "| a | b |\n| --- | --- |\n| c |  |",
+		},
+		{
+			// Truncating would silently drop cell data, so the widest row
+			// sizes the table.
+			name:     "row wider than header widens the table",
+			input:    "<table><tr><th>a</th></tr><tr><td>b</td><td>c</td></tr></table>",
+			expected: "| a |  |\n| --- | --- |\n| b | c |",
+		},
+		{
+			// A literal backslash must double, or GFM's left-to-right escape
+			// processing would pair it with the escaped pipe's backslash and
+			// turn the pipe back into a delimiter.
+			name:     "backslash before pipe in cell text",
+			input:    `<table><tr><td>a\|b</td><td>c</td></tr></table>`,
+			expected: "| a\\\\\\|b | c |\n| --- | --- |",
+		},
+		{
+			// Backslashes are literal inside code spans, so only the pipe is
+			// escaped there.
+			name:     "code span with pipe and backslash",
+			input:    `<table><tr><td><code>a|b</code></td><td><code>c\d</code></td></tr></table>`,
+			expected: "| `a\\|b` | `c\\d` |\n| --- | --- |",
+		},
+		{
+			name:     "table between paragraphs",
+			input:    "<p>Intro.</p>\n<p><br></p>\n<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n</tbody>\n</table>\n<p><br></p>\n<p>After.</p>",
+			expected: "Intro.\n\n| a |\n| --- |\n| b |\n\nAfter.",
+		},
+		{
+			// Best-effort display of shapes GFM can't represent: merged cells
+			// emit as ordinary cells (editing stays guarded by
+			// HasComplexTableHTML).
+			name:     "colspan cell emits as ordinary cell",
+			input:    `<table><tr><th>a</th><th>b</th></tr><tr><td colspan="2">wide</td></tr></table>`,
+			expected: "| a | b |\n| --- | --- |\n| wide |  |",
+		},
+		{
+			// Quoted tables convert inside the blockquote pass so every pipe
+			// row carries the quote prefix; editing them stays guarded.
+			name:     "table inside blockquote keeps the quote",
+			input:    "<blockquote><table><tr><th>a</th></tr><tr><td>b</td></tr></table></blockquote>",
+			expected: "> | a |\n> | --- |\n> | b |",
+		},
+		{
+			// List-nested tables convert inside the list pass so every pipe
+			// row carries the item indent; editing them stays guarded.
+			name:     "table inside list item keeps the indent",
+			input:    "<ul><li><table><tr><th>a</th></tr><tr><td>b</td></tr></table></li></ul>",
+			expected: "- | a |\n  | --- |\n  | b |",
+		},
+		{
+			// GFM has no captions; the text surfaces as a paragraph above the
+			// grid instead of vanishing. Editing stays guarded.
+			name:     "caption becomes a leading paragraph",
+			input:    "<table><caption>Quarterly results</caption><tr><th>a</th></tr><tr><td>b</td></tr></table>",
+			expected: "Quarterly results\n\n| a |\n| --- |\n| b |",
+		},
+		{
+			name:     "empty table vanishes",
+			input:    "<p>Before.</p><table></table><p>After.</p>",
+			expected: "Before.\n\nAfter.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HTMLToMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("HTMLToMarkdown(%q)\ngot:  %q\nwant: %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestHTMLToMarkdownTableGoldmarkRoundTrip verifies cell CONTENT survives a
+// full HTML -> Markdown -> HTML cycle by checking what goldmark parses back
+// out of the emitted pipe table — not just the Markdown bytes. This is what
+// proves the escaping actually escapes: a broken escape still produces
+// plausible-looking Markdown, but goldmark splits the row differently.
+func TestHTMLToMarkdownTableGoldmarkRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantInHTML []string
+		wantTables int
+	}{
+		{
+			name:       "backslash before pipe in text",
+			input:      `<table><tr><th>h</th></tr><tr><td>a\|b</td></tr></table>`,
+			wantInHTML: []string{`<td>a\|b</td>`},
+			wantTables: 1,
+		},
+		{
+			name:       "code span containing a pipe",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a|b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a|b</code></td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "code span containing a backslash",
+			input:      `<table><tr><th>h</th></tr><tr><td><code>a\b</code></td></tr></table>`,
+			wantInHTML: []string{`<td><code>a\b</code></td>`},
+			wantTables: 1,
+		},
+		{
+			// goldmark percent-encodes the escaped pipe in the destination;
+			// the URL is equivalent and the row stays intact.
+			name:       "link destination containing a pipe",
+			input:      `<table><tr><th>h</th></tr><tr><td><a href="https://example.com/a|b">t</a></td></tr></table>`,
+			wantInHTML: []string{`<td><a href="https://example.com/a%7Cb">t</a></td>`},
+			wantTables: 1,
+		},
+		{
+			// An encoded pipe is still a pipe: goldmark decodes the entity on
+			// the next render, so cellMarkdown must decode-then-escape or the
+			// entity smuggles an unescaped pipe into the cell.
+			name:       "entity-encoded pipe in text",
+			input:      "<table><tr><th>h</th></tr><tr><td>a&#124;b</td></tr></table>",
+			wantInHTML: []string{"<td>a|b</td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "entity-encoded backslash before pipe",
+			input:      "<table><tr><th>h</th></tr><tr><td>a&#92;|b</td></tr></table>",
+			wantInHTML: []string{`<td>a\|b</td>`},
+			wantTables: 1,
+		},
+		{
+			name:       "entity-encoded pipe inside code",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a&#124;b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a|b</code></td>"},
+			wantTables: 1,
+		},
+		{
+			// A decoded literal that still looks like an entity must not be
+			// decoded a second time: the escaped ampersand keeps it literal.
+			name:       "entity-looking literal survives",
+			input:      "<table><tr><th>h</th></tr><tr><td>&amp;#124;</td></tr></table>",
+			wantInHTML: []string{"<td>&amp;#124;</td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "code span containing a backtick",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a`b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a`b</code></td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "code span keeps interior spaces",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a  b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a  b</code></td>"},
+			wantTables: 1,
+		},
+		{
+			// Edge spaces are significant in code spans: the emission pads so
+			// the parser's one-space strip restores the original content.
+			name:       "code span keeps edge spaces",
+			input:      "<table><tr><th>h</th></tr><tr><td><code> a </code></td></tr></table>",
+			wantInHTML: []string{"<td><code> a </code></td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "code span keeps a trailing space",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a </code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a </code></td>"},
+			wantTables: 1,
+		},
+		{
+			name:       "all-space code span survives",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>   </code></td></tr></table>",
+			wantInHTML: []string{"<td><code>   </code></td>"},
+			wantTables: 1,
+		},
+		{
+			// Decode-then-collapse: an entity-encoded newline must not split
+			// the row.
+			name:       "code span with entity-encoded newline",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a&#10;b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>a b</code></td>"},
+			wantTables: 1,
+		},
+		{
+			// Zero-gap adjacent code elements coalesce: GFM can't express
+			// them separately, and one span renders identically.
+			name:       "adjacent code spans coalesce",
+			input:      "<table><tr><th>h</th></tr><tr><td><code>a</code><code>b</code></td></tr></table>",
+			wantInHTML: []string{"<td><code>ab</code></td>"},
+			wantTables: 1,
+		},
+		{
+			// goldmark honors the escaped pipe inside code spans, backslash
+			// context included — the row must not split here.
+			name:       "code span with backslash before pipe",
+			input:      `<table><tr><th>h</th></tr><tr><td><code>a\|b</code></td></tr></table>`,
+			wantInHTML: []string{`<td><code>a\|b</code></td>`},
+			wantTables: 1,
+		},
+		{
+			name:       "adjacent tables stay separate",
+			input:      "<table><tr><th>one</th></tr></table>\n<p><br></p>\n<table><tr><th>two</th></tr></table>",
+			wantInHTML: []string{"<th>one</th>", "<th>two</th>"},
+			wantTables: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := HTMLToMarkdown(tt.input)
+			html := MarkdownToHTML(md)
+			for _, want := range tt.wantInHTML {
+				if !strings.Contains(html, want) {
+					t.Errorf("round-trip HTML missing %q\nmarkdown: %q\nhtml:     %q", want, md, html)
+				}
+			}
+			if got := strings.Count(html, "<table"); got != tt.wantTables {
+				t.Errorf("round-trip HTML has %d tables, want %d\nmarkdown: %q\nhtml:     %q", got, tt.wantTables, md, html)
 			}
 		})
 	}
@@ -1330,25 +1645,59 @@ func TestIsHTML(t *testing.T) {
 	}
 }
 
-func TestHasTableHTML(t *testing.T) {
+func TestHasComplexTableHTML(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
 		expected bool
 	}{
-		{name: "lowercase table tag", input: "<table><tr><td>x</td></tr></table>", expected: true},
-		{name: "uppercase table tag with attrs", input: `<TABLE class="x"><tr></tr></TABLE>`, expected: true},
-		{name: "self-closing table tag", input: "<table/>", expected: true},
-		{name: "wrapped table", input: "<figure><table></table></figure>", expected: true},
-		{name: "plain text", input: "just some text", expected: false},
-		{name: "pipe markdown", input: "| a | b |\n| --- | --- |\n| 1 | 2 |", expected: false},
+		{name: "colspan cell", input: `<table><tr><td colspan="2">x</td></tr></table>`, expected: true},
+		{name: "rowspan cell", input: `<table><tr><td rowspan="3">x</td><td>y</td></tr></table>`, expected: true},
+		{name: "uppercase colspan", input: `<TABLE><TR><TD COLSPAN="2">x</TD></TR></TABLE>`, expected: true},
+		{name: "whitespace around colspan equals", input: `<table><tr><td colspan = "2">x</td></tr></table>`, expected: true},
+		{name: "colspan mentioned in cell text stays simple", input: "<table><tr><td>Set colspan=2 here</td></tr></table>", expected: false},
+		{name: "second header row", input: "<table><thead><tr><th>A</th></tr><tr><th>B</th></tr></thead></table>", expected: true},
+		{name: "div-separated cell", input: "<table><tr><td><div>one</div><div>two</div></td></tr></table>", expected: true},
+		{name: "single-div cell stays simple", input: "<table><tr><td><div>one</div></td></tr></table>", expected: false},
+		{name: "partially wrapped cell", input: "<table><tr><td>before<p>inside</p>after</td></tr></table>", expected: true},
+		{name: "hr in cell", input: "<table><tr><td>a<hr>b</td></tr></table>", expected: true},
+		{name: "body cell align conflicts with column", input: `<table><tr><th>h</th></tr><tr><td align="right">x</td></tr></table>`, expected: true},
+		{name: "body cell align matches column stays simple", input: `<table><tr><th align="right">h</th></tr><tr><td align="right">x</td></tr></table>`, expected: false},
+		{name: "styled span in cell", input: `<table><tr><td><span style="color: red">urgent</span></td></tr></table>`, expected: true},
+		{name: "plain span in cell stays simple", input: "<table><tr><td><span>plain</span></td></tr></table>", expected: false},
+		{name: "nested table", input: "<table><tr><td><table><tr><td>x</td></tr></table></td></tr></table>", expected: true},
+		{name: "list in cell", input: "<table><tr><td><ul><li>x</li></ul></td></tr></table>", expected: true},
+		{name: "ordered list in cell", input: "<table><tr><td><ol><li>x</li></ol></td></tr></table>", expected: true},
+		{name: "code block in cell", input: "<table><tr><td><pre>x</pre></td></tr></table>", expected: true},
+		{name: "blockquote in cell", input: "<table><tr><td><blockquote>x</blockquote></td></tr></table>", expected: true},
+		{name: "heading in cell", input: "<table><tr><td><h3>x</h3></td></tr></table>", expected: true},
+		{name: "plain grid", input: "<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>x</td></tr></tbody></table>", expected: false},
+		{name: "grid with inline formatting", input: "<table><tr><td><strong>x</strong> and <a href=\"u\">y</a></td></tr></table>", expected: false},
+		{name: "no table at all", input: "<p>colspan= is mentioned outside a table</p><ul><li>x</li></ul>", expected: false},
+		{name: "block after simple table", input: "<table><tr><td>x</td></tr></table><ul><li>y</li></ul>", expected: false},
+		{name: "second table is complex", input: `<table><tr><td>x</td></tr></table><table><tr><td colspan="2">y</td></tr></table>`, expected: true},
+		{name: "caption", input: "<table><caption>c</caption><tr><td>x</td></tr></table>", expected: true},
+		{name: "rowless table with content", input: "<table><div>orphan</div></table>", expected: true},
+		{name: "cellless row with content", input: "<table><tr>orphan</tr></table>", expected: true},
+		{name: "empty table stays simple", input: "<table></table>", expected: false},
+		{name: "unclosed table", input: "<table><tr><td>x</td></tr>", expected: true},
+		{name: "image in cell", input: `<table><tr><td><img src="u" alt="a"></td></tr></table>`, expected: true},
+		{name: "attachment in cell", input: `<table><tr><td><bc-attachment filename="f.pdf"/></td></tr></table>`, expected: true},
+		{name: "mention in cell stays simple", input: `<table><tr><td><bc-attachment content-type="application/vnd.basecamp.mention"><figure><img alt="Jane"><figcaption>Jane</figcaption></figure></bc-attachment></td></tr></table>`, expected: false},
+		{name: "multi-paragraph cell", input: "<table><tr><td><p>a</p><p>b</p></td></tr></table>", expected: true},
+		{name: "br in cell", input: "<table><tr><td>a<br>b</td></tr></table>", expected: true},
+		{name: "single-paragraph cell stays simple", input: "<table><tr><td><p>a</p></td></tr></table>", expected: false},
+		{name: "table inside blockquote", input: "<blockquote><table><tr><td>x</td></tr></table></blockquote>", expected: true},
+		{name: "table inside list item", input: "<ul><li><table><tr><td>x</td></tr></table></li></ul>", expected: true},
+		{name: "blockquote then separate table", input: "<blockquote>quote</blockquote><table><tr><td>x</td></tr></table>", expected: false},
 		{name: "word starting with table", input: "the tablet is here", expected: false},
+		{name: "pipe markdown", input: "| a | b |\n| --- | --- |\n| 1 | 2 |", expected: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := HasTableHTML(tt.input); got != tt.expected {
-				t.Errorf("HasTableHTML(%q) = %v, want %v", tt.input, got, tt.expected)
+			if got := HasComplexTableHTML(tt.input); got != tt.expected {
+				t.Errorf("HasComplexTableHTML(%q) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/internal/tui/workspace/views/detail.go
+++ b/internal/tui/workspace/views/detail.go
@@ -757,9 +757,9 @@ func (v *Detail) startCommentEdit() tea.Cmd {
 		return nil
 	}
 	c := v.data.comments[v.focusedComment]
-	// Fail closed on table-bearing content (see startEditBody).
-	if richtext.HasTableHTML(c.content) {
-		return workspace.SetStatus("This comment contains a table — edit it on Basecamp web", true)
+	// Fail closed on complex tables (see startEditBody).
+	if richtext.HasComplexTableHTML(c.content) {
+		return workspace.SetStatus("This comment contains a table too complex to edit as Markdown — edit it on Basecamp web", true)
 	}
 	v.editingComment = true
 	v.commentEditComposer = widget.NewComposer(v.styles,
@@ -1078,10 +1078,12 @@ func (v *Detail) startEditBody() tea.Cmd {
 	if v.data == nil {
 		return nil
 	}
-	// Fail closed on table-bearing content: HTMLToMarkdown has no table handling,
-	// so entering edit mode and resubmitting would strip the table. Block the edit.
-	if richtext.HasTableHTML(v.data.content) {
-		return workspace.SetStatus("This message contains a table — edit it on Basecamp web", true)
+	// Fail closed on complex tables — shapes a GFM pipe table can't
+	// represent (see richtext.HasComplexTableHTML): HTMLToMarkdown flattens
+	// them, so an edit-and-resubmit would lose structure. Simple grids
+	// round-trip and stay editable.
+	if richtext.HasComplexTableHTML(v.data.content) {
+		return workspace.SetStatus("This message contains a table too complex to edit as Markdown — edit it on Basecamp web", true)
 	}
 	v.editingBody = true
 	v.bodyEditComposer = widget.NewComposer(v.styles,

--- a/internal/tui/workspace/views/detail_test.go
+++ b/internal/tui/workspace/views/detail_test.go
@@ -573,12 +573,18 @@ func TestDetail_CommentEdit_Ignored_WhenNoFocus(t *testing.T) {
 	assert.False(t, v.editingComment)
 }
 
-const tableHTML = "<figure><table><thead><tr><th>Foo</th></tr></thead>" +
+// A simple grid round-trips through HTMLToMarkdown and stays editable; a
+// merged-cell grid cannot be represented as a GFM pipe table, so its edits
+// fail closed.
+const simpleTableHTML = "<figure><table><thead><tr><th>Foo</th></tr></thead>" +
 	"<tbody><tr><td>Baz</td></tr></tbody></table></figure>"
 
-func TestDetail_EditBody_BlockedForTable(t *testing.T) {
+const complexTableHTML = "<figure><table><thead><tr><th>Foo</th><th>Bar</th></tr></thead>" +
+	"<tbody><tr><td colspan=\"2\">Baz</td></tr></tbody></table></figure>"
+
+func TestDetail_EditBody_BlockedForComplexTable(t *testing.T) {
 	v := testDetailWithSession("Message", false)
-	v.data.content = tableHTML
+	v.data.content = complexTableHTML
 
 	cmd := v.startEditBody()
 	assert.False(t, v.editingBody, "must not enter edit mode on table content")
@@ -601,10 +607,35 @@ func TestDetail_EditBody_EntersForNonTable(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-func TestDetail_CommentEdit_BlockedForTable(t *testing.T) {
+func TestDetail_EditBody_EntersForSimpleTable(t *testing.T) {
+	v := testDetailWithSession("Message", false)
+	v.data.content = simpleTableHTML
+
+	cmd := v.startEditBody()
+	assert.True(t, v.editingBody, "should enter edit mode on simple-table content")
+	require.NotNil(t, v.bodyEditComposer, "composer should be built")
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "| Foo |\n| --- |\n| Baz |", v.bodyEditComposer.Value(),
+		"composer should hold the table as Markdown")
+}
+
+func TestDetail_CommentEdit_EntersForSimpleTable(t *testing.T) {
 	v := detailWithComments()
 	v.focusedComment = 0
-	v.data.comments[0].content = tableHTML
+	v.data.comments[0].content = simpleTableHTML
+
+	cmd := v.startCommentEdit()
+	assert.True(t, v.editingComment, "should enter edit mode on simple-table content")
+	require.NotNil(t, v.commentEditComposer, "composer should be built")
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "| Foo |\n| --- |\n| Baz |", v.commentEditComposer.Value(),
+		"composer should hold the table as Markdown")
+}
+
+func TestDetail_CommentEdit_BlockedForComplexTable(t *testing.T) {
+	v := detailWithComments()
+	v.focusedComment = 0
+	v.data.comments[0].content = complexTableHTML
 
 	cmd := v.startCommentEdit()
 	assert.False(t, v.editingComment, "must not enter edit mode on table content")

--- a/internal/tui/workspace/views/todos.go
+++ b/internal/tui/workspace/views/todos.go
@@ -1042,10 +1042,12 @@ func (v *Todos) startEditDescription() tea.Cmd {
 		}
 	}
 
-	// Fail closed on table-bearing content: HTMLToMarkdown has no table handling,
-	// so entering edit mode and resubmitting would strip the table. Block the edit.
-	if richtext.HasTableHTML(description) {
-		return workspace.SetStatus("This to-do description contains a table — edit it on Basecamp web", true)
+	// Fail closed on complex tables — shapes a GFM pipe table can't
+	// represent (see richtext.HasComplexTableHTML): HTMLToMarkdown flattens
+	// them, so an edit-and-resubmit would lose structure. Simple grids
+	// round-trip and stay editable.
+	if richtext.HasComplexTableHTML(description) {
+		return workspace.SetStatus("This to-do description contains a table too complex to edit as Markdown — edit it on Basecamp web", true)
 	}
 
 	v.editingDesc = true

--- a/internal/tui/workspace/views/todos_test.go
+++ b/internal/tui/workspace/views/todos_test.go
@@ -942,20 +942,23 @@ func TestTodos_BoostTarget_IncludesAccountID(t *testing.T) {
 	assert.Equal(t, int64(42), picker.Target.ProjectID)
 }
 
-// --- Edit description: table fail-closed guard ---
+// --- Edit description: complex-table fail-closed guard ---
 
-const todoTableHTML = "<figure><table><thead><tr><th>Foo</th></tr></thead>" +
+const todoSimpleTableHTML = "<figure><table><thead><tr><th>Foo</th></tr></thead>" +
 	"<tbody><tr><td>Baz</td></tr></tbody></table></figure>"
 
-func TestTodos_EditDescription_BlockedForTable(t *testing.T) {
+const todoComplexTableHTML = "<figure><table><thead><tr><th>Foo</th><th>Bar</th></tr></thead>" +
+	"<tbody><tr><td colspan=\"2\">Baz</td></tr></tbody></table></figure>"
+
+func TestTodos_EditDescription_BlockedForComplexTable(t *testing.T) {
 	v := testTodosViewWithTodos()
 
 	todos := sampleTodos()
-	todos[0].Description = todoTableHTML
+	todos[0].Description = todoComplexTableHTML
 	v.session.Hub().Todos(42, 10).Set(todos)
 
 	cmd := v.startEditDescription()
-	assert.False(t, v.editingDesc, "must not enter edit mode on table content")
+	assert.False(t, v.editingDesc, "must not enter edit mode on complex-table content")
 
 	require.NotNil(t, cmd, "should return a status command")
 	status, ok := cmd().(workspace.StatusMsg)
@@ -975,6 +978,21 @@ func TestTodos_EditDescription_EntersForNonTable(t *testing.T) {
 	cmd := v.startEditDescription()
 	assert.True(t, v.editingDesc, "should enter edit mode on table-free content")
 	assert.NotNil(t, cmd)
+}
+
+func TestTodos_EditDescription_EntersForSimpleTable(t *testing.T) {
+	v := testTodosViewWithTodos()
+	v.descComposer = widget.NewComposer(v.styles, widget.WithMode(widget.ComposerRich))
+
+	todos := sampleTodos()
+	todos[0].Description = todoSimpleTableHTML
+	v.session.Hub().Todos(42, 10).Set(todos)
+
+	cmd := v.startEditDescription()
+	assert.True(t, v.editingDesc, "should enter edit mode on simple-table content")
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "| Foo |\n| --- |\n| Baz |", v.descComposer.Value(),
+		"composer should hold the table as Markdown, line structure intact")
 }
 
 // newTextInputWithValue creates a textinput with a preset value for testing.

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -97,12 +97,17 @@ Full CLI coverage: 155 endpoints across todos, cards, messages, files, schedule,
    - **`@Name` / `@First.Last`** — fuzzy name resolution (may be ambiguous)
    For todos, documents, and cards, content is sent as-is — use plain text or HTML directly.
 
-   **Table boundary:** GFM tables render in message/comment bodies, but the TUI
-   in-place editors **refuse to open** table-bearing content (edit it on Basecamp
-   web, or replace the whole field via `messages update` / `comments update` /
-   `todos update --description`, which take fresh content and are unaffected), and
-   human-readable CLI/TUI **display** of such content may lose table structure —
-   both pending server-side Markdown support (BC3 #11986).
+   **Table boundary:** GFM tables round-trip: they render in message/comment
+   bodies, display converts them back to pipe tables, and the TUI in-place
+   editors open simple grids for editing. Only **complex** tables — merged
+   cells (colspan/rowspan), captions, extra header rows, nested tables,
+   attachments/images or block content inside cells, multi-paragraph or
+   multi-line cells, or a table inside a blockquote or list — refuse to open,
+   since a GFM pipe table can't represent those shapes (edit them on Basecamp
+   web, or replace the
+   whole field via `messages update` / `comments update` / `todos update
+   --description`, which take fresh content and are unaffected). Complex
+   tables still **display** best-effort, flattened to a plain grid.
 
    **Multiline / non-ASCII content:** do not rely on bash ANSI-C quoting (`$'...\n...'`) — it is a bash/zsh extension. Under a POSIX `/bin/sh` (dash, busybox-ash, common in sandboxes) the `$` is passed through literally and posts a stray leading `$`, and `\n` stays a literal backslash-n. Pipe the content via stdin instead, using `-` as the content argument:
    ```bash


### PR DESCRIPTION
**Stacked on #651** — the composer Reset fix is a prerequisite: without it, the todos description composer drops to single-line mode on `Reset()` and flattens the freshly-converted pipe table on `SetValue()`. This PR's base is `composer-reset-keeps-mode`; merge #651 first.

Follow-up to #637/#648. `HTMLToMarkdown` had no table handling: `<table>` markup survived every conversion pass untouched until the final tag-stripping regex deleted the tags and ran the cell text together. Any table-bearing message, comment, or to-do description displayed as one smeared line, and the TUI in-place editors refused table-bearing content wholesale to avoid destroying it on resubmit.

## What changed

**Converter.** A new pass converts each `<table>` block to a GFM pipe table while row/cell tags are still intact. BC3 rich text is sanitized editor output — always flat editor-authored grids, no nesting, no layout tables — so a non-greedy regex extractor is consistent and sufficient; no DOM walker, no new dependency. Emission shape:

- First row is the header whether its cells are `<th>` or `<td>` (GFM has no headerless tables); the **widest row sizes the table** and narrower rows are padded — no row is ever truncated, so no cell data is dropped.
- `align` attributes — exactly what `MarkdownToHTML` emits for GFM column alignment via `TableCellAlignAttribute` — map back to `:---` / `:---:` / `---:`.
- Cell content gets the same inline conversions as body text (bold/italic/code/links/strikethrough, `bc-attachment` mentions → `**@Name**`); block boundaries collapse to spaces.
- **Escaping is GFM-exact**: pipes escape as `\|`, literal backslashes double (GFM processes escapes left to right, so a lone `\` before an escaped pipe would swallow its backslash and turn the pipe back into a delimiter), and ampersands escape so decoded text that still looks like an entity can't decode a second time on the next render. Code spans pass through as placeholders — backslashes are literal inside code, so only their pipes are escaped, interior spaces are preserved, and the emitted fence is one backtick longer than the longest backtick run in the content (CommonMark space padding included).
- **Entities decode before escaping**: an encoded pipe (`&#124;`) is still a pipe — goldmark decodes it on the next render — so cell text is fully entity-decoded once tags are gone, then escaped. The emitted tables are parked behind placeholders until `HTMLToMarkdown`'s document-level unescape pass has run, so nothing double-decodes.
- Pipe tables round-trip **byte-identical** through `MarkdownToHTML` → `HTMLToMarkdown` (asserted in `TestEditLoopRoundTrip`, alignment and the #648 separator included), and a goldmark-backed test (`TestHTMLToMarkdownTableGoldmarkRoundTrip`) verifies the **parsed cell content** survives the full HTML → Markdown → HTML cycle: backslash-before-pipe text, code spans containing pipes and backslashes, pipes in link destinations, adjacent tables.
- Complex tables still display, best-effort: colspan/rowspan cells emit as ordinary cells — a merged grid displays better flattened than smeared. Tables inside blockquotes convert within the blockquote pass so every pipe row carries its `>` prefix.

**Guards.** The blanket `HasTableHTML` gate on the three TUI in-place editors is replaced by `HasComplexTableHTML`, which fails closed on every shape the pipe-table round trip can't preserve — checking **every** table in the content, not just the first:

- merged cells (`colspan`/`rowspan`, matched case- and whitespace-insensitively against cell attributes — prose that merely mentions `colspan=` stays editable)
- captions, and header cells in any row after the first (GFM has exactly one header row)
- nested tables, and tables nested inside a blockquote or list item (reachable from CLI-posted `> | a | b |` markdown)
- attachments, images, or block elements (`ul`/`ol`/`pre`/`blockquote`/headings) inside the table
- cells spanning multiple paragraphs or divs, or containing `<br>` (the converter flattens those to one line for display; a single wrapper element stays editable)
- unclosed tables, and tables the converter can't extract a grid from (rowless/cellless structures that would otherwise vanish with their content)

Mentions are the one rich element cells may keep: they convert to `**@Name**` exactly as they already do in body text, so editing them loses no more than any body-text edit does. Simple grids now open for editing like any other content, and the guard message names the real blocker ("too complex to edit as Markdown").

The mention-conversion closure is extracted to a named `mentionMarkdown` function so cell conversion reuses it — behavior unchanged. The skill's "Table boundary" paragraph is updated to match the new behavior.

## Testing

- `TestHTMLToMarkdownTable`: header promotion, alignment, escaping (pipe, backslash-before-pipe, code spans), inline formatting and mentions in cells, multi-paragraph/`<br>` cells (display), ragged rows padded and wide rows widening the table, `<p><br></p>` separators, best-effort colspan display, empty table.
- `TestHTMLToMarkdownTableGoldmarkRoundTrip`: parsed-content verification through goldmark, not just Markdown bytes — including entity-encoded pipes and backslashes in text and in code spans.
- `TestEditLoopRoundTrip`: five new byte-identical cases (plain, aligned, paragraph-then-table, escaped-pipe-after-backslash, code-span-with-pipe).
- `TestHasComplexTableHTML` replaces `TestHasTableHTML` (the blanket predicate is folded into the new one) with cases covering both halves of every rule.
- TUI guard tests prove both halves at all three sites: complex tables blocked, simple tables enter edit mode — the todos test asserts the **exact multiline pipe table** in the composer, which only holds with #651 underneath.
- Full `bin/ci` green.
