### PR TITLE
Bump github.com/basecamp/cli for the keyring probe race fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The `go.work` file is gitignored - your local setup won't affect the repo.
 
 ## Requirements
 
-- Go 1.26+
+- Go 1.26.7+
 - [bats-core](https://github.com/bats-core/bats-core) for integration tests
 - [golangci-lint](https://golangci-lint.run/) for linting
 - [jq](https://jqlang.github.io/jq/) for CLI surface checks

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1787814960,
+        "narHash": "sha256-PYZq1qzCJXC2zGI0mH07vrZBsw6DRBAOX0jN1pPtqOQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/basecamp/basecamp-cli
 
-go 1.26.5
-
-toolchain go1.26.7
+go 1.26.7
 
 require (
 	charm.land/bubbles/v2 v2.2.0
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/basecamp-sdk/go v0.14.0
-	github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c
+	github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/basecamp-sdk/go v0.14.0 h1:Jyzmu3ucqwVe+YNC1zWJBOdPjBaTapyZWX7y0cAvaYo=
 github.com/basecamp/basecamp-sdk/go v0.14.0/go.mod h1:BlEtZTW78rOY5geVtKaCiccYT9Jz+QGgPuXLo2pROWk=
-github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c h1:+5sQBl8sqYoD1Qhwsibn8sBCKWPyZ9NDez6mnuo9Afo=
-github.com/basecamp/cli v0.2.2-0.20260728023309-04e401b12c6c/go.mod h1:EK1Dba6DEw8ZAilVBpf/jri3ONDV7LQkLACSDe73f/c=
+github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144 h1:ZJxdRGsb6QyuXNFge6wVx7772e8kDHC9a72aBokaTwM=
+github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/install.md
+++ b/install.md
@@ -255,6 +255,7 @@ cd basecamp-cli
 go build -o basecamp ./cmd/basecamp   # or: make build → bin/basecamp
 ```
 
-Then move the `basecamp` binary onto your PATH. Requires Go 1.26+; if your
-Termux Go is an earlier patch release, lower the `go` line in `go.mod` to
-match the version you have installed.
+Then move the `basecamp` binary onto your PATH. Requires Go 1.26.7+ — the
+pinned `github.com/basecamp/cli` module sets that floor, so lowering the `go`
+line in `go.mod` no longer helps. If your Termux Go is an earlier patch
+release, upgrade the `golang` package first (`pkg upgrade golang`).

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-zZ3+CTLZ4hOkA2IvEbgSj5hQhTDn0agUDVrT+4EN1co=";
+  vendorHash = "sha256-6TAf9LSEQ8AEYAzFLCHN3mHT8gGoOGQ5zcsy55P2luc=";
 
   subPackages = [ "cmd/basecamp" ];
 


### PR DESCRIPTION
Bumps the `github.com/basecamp/cli` pin to `844e9f9`, picking up basecamp/cli#69.

Root cause: two concurrent CLI processes racing the keychain availability probe — the loser saw its probe write missing and misread the lost race as an unavailable keyring, so auth failed intermittently with "credentials not found" (reproduced 199/200 under two concurrent `basecamp me -j` loops).

`go mod tidy` raises the `go` directive to 1.26.7 to match the dependency and collapses the now-redundant `toolchain` line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/basecamp/cli` to pick up a fix for a keyring probe race that caused intermittent auth failures with "credentials not found" under concurrent CLI processes.

- `go mod tidy` raises the `go` directive to 1.26.7 and collapses the redundant `toolchain` line.
- Advances `flake.lock` so Nix builds get Go 1.26.7 and recomputes `vendorHash`.
- Docs now require Go 1.26.7+; lowering the `go.mod` line no longer builds with older patch releases.

<sup>Written for commit f1f7cfeb8c47277c2cb8f9981a3670b4e1a3f46c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

