### PR TITLE
Bump github.com/basecamp/cli for the per-probe keyring item

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
 	github.com/basecamp/basecamp-sdk/go v0.14.0
-	github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144
+	github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/basecamp/basecamp-sdk/go v0.14.0 h1:Jyzmu3ucqwVe+YNC1zWJBOdPjBaTapyZWX7y0cAvaYo=
 github.com/basecamp/basecamp-sdk/go v0.14.0/go.mod h1:BlEtZTW78rOY5geVtKaCiccYT9Jz+QGgPuXLo2pROWk=
-github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144 h1:ZJxdRGsb6QyuXNFge6wVx7772e8kDHC9a72aBokaTwM=
-github.com/basecamp/cli v0.2.2-0.20260828032417-844e9f965144/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
+github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d h1:jAzDrCCzDpIwhbFT1xVVs0z2xpXoDEkomHfKB2bUUp8=
+github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d/go.mod h1:Ee2c/q1/pg+5T5741PIuA3s6VJMQC7I0XBNXIHIujzA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-LzlQIdoEp5SKChmkWK4tw2x78NQmT7VeeOGRz3ve5T0=";
+  vendorHash = "sha256-/ZlKQETlhqPgzMd9/e7R4Pochvo0dnjA39i7mkcgjk4=";
 
   subPackages = [ "cmd/basecamp" ];
 


### PR DESCRIPTION
Bumps the `github.com/basecamp/cli` pin from `844e9f9` (cli#69) to `767413f`, picking up basecamp/cli#70: the keyring availability probe now writes a **per-probe keychain item** (service `credstore.probe.<name>`, account `__probe__.<pid>.<n>`), so concurrent CLI processes never share a probe entry and can't race each other's read-back. `FallbackWarning()` now carries the probe failure reason, so the fallback warning this repo added in #664 names its cause instead of just stating the fallback; `ProbeError()` is also newly available (not yet consumed here — see follow-up).

This is the follow-up promised in #664 ("Bump credstore once basecamp/cli#70 merges").

## Why

cli#69 stopped the lost probe-write race from being misread as an unavailable keyring, but all concurrent processes still shared one probe item, so parallel invocations kept degrading to the file store and reading stale credentials there. Under agent workloads (many `basecamp` processes at once) that showed up as intermittent `expired: true` / "Not authenticated" from processes that lost the race.

## Verification on a real macOS keychain

20 parallel invocations, same machine, same keychain, same load:

| Run (20-way parallel) | installed v0.9.1 (cli#69) | this PR (cli#70) |
|---|---|---|
| `auth status -j` | **1/20** authenticated, 19 fell back (`authenticated: false`) | **20/20** authenticated, `user_id` `"3"`, `source` `"oauth"` |
| `auth status --profile clawdito -j` | **1/20** authenticated | **20/20** authenticated |
| `me --profile clawdito -j` | **3/20** ok, 17 × `auth_required` ("Not authenticated. Run: basecamp auth login") | **10/20** ok with `identity.id` 28142355, 10 × HTTP 429 `rate_limit` ("Too many concurrent requests"), **0 auth failures** |
| `me --profile clawdito -j`, 10-way | 1/10 ok, 9 × `auth_required` | **10/10** ok |

The 429s in the 20-way `me` run are the API's per-token concurrency cap — those requests carried valid credentials (the old binary never got far enough to be rate-limited). At 10-way, below the cap, it's 10/10.

Also checked: no probe items accumulate in the keychain after ~100 invocations — the per-probe entry is cleaned up synchronously on darwin (the one `credstore.probe.*` item present predates this run and belongs to a `reviewtest` service, not `basecamp`).

## Checks

- `make fmt-check vet lint lint-actions` — pass (lint under mise Go 1.26.7; the Homebrew golangci-lint panics against a Go 1.27 toolchain regardless of this change)
- `make test` — passes except 10 terminal-detection tests (`TestIsInteractive*`, `TestInteractiveStdio`/`Prompt`, `TestPredicatesDisagreeOnTheStreamTheyAskAbout`, `TestDeleteConfirmableFollowsTheAudienceNotTheDevice`, `TestBareBasecampNeverReportsASetupError`, `TestExplicitSetupStillRefuses`, `TestIsInteractiveRequiresTerminalStdio`) that fail identically on untouched `main` in this PTY-less sandbox — environmental, not from this change. Full suite minus those: 30/30 packages ok.
- `make test-e2e` — 430/430 pass, run from this branch on an idle Linux host (the local rush-parallel bats harness wedged under a load-average-27 macOS machine before any test of substance ran — also unrelated to this change)
- `make check-naming check-surface check-skill-drift check-bare-groups check-lint-lockstep check-smoke-coverage provenance-check tidy-check replace-check` — pass
- `make update-nix-hash` — vendorHash recomputed and the Nix build verified in Docker
- **Trivy Security Scan is red — pre-existing, not from this PR**: CVE-2026-56854 in the indirect dep `golang.org/x/crypto v0.54.0` (fixed in v0.55.0), published between main's last green Security run (18:10 UTC) and the base commit's run — the same workflow is red on `main` at this PR's base `af381b34` (run 33219046926, 23:02 UTC, before this PR's 23:49 UTC run). This diff doesn't touch x/crypto (the go.sum delta is cli-only). The check isn't in the main-gate required set. The fix is a separate `go get golang.org/x/crypto@v0.55.0 && go mod tidy` + vendorHash recompute — see Declined.

## Declined

- **Adopting `ProbeError()` now** (e.g. surfacing the probe diagnostic in `basecamp doctor`). Separate feature; this PR is the pin bump promised in #664, and the reason already reaches stderr through `FallbackWarning()`.
- **A regression test in this repo.** The race lives in `credstore` and is covered by its own tests in basecamp/cli (`TestProbeUsesIsolatedPerProbeEntry`, `TestProbeDirectUsesPerProbeEntry`); reproducing it here would mean hammering the real OS keychain from CI, which the suite deliberately avoids (`BASECAMP_NO_KEYRING=1`). The end-to-end proof above is the verification.
- **Fixing the Trivy-flagged x/crypto CVE here.** It predates this PR and is unrelated to the cli pin; folding `golang.org/x/crypto v0.55.0` into this diff would mix an independent dependency bump (and another vendorHash recompute) into a change that's otherwise a verified single-purpose pin. It belongs in its own PR against `main`, where it also clears the red check for every other open PR.
- **Waiting for a tagged cli release instead of a pseudo-version.** The module has no post-#70 tag, and the previous pins already ride pseudo-versions; the pinned commit `767413f` is basecamp/cli `main`.

## Release follow-up

Not released here. Per RELEASING.md: `make release VERSION=0.9.2` (pre-1.0 convention: patch bump for fixes) from a clean, synced `main` once merged.

