### PR TITLE
Fix stale comments in ensureDeleteConfirmable

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -112,10 +112,10 @@ func deleteNeedsForce(cmd *cobra.Command) bool {
 // Machine-output mode skips the prompt entirely, so the delete went through
 // unconfirmed — `basecamp chat delete <id> --json` destroyed a message with no
 // statement of intent anywhere in the invocation. And a terminal with stdin
-// redirected does not skip the prompt: isNonInteractiveCommand reads flags, the
-// env var and stdout, never stdin, so the confirmation is shown to an agent
-// that has nothing to type with, and bubbletea answers a non-terminal stdin by
-// opening /dev/tty and waiting on the real terminal.
+// redirected did not skip the prompt at all: the old gate looked at flags, the
+// env var and stdout, never stdin, so the confirmation was shown to an agent
+// with nothing to type, and bubbletea answers a non-terminal stdin by opening
+// /dev/tty and waiting on the real terminal.
 //
 // Both are the same failure — a destructive act with nobody affirming it — so
 // both get the same answer. Requiring the flag precisely where no human can
@@ -125,9 +125,11 @@ func deleteNeedsForce(cmd *cobra.Command) bool {
 // It asks InteractivePrompt rather than InteractiveStdio because the
 // confirmation is a huh form, which draws to stderr.
 //
-// isNonInteractiveCommand is read, never widened: its other callers (missingArg,
-// noChanges) use it to choose between help and a structured error, and changing
-// it would move behavior across many commands.
+// isNonInteractiveCommand is deliberately bypassed, not widened. The delete path
+// no longer consults it at all — machineReadsThisOutput asks the narrower
+// question this needs — and it is left untouched because its other callers
+// (missingArg, noChanges) use it to choose between help and a structured error,
+// where widening would move behavior across many commands.
 func ensureDeleteConfirmable(cmd *cobra.Command, force bool) error {
 	if force || !deleteNeedsForce(cmd) {
 		return nil


### PR DESCRIPTION
#654 merged at 7ea0be6, before two comment-only revisions landed on the feature branch. This applies just those 16 lines — no code changes.

- The historical paragraph now describes the old gate in the past tense ("the old gate looked at flags, the env var and stdout, never stdin").
- The closing note on `isNonInteractiveCommand` said "read, never widened", but the delete path no longer consults it at all: it is deliberately bypassed — `machineReadsThisOutput` asks the narrower question this needs — and left untouched for its other callers (`missingArg`, `noChanges`), where widening would move behavior across many commands.

`bin/ci` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two stale comments in `ensureDeleteConfirmable` that were left behind when the force-flag work merged in #654. No code behavior changes; this is comment text only.

- The historical paragraph now describes the old gate in the past tense.
- The closing note now says `isNonInteractiveCommand` is deliberately bypassed—`machineReadsThisOutput` asks the narrower question—and left untouched for its other callers (`missingArg`, `noChanges`), not "read, never widened".

<sup>Written for commit 27af253c662cfb6af51dc872e644a8f6f22cfa49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

