### PR TITLE
Make IsMachineOutput honor an explicit --styled/--md

### DIFF
--- a/internal/appctx/context.go
+++ b/internal/appctx/context.go
@@ -318,6 +318,12 @@ func (a *App) IsMachineOutput() bool {
 	if a.Flags.Agent || a.Flags.Quiet || a.Flags.IDsOnly || a.Flags.Count || a.Flags.JSON || a.Flags.JQFilter != "" {
 		return true
 	}
+	// An explicit --styled/--md is what ApplyFlags honors over a configured
+	// machine format; this predicate must agree, or the same invocation is
+	// human to the renderer and machine to every gate.
+	if a.Flags.Styled || a.Flags.MD {
+		return false
+	}
 	// Config-driven machine output formats
 	if a.Config != nil {
 		switch a.Config.Format {

--- a/internal/appctx/context_test.go
+++ b/internal/appctx/context_test.go
@@ -586,6 +586,35 @@ func TestIsMachineOutputConfigFormat(t *testing.T) {
 	}
 }
 
+// Test that an explicit --styled/--md overrides a configured machine format,
+// matching ApplyFlags: the flag rebuilds the writer as styled/markdown, so the
+// predicate must stand down too, or the same invocation is human to the
+// renderer and machine to every gate. Machine flags still win over style flags,
+// mirroring ApplyFlags' JSON-first ordering.
+func TestIsMachineOutputStyleFlagOverridesConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		setFlags func(*App)
+		expected bool
+	}{
+		{"styled over config json", "json", func(a *App) { a.Flags.Styled = true }, false},
+		{"md over config quiet", "quiet", func(a *App) { a.Flags.MD = true }, false},
+		{"config json with no style flag stays machine", "json", func(a *App) {}, true},
+		{"json flag beats styled flag", "json", func(a *App) { a.Flags.JSON = true; a.Flags.Styled = true }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{Format: tt.format}
+			app := NewApp(cfg)
+			tt.setFlags(app)
+
+			assert.Equal(t, tt.expected, app.IsMachineOutput())
+		})
+	}
+}
+
 // Test that app.Err doesn't print stats in machine output modes
 func TestAppErrMachineOutputNoStats(t *testing.T) {
 	tests := []struct {

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -207,6 +208,76 @@ func TestIsMachineOutput_JSONFlag(t *testing.T) {
 	cmd := newTestCmd(false, "")
 	_ = cmd.Root().PersistentFlags().Set("json", "true")
 	assert.True(t, isMachineOutput(cmd))
+}
+
+// TestMachinePredicatesAgree is the regression net for app.IsMachineOutput and
+// machineReadsThisOutput drifting apart. They answer the same question through
+// different lenses — flags+config vs the writer ApplyFlags built — and the chat
+// delete --force corner came from them disagreeing on `--styled` over a
+// configured json. Every flag/config combination must agree, with one
+// deliberate exception: FormatAuto on a pipe, where the renderer emits JSON
+// (machineReadsThisOutput true) while gates keep treating `basecamp foo | grep`
+// as human (IsMachineOutput false) so notices, progress, and wizard gating
+// don't flip on redirection alone. That row is asserted as a divergence, not
+// skipped, so a change to either side of it shows up here.
+func TestMachinePredicatesAgree(t *testing.T) {
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// Neither predicate may consult a real terminal: pin all three stdio
+	// streams to pipes and assert the precondition, so the FormatAuto rows
+	// resolve deterministically wherever the test runs.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { r.Close(); w.Close() })
+	origIn, origOut, origErr := os.Stdin, os.Stdout, os.Stderr
+	os.Stdin, os.Stdout, os.Stderr = r, w, w
+	t.Cleanup(func() { os.Stdin, os.Stdout, os.Stderr = origIn, origOut, origErr })
+	fi, err := os.Stdout.Stat()
+	require.NoError(t, err)
+	require.Zero(t, fi.Mode()&os.ModeCharDevice, "precondition: stdout must not be a terminal")
+
+	configFormats := []string{"", "json", "quiet", "markdown"}
+	flagSets := []struct {
+		name string
+		set  func(*appctx.App)
+	}{
+		{"none", func(a *appctx.App) {}},
+		{"json", func(a *appctx.App) { a.Flags.JSON = true }},
+		{"agent", func(a *appctx.App) { a.Flags.Agent = true }},
+		{"quiet", func(a *appctx.App) { a.Flags.Quiet = true }},
+		{"ids-only", func(a *appctx.App) { a.Flags.IDsOnly = true }},
+		{"count", func(a *appctx.App) { a.Flags.Count = true }},
+		{"jq", func(a *appctx.App) { a.Flags.JQFilter = ".x" }},
+		{"styled", func(a *appctx.App) { a.Flags.Styled = true }},
+		{"md", func(a *appctx.App) { a.Flags.MD = true }},
+		{"styled+json", func(a *appctx.App) { a.Flags.Styled = true; a.Flags.JSON = true }},
+	}
+
+	for _, format := range configFormats {
+		for _, flags := range flagSets {
+			name := "config=" + format + "/flags=" + flags.name
+			t.Run(name, func(t *testing.T) {
+				app := appctx.NewApp(&config.Config{Format: format})
+				flags.set(app)
+				app.ApplyFlags()
+
+				cmd := &cobra.Command{Use: "test"}
+				cmd.SetContext(appctx.WithApp(context.Background(), app))
+
+				gate := app.IsMachineOutput()
+				renderer := machineReadsThisOutput(cmd)
+
+				if format == "" && flags.name == "none" {
+					// The FormatAuto-on-a-pipe exception described above.
+					assert.False(t, gate, "IsMachineOutput must not flip on redirection alone")
+					assert.True(t, renderer, "FormatAuto on a pipe renders JSON")
+					return
+				}
+				assert.Equal(t, gate, renderer,
+					"IsMachineOutput=%v but machineReadsThisOutput=%v for %s", gate, renderer, name)
+			})
+		}
+	}
 }
 
 func TestIsNonInteractiveCommand_NonInteractiveEnv(t *testing.T) {

--- a/internal/commands/wizard.go
+++ b/internal/commands/wizard.go
@@ -487,7 +487,9 @@ func fetchProjectName(cmd *cobra.Command, app *appctx.App, projectID string) str
 // no one of them sees everything: IsInteractive covers non-terminal
 // stdin/stdout, the machine-output flags and the BASECAMP_NONINTERACTIVE escape
 // hatch; IsMachineOutput adds the config-driven json/quiet formats it does not
-// look at; InteractivePrompt adds stderr, which is where huh actually draws.
+// look at (standing down when an explicit --styled/--md overrides them, since
+// ApplyFlags renders those human); InteractivePrompt adds stderr, which is
+// where huh actually draws.
 //
 // Two callers, deliberately different responses. `basecamp setup` was asked for
 // by name, so it refuses out loud. Bare `basecamp` never asked for a wizard at

--- a/internal/commands/wizard_test.go
+++ b/internal/commands/wizard_test.go
@@ -756,7 +756,9 @@ func TestSetupRefusesUnderNonInteractiveEnv(t *testing.T) {
 // Terminal stdio is not enough: a caller that asked for machine output has
 // declared it is not there to answer questions, and the wizard is nothing but
 // questions. Config-driven json/quiet counts too — app.IsInteractive() does not
-// look at it, which is why the gate also asks IsMachineOutput().
+// look at it, which is why the gate also asks IsMachineOutput(). An explicit
+// --styled/--md overrides a configured machine format there, so that pairing
+// prompts like any human invocation.
 func TestSetupRefusesMachineOutputOnATerminal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no /dev/ptmx on Windows")


### PR DESCRIPTION
Follow-through on the one declined thread from #654: `IsMachineOutput` read flags and config but never `Flags.Styled`/`Flags.MD`, while `ApplyFlags` lets those flags overwrite a configured `json`/`quiet` writer. The same invocation was human to the renderer and machine to every gate, and `humanFormatOverride` in `chat.go` is this exact rule written once at one call site because the predicate couldn't say it.

## Change

One clause in `IsMachineOutput`, between the machine-flag block and the config switch — machine flags must stay above it, since `--json --styled` resolves JSON-first in `ApplyFlags` and the predicate mirrors that ordering.

**Deliberately not delegated to `EffectiveFormat()`.** That would also pull in FormatAuto-on-a-pipe (`EffectiveFormat()==FormatJSON` where `IsMachineOutput()` is `false` today), flipping `upgrade` stdout→stderr, attachment progress, the skill-update nudge, and quickstart/skill/wizard gating for every `basecamp foo | grep`. It would also be order-sensitive: the existing `TestIsMachineOutput*` tables never call `ApplyFlags`, so every row would read the writer's JSON default and pass vacuously.

## Callers whose behavior changes

Only when an explicit `--styled`/`--md` overrides a configured `json`/`quiet` — all flip toward "treat as human", which is what the flag asked for:

- `shouldIncludeStatsInError` / `shouldPrintStatsToStderr` (`context.go`)
- root post-run notices (`root.go:207,221`)
- attachment progress (`attachments.go`)
- `quickstart.go` routing, `skill.go` dump→picker (still TTY-gated), `upgrade.go`
- the setup/wizard gate (`wizardCanRun`, `setupCanRun` after #660)

`humanFormatOverride` in `chat.go` stays — the breadcrumb must still carry the flag for the future invocation it suggests.

## Tests

- New table in `context_test.go`: `--styled` over config `json` and `--md` over config `quiet` → not machine; config `json` alone and `--json --styled` → machine. Existing rows unchanged.
- `TestMachinePredicatesAgree` in `internal/commands`: the regression net for "these must not drift again" — every flag×config combination asserts `app.IsMachineOutput() == machineReadsThisOutput(cmd)`, with all three stdio streams pinned to pipes and the precondition asserted. The one deliberate divergence (FormatAuto on a pipe) is asserted as a divergence rather than skipped, so a change to either side of it shows up.
- Mutation-checked: deleting the clause fails exactly the six new rows and nothing else; `TestChatDeleteConfirmationMatrix` passes with and without.

Note: #660 also touches `wizard.go` (renames the gate to `setupCanRun` and moves its doc comment). The comment amendment here will need a trivial rebase whichever lands second.

`bin/ci` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `IsMachineOutput` honor explicit `--styled`/`--md` flags, so an invocation that overrides a configured `json`/`quiet` format is treated as human by all gates instead of being routed as machine while rendering human.

**Behavior changes**
- All callers that consulted `IsMachineOutput` now flip to human for `--styled`/`--md` over machine config, covering error stats, post-run notices, attachment progress, quickstart/skill/upgrade routing, and wizard gating.
- Machine flags (`--json`, `--quiet`, etc.) still win over style flags, matching `ApplyFlags` ordering.

**Testing**
- Adds a table test covering the override behavior and a `TestMachinePredicatesAgree` regression net that asserts the full flag×config matrix against the renderer, with the one deliberate `FormatAuto`-on-pipe divergence enforced explicitly.

<sup>Written for commit 1f415ecc98928d72a58177f372a162a77c6dda5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

