### PR TITLE
Stop injecting Basecamp context into every session

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ CLI needs upgrading.
 
 **Claude Code:** `basecamp setup claude` — installs the plugin with skills, hooks, and agent workflow support.
 
-**Codex:** `basecamp setup codex` — registers the 37signals marketplace and installs the native plugin with Basecamp skills, diagnostics, and opt-in hooks. In Codex, review and trust the plugin hooks with `/hooks`, then start a new thread to load the skills and hooks.
+**Codex:** `basecamp setup codex` — registers the 37signals marketplace and installs the native plugin with Basecamp skills, diagnostics, and opt-in commit-reference hooks. In Codex, review and trust the plugin hooks with `/hooks`, then start a new thread to load the skills and hooks. The plugin does not inject Basecamp context at session start; Codex selects the skill when a request is relevant or explicitly references Basecamp.
 
 Manual Codex installation uses the same marketplace:
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,19 +1,6 @@
 {
-  "description": "Basecamp agent hooks: session context and commit-reference nudges.",
+  "description": "Basecamp agent hooks: commit-reference nudges.",
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|resume|clear|compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "basecamp agent-hook session-start",
-            "timeout": 5,
-            "statusMessage": "Checking Basecamp status"
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/install.md
+++ b/install.md
@@ -152,7 +152,7 @@ plugin, run `basecamp upgrade` and start a new session; `basecamp agent-hook
 basecamp setup codex
 ```
 
-This installs the shared Basecamp skill, registers the 37signals Codex marketplace, and installs the native plugin. After setup, review and trust the plugin hooks with `/hooks` (Codex lists untrusted hooks but does not run them until trusted), then start a new Codex thread to load the skills and hooks.
+This installs the shared Basecamp skill, registers the 37signals Codex marketplace, and installs the native plugin. After setup, review and trust the plugin's commit-reference hooks with `/hooks` (Codex lists untrusted hooks but does not run them until trusted), then start a new Codex thread to load the skills and hooks. The plugin does not inject Basecamp context at session start; Codex selects the skill when a request is relevant or explicitly references Basecamp.
 
 For a manual install:
 

--- a/internal/commands/wizard_codex.go
+++ b/internal/commands/wizard_codex.go
@@ -65,8 +65,6 @@ func runCodexSetup(cmd *cobra.Command, styles *tui.Styles) error {
 	fmt.Fprintln(w, styles.RenderStatus(true, "37signals marketplace ready"))
 	fmt.Fprintln(w, styles.RenderStatus(true, "Codex plugin installed and enabled"))
 	fmt.Fprintln(w)
-	// Trust must come first: an untrusted SessionStart hook is silently
-	// skipped, so a thread started before trusting gets no hook context.
 	fmt.Fprintln(w, styles.Muted.Render("  Review and trust the plugin hooks with /hooks."))
 	fmt.Fprintln(w, styles.Muted.Render("  Then start a new Codex thread to load the Basecamp skills."))
 	return nil

--- a/internal/commands/wizard_codex_test.go
+++ b/internal/commands/wizard_codex_test.go
@@ -156,9 +156,8 @@ func TestRunCodexSetupInteractiveExplainsNextSteps(t *testing.T) {
 
 	assert.Contains(t, output.String(), "Registering 37signals marketplace")
 	assert.Contains(t, output.String(), "Installing basecamp plugin")
-	// Codex lists untrusted hooks but does not run them until trusted, and
-	// an untrusted SessionStart is skipped — so the trust step must come
-	// before the new-thread step.
+	// Codex lists untrusted hooks but does not run them until trusted, so
+	// complete hook setup before starting the thread that loads the skills.
 	trustAt := strings.Index(output.String(), "trust the plugin hooks with /hooks")
 	newThreadAt := strings.Index(output.String(), "start a new Codex thread")
 	require.GreaterOrEqual(t, trustAt, 0)

--- a/internal/release/manifests_test.go
+++ b/internal/release/manifests_test.go
@@ -140,6 +140,7 @@ func TestHooksFileCommandsInvokeBasecamp(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(data, &config))
 	require.NotEmpty(t, config.Hooks)
+	assert.NotContains(t, config.Hooks, "SessionStart", "plugins must not inject Basecamp context into every agent session")
 
 	for event, matchers := range config.Hooks {
 		require.NotEmpty(t, matchers, event)


### PR DESCRIPTION
## Problem

Installing and trusting the Basecamp plugin registers an unconditional `SessionStart` hook. Every new Codex or Claude Code session then receives:

> Basecamp is active and OAuth is ready. Use the Basecamp skills for project work.

That context is injected even in repositories and conversations unrelated to Basecamp. It can steer the agent toward Basecamp simply because the plugin is installed.

This is separate from normal skill discovery: the Basecamp skill should remain available for natural-language requests and explicit references.

## Change

- Remove only the unconditional `SessionStart` hook from the shared plugin manifest.
- Keep the silent commit-reference hooks (`PreToolUse`, `PostToolUse`, and `PostToolUseFailure`).
- Update the Codex setup docs to describe those remaining hooks accurately.
- Add a regression assertion preventing `SessionStart` from returning to the plugin hook manifest.

No `.basecamp/config.json` is required to activate the skill. Codex can continue selecting it when a request is relevant.

## Verification

- `go test ./internal/release`
- `go test ./internal/commands -run TestRunCodexSetupInteractiveExplainsNextSteps -count=1`
- `git diff --check`
- Full `make check` passed vet, lint, Actionlint, and zizmor, then hit pre-existing terminal-detection failures because the Codex command runner is not recognized as an interactive terminal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unconditional `SessionStart` hook so Basecamp no longer injects context into every Codex or Claude Code session. The Basecamp skill stays available for relevant requests and explicit references.

**Details**
- Keeps the silent commit-reference hooks (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`).
- Updates Codex setup docs to describe the remaining hooks accurately.
- Adds a regression assertion preventing `SessionStart` from returning to the hook manifest.

<sup>Written for commit 9b52b63ad4c3642734690a19c76c6883d222d1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

