### PR TITLE
Resolve a bare numeric `cards <id>` to a clear error instead of silent exit-0

### DIFF
--- a/e2e/cards_columns_steps.bats
+++ b/e2e/cards_columns_steps.bats
@@ -196,16 +196,16 @@ load test_helper
 }
 
 
-# Column unknown action - Cobra shows help for unknown subcommands
+# Column unknown action - a positional matching no subcommand is a usage error
 
-@test "cards column unknown action shows help" {
+@test "cards column unknown action errors" {
   create_credentials
   create_global_config '{"account_id": 99999}'
 
   run basecamp cards column foobar
-  # Cobra doesn't error on unknown args, shows help
-  assert_success
-  assert_output_contains "COMMANDS"
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "foobar" for "basecamp cards column"'
 }
 
 
@@ -369,14 +369,14 @@ load test_helper
 }
 
 
-# Step unknown action - Cobra shows help for unknown subcommands
+# Step unknown action - a positional matching no subcommand is a usage error
 
-@test "cards step unknown action shows help" {
+@test "cards step unknown action errors" {
   create_credentials
   create_global_config '{"account_id": 99999}'
 
   run basecamp cards step foobar
-  # Cobra doesn't error on unknown args, shows help
-  assert_success
-  assert_output_contains "COMMANDS"
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "foobar" for "basecamp cards step"'
 }

--- a/e2e/chat.bats
+++ b/e2e/chat.bats
@@ -174,15 +174,17 @@ load test_helper
 }
 
 
-# Unknown action - Cobra treats unknown args as command arguments, not subcommands
+# Unknown action - a positional matching no subcommand is a usage error,
+# not silent help with a zero exit.
 
-@test "chat unknown action shows help" {
+@test "chat unknown action errors" {
   create_credentials
   create_global_config '{"account_id": 99999}'
 
   run basecamp chat foobar
-  # Parent command with no RunE — cobra shows help for unknown subcommands
-  assert_success
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "foobar" for "basecamp chat"'
 }
 
 

--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -459,6 +459,29 @@ load test_helper
   assert_json_value '.error' 'unknown command "shwo" for "basecamp messages"'
 }
 
+@test "singleton group does not steer a numeric id to show" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  # accounts show reads the current account and takes no id, so the hint must
+  # not point at "accounts show 123".
+  run basecamp accounts 123
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.hint' 'Run: basecamp accounts --help'
+}
+
+@test "help for a group with a stray id still renders help" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  # The explicit help path renders help and exits zero; it must not be
+  # converted into an error or suppressed into silence.
+  run basecamp help cards 12345
+  assert_success
+  assert_output_contains "COMMANDS"
+}
+
 @test "messages --json shows structured JSON help" {
   create_credentials
   create_global_config '{"account_id": 99999}'

--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -436,6 +436,29 @@ load test_helper
   assert_output_contains "COMMANDS"
 }
 
+@test "cards with a bare numeric id errors instead of silent help" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  # "cards 12345" matches no subcommand — a caller who meant "cards show
+  # 12345" must get a non-zero usage error, not help with a zero exit.
+  run basecamp cards 12345
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "12345" for "basecamp cards"'
+  assert_json_value '.hint' 'Did you mean "basecamp cards show 12345"?'
+}
+
+@test "group with an unknown subcommand errors non-zero" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  run basecamp messages shwo
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "shwo" for "basecamp messages"'
+}
+
 @test "messages --json shows structured JSON help" {
   create_credentials
   create_global_config '{"account_id": 99999}'

--- a/e2e/errors.bats
+++ b/e2e/errors.bats
@@ -459,6 +459,30 @@ load test_helper
   assert_json_value '.error' 'unknown command "shwo" for "basecamp messages"'
 }
 
+@test "a scoped bare numeric id keeps the specific unknown-command error" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  # With a group-local flag present the unknown-arg guard still wins over the
+  # generic "subcommand required" bare-flags error.
+  run basecamp cards 12345 --in myproject
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.error' 'unknown command "12345" for "basecamp cards"'
+  assert_json_value '.hint' 'Did you mean "basecamp cards show 12345"?'
+}
+
+@test "a numeric id resolves a show alias" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  # chat's id-taking "line" command exposes "show" as an alias.
+  run basecamp chat 123
+  assert_failure
+  assert_json_value '.code' 'usage'
+  assert_json_value '.hint' 'Did you mean "basecamp chat show 123"?'
+}
+
 @test "singleton group does not steer a numeric id to show" {
   create_credentials
   create_global_config '{"account_id": 99999}'

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -20,7 +20,7 @@ func rootHelpFunc() func(*cobra.Command, []string) {
 		// Bare group with explicit flags (e.g. "cards --in X"): suppress
 		// help output so Execute() can emit a usage error with non-zero exit.
 		// Must run before machine-help branches to avoid mixed output.
-		if isBareGroupWithFlags(cmd) {
+		if isBareGroupWithFlags(cmd) || isBareGroupWithUnknownArg(cmd) {
 			return
 		}
 
@@ -65,6 +65,21 @@ func isBareGroupWithFlags(cmd *cobra.Command) bool {
 		return false
 	}
 	return hasExplicitLocalFlags(cmd)
+}
+
+// isBareGroupWithUnknownArg reports whether cmd is a non-runnable group command
+// that was handed a positional argument matching no subcommand. Cobra stops at
+// the group, so the leftover arg surfaces here; Execute() turns it into a usage
+// error instead of the silent help-with-zero-exit that masks the no-op.
+// Explicit --help always renders help regardless of the stray arg.
+func isBareGroupWithUnknownArg(cmd *cobra.Command) bool {
+	if cmd.Runnable() || !cmd.HasSubCommands() {
+		return false
+	}
+	if helpFlag := cmd.Flags().Lookup("help"); helpFlag != nil && helpFlag.Changed {
+		return false
+	}
+	return len(cmd.Flags().Args()) > 0
 }
 
 // curatedCategories defines the subset of categories and commands shown in root help.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -54,29 +54,36 @@ func hasExplicitLocalFlags(cmd *cobra.Command) bool {
 	return found
 }
 
-// isBareGroupWithFlags reports whether cmd is a non-runnable group command
-// that was invoked bare (no subcommand) with explicitly-set local flags.
-// Explicit --help always renders help regardless of other flags.
+// isBareGroup reports whether cmd is a non-runnable command carrying
+// subcommands — a group whose bare invocation shows help.
+func isBareGroup(cmd *cobra.Command) bool {
+	return !cmd.Runnable() && cmd.HasSubCommands()
+}
+
+// helpRequested reports whether --help resolved to true for cmd. Reading the
+// parsed value rather than the changed flag means an explicit --help=false
+// still counts as "help not requested".
+func helpRequested(cmd *cobra.Command) bool {
+	v, _ := cmd.Flags().GetBool("help")
+	return v
+}
+
+// isBareGroupWithFlags reports whether cmd is a bare group invoked with
+// explicitly-set local flags but no subcommand. Explicit --help always renders
+// help regardless of other flags.
 func isBareGroupWithFlags(cmd *cobra.Command) bool {
-	if cmd.Runnable() || !cmd.HasSubCommands() {
-		return false
-	}
-	if helpFlag := cmd.Flags().Lookup("help"); helpFlag != nil && helpFlag.Changed {
+	if !isBareGroup(cmd) || helpRequested(cmd) {
 		return false
 	}
 	return hasExplicitLocalFlags(cmd)
 }
 
-// isBareGroupWithUnknownArg reports whether cmd is a non-runnable group command
-// that was handed a positional argument matching no subcommand. Cobra stops at
-// the group, so the leftover arg surfaces here; Execute() turns it into a usage
-// error instead of the silent help-with-zero-exit that masks the no-op.
-// Explicit --help always renders help regardless of the stray arg.
+// isBareGroupWithUnknownArg reports whether cmd is a bare group handed a
+// positional argument matching no subcommand. Without conversion the group
+// renders help with a zero exit, masking the no-op; Execute() turns it into a
+// usage error. Explicit --help still renders help.
 func isBareGroupWithUnknownArg(cmd *cobra.Command) bool {
-	if cmd.Runnable() || !cmd.HasSubCommands() {
-		return false
-	}
-	if helpFlag := cmd.Flags().Lookup("help"); helpFlag != nil && helpFlag.Changed {
+	if !isBareGroup(cmd) || helpRequested(cmd) {
 		return false
 	}
 	return len(cmd.Flags().Args()) > 0

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/basecamp/basecamp-cli/internal/commands"
+	"github.com/basecamp/basecamp-cli/internal/output"
 )
 
 // isolateHelpTest sets env vars for hermetic help tests: disables keyring
@@ -665,6 +666,101 @@ func TestBareGroupWithFlagsAndHelpShowsHelp(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "COMMANDS")
 	assert.Contains(t, out, "USAGE")
+}
+
+func TestBareGroupWithUnknownArgSuppressesHelp(t *testing.T) {
+	// A group handed a positional that matches no subcommand (e.g. "cards
+	// 12345") must not print help with a zero exit — that reads as success to
+	// an agent while nothing ran. Help is suppressed so Execute() can emit a
+	// usage error; Cobra itself still returns nil for the non-runnable group.
+	isolateHelpTest(t)
+
+	tests := []struct {
+		name   string
+		args   []string
+		addCmd func() *cobra.Command
+	}{
+		{"cards numeric", []string{"cards", "12345"}, commands.NewCardsCmd},
+		{"todos numeric", []string{"todos", "999"}, commands.NewTodosCmd},
+		{"comments numeric", []string{"comments", "55"}, commands.NewCommentsCmd},
+		{"messages typo", []string{"messages", "shwo"}, commands.NewMessagesCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := NewRootCmd()
+			cmd.AddCommand(tt.addCmd())
+			cmd.SetOut(&buf)
+			cmd.SetArgs(tt.args)
+
+			executedCmd, err := cmd.ExecuteC()
+			require.NoError(t, err, "Cobra returns nil for non-runnable commands")
+			assert.Empty(t, buf.String(), "help text should be suppressed")
+			assert.True(t, isBareGroupWithUnknownArg(executedCmd),
+				"Execute() should detect this and convert to a usage error")
+		})
+	}
+}
+
+func TestUnknownSubcommandErrorClassifiesAndHints(t *testing.T) {
+	isolateHelpTest(t)
+
+	tests := []struct {
+		name     string
+		args     []string
+		addCmd   func() *cobra.Command
+		wantMsg  string
+		wantHint string
+	}{
+		{
+			name:     "numeric id hints show",
+			args:     []string{"cards", "12345"},
+			addCmd:   commands.NewCardsCmd,
+			wantMsg:  `unknown command "12345" for "basecamp cards"`,
+			wantHint: `Did you mean "basecamp cards show 12345"?`,
+		},
+		{
+			name:     "typo falls back to help",
+			args:     []string{"messages", "shwo"},
+			addCmd:   commands.NewMessagesCmd,
+			wantMsg:  `unknown command "shwo" for "basecamp messages"`,
+			wantHint: "Run: basecamp messages --help",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := NewRootCmd()
+			cmd.AddCommand(tt.addCmd())
+			cmd.SetOut(&buf)
+			cmd.SetArgs(tt.args)
+
+			executedCmd, err := cmd.ExecuteC()
+			require.NoError(t, err)
+
+			outErr := output.AsError(unknownSubcommandError(executedCmd))
+			assert.Equal(t, output.CodeUsage, outErr.Code)
+			assert.Equal(t, tt.wantMsg, outErr.Message)
+			assert.Equal(t, tt.wantHint, outErr.Hint)
+		})
+	}
+}
+
+func TestSubcommandRoutesPastUnknownArgGuard(t *testing.T) {
+	// A real subcommand (e.g. "cards show 123") resolves to the leaf command,
+	// which is runnable — so the group guard never fires for it.
+	isolateHelpTest(t)
+
+	cmd := NewRootCmd()
+	cmd.AddCommand(commands.NewCardsCmd())
+
+	target, _, err := cmd.Find([]string{"cards", "show", "123"})
+	require.NoError(t, err)
+	assert.Equal(t, "show", target.Name())
+	assert.False(t, isBareGroupWithUnknownArg(target),
+		"a runnable leaf command is never treated as a bare group")
 }
 
 func TestGroupCommandHelpOmitsArguments(t *testing.T) {

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -686,6 +686,9 @@ func TestBareGroupWithUnknownArgSuppressesHelp(t *testing.T) {
 		{"messages typo", []string{"messages", "shwo"}, commands.NewMessagesCmd},
 		// --help=false disables help, so the stray positional still errors.
 		{"help disabled", []string{"cards", "12345", "--help=false"}, commands.NewCardsCmd},
+		// A scoped invocation still trips the unknown-arg guard; Execute()
+		// checks it ahead of the bare-flags case so the specific hint wins.
+		{"scoped positional", []string{"cards", "12345", "--in", "myproject"}, commands.NewCardsCmd},
 	}
 
 	for _, tt := range tests {
@@ -744,6 +747,15 @@ func TestUnknownSubcommandErrorClassifiesAndHints(t *testing.T) {
 			addCmd:   commands.NewAccountsCmd,
 			wantMsg:  `unknown command "123" for "basecamp accounts"`,
 			wantHint: "Run: basecamp accounts --help",
+		},
+		{
+			// chat's id-taking "line" command exposes "show" as an alias, so
+			// the hint resolves through the alias.
+			name:     "id-taking show alias still hints show",
+			args:     []string{"chat", "123"},
+			addCmd:   commands.NewChatCmd,
+			wantMsg:  `unknown command "123" for "basecamp chat"`,
+			wantHint: `Did you mean "basecamp chat show 123"?`,
 		},
 	}
 

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -684,6 +684,8 @@ func TestBareGroupWithUnknownArgSuppressesHelp(t *testing.T) {
 		{"todos numeric", []string{"todos", "999"}, commands.NewTodosCmd},
 		{"comments numeric", []string{"comments", "55"}, commands.NewCommentsCmd},
 		{"messages typo", []string{"messages", "shwo"}, commands.NewMessagesCmd},
+		// --help=false disables help, so the stray positional still errors.
+		{"help disabled", []string{"cards", "12345", "--help=false"}, commands.NewCardsCmd},
 	}
 
 	for _, tt := range tests {
@@ -734,6 +736,15 @@ func TestUnknownSubcommandErrorClassifiesAndHints(t *testing.T) {
 			wantMsg:  `unknown command "zzzzzz" for "basecamp messages"`,
 			wantHint: "Run: basecamp messages --help",
 		},
+		{
+			// accounts show reads the current account and takes no id, so a
+			// numeric positional must not be steered to "accounts show 123".
+			name:     "singleton show does not get a numeric id hint",
+			args:     []string{"accounts", "123"},
+			addCmd:   commands.NewAccountsCmd,
+			wantMsg:  `unknown command "123" for "basecamp accounts"`,
+			wantHint: "Run: basecamp accounts --help",
+		},
 	}
 
 	for _, tt := range tests {
@@ -747,7 +758,7 @@ func TestUnknownSubcommandErrorClassifiesAndHints(t *testing.T) {
 			executedCmd, err := cmd.ExecuteC()
 			require.NoError(t, err)
 
-			outErr := output.AsError(unknownSubcommandError(executedCmd))
+			outErr := output.AsError(unknownSubcommandError(executedCmd, executedCmd.Flags().Args()[0]))
 			assert.Equal(t, output.CodeUsage, outErr.Code)
 			assert.Equal(t, tt.wantMsg, outErr.Message)
 			assert.Equal(t, tt.wantHint, outErr.Hint)

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -721,10 +721,17 @@ func TestUnknownSubcommandErrorClassifiesAndHints(t *testing.T) {
 			wantHint: `Did you mean "basecamp cards show 12345"?`,
 		},
 		{
-			name:     "typo falls back to help",
+			name:     "typo suggests the nearest subcommand",
 			args:     []string{"messages", "shwo"},
 			addCmd:   commands.NewMessagesCmd,
 			wantMsg:  `unknown command "shwo" for "basecamp messages"`,
+			wantHint: "Did you mean: show?",
+		},
+		{
+			name:     "unrecognizable arg falls back to help",
+			args:     []string{"messages", "zzzzzz"},
+			addCmd:   commands.NewMessagesCmd,
+			wantMsg:  `unknown command "zzzzzz" for "basecamp messages"`,
 			wantHint: "Run: basecamp messages --help",
 		},
 	}
@@ -761,6 +768,26 @@ func TestSubcommandRoutesPastUnknownArgGuard(t *testing.T) {
 	assert.Equal(t, "show", target.Name())
 	assert.False(t, isBareGroupWithUnknownArg(target),
 		"a runnable leaf command is never treated as a bare group")
+}
+
+func TestBareGroupWithUnknownArgAndHelpShowsHelp(t *testing.T) {
+	// Explicit --help renders help and exits zero even with a stray positional,
+	// so the documented exception can't silently regress into a suppressed error.
+	isolateHelpTest(t)
+
+	var buf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.AddCommand(commands.NewCardsCmd())
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cards", "12345", "--help"})
+
+	executedCmd, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.False(t, isBareGroupWithUnknownArg(executedCmd),
+		"explicit --help opts out of the unknown-arg guard")
+	out := buf.String()
+	assert.Contains(t, out, "COMMANDS")
+	assert.Contains(t, out, "USAGE")
 }
 
 func TestGroupCommandHelpOmitsArguments(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -382,6 +382,15 @@ func Execute() {
 		)
 	}
 
+	// Bare group command with a positional that matches no subcommand
+	// (e.g. "cards 12345"): Cobra stops at the group and renders help with a
+	// zero exit, so an agent that meant "cards show 12345" reads success while
+	// nothing ran. The help function suppressed output; convert to a usage
+	// error that names the mistake and points at the canonical path.
+	if err == nil && executedCmd != cmd && isBareGroupWithUnknownArg(executedCmd) {
+		err = unknownSubcommandError(executedCmd)
+	}
+
 	if err != nil {
 		// When a command receives zero args but requires some, show help instead of an error —
 		// but only for interactive human users. Machine consumers (--agent, --json, piped stdout)
@@ -669,6 +678,48 @@ func promptForProfile(cfg *config.Config) (string, error) {
 func isConfigCmd(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
 		if c.Name() == "config" {
+			return true
+		}
+	}
+	return false
+}
+
+// unknownSubcommandError builds a usage error for a group command handed a
+// positional that matches no subcommand. A bare numeric positional almost
+// always means the caller wanted "<group> show <id>", so when the group has a
+// show subcommand the hint spells that path out; otherwise it offers cobra's
+// spelling suggestions, falling back to help.
+func unknownSubcommandError(cmd *cobra.Command) error {
+	arg := cmd.Flags().Args()[0]
+	msg := fmt.Sprintf("unknown command %q for %q", arg, cmd.CommandPath())
+
+	if isAllDigits(arg) && hasSubcommandNamed(cmd, "show") {
+		return output.ErrUsageHint(msg, fmt.Sprintf("Did you mean %q?", cmd.CommandPath()+" show "+arg))
+	}
+	if suggestions := cmd.SuggestionsFor(arg); len(suggestions) > 0 {
+		return output.ErrUsageHint(msg, "Did you mean: "+strings.Join(suggestions, ", ")+"?")
+	}
+	return output.ErrUsageHint(msg, "Run: "+cmd.CommandPath()+" --help")
+}
+
+// isAllDigits reports whether s is a non-empty run of ASCII digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// hasSubcommandNamed reports whether cmd has an immediate subcommand with the
+// given name.
+func hasSubcommandNamed(cmd *cobra.Command, name string) bool {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name {
 			return true
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -384,11 +384,11 @@ func Execute() {
 
 	// Bare group command with a positional that matches no subcommand
 	// (e.g. "cards 12345"): Cobra stops at the group and renders help with a
-	// zero exit, so an agent that meant "cards show 12345" reads success while
-	// nothing ran. The help function suppressed output; convert to a usage
-	// error that names the mistake and points at the canonical path.
+	// zero exit — so an agent that meant "cards show 12345" reads success while
+	// nothing ran. The help function suppressed the output; convert it to a
+	// usage error that names the mistake and points at the canonical path.
 	if err == nil && executedCmd != cmd && isBareGroupWithUnknownArg(executedCmd) {
-		err = unknownSubcommandError(executedCmd)
+		err = unknownSubcommandError(executedCmd, executedCmd.Flags().Args()[0])
 	}
 
 	if err != nil {
@@ -686,14 +686,13 @@ func isConfigCmd(cmd *cobra.Command) bool {
 
 // unknownSubcommandError builds a usage error for a group command handed a
 // positional that matches no subcommand. A bare numeric positional almost
-// always means the caller wanted "<group> show <id>", so when the group has a
-// show subcommand the hint spells that path out; otherwise it offers cobra's
-// spelling suggestions, falling back to help.
-func unknownSubcommandError(cmd *cobra.Command) error {
-	arg := cmd.Flags().Args()[0]
+// always means the caller wanted "<group> show <id>", so when the group's show
+// subcommand actually accepts an id the hint spells that path out; otherwise it
+// offers cobra's spelling suggestions, falling back to help.
+func unknownSubcommandError(cmd *cobra.Command, arg string) error {
 	msg := fmt.Sprintf("unknown command %q for %q", arg, cmd.CommandPath())
 
-	if isAllDigits(arg) && hasSubcommandNamed(cmd, "show") {
+	if isAllDigits(arg) && showAcceptsID(cmd) {
 		return output.ErrUsageHint(msg, fmt.Sprintf("Did you mean %q?", cmd.CommandPath()+" show "+arg))
 	}
 	// Only the root sets SuggestionsMinimumDistance; a group left at zero would
@@ -720,13 +719,21 @@ func isAllDigits(s string) bool {
 	return true
 }
 
-// hasSubcommandNamed reports whether cmd has an immediate subcommand with the
-// given name.
-func hasSubcommandNamed(cmd *cobra.Command, name string) bool {
+// showAcceptsID reports whether cmd has a show subcommand that takes an
+// identifier positional. A singleton "show" (accounts, config, hillcharts)
+// takes no id, so suggesting "<group> show <id>" there would send the caller to
+// a command that silently ignores the number.
+func showAcceptsID(cmd *cobra.Command) bool {
 	for _, sub := range cmd.Commands() {
-		if sub.Name() == name {
-			return true
+		if sub.Name() != "show" {
+			continue
 		}
+		for _, a := range ParseArgs(sub) {
+			if a.Kind == "identifier" {
+				return true
+			}
+		}
+		return false
 	}
 	return false
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -373,22 +373,24 @@ func Execute() {
 	// Use ExecuteC to get the executed command (for correct context access)
 	executedCmd, err := cmd.ExecuteC()
 
-	// Bare group command with explicit flags (e.g. "cards --in X"): the help
-	// function suppressed output. Convert to a usage error.
+	// Bare group command with a positional that matches no subcommand
+	// (e.g. "cards 12345", or "cards 12345 --in X"): Cobra stops at the group
+	// and renders help with a zero exit — so an agent that meant "cards show
+	// 12345" reads success while nothing ran. The help function suppressed the
+	// output; convert it to a usage error that names the mistake and points at
+	// the canonical path. This is checked before the bare-flags case so a
+	// scoped invocation keeps the specific hint rather than the generic one.
+	if err == nil && executedCmd != cmd && isBareGroupWithUnknownArg(executedCmd) {
+		err = unknownSubcommandError(executedCmd, executedCmd.Flags().Args()[0])
+	}
+
+	// Bare group command with explicit flags but no positional (e.g. "cards
+	// --in X"): the help function suppressed output. Convert to a usage error.
 	if err == nil && executedCmd != cmd && isBareGroupWithFlags(executedCmd) {
 		err = output.ErrUsageHint(
 			"subcommand required",
 			"Usage: "+executedCmd.CommandPath()+" <command> [flags]",
 		)
-	}
-
-	// Bare group command with a positional that matches no subcommand
-	// (e.g. "cards 12345"): Cobra stops at the group and renders help with a
-	// zero exit — so an agent that meant "cards show 12345" reads success while
-	// nothing ran. The help function suppressed the output; convert it to a
-	// usage error that names the mistake and points at the canonical path.
-	if err == nil && executedCmd != cmd && isBareGroupWithUnknownArg(executedCmd) {
-		err = unknownSubcommandError(executedCmd, executedCmd.Flags().Args()[0])
 	}
 
 	if err != nil {
@@ -719,13 +721,14 @@ func isAllDigits(s string) bool {
 	return true
 }
 
-// showAcceptsID reports whether cmd has a show subcommand that takes an
-// identifier positional. A singleton "show" (accounts, config, hillcharts)
-// takes no id, so suggesting "<group> show <id>" there would send the caller to
-// a command that silently ignores the number.
+// showAcceptsID reports whether cmd has a show action that takes an identifier
+// positional. A singleton "show" (accounts, config, hillcharts) takes no id, so
+// suggesting "<group> show <id>" there would send the caller to a command that
+// silently ignores the number. The action is matched by name or alias, so a
+// command like chat's "line" that exposes "show" as an alias still counts.
 func showAcceptsID(cmd *cobra.Command) bool {
 	for _, sub := range cmd.Commands() {
-		if sub.Name() != "show" {
+		if !commandMatches(sub, "show") {
 			continue
 		}
 		for _, a := range ParseArgs(sub) {
@@ -734,6 +737,20 @@ func showAcceptsID(cmd *cobra.Command) bool {
 			}
 		}
 		return false
+	}
+	return false
+}
+
+// commandMatches reports whether name is cmd's primary name or one of its
+// aliases.
+func commandMatches(cmd *cobra.Command, name string) bool {
+	if cmd.Name() == name {
+		return true
+	}
+	for _, alias := range cmd.Aliases {
+		if alias == name {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -696,6 +696,11 @@ func unknownSubcommandError(cmd *cobra.Command) error {
 	if isAllDigits(arg) && hasSubcommandNamed(cmd, "show") {
 		return output.ErrUsageHint(msg, fmt.Sprintf("Did you mean %q?", cmd.CommandPath()+" show "+arg))
 	}
+	// Only the root sets SuggestionsMinimumDistance; a group left at zero would
+	// match nothing but an exact prefix, so borrow the root's threshold.
+	if cmd.SuggestionsMinimumDistance <= 0 {
+		cmd.SuggestionsMinimumDistance = cmd.Root().SuggestionsMinimumDistance
+	}
 	if suggestions := cmd.SuggestionsFor(arg); len(suggestions) > 0 {
 		return output.ErrUsageHint(msg, "Did you mean: "+strings.Join(suggestions, ", ")+"?")
 	}


### PR DESCRIPTION
## The defect

`basecamp cards 12345` — a bare numeric positional on the group noun `cards` — returned **exit 0 and the group help**. To an agent that meant `basecamp cards show 12345`, that reads as success while nothing ran: a silent no-op masked as OK.

This is the residual from #416 ("Remove shortcut commands that shadow group nouns"). That PR fixed the *top-level* `basecamp card 12345` case — it now errors non-zero with `unknown command "card" … Did you mean cards?`. But the same footgun survived one level down on the group nouns themselves.

Investigation showed it is **systemic, not cards-only**: `cards`, `todos`, `messages`, and `comments` all exited 0 + help on a bare positional. Root cause — Cobra's default `legacyArgs` rejects an unknown first arg **only for the root command**; every non-root group parent (no `RunE`) falls through to help with a zero exit.

## Convention matched

The CLI already has a bare-group seam: `isBareGroupWithFlags` converts `basecamp cards --in X` (a group invoked with stray flags, no subcommand) into a non-zero usage error, and the root help function suppresses help output so `Execute()` can emit it. This change extends that exact seam to cover a stray **positional** the same way it already covers stray **flags** — mirroring #416's top-level fix one level down, and honoring the Agent Accessibility principle: no silent exit-0 that hides a no-op. Bare `cards` (no args) still shows help with exit 0; nothing about the command surface changes.

## The fix

- `isBareGroupWithUnknownArg` — a non-runnable group carrying a leftover positional (parallel to `isBareGroupWithFlags`). The root help function suppresses help for it; `Execute()` converts it to a usage error.
- `unknownSubcommandError` returns `output.ErrUsageHint` (code `usage`, exit 1) that names the unknown command and points at the canonical path: for a numeric id it spells out `Did you mean "basecamp cards show 12345"?`; otherwise it offers Cobra's spelling suggestions, falling back to `--help`.

Because the fix lives at the shared seam, it resolves `cards` (the residual) **and** every sibling group noun uniformly.

```
$ basecamp cards 12345
{ "ok": false, "error": "unknown command \"12345\" for \"basecamp cards\"",
  "code": "usage", "hint": "Did you mean \"basecamp cards show 12345\"?" }   # exit 1

$ basecamp cards            # unchanged: help, exit 0
$ basecamp cards show 123   # unchanged: routes to the show subcommand
```

The error is classified `usage` (exit 1), not `api_error` — an agent branching on the code sees a usage mistake it must not retry, per the same reasoning behind `TestTransformCobraErrorClassifiesArityAsUsage`.

## Test coverage

- `internal/cli/help_test.go`: `isBareGroupWithUnknownArg` detects `cards 12345` / `todos 999` / `comments 55` / a typo, with help suppressed; `unknownSubcommandError` asserts code, message, and both hint variants (numeric→show, typo→help); a routing test confirms `cards show 123` resolves past the guard to the runnable leaf.
- `e2e/errors.bats`: `basecamp cards 12345` and `basecamp messages shwo` exit non-zero with the usage envelope and hint.

Tracking: [Agent Accessibility card 10265932727](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10265932727) (residual from #416).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group commands previously treated stray positional arguments as successful help; they now return a non-zero `usage` error. For example, `basecamp cards 12345` suggests `cards show 12345` instead of masking a no-op as success.

- Applies to `cards`, `todos`, `messages`, `comments`, `chat`, and nested groups such as `cards column` and `cards step`.
- Numeric hints target only identifier-taking `show` commands; singleton groups such as `accounts` fall back to `--help`.
- Typos suggest the nearest subcommand, including aliases, while scoped calls such as `cards 12345 --in myproject` retain the specific hint.
- Bare groups and explicit `--help` remain unchanged; `--help=false` still reports the stray argument.
- Adds unit and end-to-end coverage for the usage envelope and routing behavior.

<sup>Written for commit 11011ee393e8e03244aabe93e89017e81f1370cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

