### PR TITLE
deps: bump google.golang.org/grpc to v1.83.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,8 +140,8 @@ require (
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.83.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -506,10 +506,10 @@ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgn
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:Kjn0N0tCrDgiAFW+lGO4JZ3ck44CehvJQMAwj9QF0G8=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 h1:PvEgGJf9C/1u5CHkInMg7UFYYUoiaQmW2LbtH0pjB78=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-aiOnf1ZoeFKVCDrc47QIP0aNWPf63bqdeDrpqDbWt5Y=";
+  vendorHash = "sha256-2N7ar+f9S2WjppdHFbeiOhoREM81+yhTPn4bJZBGG/U=";
 
   subPackages = [ "cmd/basecamp" ];
 


### PR DESCRIPTION
## What

Bumps the indirect dependency `google.golang.org/grpc` from v1.82.1 to v1.83.1 (and its `genproto/googleapis/rpc` transitive along with it).

## Why

Trivy's filesystem scan (`severity: HIGH,CRITICAL`, `ignore-unfixed: true`) fails the build on [CVE-2026-84304](https://avd.aquasec.com/nvd/cve-2026-84304) (HIGH) in grpc v1.82.1, fixed in v1.83.1. The advisory was disclosed after `main`'s last green scan, so the same pinned dependency that passed before now fails — the red is **repo-wide**, reproducing on clean `main` and every open PR, which obscures real CI signal.

## Scope

- `go.mod` / `go.sum` only — grpc is indirect, so no first-party code changes.
- `GOWORK=off make build` and `go build ./...` pass; `make tidy-check` is clean.
- Verified locally with the CI Trivy flags: the scan now reports zero HIGH/CRITICAL fixable findings (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps indirect `google.golang.org/grpc` from v1.82.1 to v1.83.1 to clear CVE-2026-84304 (HIGH), which Trivy's CI scan fails on. Also updates the `google.golang.org/genproto/googleapis/rpc` transitive dependency and refreshes the Nix `vendorHash` in `nix/package.nix` to match the new `go.sum`. No first-party code changes; `go build ./...` and `make tidy-check` pass, and Trivy reports zero HIGH/CRITICAL fixable findings.

<sup>Written for commit 7039b073f069374a307b21ccd485246e3deb72a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

