### PR TITLE
Preserve account context in template library breadcrumbs

### DIFF
--- a/internal/commands/templates.go
+++ b/internal/commands/templates.go
@@ -144,10 +144,15 @@ func newTemplatesLibraryCmd() *cobra.Command {
 		Long:  "List the account's active to-do list templates.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
-
+			persistentAccount := hasPersistentAccount(app.Config)
 			if err := ensureAccount(cmd, app); err != nil {
 				return err
 			}
+			contextArgs := templateCommandContextArgs(
+				app.Config.ActiveProfile,
+				persistentAccount,
+				app.Config.AccountID,
+			)
 
 			library, err := app.Account().Templates().GetLibrary(cmd.Context())
 			if err != nil {
@@ -169,7 +174,7 @@ func newTemplatesLibraryCmd() *cobra.Command {
 				output.WithBreadcrumbs(
 					output.Breadcrumb{
 						Action:      "copy",
-						Cmd:         "basecamp templates copy <template-id> --in <project>",
+						Cmd:         "basecamp templates copy <template-id> --in <project>" + contextArgs,
 						Description: "Copy a template into a project",
 					},
 				),

--- a/internal/commands/templates_test.go
+++ b/internal/commands/templates_test.go
@@ -72,6 +72,8 @@ func TestTemplatesLibraryUsesSDKLibraryEndpoint(t *testing.T) {
 		body:   templateLibraryJSON,
 	})
 	buf := captureTemplateOutput(app)
+	app.Config.ActiveProfile = "work profile"
+	app.Config.Sources = map[string]string{"account_id": string(config.SourceFlag)}
 
 	err := executeRecordingCommand(NewTemplatesCmd(), app, "library")
 	require.NoError(t, err)
@@ -82,7 +84,7 @@ func TestTemplatesLibraryUsesSDKLibraryEndpoint(t *testing.T) {
 	envelope := decodeTemplateEnvelope(t, buf)
 	assert.Equal(t, "1 active to-do list templates", envelope.Summary)
 	require.Len(t, envelope.Breadcrumbs, 1)
-	assert.Equal(t, "basecamp templates copy <template-id> --in <project>", envelope.Breadcrumbs[0].Cmd)
+	assert.Equal(t, "basecamp templates copy <template-id> --in <project> --profile 'work profile' --account 99999", envelope.Breadcrumbs[0].Cmd)
 }
 
 func TestTemplatesLibraryHumanOutputShowsCopyableID(t *testing.T) {


### PR DESCRIPTION
## What

- Preserve the active profile and any process-local account selection in the `templates library` copy breadcrumb.
- Cover profile quoting and flag-sourced account propagation with a regression test.

## Why

Following the advertised copy command after running `templates library` with a one-off `--profile` or `--account` could resolve against a different account in the next process. The other template copy and status breadcrumbs already carry this context.

## Testing

- [x] `bin/ci`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the active profile and account selection in the `templates library` copy breadcrumb so the advertised command works against the same account in the next process. Previously, following the breadcrumb after a one-off `--profile` or `--account` could resolve against a different account.

- Appends `--profile` and `--account` flags to the copy breadcrumb when they are set.
- Adds a regression test covering profile quoting and flag-sourced account propagation.

<sup>Written for commit 54be488d268c066d12d0205e8383d9fa1b7c237d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

