### PR TITLE
Update release metadata for v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "basecamp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Basecamp integration for Claude Code. Create todos, track work, link code to projects.",
   "author": {
     "name": "37signals",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "basecamp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Use Basecamp from Codex to find work, create todos, and keep projects up to date.",
   "author": {
     "name": "37signals",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,7 +3,7 @@
 buildGoModule.override { go = go_1_26; } (finalAttrs: {
   pname = "basecamp";
   # Updated automatically by scripts/update-nix-flake.sh on each release.
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = lib.cleanSource ./..;
 


### PR DESCRIPTION
## Summary

- set the Nix package version to `0.10.0`
- set the Claude and Codex plugin versions to `0.10.0`

## Validation

- `make release-check`
- `make test-release`
- Nix build verification from `scripts/update-nix-flake.sh`

This release-prep PR is required because `main` accepts changes through pull requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v0.10.0 release by bumping the Nix package and the Claude and Codex plugin versions from 0.9.1 to 0.10.0.

<sup>Written for commit 22e617cfa2a792f22bc85dd2fa4eddbd1f555a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

