### PR TITLE
Refuse browser and pasted-callback logins under BASECAMP_NONINTERACTIVE

### DIFF
--- a/e2e/auth.bats
+++ b/e2e/auth.bats
@@ -119,6 +119,14 @@ load test_helper
   assert_output_contains "with-token"
 }
 
+@test "basecamp auth login refuses to run under BASECAMP_NONINTERACTIVE" {
+  run env BASECAMP_NONINTERACTIVE=1 basecamp auth login
+  assert_failure
+  assert_output_contains "BASECAMP_NONINTERACTIVE"
+  assert_output_contains "--device-code"
+  assert_output_contains "--with-token"
+}
+
 @test "basecamp auth login rejects --device-code --local" {
   run basecamp auth login --device-code --local
   assert_failure

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -528,6 +528,12 @@ func (m *Manager) loginLaunchpad(ctx context.Context, credKey string, oauthCfg *
 	resolve := func(bool) {} // no-op default for remote mode
 
 	if opts.Remote {
+		if config.NonInteractiveEnv() {
+			return nil, output.ErrUsageHint("Cannot prompt for the callback URL under BASECAMP_NONINTERACTIVE",
+				"This server signs in through the browser flow, which in remote mode waits for the redirect URL to be pasted here. "+
+					"Unset BASECAMP_NONINTERACTIVE to paste it, or import a token headlessly: "+
+					"`... | basecamp auth login --with-token -P <profile> --account <id>`.")
+		}
 		// Remote/headless mode: prompt user to paste callback URL
 		opts.log("\nRemote Authentication")
 		opts.log("")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -399,7 +399,7 @@ func (o *LoginOptions) defaults() {
 	if !o.Remote && !o.Local && hostutil.IsRemoteSession() {
 		o.Remote = true
 	}
-	if o.Remote {
+	if o.Remote || config.NonInteractiveEnv() {
 		o.NoBrowser = true
 	}
 	if o.BrowserLauncher == nil && !o.NoBrowser {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -487,6 +487,17 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) (*LoginResult, e
 // browser (or printed) auth URL, then a loopback callback or pasted
 // callback URL in remote mode.
 func (m *Manager) loginLaunchpad(ctx context.Context, credKey string, oauthCfg *oauth.Config, opts *LoginOptions) (*LoginResult, error) {
+	// Both Launchpad shapes wait on a person: the loopback callback on a
+	// browser someone signs into, the remote one on a pasted redirect URL.
+	// Every login entry point converges here, so this is where the
+	// environment's word that nobody is at the terminal is final.
+	if config.NonInteractiveEnv() {
+		return nil, output.ErrUsageHint("Interactive login cannot run under BASECAMP_NONINTERACTIVE",
+			"This authorization server signs in through the browser — a loopback callback, or a pasted redirect URL in remote mode — and does not offer the device flow. "+
+				"Unset BASECAMP_NONINTERACTIVE to sign in, or import a token headlessly: "+
+				"`... | basecamp auth login --with-token -P <profile> --account <id>`.")
+	}
+
 	// Resolve redirect URI and listener address
 	redirectURI, listenAddr, err := resolveOAuthCallback(opts)
 	if err != nil {
@@ -528,12 +539,6 @@ func (m *Manager) loginLaunchpad(ctx context.Context, credKey string, oauthCfg *
 	resolve := func(bool) {} // no-op default for remote mode
 
 	if opts.Remote {
-		if config.NonInteractiveEnv() {
-			return nil, output.ErrUsageHint("Cannot prompt for the callback URL under BASECAMP_NONINTERACTIVE",
-				"This server signs in through the browser flow, which in remote mode waits for the redirect URL to be pasted here. "+
-					"Unset BASECAMP_NONINTERACTIVE to paste it, or import a token headlessly: "+
-					"`... | basecamp auth login --with-token -P <profile> --account <id>`.")
-		}
 		// Remote/headless mode: prompt user to paste callback URL
 		opts.log("\nRemote Authentication")
 		opts.log("")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -869,6 +869,21 @@ func TestLoginRemoteAndLocalMutuallyExclusive(t *testing.T) {
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
+// TestLoginDefaultsNeverOpenABrowserUnderNonInteractiveEnv: whatever flow a
+// caller reaches under the variable, no browser is launched for it — the
+// device flow prints its code instead, which is the shape the variable's
+// callers can relay.
+func TestLoginDefaultsNeverOpenABrowserUnderNonInteractiveEnv(t *testing.T) {
+	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+	opts := LoginOptions{Local: true}
+	opts.defaults()
+	assert.True(t, opts.NoBrowser)
+	assert.Nil(t, opts.BrowserLauncher)
+}
+
 // TestLoginLaunchpadRefusesNonInteractiveEnv: both Launchpad shapes wait on a
 // person — a browser at the loopback callback, or a pasted redirect URL —
 // and every login entry point reaches them through loginLaunchpad. Under

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -869,50 +869,61 @@ func TestLoginRemoteAndLocalMutuallyExclusive(t *testing.T) {
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
-// TestLoginRemoteModeRefusesNonInteractiveEnv: the pasted-callback prompt is
-// the one place a login reads the terminal. Under BASECAMP_NONINTERACTIVE it
-// becomes an actionable error, before the instructions it would otherwise
-// print and without reading a byte of stdin.
-func TestLoginRemoteModeRefusesNonInteractiveEnv(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
-	}))
-	defer srv.Close()
+// TestLoginLaunchpadRefusesNonInteractiveEnv: both Launchpad shapes wait on a
+// person — a browser at the loopback callback, or a pasted redirect URL —
+// and every login entry point reaches them through loginLaunchpad. Under
+// BASECAMP_NONINTERACTIVE they become an actionable error before a browser
+// is launched, a listener opened, or a byte of stdin read.
+func TestLoginLaunchpadRefusesNonInteractiveEnv(t *testing.T) {
+	for name, opts := range map[string]LoginOptions{
+		"local":  {Local: true},
+		"remote": {Remote: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
 
-	tmpDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-	t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
-	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+			tmpDir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", tmpDir)
+			t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
+			t.Setenv("BASECAMP_NONINTERACTIVE", "1")
 
-	cfg := &config.Config{BaseURL: srv.URL}
-	m := NewManager(cfg, srv.Client())
-	m.store = newTestStore(t, tmpDir)
+			cfg := &config.Config{BaseURL: srv.URL}
+			m := NewManager(cfg, srv.Client())
+			m.store = newTestStore(t, tmpDir)
 
-	sl := newSyncLogger()
-	pr, pw := io.Pipe()
-	defer pr.Close()
-	defer pw.Close()
+			sl := newSyncLogger()
+			pr, pw := io.Pipe()
+			defer pr.Close()
+			defer pw.Close()
+			opts.Logger = sl.log
+			opts.InputReader = pr
+			opts.BrowserLauncher = func(string) error {
+				t.Error("browser launched under BASECAMP_NONINTERACTIVE")
+				return nil
+			}
 
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := m.Login(context.Background(), LoginOptions{
-			Remote:      true,
-			Logger:      sl.log,
-			InputReader: pr,
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := m.Login(context.Background(), opts)
+				errCh <- err
+			}()
+
+			select {
+			case err := <-errCh:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
+				assert.Contains(t, err.Error(), "--with-token")
+			case <-time.After(5 * time.Second):
+				t.Fatal("Launchpad login waited on a person under BASECAMP_NONINTERACTIVE")
+			}
+			for _, line := range sl.snapshot() {
+				assert.NotContains(t, line, "Paste the callback URL")
+				assert.NotContains(t, line, "Opening browser")
+			}
 		})
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
-		assert.Contains(t, err.Error(), "--with-token")
-	case <-time.After(5 * time.Second):
-		t.Fatal("remote login waited on stdin under BASECAMP_NONINTERACTIVE")
-	}
-	for _, line := range sl.snapshot() {
-		assert.NotContains(t, line, "Paste the callback URL")
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -869,6 +869,53 @@ func TestLoginRemoteAndLocalMutuallyExclusive(t *testing.T) {
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
+// TestLoginRemoteModeRefusesNonInteractiveEnv: the pasted-callback prompt is
+// the one place a login reads the terminal. Under BASECAMP_NONINTERACTIVE it
+// becomes an actionable error, before the instructions it would otherwise
+// print and without reading a byte of stdin.
+func TestLoginRemoteModeRefusesNonInteractiveEnv(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
+	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+
+	cfg := &config.Config{BaseURL: srv.URL}
+	m := NewManager(cfg, srv.Client())
+	m.store = newTestStore(t, tmpDir)
+
+	sl := newSyncLogger()
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	defer pw.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := m.Login(context.Background(), LoginOptions{
+			Remote:      true,
+			Logger:      sl.log,
+			InputReader: pr,
+		})
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
+		assert.Contains(t, err.Error(), "--with-token")
+	case <-time.After(5 * time.Second):
+		t.Fatal("remote login waited on stdin under BASECAMP_NONINTERACTIVE")
+	}
+	for _, line := range sl.snapshot() {
+		assert.NotContains(t, line, "Paste the callback URL")
+	}
+}
+
 func TestLoginRemoteMode(t *testing.T) {
 	// No protected-resource metadata (404) => Launchpad fallback, pointed
 	// at this server via BASECAMP_LAUNCHPAD_URL.

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -304,12 +304,8 @@ named profile, creating the profile when --account is given.
 						"Check credentials with `basecamp auth status`, or import a token headlessly: "+
 						"`... | basecamp auth login --with-token -P <profile> --account <id> --json`.")
 			}
-			if config.NonInteractiveEnv() && !deviceCode {
-				return output.ErrUsageHint("Interactive login cannot run under BASECAMP_NONINTERACTIVE",
-					"Browser and pasted-callback logins wait on a person at this terminal. "+
-						"Import a token headlessly: `... | basecamp auth login --with-token -P <profile> --account <id>`; "+
-						"pass --device-code where the server offers the device flow (Launchpad does not) to approve the printed code from any device; "+
-						"or check credentials with `basecamp auth status`.")
+			if err := refuseNonInteractiveLogin(deviceCode); err != nil {
+				return err
 			}
 			if expect != 0 && os.Getenv("BASECAMP_TOKEN") != "" {
 				return errEnvTokenShadows("--expect-identity cannot be checked while BASECAMP_TOKEN is set")
@@ -627,6 +623,23 @@ func readTokenFromStdin(cmd *cobra.Command) (string, error) {
 		return "", output.ErrUsage("Token on stdin must be a single line with no whitespace or control characters (one trailing line ending is allowed)")
 	}
 	return token, nil
+}
+
+// refuseNonInteractiveLogin is the environment half of the login gate.
+// BASECAMP_NONINTERACTIVE says nobody is at this terminal, and every OAuth
+// flow but one waits on a person: a browser at the loopback callback, a
+// pasted redirect URL, or an approval page the browser was opened to.
+// --device-code is that one: it prints a code to approve from any device
+// and asks nothing of the terminal, so it is the caller's stated intent.
+func refuseNonInteractiveLogin(deviceCode bool) error {
+	if !config.NonInteractiveEnv() || deviceCode {
+		return nil
+	}
+	return output.ErrUsageHint("Interactive login cannot run under BASECAMP_NONINTERACTIVE",
+		"Browser and pasted-callback logins wait on a person at this terminal. "+
+			"Import a token headlessly: `... | basecamp auth login --with-token -P <profile> --account <id>`; "+
+			"pass --device-code where the server offers the device flow (Launchpad does not) to approve the printed code from any device; "+
+			"or check credentials with `basecamp auth status`.")
 }
 
 // machineOutputFlagSet reports whether an explicit output flag asked for a

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -307,8 +307,9 @@ named profile, creating the profile when --account is given.
 			if config.NonInteractiveEnv() && !deviceCode {
 				return output.ErrUsageHint("Interactive login cannot run under BASECAMP_NONINTERACTIVE",
 					"Browser and pasted-callback logins wait on a person at this terminal. "+
-						"Pass --device-code to approve the printed code from any device, import a token headlessly: "+
-						"`... | basecamp auth login --with-token -P <profile> --account <id>`, or check credentials with `basecamp auth status`.")
+						"Import a token headlessly: `... | basecamp auth login --with-token -P <profile> --account <id>`; "+
+						"pass --device-code where the server offers the device flow (Launchpad does not) to approve the printed code from any device; "+
+						"or check credentials with `basecamp auth status`.")
 			}
 			if expect != 0 && os.Getenv("BASECAMP_TOKEN") != "" {
 				return errEnvTokenShadows("--expect-identity cannot be checked while BASECAMP_TOKEN is set")

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -304,6 +304,12 @@ named profile, creating the profile when --account is given.
 						"Check credentials with `basecamp auth status`, or import a token headlessly: "+
 						"`... | basecamp auth login --with-token -P <profile> --account <id> --json`.")
 			}
+			if config.NonInteractiveEnv() && !deviceCode {
+				return output.ErrUsageHint("Interactive login cannot run under BASECAMP_NONINTERACTIVE",
+					"Browser and pasted-callback logins wait on a person at this terminal. "+
+						"Pass --device-code to approve the printed code from any device, import a token headlessly: "+
+						"`... | basecamp auth login --with-token -P <profile> --account <id>`, or check credentials with `basecamp auth status`.")
+			}
 			if expect != 0 && os.Getenv("BASECAMP_TOKEN") != "" {
 				return errEnvTokenShadows("--expect-identity cannot be checked while BASECAMP_TOKEN is set")
 			}

--- a/internal/commands/auth_login_test.go
+++ b/internal/commands/auth_login_test.go
@@ -743,6 +743,47 @@ func TestAuthLoginRefusesMachineOutputForInteractiveFlows(t *testing.T) {
 	}
 }
 
+// TestAuthLoginRefusesNonInteractiveEnvWithoutDeviceCode covers the env half
+// of the gate. BASECAMP_NONINTERACTIVE says nobody is at this terminal, so the
+// flows that wait on one — a browser callback, a pasted URL — refuse before
+// any network call. --device-code is the stated exception: it prints a code
+// to approve from any device and asks nothing of the terminal.
+func TestAuthLoginRefusesNonInteractiveEnvWithoutDeviceCode(t *testing.T) {
+	for name, args := range map[string][]string{
+		"default":    nil,
+		"remote":     {"--remote"},
+		"local":      {"--local"},
+		"no-browser": {"--no-browser"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+			srv := startLoginIdentityServer(t, "bc_at_secret")
+			app, _ := loginTestApp(t, srv, &config.Config{})
+			_, err := runLogin(t, app, strings.NewReader(""), args...)
+			require.Error(t, err)
+			assert.Equal(t, output.CodeUsage, output.AsError(err).Code)
+			assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
+			assert.Contains(t, err.Error(), "--device-code")
+			assert.Contains(t, err.Error(), "--with-token")
+			assert.Empty(t, srv.seenBearers())
+		})
+	}
+}
+
+func TestAuthLoginDeviceCodeRunsUnderNonInteractiveEnv(t *testing.T) {
+	srv := startLoginIdentityServer(t, "dev-tok")
+	srv.srv.Config.Handler = deviceGrantThen(t, srv.srv.Config.Handler)
+	app, _ := loginTestApp(t, srv, &config.Config{ActiveProfile: "bot", Profiles: map[string]*config.ProfileConfig{"bot": {AccountID: "999"}}})
+	withAccount(app, "999", "profile")
+	t.Setenv("BASECAMP_OAUTH_ISSUER", srv.srv.URL)
+	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+
+	out, err := runLogin(t, app, strings.NewReader(""), "--device-code")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "and enter the code: ABCD-EFGH")
+	assert.Contains(t, out, "Authentication successful")
+}
+
 func TestAuthLoginUnknownProfileNeedsCreateOrToken(t *testing.T) {
 	srv := startLoginIdentityServer(t, "bc_at_secret")
 	app, _ := loginTestApp(t, srv, &config.Config{ActiveProfile: "ghost"})

--- a/internal/commands/auth_login_test.go
+++ b/internal/commands/auth_login_test.go
@@ -763,8 +763,8 @@ func TestAuthLoginRefusesNonInteractiveEnvWithoutDeviceCode(t *testing.T) {
 			require.Error(t, err)
 			assert.Equal(t, output.CodeUsage, output.AsError(err).Code)
 			assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
-			assert.Contains(t, err.Error(), "--device-code")
 			assert.Contains(t, err.Error(), "--with-token")
+			assert.Contains(t, err.Error(), "--device-code where the server offers the device flow")
 			assert.Empty(t, srv.seenBearers())
 		})
 	}

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -246,6 +246,10 @@ Examples:
 				profileCfg.AccountID = accountID
 			}
 
+			if err := refuseNonInteractiveLogin(deviceCode); err != nil {
+				return err
+			}
+
 			// The entry is written only after the login succeeds, so prove
 			// the config file can take it before a credential exists to
 			// orphan: a malformed file is refused here, not after OAuth.
@@ -265,9 +269,6 @@ Examples:
 			app.Config.ActiveProfile = name
 			app.Config.BaseURL = profileCfg.BaseURL
 
-			if err := refuseNonInteractiveLogin(deviceCode); err != nil {
-				return err
-			}
 			if deviceCode {
 				remote = true
 			}

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -265,6 +265,9 @@ Examples:
 			app.Config.ActiveProfile = name
 			app.Config.BaseURL = profileCfg.BaseURL
 
+			if err := refuseNonInteractiveLogin(deviceCode); err != nil {
+				return err
+			}
 			if deviceCode {
 				remote = true
 			}

--- a/internal/commands/profile_test.go
+++ b/internal/commands/profile_test.go
@@ -287,43 +287,50 @@ func TestProfileCreateDeviceCodeForcesRemoteMode(t *testing.T) {
 		"--device-code must select the remote paste-callback flow")
 }
 
-// TestProfileCreateRefusesNonInteractiveEnvOnLaunchpad: profile create
-// reaches Manager.Login without the login command's gate, so the auth-layer
-// refusal is what stops it opening a browser and waiting on the loopback
-// callback under BASECAMP_NONINTERACTIVE.
-func TestProfileCreateRefusesNonInteractiveEnvOnLaunchpad(t *testing.T) {
-	t.Setenv("BASECAMP_NO_KEYRING", "1")
-	tmpDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+// TestProfileCreateRefusesNonInteractiveEnv: profile create runs the same
+// OAuth flows as login, so it carries the same gate. Without --device-code
+// it refuses before discovery; with it, a Launchpad-backed server — whose
+// device-code shape is the pasted callback — is refused by the auth layer.
+func TestProfileCreateRefusesNonInteractiveEnv(t *testing.T) {
+	for name, args := range map[string][]string{
+		"default":     nil,
+		"device-code": {"--device-code"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("BASECAMP_NO_KEYRING", "1")
+			tmpDir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", tmpDir)
+			t.Setenv("BASECAMP_NONINTERACTIVE", "1")
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
-	}))
-	defer srv.Close()
-	t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+			t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
 
-	cfg := &config.Config{BaseURL: srv.URL, CacheDir: t.TempDir(), Sources: make(map[string]string)}
-	authMgr := auth.NewManager(cfg, srv.Client())
-	authMgr.SetStore(auth.NewStore(tmpDir))
-	app := &appctx.App{Config: cfg, Auth: authMgr}
+			cfg := &config.Config{BaseURL: srv.URL, CacheDir: t.TempDir(), Sources: make(map[string]string)}
+			authMgr := auth.NewManager(cfg, srv.Client())
+			authMgr.SetStore(auth.NewStore(tmpDir))
+			app := &appctx.App{Config: cfg, Auth: authMgr}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-	root := &cobra.Command{Use: "basecamp"}
-	root.AddCommand(NewProfileCmd())
-	root.SetArgs([]string{"profile", "create", "test-profile", "--base-url", srv.URL, "--local", "--no-browser"})
-	root.SetContext(appctx.WithApp(ctx, app))
-	root.SetOut(&bytes.Buffer{})
-	root.SetErr(&bytes.Buffer{})
+			root := &cobra.Command{Use: "basecamp"}
+			root.AddCommand(NewProfileCmd())
+			root.SetArgs(append([]string{"profile", "create", "test-profile", "--base-url", srv.URL}, args...))
+			root.SetContext(appctx.WithApp(ctx, app))
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
 
-	err := root.Execute()
-	require.Error(t, err)
-	assert.Equal(t, output.CodeUsage, output.AsError(err).Code)
-	assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
-	assert.Contains(t, err.Error(), "--with-token")
-	assert.Empty(t, cfg.Profiles, "a refused login registers no profile")
+			err := root.Execute()
+			require.Error(t, err)
+			assert.Equal(t, output.CodeUsage, output.AsError(err).Code)
+			assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
+			assert.Contains(t, err.Error(), "--with-token")
+			assert.Empty(t, cfg.Profiles, "a refused login registers no profile")
+		})
+	}
 }
 
 func TestProfileCreateRejectsDuplicateName(t *testing.T) {

--- a/internal/commands/profile_test.go
+++ b/internal/commands/profile_test.go
@@ -287,6 +287,45 @@ func TestProfileCreateDeviceCodeForcesRemoteMode(t *testing.T) {
 		"--device-code must select the remote paste-callback flow")
 }
 
+// TestProfileCreateRefusesNonInteractiveEnvOnLaunchpad: profile create
+// reaches Manager.Login without the login command's gate, so the auth-layer
+// refusal is what stops it opening a browser and waiting on the loopback
+// callback under BASECAMP_NONINTERACTIVE.
+func TestProfileCreateRefusesNonInteractiveEnvOnLaunchpad(t *testing.T) {
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("BASECAMP_NONINTERACTIVE", "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("BASECAMP_LAUNCHPAD_URL", srv.URL)
+
+	cfg := &config.Config{BaseURL: srv.URL, CacheDir: t.TempDir(), Sources: make(map[string]string)}
+	authMgr := auth.NewManager(cfg, srv.Client())
+	authMgr.SetStore(auth.NewStore(tmpDir))
+	app := &appctx.App{Config: cfg, Auth: authMgr}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	root := &cobra.Command{Use: "basecamp"}
+	root.AddCommand(NewProfileCmd())
+	root.SetArgs([]string{"profile", "create", "test-profile", "--base-url", srv.URL, "--local", "--no-browser"})
+	root.SetContext(appctx.WithApp(ctx, app))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Equal(t, output.CodeUsage, output.AsError(err).Code)
+	assert.Contains(t, err.Error(), "BASECAMP_NONINTERACTIVE")
+	assert.Contains(t, err.Error(), "--with-token")
+	assert.Empty(t, cfg.Profiles, "a refused login registers no profile")
+}
+
 func TestProfileCreateRejectsDuplicateName(t *testing.T) {
 	cfg := &config.Config{
 		BaseURL:  "https://3.basecampapi.com",

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -1385,7 +1385,7 @@ basecamp auth login                               # Re-authenticate
 basecamp auth login --scope full                  # Full access (the default; ignored by Launchpad)
 basecamp auth login --scope read                  # Read-only access (ignored by Launchpad)
 basecamp auth login --device-code                 # Headless authentication with manual browser instructions
-BASECAMP_NONINTERACTIVE=1 basecamp auth login --device-code  # The only OAuth login that runs under BASECAMP_NONINTERACTIVE; browser and pasted-callback flows refuse
+BASECAMP_NONINTERACTIVE=1 basecamp auth login --device-code  # The only OAuth login that runs under BASECAMP_NONINTERACTIVE, and only where the server offers the device flow (Launchpad does not); browser and pasted-callback flows refuse — prefer --with-token
 basecamp auth login --with-token -P bot --account <id>  # Import a personal access token from stdin (pipe it in)
 basecamp auth login --expect-identity <id>        # Discard the login unless it authenticated as this identity
 basecamp profile create <name> --account <id> --expect-identity <id>  # Same assertion for a new profile

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -1385,6 +1385,7 @@ basecamp auth login                               # Re-authenticate
 basecamp auth login --scope full                  # Full access (the default; ignored by Launchpad)
 basecamp auth login --scope read                  # Read-only access (ignored by Launchpad)
 basecamp auth login --device-code                 # Headless authentication with manual browser instructions
+BASECAMP_NONINTERACTIVE=1 basecamp auth login --device-code  # The only OAuth login that runs under BASECAMP_NONINTERACTIVE; browser and pasted-callback flows refuse
 basecamp auth login --with-token -P bot --account <id>  # Import a personal access token from stdin (pipe it in)
 basecamp auth login --expect-identity <id>        # Discard the login unless it authenticated as this identity
 basecamp profile create <name> --account <id> --expect-identity <id>  # Same assertion for a new profile


### PR DESCRIPTION
#681 gated interactive login on the explicit machine-output flags and left the environment half of #669 open: `BASECAMP_NONINTERACTIVE=1 basecamp login` still opened a browser (or, under SSH, printed a URL and read stdin for a pasted callback) and sat there for up to five minutes. The repo's own contract for the variable — "the CLI must not show interactive prompts regardless of TTY detection; they become actionable errors" (`config.NonInteractiveEnv`, SKILL.md) — is what this applies to login.

## What

- **`auth login` / `login` refuse under `BASECAMP_NONINTERACTIVE` unless `--device-code` is given.** The check sits after the machine-output gate and before any network call, and its hint names the two headless shapes: `--device-code`, which prints a code to approve from any device and asks nothing of the terminal (the exception #681 argued for), and `--with-token`, plus `auth status` for a check. Same usage-error shape as the flag gate.
- **The pasted-callback prompt refuses under the variable too** (`internal/auth`). A device login on a Launchpad-backed host — every production account until the BC5 authorization server ships — falls back to remote mode, whose "Paste the callback URL" read is the one place a login consumes stdin. That prompt now returns the same actionable error before printing instructions, so the `--device-code` exemption cannot route a harness into a stdin wait.
- SKILL.md's auth block gains the one-line rule; no surface change.

## Verification

- Failing first: on `main`, `TestAuthLoginRefusesNonInteractiveEnvWithoutDeviceCode` (default, `--remote`, `--local`, `--no-browser`) and `TestLoginRemoteModeRefusesNonInteractiveEnv` do not fail fast — they hang on the callback wait until the harness timeout, which is the reported behavior. With the gates they refuse with `usage`, name `BASECAMP_NONINTERACTIVE`, `--device-code` and `--with-token`, and the identity server sees no request; the remote test also asserts the paste prompt was never logged.
- `TestAuthLoginDeviceCodeRunsUnderNonInteractiveEnv` proves the exemption end-to-end: a pinned-issuer device grant under the variable prints the code and completes.
- e2e: `auth.bats` case for the env refusal (exit non-zero, hint names both flags).
- `bin/ci` green on Linux (thelio, Go 1.26.7): fmt, vet, lint, unit, e2e, naming, surface, skill drift, bare groups, provenance, tidy.

## Not doing here

- Gating on a non-terminal stdin without the variable: the remote paste read already errors at EOF, and the browser flows never read stdin.
- Bounding the device flow's poll with `signal.NotifyContext`: separate from this gate.

Fixes #669

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #669: `basecamp auth login` and `basecamp profile create` now refuse browser and pasted-callback logins under `BASECAMP_NONINTERACTIVE` instead of opening a browser or waiting up to five minutes on a pasted callback. `--device-code` remains the exception, but only where the server offers the device flow — Launchpad does not.

**Changes**
- The gate now runs at the command layer for both `auth login` and `profile create`, plus again in the auth layer for every converging Launchpad shape, so the refusal happens before any network call, stdin read, or in-memory profile entry.
- `LoginOptions.defaults` treats the variable as `--no-browser` for every flow, so no login shape can launch a browser under it.
- The usage error names `--device-code` and `--with-token`; SKILL.md documents the rule.

<sup>Written for commit 4c767d3f72551fc3183b3859057a68642a28485d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

