### PR TITLE
feat(templates): add --start-date to templates construct

### DIFF
--- a/.surface
+++ b/.surface
@@ -13442,6 +13442,7 @@ FLAG basecamp templates construct --no-stats type=bool
 FLAG basecamp templates construct --profile type=string
 FLAG basecamp templates construct --project type=string
 FLAG basecamp templates construct --quiet type=bool
+FLAG basecamp templates construct --start-date type=string
 FLAG basecamp templates construct --stats type=bool
 FLAG basecamp templates construct --styled type=bool
 FLAG basecamp templates construct --todolist type=string

--- a/e2e/templates.bats
+++ b/e2e/templates.bats
@@ -109,6 +109,15 @@ load test_helper
   assert_output_contains "name required"
 }
 
+@test "templates construct with malformed start date shows error" {
+  create_credentials
+  create_global_config '{"account_id": 99999}'
+
+  run basecamp templates construct 123 --name "Project" --start-date someday
+  assert_failure
+  assert_output_contains "Invalid start date"
+}
+
 
 # Construction status errors
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/basecamp-sdk/go v0.17.0
+	github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe
 	github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/basecamp/surfguard/go v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe
+	github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d
 	github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/basecamp/surfguard/go v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
-	github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d
+	github.com/basecamp/basecamp-sdk/go v0.18.0
 	github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d
 	github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d
 	github.com/basecamp/surfguard/go v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe h1:oMOjC86dOmjeJitWcaO7ELmAmG/LnACewwDoaGeoATo=
-github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
+github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d h1:PUtCjOcMs3uinaUxQIDFmc1K3FceiS9kQRedlPdEKr4=
+github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d h1:jAzDrCCzDpIwhbFT1xVVs0z2xpXoDEkomHfKB2bUUp8=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d h1:PUtCjOcMs3uinaUxQIDFmc1K3FceiS9kQRedlPdEKr4=
-github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040941-9610e51f759d/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
+github.com/basecamp/basecamp-sdk/go v0.18.0 h1:A6Mu1ugnvvExNdLN4w9th6Tz2fktSdfbqbbDhxYgPPE=
+github.com/basecamp/basecamp-sdk/go v0.18.0/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d h1:jAzDrCCzDpIwhbFT1xVVs0z2xpXoDEkomHfKB2bUUp8=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/basecamp/basecamp-sdk/go v0.17.0 h1:u2kIDtr7bmHXLSkF61HXkLDymQdwoI+pzbT0F6OwHYM=
-github.com/basecamp/basecamp-sdk/go v0.17.0/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
+github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe h1:oMOjC86dOmjeJitWcaO7ELmAmG/LnACewwDoaGeoATo=
+github.com/basecamp/basecamp-sdk/go v0.17.1-0.20260910040302-11cc4b54ecfe/go.mod h1:Cs9DV8iRJaVT4+IQXGZTeyG2nQAV2kQda7GHuBOeonY=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d h1:jAzDrCCzDpIwhbFT1xVVs0z2xpXoDEkomHfKB2bUUp8=
 github.com/basecamp/cli v0.2.2-0.20260828230226-767413fc712d/go.mod h1:iTBTaWvsPEFIcZfkxQHEfISyJ6sZ7036K6bNx0RY3EE=
 github.com/basecamp/mcp v0.0.0-20260828100356-2d6f44b51e9d h1:zEQVGq1x1nhKMZ2TudFAcSJ32CHT8richI1vQakIKz4=

--- a/internal/commands/templates.go
+++ b/internal/commands/templates.go
@@ -655,7 +655,7 @@ the given date; without it they anchor to the week the project is constructed.`,
 			}
 
 			var parsedStart string
-			if strings.TrimSpace(startDate) != "" {
+			if cmd.Flags().Changed("start-date") {
 				parsedStart = dateparse.Parse(startDate)
 				if _, err := time.Parse("2006-01-02", parsedStart); err != nil {
 					return output.ErrUsage(fmt.Sprintf("Invalid start date: %q", startDate))

--- a/internal/commands/templates.go
+++ b/internal/commands/templates.go
@@ -12,6 +12,7 @@ import (
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 
 	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/dateparse"
 	"github.com/basecamp/basecamp-cli/internal/output"
 )
 
@@ -24,7 +25,7 @@ func NewTemplatesCmd() *cobra.Command {
 
 Project templates create projects with predefined structure, tools, and content.
 Library templates copy a reusable to-do list into an existing project.`,
-		Annotations: map[string]string{"agent_notes": "Project construction and to-do list template copies are asynchronous. Poll construction or copy-status until status=completed. Copy grants referenced people project access only with --confirm-adding-people."},
+		Annotations: map[string]string{"agent_notes": "Project construction and to-do list template copies are asynchronous. Poll construction or copy-status until status=completed. construct --start-date anchors the template's relative dates to the Sunday of that week; without it they anchor to the week of construction. Copy grants referenced people project access only with --confirm-adding-people."},
 	}
 
 	cmd.AddCommand(
@@ -629,6 +630,7 @@ func newTemplatesDeleteCmd() *cobra.Command {
 func newTemplatesConstructCmd() *cobra.Command {
 	var projectName string
 	var projectDesc string
+	var startDate string
 
 	cmd := &cobra.Command{
 		Use:   "construct <template_id>",
@@ -636,7 +638,11 @@ func newTemplatesConstructCmd() *cobra.Command {
 		Long: `Create a new project from a template.
 
 This is an asynchronous operation. The command returns a construction ID
-which can be polled via 'templates construction' until the status is "completed".`,
+which can be polled via 'templates construction' until the status is "completed".
+
+A template's dates are relative to the start of its first week, and template
+weeks start on a Sunday. --start-date anchors them to the Sunday on or before
+the given date; without it they anchor to the week the project is constructed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if projectName == "" {
@@ -646,6 +652,14 @@ which can be polled via 'templates construction' until the status is "completed"
 			templateID, err := strconv.ParseInt(args[0], 10, 64)
 			if err != nil {
 				return output.ErrUsage("Invalid template ID")
+			}
+
+			var parsedStart string
+			if strings.TrimSpace(startDate) != "" {
+				parsedStart = dateparse.Parse(startDate)
+				if _, err := time.Parse("2006-01-02", parsedStart); err != nil {
+					return output.ErrUsage(fmt.Sprintf("Invalid start date: %q", startDate))
+				}
 			}
 
 			// Syntactic checks first, then "-", then account and network.
@@ -660,7 +674,8 @@ which can be polled via 'templates construction' until the status is "completed"
 				return err
 			}
 
-			construction, err := app.Account().Templates().CreateProject(cmd.Context(), templateID, projectName, projectDesc)
+			construction, err := app.Account().Templates().CreateProject(cmd.Context(), templateID, projectName, projectDesc,
+				&basecamp.CreateProjectOptions{StartDate: parsedStart})
 			if err != nil {
 				return convertSDKError(err)
 			}
@@ -681,6 +696,7 @@ which can be polled via 'templates construction' until the status is "completed"
 	cmd.Flags().StringVar(&projectName, "name", "", "Project name (required)")
 	cmd.Flags().StringVar(&projectDesc, "description", "", "Project description; use - to read from stdin")
 	cmd.Flags().StringVar(&projectDesc, "desc", "", "Project description (alias)")
+	cmd.Flags().StringVar(&startDate, "start-date", "", "Project start date (YYYY-MM-DD or natural, e.g. \"next monday\"); template dates anchor to the Sunday of that week")
 	_ = cmd.MarkFlagRequired("name")
 
 	allowDash(cmd, "flag:description", "flag:desc")

--- a/internal/commands/templates_test.go
+++ b/internal/commands/templates_test.go
@@ -289,7 +289,9 @@ func TestTemplatesConstructParsesNaturalStartDate(t *testing.T) {
 	)
 	captureTemplateOutput(app)
 
+	before := time.Now()
 	err := executeRecordingCommand(NewTemplatesCmd(), app, "construct", "2085958507", "--name", "Marketing Campaign", "--start-date", "tomorrow")
+	after := time.Now()
 	require.NoError(t, err)
 
 	requests := transport.recorded()
@@ -300,7 +302,18 @@ func TestTemplatesConstructParsesNaturalStartDate(t *testing.T) {
 		} `json:"project"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(requests[0].Body), &body))
-	assert.Equal(t, time.Now().AddDate(0, 0, 1).Format("2006-01-02"), body.Project.StartDate)
+	tomorrow := func(now time.Time) string { return now.AddDate(0, 0, 1).Format("2006-01-02") }
+	assert.Contains(t, []string{tomorrow(before), tomorrow(after)}, body.Project.StartDate)
+}
+
+func TestTemplatesConstructRejectsBlankStartDate(t *testing.T) {
+	app, transport := setupRecordingTestApp(t)
+	captureTemplateOutput(app)
+
+	err := executeRecordingCommand(NewTemplatesCmd(), app, "construct", "2085958507", "--name", "Marketing Campaign", "--start-date", "")
+	outErr := requireUsageErr(t, err)
+	assert.Contains(t, outErr.Message, "Invalid start date")
+	assert.Empty(t, transport.recorded())
 }
 
 func TestTemplatesConstructRejectsMalformedStartDateBeforeAnyRequest(t *testing.T) {

--- a/internal/commands/templates_test.go
+++ b/internal/commands/templates_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -226,6 +227,90 @@ func TestTemplatesCopyExplainsPeopleConfirmation(t *testing.T) {
 
 	var confirmationErr *basecamp.PeopleConfirmationRequiredError
 	assert.True(t, errors.As(err, &confirmationErr), "typed SDK error should remain available")
+}
+
+func TestTemplatesConstructSendsStartDateUnderProjectEnvelope(t *testing.T) {
+	app, transport := setupRecordingTestApp(t,
+		stubRoute{
+			method: http.MethodPost,
+			path:   "/99999/templates/2085958507/project_constructions.json",
+			status: http.StatusCreated,
+			body:   `{"id":598194962,"status":"pending","url":"https://example.test/constructions/598194962.json"}`,
+		},
+	)
+	buf := captureTemplateOutput(app)
+
+	err := executeRecordingCommand(NewTemplatesCmd(), app,
+		"construct", "2085958507", "--name", "Marketing Campaign",
+		"--description", "For Client: Xyz Corp Conference", "--start-date", "2026-09-01")
+	require.NoError(t, err)
+
+	requests := transport.recorded()
+	require.Len(t, requests, 1)
+	assert.Equal(t, http.MethodPost, requests[0].Method)
+	assert.JSONEq(t,
+		`{"project":{"name":"Marketing Campaign","description":"For Client: Xyz Corp Conference","start_date":"2026-09-01"}}`,
+		requests[0].Body,
+	)
+
+	envelope := decodeTemplateEnvelope(t, buf)
+	assert.Equal(t, "Started project construction #598194962 (pending)", envelope.Summary)
+	require.Len(t, envelope.Breadcrumbs, 1)
+	assert.Equal(t, "basecamp templates construction 2085958507 598194962", envelope.Breadcrumbs[0].Cmd)
+}
+
+func TestTemplatesConstructOmitsStartDateWhenUnset(t *testing.T) {
+	app, transport := setupRecordingTestApp(t,
+		stubRoute{
+			method: http.MethodPost,
+			path:   "/99999/templates/2085958507/project_constructions.json",
+			status: http.StatusCreated,
+			body:   `{"id":598194962,"status":"pending","url":"https://example.test/constructions/598194962.json"}`,
+		},
+	)
+	captureTemplateOutput(app)
+
+	err := executeRecordingCommand(NewTemplatesCmd(), app, "construct", "2085958507", "--name", "Marketing Campaign")
+	require.NoError(t, err)
+
+	requests := transport.recorded()
+	require.Len(t, requests, 1)
+	assert.JSONEq(t, `{"project":{"name":"Marketing Campaign"}}`, requests[0].Body)
+}
+
+func TestTemplatesConstructParsesNaturalStartDate(t *testing.T) {
+	app, transport := setupRecordingTestApp(t,
+		stubRoute{
+			method: http.MethodPost,
+			path:   "/99999/templates/2085958507/project_constructions.json",
+			status: http.StatusCreated,
+			body:   `{"id":598194962,"status":"pending","url":"https://example.test/constructions/598194962.json"}`,
+		},
+	)
+	captureTemplateOutput(app)
+
+	err := executeRecordingCommand(NewTemplatesCmd(), app, "construct", "2085958507", "--name", "Marketing Campaign", "--start-date", "tomorrow")
+	require.NoError(t, err)
+
+	requests := transport.recorded()
+	require.Len(t, requests, 1)
+	var body struct {
+		Project struct {
+			StartDate string `json:"start_date"`
+		} `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(requests[0].Body), &body))
+	assert.Equal(t, time.Now().AddDate(0, 0, 1).Format("2006-01-02"), body.Project.StartDate)
+}
+
+func TestTemplatesConstructRejectsMalformedStartDateBeforeAnyRequest(t *testing.T) {
+	app, transport := setupRecordingTestApp(t)
+	captureTemplateOutput(app)
+
+	err := executeRecordingCommand(NewTemplatesCmd(), app, "construct", "2085958507", "--name", "Marketing Campaign", "--start-date", "someday")
+	outErr := requireUsageErr(t, err)
+	assert.Contains(t, outErr.Message, "Invalid start date")
+	assert.Empty(t, transport.recorded())
 }
 
 func TestTemplatesCopyStatusStates(t *testing.T) {

--- a/internal/mcpserver/model/PROVENANCE.json
+++ b/internal/mcpserver/model/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source": "github.com/basecamp/basecamp-sdk",
-  "commit": "11cc4b54ecfee747cb13e7e3035d91ec862d4824",
-  "ref": "go/v0.17.1-0.20260910040302-11cc4b54ecfe",
+  "commit": "9610e51f759dfdae75e2a3a621b77b7056d5a072",
+  "ref": "go/v0.17.1-0.20260910040941-9610e51f759d",
   "files": ["behavior-model.json", "openapi.json"],
   "synced_by": "scripts/sync-mcp-model.sh",
   "patches": "tags assigned to operations the export leaves untagged (PATCHED_TAGS); binary-upload operations dropped (EXCLUDED_OPERATIONS) — see the sync script"

--- a/internal/mcpserver/model/PROVENANCE.json
+++ b/internal/mcpserver/model/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source": "github.com/basecamp/basecamp-sdk",
-  "commit": "9610e51f759dfdae75e2a3a621b77b7056d5a072",
-  "ref": "go/v0.17.1-0.20260910040941-9610e51f759d",
+  "commit": "400c76ca433d5ae08e1e7d6a561ab113949c70d8",
+  "ref": "go/v0.18.0",
   "files": ["behavior-model.json", "openapi.json"],
   "synced_by": "scripts/sync-mcp-model.sh",
   "patches": "tags assigned to operations the export leaves untagged (PATCHED_TAGS); binary-upload operations dropped (EXCLUDED_OPERATIONS) — see the sync script"

--- a/internal/mcpserver/model/PROVENANCE.json
+++ b/internal/mcpserver/model/PROVENANCE.json
@@ -1,7 +1,7 @@
 {
   "source": "github.com/basecamp/basecamp-sdk",
-  "commit": "6e73a06f4262062b2c973b2d0787ab0029b08d0d",
-  "ref": "go/v0.17.0",
+  "commit": "11cc4b54ecfee747cb13e7e3035d91ec862d4824",
+  "ref": "go/v0.17.1-0.20260910040302-11cc4b54ecfe",
   "files": ["behavior-model.json", "openapi.json"],
   "synced_by": "scripts/sync-mcp-model.sh",
   "patches": "tags assigned to operations the export leaves untagged (PATCHED_TAGS); binary-upload operations dropped (EXCLUDED_OPERATIONS) — see the sync script"

--- a/internal/mcpserver/model/openapi.json
+++ b/internal/mcpserver/model/openapi.json
@@ -33601,6 +33601,10 @@
           },
           "description": {
             "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Date the new project starts on. Template dates are relative to the start\nof the template's first week, and template weeks start on a Sunday, so\nthe project's dates are anchored to the Sunday on or before this date.\nOmitted, they are anchored to the week in which the construction is\nprocessed."
           }
         },
         "required": [

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.17.0",
-    "revision": "6e73a06f4262",
-    "updated_at": "2026-09-09T22:00:24Z"
+    "version": "v0.17.1-0.20260910040302-11cc4b54ecfe",
+    "revision": "11cc4b54ecfe",
+    "updated_at": "2026-09-10T04:03:02Z"
   },
   "api": {
     "repo": "basecamp/bc3",

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.17.1-0.20260910040941-9610e51f759d",
-    "revision": "9610e51f759d",
-    "updated_at": "2026-09-10T04:09:41Z"
+    "version": "v0.18.0",
+    "revision": "400c76ca433d",
+    "updated_at": "2026-09-10T05:31:19Z"
   },
   "api": {
     "repo": "basecamp/bc3",

--- a/internal/version/sdk-provenance.json
+++ b/internal/version/sdk-provenance.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
     "module": "github.com/basecamp/basecamp-sdk/go",
-    "version": "v0.17.1-0.20260910040302-11cc4b54ecfe",
-    "revision": "11cc4b54ecfe",
-    "updated_at": "2026-09-10T04:03:02Z"
+    "version": "v0.17.1-0.20260910040941-9610e51f759d",
+    "revision": "9610e51f759d",
+    "updated_at": "2026-09-10T04:09:41Z"
   },
   "api": {
     "repo": "basecamp/bc3",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-nWEquNPUTr46bza902GOP41Y3RLjDG+HcNGdskQYx4A=";
+  vendorHash = "sha256-MdVsRrJ3SEEtFFU6X2gP5s414kEhulSkxLqoD9GxiIg=";
 
   subPackages = [ "cmd/basecamp" ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-GCw7WkPmXDWDAhJrVqbXUfwLa9YzpWdTcSimwovjpcQ=";
+  vendorHash = "sha256-NqML00Kc1RnvF2BehjOQi0ZXY3NFe4Z3MUS71m7QPtg=";
 
   subPackages = [ "cmd/basecamp" ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-NqML00Kc1RnvF2BehjOQi0ZXY3NFe4Z3MUS71m7QPtg=";
+  vendorHash = "sha256-nWEquNPUTr46bza902GOP41Y3RLjDG+HcNGdskQYx4A=";
 
   subPackages = [ "cmd/basecamp" ];
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -975,6 +975,7 @@ basecamp templates create "Template Name"         # Create empty project templat
 basecamp templates update <id> --name "New Name"
 basecamp templates delete <id>                    # Trash project template
 basecamp templates construct <id> --name "New Project"  # Create project (async)
+basecamp templates construct <id> --name "New Project" --start-date 2026-09-01  # Anchor template dates to that week
 basecamp templates construction <template_id> <construction_id>  # Check project status
 
 basecamp templates library --json                 # List active to-do list templates
@@ -983,7 +984,10 @@ basecamp templates copy-status <copy_id>          # Check copy status
 ```
 
 **Asynchronous results:** `construct` returns a construction ID; poll `construction`
-until `status="completed"` to get the project. `copy` returns a copy ID; poll
+until `status="completed"` to get the project. A template's dates are relative to its
+first week, and template weeks start on Sunday: `--start-date` (YYYY-MM-DD or natural,
+e.g. `next monday`) anchors them to the Sunday on or before that date; without it they
+anchor to the week of construction. `copy` returns a copy ID; poll
 `copy-status` through `pending` and `processing` until it is `completed` or `failed`.
 
 A copy can report the people who need access to the destination project. Show those


### PR DESCRIPTION
## What

`basecamp templates construct <id> --name NAME [--start-date DATE]`

The API has accepted `project[start_date]` on template construction since 2022 (bc3 `project_operations.rb#project_from_template_params`), but the command exposed only `--name`/`--description`, so every constructed project anchored the template's relative dates to the day of construction and a script had to re-date each to-do and schedule entry afterwards (#659).

- `--start-date` takes `YYYY-MM-DD` or the natural forms the other date flags accept (`tomorrow`, `next monday`, `+7`), is validated before any request (`Invalid start date: "…"`, usage exit, no network), and rides under the `project` envelope through the SDK's `CreateProjectOptions`. Unset, it stays off the wire.
- Template weeks start on Sunday, so the server anchors the template's dates to the Sunday on or before the date; without the flag they anchor to the week of construction. The command's long help, the `templates` group's `agent_notes`, and `skills/basecamp/SKILL.md` say so; `.surface` carries the new flag.

## Dependency — pinned to the tagged SDK release

Depends on **basecamp/basecamp-sdk#856** (`ProjectConstructionAttributes.start_date`, Go `CreateProjectOptions`), which shipped in [basecamp-sdk v0.18.0](https://github.com/basecamp/basecamp-sdk/releases/tag/v0.18.0). `go.mod` pins `github.com/basecamp/basecamp-sdk/go v0.18.0` via `make bump-sdk REF=v0.18.0`; the vendored MCP model is re-synced from the `go/v0.18.0` checkout (`scripts/sync-mcp-model.sh`, `PROVENANCE.json` ref `go/v0.18.0`) and the Nix `vendorHash` recomputed and build-verified (`make update-nix-hash`). No `replace` directive. The earlier pseudo-version pin to the #856 branch head is gone; this is the same flip #689 made to `v0.17.0`.

Fixes #659. Tracked on [this card](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10288896939); the bc3 doc side is [basecamp/bc3#13259](https://github.com/basecamp/bc3/pull/13259).

## Tests

- `templates_test.go`: the literal wire body `{"project":{"name","description","start_date":"2026-09-01"}}` from the recording transport; `start_date` absent when the flag is unset; natural-language parsing; a malformed date rejected as a usage error before any request.
- `e2e/templates.bats`: offline usage error for a malformed `--start-date`.

Every `bin/ci` target run locally: fmt, vet, lint, lint-actions, e2e, naming, surface, skill drift, bare groups, lint lockstep, smoke coverage, SDK provenance, and go mod tidy green; MCP catalog provenance test green against the `v0.18.0` pin. The Go unit run is green except `TestBareBasecampNeverReportsASetupError`, `TestExplicitSetupStillRefuses`, `TestDeleteConfirmableFollowsTheAudienceNotTheDevice` and the `TestIsInteractive*`/`TestInteractive*`/`TestIsTerminal` cases in `appctx`/`cli`, which fail identically on pristine `main` in this non-TTY shell (as #689 and #677 noted).

I'm babysitting the review loop on this PR through to convergence.

Release note: **Features** (`enhancement`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--start-date` to `templates construct` so template relative dates anchor to a chosen week instead of the week of construction (fixes #659).

- Accepts `YYYY-MM-DD` or natural forms (`tomorrow`, `next monday`, `+7`); malformed or explicitly blank values fail with a usage error before any request.
- Template weeks start on Sunday, so dates anchor to the Sunday on or before the given date; without the flag the field stays off the wire.
- Updated command help, agent notes, skill docs, and the MCP model to cover the new flag.

**Dependencies**
- Upgrades `github.com/basecamp/basecamp-sdk/go` to v0.18.0, which provides `CreateProjectOptions.StartDate`.

<sup>Written for commit 902b2c413f2973f148ef05a7628cc432babb9cb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

