### PR TITLE
Reference in-repo workflows with GitHub's self-repository syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint's rules for this repository. See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
+      # self-repository audit asks for in place of `./...`, and what our reusable-workflow
+      # calls use. actionlint 1.7.12 predates it and has no release that knows it
+      # (rhysd/actionlint#711); drop this once one does.
+      - 'reusable workflow call "\$/.+" at "uses" is not following the format'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,5 +5,6 @@ paths:
       # GitHub's self-repository `uses: $/...` syntax (July 2026) is what zizmor's
       # self-repository audit asks for in place of `./...`, and what our reusable-workflow
       # calls use. actionlint 1.7.12 predates it and has no release that knows it
-      # (rhysd/actionlint#711); drop this once one does.
-      - 'reusable workflow call "\$/.+" at "uses" is not following the format'
+      # (rhysd/actionlint#711); drop this once one does. The ignore names the exact calls,
+      # so a new `$/` call is a deliberate edit here rather than a silent pass.
+      - 'reusable workflow call "\$/\.github/workflows/(security|headless-probe-composition)\.yml" at "uses" is not following the format'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   security:
     name: Security scan
-    uses: ./.github/workflows/security.yml
+    uses: $/.github/workflows/security.yml
     permissions:
       contents: read
       security-events: write
@@ -31,7 +31,7 @@ jobs:
   # actions/checkout inside the reusable workflow has no repository access.
   headless-probe:
     name: Headless keyring probe
-    uses: ./.github/workflows/headless-probe-composition.yml
+    uses: $/.github/workflows/headless-probe-composition.yml
     permissions:
       contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,13 +93,13 @@ jobs:
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
         with:
           # The action resolves `version` (default "latest") through the digest
           # map checked in at its pinned SHA, so this stays stable either way —
           # the explicit pin keeps the release from shifting when the action SHA
           # is bumped, and matches the .mise.toml zizmor pin for local parity.
-          version: "1.29.0"
+          version: "1.30.0"
           advanced-security: false
 
   security:

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,4 +12,4 @@ shellcheck = "0.11.0"
 powershell = "7.6.5"
 # Keep in sync with the zizmor-action `version:` input in
 # .github/workflows/test.yml so local bin/ci runs the same release CI does.
-zizmor = "1.29.0"
+zizmor = "1.30.0"


### PR DESCRIPTION
zizmor 1.30.0, which zizmor-action 0.6.3 runs by default, adds a self-repository audit that flags workspace-relative `uses: ./...` references to in-repo actions and reusable workflows. This rewrites the two reusable-workflow calls in `release.yml` to GitHub's `uses: $/...` form. GitHub's `uses: $/...` form is the syntax GitHub now recommends for same-repository references and the one zizmor's audit requires. For a job-level reusable-workflow call it changes nothing at runtime: `./` already resolves to the caller's commit, and reusable workflows are exempt from the org SHA-pinning policy, so the gain is conformance with the recommended form, not security. This repo pins zizmor 1.29.0 explicitly (the action's `version:` input and `.mise.toml`), so the audit fails as soon as that pin moves to 1.30.0.

actionlint 1.7.12 rejects the new form and no release knows it yet (rhysd/actionlint#711), so `.github/actionlint.yaml` ignores that one message for workflow files, with a note to drop it once a release does. Locally: actionlint exits 0 with the config and 1 without it; zizmor 1.30.0 reports no findings after the change.

CI's audit job on this PR is the proof.

Same change as basecamp/hey-sdk#171 and #174.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the two reusable-workflow calls in `release.yml` from `uses: ./...` to GitHub's `uses: $/...` form, which resolves against the running commit and counts as pinned under zizmor 1.30.0's self-repository audit.

Bumps zizmor-action to 0.6.3 and zizmor to 1.30.0 in the action's `version:` input and `.mise.toml`, so CI runs the audit this change addresses; the 0.6.2 version map doesn't know 1.30.0, so the pins move together and the audit job on this branch is the proof.

Adds `.github/actionlint.yaml` to ignore actionlint 1.7.12's rejection of the `$/` form until a release recognizes it (rhysd/actionlint#711). The ignore names the exact calls, so a new `$/` call requires a deliberate config edit rather than passing silently.

<sup>Written for commit 792dd6566de787dd1c61adb0f7149824cf163799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


