### PR TITLE
Refresh the Nix vendorHash for the go-dependencies bump

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
   src = lib.cleanSource ./..;
 
   # To update: set to lib.fakeHash, run `nix build`, use the hash from the error.
-  vendorHash = "sha256-MdVsRrJ3SEEtFFU6X2gP5s414kEhulSkxLqoD9GxiIg=";
+  vendorHash = "sha256-epvdZN17f1Ui3khPEUz1L6sQncs1FWlcg/IZlVbTtaI=";
 
   subPackages = [ "cmd/basecamp" ];
 


### PR DESCRIPTION
#697 changed `go.sum` this morning and the Nix `vendorHash` in `nix/package.nix` stayed at the previous value, so `nix build` now fails with a hash mismatch. Main's own Test run did not show it: the Nix job builds only when a flake-relevant path changes, and the merge commit that landed on main touched none of them, so the job reported success with the build skipped. Any branch that touches `go.sum`, `flake.*`, `nix/`, or `test.yml` fails on it; #700 hit it by editing `test.yml`.

The new hash is the value CI computed on two independent runs. This PR touches `nix/package.nix`, so its own Nix job runs the build and is the verification.

Worth noting for the filter: a Dependabot Go bump changes `go.sum`, so the bump PR's own run does build the flake, but the stale hash only fails there if that check is required. This one merged with it red or skipped; the `Nix flake builds` check may be worth marking required so the next one cannot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Nix `vendorHash` in `nix/package.nix` to match the recent `go.sum` update, fixing `nix build` hash mismatches on branches that touch `go.sum`, `flake.*`, `nix/`, or `test.yml`. The new hash is from two independent CI runs, and this PR's Nix job verifies the build because it changes `nix/package.nix`.

<sup>Written for commit 5a9cfcc30aab2f87e7ec88d2a40dfecba9c7f294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

