### PR TITLE
Resolve the basecamp CLI through mise in agent hooks when it is off PATH

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook session-start || true",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise -C \"${HOME:-/}\" which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook session-start || true",
             "timeout": 5,
             "statusMessage": "Checking Basecamp status"
           }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook pre-commit-snapshot || true",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise -C \"${HOME:-/}\" which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook pre-commit-snapshot || true",
             "timeout": 10
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise -C \"${HOME:-/}\" which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
             "timeout": 12
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise -C \"${HOME:-/}\" which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
             "timeout": 12
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "basecamp agent-hook session-start",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook session-start || true",
             "timeout": 5,
             "statusMessage": "Checking Basecamp status"
           }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "basecamp agent-hook pre-commit-snapshot",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook pre-commit-snapshot || true",
             "timeout": 10
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "basecamp agent-hook post-commit",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
             "timeout": 12
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "basecamp agent-hook post-commit",
+            "command": "command -v basecamp >/dev/null 2>&1 || { d=\"$(mise which basecamp 2>/dev/null)\" && PATH=\"${d%/*}:$PATH\"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook post-commit || true",
             "timeout": 12
           }
         ]

--- a/internal/release/hooks_test.go
+++ b/internal/release/hooks_test.go
@@ -1,0 +1,117 @@
+package release_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hookCommands returns every leaf command string in hooks/hooks.json.
+func hookCommands(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repositoryRoot(t), "hooks", "hooks.json"))
+	if os.IsNotExist(err) {
+		t.Skip("hooks/hooks.json not present (expected until hooks ship)")
+	}
+	require.NoError(t, err)
+
+	var config struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(data, &config))
+
+	var commands []string
+	for _, matchers := range config.Hooks {
+		for _, matcher := range matchers {
+			for _, hook := range matcher.Hooks {
+				commands = append(commands, hook.Command)
+			}
+		}
+	}
+	require.NotEmpty(t, commands)
+	return commands
+}
+
+// writeExecutable writes a shell script and marks it runnable.
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+}
+
+// TestHookCommandsResolveBasecamp executes every hooks.json command against
+// fake basecamp/mise binaries to prove the resolution contract the string
+// matcher in TestHooksFileCommandsInvokeBasecamp cannot see: basecamp on PATH
+// wins (mise is never consulted), a mise-only install is resolved through
+// `mise which` and executed, and when neither is available the hook fails open
+// with exit 0 so it never blocks a tool call.
+func TestHookCommandsResolveBasecamp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hook commands are POSIX shell")
+	}
+
+	for _, command := range hookCommands(t) {
+		name := command
+		if idx := strings.Index(command, "agent-hook "); idx >= 0 {
+			name = command[idx:]
+		}
+
+		t.Run(name, func(t *testing.T) {
+			// A basecamp reachable on PATH, and a different one reachable only
+			// by resolving through mise, each record which of them ran.
+			pathBin := filepath.Join(t.TempDir(), "path")
+			miseBin := filepath.Join(t.TempDir(), "mise")
+			miseTool := filepath.Join(t.TempDir(), "tool")
+			writeExecutable(t, filepath.Join(pathBin, "basecamp"),
+				"#!/bin/sh\necho \"path $*\" >> \"$MARKER\"\n")
+			writeExecutable(t, filepath.Join(miseTool, "basecamp"),
+				"#!/bin/sh\necho \"mise $*\" >> \"$MARKER\"\n")
+			writeExecutable(t, filepath.Join(miseBin, "mise"),
+				"#!/bin/sh\nwhile [ $# -gt 0 ] && [ \"$1\" != which ]; do shift; done\n"+
+					"[ \"$1\" = which ] && [ \"$2\" = basecamp ] && echo \""+filepath.Join(miseTool, "basecamp")+"\" && exit 0\nexit 1\n")
+
+			run := func(t *testing.T, path string) (string, error) {
+				marker := filepath.Join(t.TempDir(), "marker")
+				cmd := exec.Command("/bin/sh", "-c", command)
+				cmd.Env = []string{"HOME=" + t.TempDir(), "MARKER=" + marker, "PATH=" + path}
+				err := cmd.Run()
+				out, readErr := os.ReadFile(marker)
+				if os.IsNotExist(readErr) {
+					return "", err
+				}
+				require.NoError(t, readErr)
+				return string(out), err
+			}
+
+			t.Run("basecamp on PATH wins over mise", func(t *testing.T) {
+				out, err := run(t, pathBin+":"+miseBin+":/usr/bin:/bin")
+				require.NoError(t, err)
+				assert.Contains(t, out, "path agent-hook", "PATH basecamp must run")
+				assert.NotContains(t, out, "mise agent-hook", "mise must not be consulted")
+			})
+
+			t.Run("mise resolves a basecamp that is off PATH", func(t *testing.T) {
+				out, err := run(t, miseBin+":/usr/bin:/bin")
+				require.NoError(t, err)
+				assert.Contains(t, out, "mise agent-hook", "mise-resolved basecamp must run")
+			})
+
+			t.Run("neither available fails open", func(t *testing.T) {
+				out, err := run(t, "/usr/bin:/bin")
+				assert.NoError(t, err, "hook must exit 0 when basecamp cannot be resolved")
+				assert.Empty(t, out, "no basecamp should run")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The shared plugin hooks in `hooks/hooks.json` invoke `basecamp agent-hook …`
on the bare `PATH`. Under a **mise-managed install** of the CLI, the `basecamp`
binary lives under a mise install directory reachable only through the mise
shims dir, which is not reliably on the `PATH` that Claude Code (and Codex)
expose to a hook's `/bin/sh`. Every Bash tool call then failed both Bash hooks:

```
PreToolUse:Bash hook error: Failed with non-blocking status code: /bin/sh: basecamp: command not found
PostToolUse:Bash hook error: Failed with non-blocking status code: /bin/sh: basecamp: command not found
```

`SessionStart` and `PostToolUseFailure` invoke `basecamp` the same way and had
the same latent failure.

## Fix

Resolve `basecamp` **PATH-first**, falling back to `mise which basecamp` only
when it is not already on `PATH`, then `exec` it. If it cannot be resolved at
all, **fail open** (`|| true`, exit 0) — these hooks are non-blocking and must
never fail a tool call.

```
command -v basecamp >/dev/null 2>&1 || { d="$(mise which basecamp 2>/dev/null)" && PATH="${d%/*}:$PATH"; }; command -v basecamp >/dev/null 2>&1 && exec basecamp agent-hook <sub> || true
```

Applied to all four hook leaves (`session-start`, `pre-commit-snapshot`,
`post-commit` ×2). The conditional is inline in each command string because
`internal/release/manifests_test.go::TestHooksFileCommandsInvokeBasecamp`
inspects the command strings and requires each to contain `exec basecamp `
(delegating to an external resolver script would fail that test). The pattern
is install-method-agnostic: Homebrew, Nix, direct, and mise installs all work,
and it introduces no dependency on `${CLAUDE_PLUGIN_ROOT}`, keeping the shared
Claude/Codex `hooks.json` portable.

## Verification

`env -i PATH=/usr/bin:/bin` reproduces the failure with the old command and
proves the new one:

```
# BEFORE (old bare command), basecamp off PATH
$ env -i PATH=/usr/bin:/bin sh -c 'basecamp agent-hook post-commit'
sh: basecamp: command not found        # exit 127

# AFTER, mise present, basecamp shim off PATH -> resolves via mise
RESOLVED: …/mise/installs/github-basecamp-basecamp-cli/latest/basecamp
basecamp version 0.11.0

# AFTER, mise absent -> not resolved, fails open, exit 0 (no 127)
NOT RESOLVED (mise absent) -> fail-open

# AFTER, basecamp already on PATH -> mise never consulted, resolves via PATH
RESOLVED via PATH: …/basecamp
```

`go test ./internal/release/` passes, including
`TestHooksFileCommandsInvokeBasecamp`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent hooks failing with "basecamp: command not found" when the CLI is installed via mise and off the hook shell's PATH. Hooks now resolve `basecamp` PATH-first, fall back to `mise -C "${HOME:-/}" which basecamp` from a neutral directory, and fail open (exit 0) if the binary can't be resolved.

- Applies to all four hook leaves: `session-start`, `pre-commit-snapshot`, and both `post-commit` hooks.
- Runs `mise which` from a neutral directory so an untrusted project `.mise.toml` can't make the fallback skip a mise-installed CLI.
- Failing open keeps the hooks non-blocking, so tool calls never fail because the binary isn't on PATH.
- Adds a behavioral test that executes each hook command against fake binaries, verifying PATH precedence, mise-only resolution, and fail-open exit 0.

<sup>Written for commit 89ba8a2ef33f432d05b054503c45e58b78c27a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

