### PR TITLE
Skill: note that subcommand help omits the root persistent flags

### DIFF
--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -183,7 +183,7 @@ basecamp todos --agent --help
 
 Walk the tree: start at `basecamp --agent --help` for top-level commands, then drill into any subcommand. Commands carry domain-specific agent hints (e.g., "`--assignee` filters the account-wide listing only; within a project, fetch all and filter client-side").
 
-Note: persistent global flags from the Agent Invariants (e.g. `--jq`, `--agent`, `--styled`, `--verbose`) are listed only at the root (`basecamp --agent --help`) and won't show up in a subcommand's `inherited_flags`. They still apply on every subcommand.
+**Note:** a subcommand's `inherited_flags` is deliberately short — the CLI curates it down to `--account`, `--json`, `--md`, `--project`, `--quiet` (and drops `--project` where the command takes `<id|url>`). Every other global flag (`--jq`, `--agent`, `--styled`, `--verbose`, `--profile`, ...) is listed only at the root (`basecamp --agent --help`) but still applies on every subcommand (a command that cannot honor one refuses it with an explicit error — `version` rejects `--jq`); its absence from a subcommand's help does not mean it is unsupported.
 
 ### Pagination
 

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -183,6 +183,8 @@ basecamp todos --agent --help
 
 Walk the tree: start at `basecamp --agent --help` for top-level commands, then drill into any subcommand. Commands carry domain-specific agent hints (e.g., "`--assignee` filters the account-wide listing only; within a project, fetch all and filter client-side").
 
+Note: persistent global flags from the Agent Invariants (e.g. `--jq`, `--agent`, `--styled`, `--verbose`) are listed only at the root (`basecamp --agent --help`) and won't show up in a subcommand's `inherited_flags`. They still apply on every subcommand.
+
 ### Pagination
 
 ```bash


### PR DESCRIPTION
## What

Adds one note to the CLI Introspection section of `skills/basecamp/SKILL.md`, after the "Walk the tree" paragraph: a subcommand's `--agent --help` lists only a curated five in `inherited_flags` (`--account`, `--json`, `--md`, `--project`, `--quiet`, minus `--project` on `<id|url>` commands); every other root persistent flag (`--jq`, `--agent`, `--styled`, `--verbose`, `--profile`, ...) is listed only at `basecamp --agent --help` but still applies everywhere.

## Why

An agent that drills into `basecamp todos list --agent --help`, sees no `--jq` in `inherited_flags`, and concludes the flag is unsupported there will reach for external `jq` — exactly what the Agent Invariants tell it not to do. The omission is deliberate: `curatedInheritedFlags` in `internal/cli/help.go` trims the inherited set to `salientRootFlags` so text help and agent JSON help stay short and in sync. The skill now says so, so the short list reads as curation rather than as a gap.

Verified against today's build: root `--agent --help` lists all 22 globals under `flags`; `todos list` reports `inherited_flags` of exactly `account`, `json`, `md`, `project`, `quiet`; `todos show` drops `project`.

## Provenance

This originates from basecamp/skills#3 by @vmpn (https://github.com/basecamp/skills/pull/3). basecamp/skills is a publish target — its AGENTS.md says skills are never edited there but synced from `basecamp-cli/skills` on each release — so this repo is the upstream home for the change. The first commit is @vmpn's, cherry-picked with authorship intact; the second is a follow-up rewording of the same line to match the current text of the section and to name the curated set and the reason for it (the original attributed the missing flags to "the Agent Invariants", but the Invariants name `--json` and `--md`, which do appear in `inherited_flags`, while `--agent`, `--styled` and `--verbose` are not Invariants).

It will reach basecamp/skills on the next release via the skills sync.

## Checks

`make check-skill-drift` passes on the new line. Only `skills/basecamp/SKILL.md` changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a note to the basecamp skill's CLI Introspection section clarifying that a subcommand's `inherited_flags` is deliberately curated to `--account`, `--json`, `--md`, `--project`, and `--quiet` (with `--project` omitted on `<id|url>` commands). Other root persistent flags such as `--jq`, `--agent`, `--styled`, and `--verbose` still apply on every subcommand even though they're only listed at `basecamp --agent --help`, so agents won't mistake their absence for being unsupported. Docs-only change; no CLI behavior changes.

<sup>Written for commit 2e65bf19b23eaf43e3353dd96579bfc7eb26ff68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

