### PR TITLE
Sync only the skills this CLI owns to basecamp/skills

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -7,8 +7,10 @@
 # a way back without cutting a new tag. This is it.
 #
 # scripts/sync-skills.sh mirrors the skills/ tree at the given ref into
-# basecamp/skills and no-ops when the content already matches, so re-running it
-# for an already-synced release is safe.
+# basecamp/skills — only this CLI's skills, tracked in its own manifest there
+# (.managed-skills.basecamp-cli); other CLIs' skills are never touched — and
+# no-ops when the content already matches, so re-running it for an
+# already-synced release is safe.
 name: Sync skills
 
 on:
@@ -52,8 +54,8 @@ jobs:
             exit 1
           fi
 
-          # sync-skills.sh mirrors the tree wholesale, so syncing an older tag
-          # would roll basecamp/skills back. Unlike the AUR, there is no
+          # sync-skills.sh mirrors this CLI's skills wholesale, so syncing an
+          # older tag would roll them back in basecamp/skills. Unlike the AUR, there is no
           # independent record of what the distribution repo currently holds, and
           # the only reason to run this by hand is that the newest release failed
           # to sync — so require exactly that release.
@@ -63,11 +65,24 @@ jobs:
             exit 1
           fi
 
-      # Check out the tag itself, not main: the sync must mirror the skills tree
-      # as it was released, even if main has moved on since.
+      # Two checkouts: sync logic from the dispatching ref, skills content from
+      # the release tag. A defect in scripts/sync-skills.sh is one of the ways
+      # the automatic sync fails, and running the tagged copy here would just
+      # re-run the defective script — recovery must be able to run a fix merged
+      # to main without cutting a new tag.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      # The content still mirrors the skills tree as it was released, even if
+      # main has moved on since: SKILLS_SOURCE points the script at this
+      # checkout. Fully qualified: actions/checkout resolves a bare name as a
+      # branch before a tag, so a branch sharing the tag's name would win and
+      # mirror unreleased content.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          path: release
           persist-credentials: false
 
       # Needed for dry runs too: the honest preview clones the target, so it
@@ -83,12 +98,14 @@ jobs:
           repositories: skills
           permission-contents: ${{ inputs.dry_run && 'read' || 'write' }}
 
-      # github.sha is the dispatching ref's SHA (main), not the tag's, so resolve
-      # the commit actually checked out — otherwise the sync records the wrong
-      # provenance for the release it claims to mirror.
+      # github.sha is the dispatching ref's SHA (main), not the tag's, so
+      # resolve the tagged commit from its own checkout — otherwise the sync
+      # records the wrong provenance for the release it claims to mirror.
       - name: Resolve the tagged commit
         id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "sha=$(git -C release rev-parse --verify "refs/tags/${TAG}^{commit}")" >> "$GITHUB_OUTPUT"
 
       # DRY_RUN=remote, not local: the local path never clones basecamp/skills
       # and diffs against an empty repo, so every skill reads as newly added and
@@ -100,5 +117,6 @@ jobs:
           SKILLS_TOKEN: ${{ steps.skills-token.outputs.token }}
           RELEASE_TAG: ${{ inputs.tag }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          SKILLS_SOURCE: release/skills
           DRY_RUN: ${{ inputs.dry_run && 'remote' || '' }}
         run: scripts/sync-skills.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,9 @@ jobs:
       - name: Run BATS integration tests
         run: make test-e2e
 
+      - name: Test the skills sync
+        run: make test-sync-skills
+
   cli-surface:
     name: CLI Surface Check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ check-smoke-coverage: build
 
 # Run all checks (local CI gate)
 .PHONY: check
-check: fmt-check vet lint lint-actions test test-e2e check-naming check-surface check-skill-drift check-bare-groups check-lint-lockstep check-smoke-coverage provenance-check tidy-check
+check: fmt-check vet lint lint-actions test test-e2e test-sync-skills check-naming check-surface check-skill-drift check-bare-groups check-lint-lockstep check-smoke-coverage provenance-check tidy-check
 
 # Lint GitHub Actions workflows (requires actionlint + zizmor)
 .PHONY: lint-actions
@@ -564,6 +564,11 @@ sync-skills:
 	RELEASE_TAG=$(TAG) SOURCE_SHA=$$(git rev-parse HEAD) DRY_RUN=local scripts/sync-skills.sh
 
 # Sync skills (dry-run against real target repo)
+# Run the skills sync against a throwaway basecamp/skills, as two CLIs publishing in turn
+.PHONY: test-sync-skills
+test-sync-skills:
+	scripts/test-sync-skills.sh
+
 # Usage: make sync-skills-remote TAG=v1.2.3 SKILLS_TOKEN=ghp_...
 .PHONY: sync-skills-remote
 sync-skills-remote:
@@ -647,6 +652,7 @@ help:
 	@echo ""
 	@echo "Skills:"
 	@echo "  sync-skills         Local dry-run of skill sync (TAG=v1.2.3)"
+	@echo "  test-sync-skills    Run the skills sync as two CLIs against a throwaway target"
 	@echo "  sync-skills-remote  Remote dry-run (TAG=v1.2.3 SKILLS_TOKEN=...)"
 	@echo ""
 	@echo "  help           Show this help"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,6 +70,28 @@ basecamp skill
 basecamp skill install
 ```
 
+## Skills sync
+
+Stable releases mirror `skills/` into [basecamp/skills](https://github.com/basecamp/skills),
+which several CLIs share. `scripts/sync-skills.sh` owns only this CLI's skills there:
+it records the names it published in `.managed-skills.basecamp-cli` at the target root
+and removes a `skills/<name>` only when that manifest lists it, the release no longer
+ships it, and no other CLI's `.managed-skills.*` claims it (a collision is warned about
+and left alone), and refuses outright to publish a name another CLI's manifest holds.
+A target with no `.managed-skills.basecamp-cli` yet is a first run: nothing is removed.
+A push rejected because another CLI published first is retried by applying the whole
+sync again from the remote's new tip, not by replaying the stale commit. The legacy shared `.managed-skills` is rewritten as a comment-only
+tombstone so a CLI still on the pre-fix script — which deleted everything its own tree
+lacked — deletes nothing (basecamp/skills#5).
+
+If the release-time sync fails, recover with the `Sync skills` workflow
+(`workflow_dispatch`, stable tag, optional dry run). It refuses anything but the latest
+stable release so it cannot roll the distribution repo back, and it runs the sync script
+from the dispatching branch against the tag's skills tree — so when the failure was a
+defect in `sync-skills.sh` itself, merge the fix to main and dispatch; no new release
+needed. `scripts/test-sync-skills.sh` (`make test-sync-skills`, in `bin/ci`) pins the
+ownership contract by running the script as both CLIs against a throwaway target.
+
 ## Requirements
 
 - On `main` branch with clean, synced working tree

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,8 +89,10 @@ If the release-time sync fails, recover with the `Sync skills` workflow
 stable release so it cannot roll the distribution repo back, and it runs the sync script
 from the dispatching branch against the tag's skills tree — so when the failure was a
 defect in `sync-skills.sh` itself, merge the fix to main and dispatch; no new release
-needed. `scripts/test-sync-skills.sh` (`make test-sync-skills`, in `bin/ci`) pins the
-ownership contract by running the script as both CLIs against a throwaway target.
+needed. The script always clones the target fresh and pushes only the commit it made,
+so there is no checkout to hand it. `scripts/test-sync-skills.sh` (`make test-sync-skills`,
+in `bin/ci`) pins the ownership contract by running the script as both CLIs against a
+local bare repository — real clones, commits and pushes, no network.
 
 ## Requirements
 

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # sync-skills.sh — Publish this CLI's skills to the basecamp/skills distribution repo.
 #
-# Runs from CI on a release tag. Mirrors each skills/<name>/ tree (SKILL.md and its
-# supporting files; no *.go, no dotfiles) into skills/<name>/ at the root of
-# basecamp/skills — the layout `npx skills add basecamp/skills` reads — then commits
-# as <source>[bot] and pushes.
+# Runs from CI on a release tag. Clones basecamp/skills fresh into a temp directory,
+# mirrors each skills/<name>/ tree (SKILL.md and its supporting files; no *.go, no
+# dotfiles) into skills/<name>/ at its root — the layout `npx skills add
+# basecamp/skills` reads — then commits as <source>[bot], pushes, and removes the
+# clone. The script never adopts an existing checkout: the only commit it can push
+# is the one it made, against the tip it cloned or fetched.
 #
 # Several CLIs publish into that one repo, so each owns a manifest of its own at the
 # target root, .managed-skills.<source>, listing the skill names it has published,
@@ -27,26 +29,27 @@
 # by hand, which beats guessing ownership from the legacy file.
 #
 # Required env vars:
-#   RELEASE_TAG    — the release tag (e.g. v1.2.3)
-#   SOURCE_SHA     — the source commit SHA
-#   SKILLS_TOKEN   — GitHub token with push access to basecamp/skills; not needed
-#                    for DRY_RUN=local, nor when SKILLS_TARGET is set
+#   RELEASE_TAG      — the release tag (e.g. v1.2.3)
+#   SOURCE_SHA       — the source commit SHA
+#   SKILLS_TOKEN     — GitHub token with push access to basecamp/skills; not needed
+#                      for DRY_RUN=local, nor when SKILLS_REPO_URL is not on github.com
 #
 # Optional env vars:
-#   CLI_NAME       — this CLI's name; the publishing source is <CLI_NAME>-cli
-#   SYNC_SOURCE    — the publishing repo's name (default: <CLI_NAME>-cli). Names the
-#                    manifest, the bot and the commit; the test sets it to play
-#                    another CLI
-#   SKILLS_SOURCE  — directory holding the skills tree (default: skills). A manual
-#                    recovery workflow can point it at a checkout of the release tag
-#                    so the sync logic comes from a newer ref than the content
-#   SKILLS_TARGET  — an existing checkout of basecamp/skills to sync into instead of
-#                    cloning; the remote-URL and branch asserts still run against it
-#   DRY_RUN        — "local": no network. Without SKILLS_TARGET, copy into an empty
-#                    tmpdir and print what would be published; with it, apply and
-#                    commit there but do not push.
-#                    "remote": clone (or use SKILLS_TARGET), apply, print the diff,
-#                    and stop before committing
+#   CLI_NAME         — this CLI's name; the publishing source is <CLI_NAME>-cli
+#   SYNC_SOURCE      — the publishing repo's name (default: <CLI_NAME>-cli). Names the
+#                      manifest, the bot and the commit; the test sets it to play
+#                      another CLI
+#   SKILLS_SOURCE    — directory holding the skills tree (default: skills). A manual
+#                      recovery workflow can point it at a checkout of the release tag
+#                      so the sync logic comes from a newer ref than the content
+#   SKILLS_REPO_URL  — where basecamp/skills is cloned from and pushed to (default:
+#                      https://github.com/basecamp/skills.git). The test points it at
+#                      a local bare repository so a real push lands somewhere it can
+#                      read back
+#   DRY_RUN          — "local": no network; copy into an empty tmpdir and print what
+#                      would be published.
+#                      "remote": clone, apply, print the diff, and stop before
+#                      committing
 #
 
 set -euo pipefail
@@ -56,12 +59,12 @@ SYNC_SOURCE="${SYNC_SOURCE:-${CLI_NAME}-cli}"
 RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
 SOURCE_SHA="${SOURCE_SHA:?SOURCE_SHA is required}"
 SKILLS_SOURCE="${SKILLS_SOURCE:-skills}"
-SKILLS_TARGET="${SKILLS_TARGET:-}"
 SKILLS_TOKEN="${SKILLS_TOKEN:-}"
 DRY_RUN="${DRY_RUN:-}"
 
 TARGET_REPO="basecamp/skills"
 TARGET_BRANCH="main"
+SKILLS_REPO_URL="${SKILLS_REPO_URL:-https://github.com/${TARGET_REPO}.git}"
 SKILLS_SUBDIR="skills"
 LEGACY_MANIFEST=".managed-skills"
 MANIFEST="${LEGACY_MANIFEST}.${SYNC_SOURCE}"
@@ -119,33 +122,6 @@ claimed_by_other() {
   return 1
 }
 
-# The URLs as configured: `remote get-url` would show them after any insteadOf
-# rewrite, so an operator's rewrite could pass this check with a repo that is not
-# the target. Push URLs of its own are where `git push origin` would actually go,
-# and a remote may carry several of either kind, each one a push destination.
-assert_remote_url() {
-  local kind url urls
-  for kind in url pushurl; do
-    urls=$(git -C "$1" config --get-all "remote.origin.${kind}" || true)
-    [[ -z "$urls" && "$kind" == url ]] && die "origin has no url configured"
-    while IFS= read -r url; do
-      [[ -n "$url" ]] || continue
-      case "${url%.git}" in
-        "https://github.com/${TARGET_REPO}") ;;
-        https://x-access-token:*@github.com/"${TARGET_REPO}") ;;
-        "git@github.com:${TARGET_REPO}") ;;
-        *) die "origin ${kind} '$(echo "$url" | sed -E 's#(https://[^:@]+:)[^@]*@#\1***@#')' does not point to github.com/${TARGET_REPO}" ;;
-      esac
-    done <<< "$urls"
-  done
-}
-
-assert_branch() {
-  local branch
-  branch=$(git -C "$1" rev-parse --abbrev-ref HEAD)
-  [[ "$branch" == "$TARGET_BRANCH" ]] || die "checked-out branch is '$branch', expected '$TARGET_BRANCH'"
-}
-
 # --- Validate the knobs ---
 
 plain_name "$SYNC_SOURCE" || die "SYNC_SOURCE '$SYNC_SOURCE' is not a plain name"
@@ -186,9 +162,9 @@ copy_skills() {
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-# --- DRY_RUN=local without a target: what would be published ---
+# --- DRY_RUN=local: what would be published ---
 
-if [[ "$DRY_RUN" == "local" && -z "$SKILLS_TARGET" ]]; then
+if [[ "$DRY_RUN" == "local" ]]; then
   preview="${tmpdir}/preview"
   echo "DRY_RUN=local: copying skills into ${preview}"
   copy_skills "${preview}/${SKILLS_SUBDIR}"
@@ -220,30 +196,19 @@ cat > "$GIT_CONFIG_GLOBAL" <<GITCFG
 	email = ${SYNC_SOURCE}[bot]@users.noreply.github.com
 GITCFG
 chmod 600 "$GIT_CONFIG_GLOBAL"
-if [[ -n "$SKILLS_TOKEN" ]]; then
+if [[ "$SKILLS_REPO_URL" == https://github.com/* ]]; then
+  [[ -n "$SKILLS_TOKEN" ]] || die "SKILLS_TOKEN is required to push to ${SKILLS_REPO_URL} (set DRY_RUN=local for offline testing)"
   cat >> "$GIT_CONFIG_GLOBAL" <<GITCFG
 [url "https://x-access-token:${SKILLS_TOKEN}@github.com/"]
 	insteadOf = https://github.com/
 GITCFG
 fi
 
-# --- Clone the target, or take the checkout given ---
+# --- Clone the target ---
 
-if [[ -n "$SKILLS_TARGET" ]]; then
-  [[ -d "${SKILLS_TARGET}/.git" ]] || die "SKILLS_TARGET '${SKILLS_TARGET}' is not a git checkout"
-  target="$SKILLS_TARGET"
-  echo "Syncing into ${target}"
-else
-  [[ -n "$SKILLS_TOKEN" ]] || die "SKILLS_TOKEN is required (set DRY_RUN=local for offline testing)"
-  target="${tmpdir}/skills"
-  echo "Cloning ${TARGET_REPO} into ${target}..."
-  git clone -q --depth 1 --branch "$TARGET_BRANCH" "https://github.com/${TARGET_REPO}.git" "$target"
-fi
-
-assert_remote_url "$target"
-assert_branch "$target"
-# `git add -A` below would sweep anything else in the checkout into the sync commit.
-[[ -z "$(git -C "$target" status --porcelain)" ]] || die "${target} has uncommitted changes; commit or stash them before syncing into it"
+target="${tmpdir}/skills"
+echo "Cloning ${TARGET_REPO} into ${target}..."
+git clone -q --depth 1 --branch "$TARGET_BRANCH" "$SKILLS_REPO_URL" "$target"
 
 # --- Apply the sync to the target's working tree ---
 #
@@ -328,11 +293,6 @@ if [[ "$DRY_RUN" == "remote" ]]; then
 fi
 
 commit_sync
-
-if [[ "$DRY_RUN" == "local" ]]; then
-  echo "DRY_RUN=local: committed in ${target}, skipping push."
-  exit 0
-fi
 
 # --- Push; when another publisher got there first, apply again from its tip ---
 #

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,39 +1,139 @@
 #!/usr/bin/env bash
+# sync-skills.sh — Publish this CLI's skills to the basecamp/skills distribution repo.
+#
+# Runs from CI on a release tag. Mirrors each skills/<name>/ tree (SKILL.md and its
+# supporting files; no *.go, no dotfiles) into skills/<name>/ at the root of
+# basecamp/skills — the layout `npx skills add basecamp/skills` reads — then commits
+# as <source>[bot] and pushes.
+#
+# Several CLIs publish into that one repo, so each owns a manifest of its own at the
+# target root, .managed-skills.<source>, listing the skill names it has published,
+# one per line. A skills/<name> directory is removed only when all of these hold:
+# this source's manifest lists it, this source's current skill set no longer has
+# it, and no other source's manifest claims it. A name two sources claim is a
+# collision to settle upstream, never one a release resolves by deletion — the
+# script warns and leaves the directory, and refuses outright to publish a name
+# another source's manifest holds. Nothing else in the target is ever deleted: with
+# no manifest yet, the first run publishes and removes nothing.
+#
+# The shared manifest the pre-fix scripts kept, .managed-skills, is rewritten on
+# every run as a comment-only tombstone. The pre-fix script skips any line it cannot
+# parse as a skill name, but treats a missing file as licence to own every skills/*
+# directory — so the tombstone is what stops an un-upgraded sibling from deleting
+# anyone's skills, whichever CLI upgrades first (basecamp/skills#5). One case is
+# accepted: a skill a still-pre-fix sibling drops after the tombstone exists stays
+# behind in the target (that script has no names left to delete by, and the
+# sibling's own first run here removes nothing) — a lingering directory to remove
+# by hand, which beats guessing ownership from the legacy file.
+#
+# Required env vars:
+#   RELEASE_TAG    — the release tag (e.g. v1.2.3)
+#   SOURCE_SHA     — the source commit SHA
+#   SKILLS_TOKEN   — GitHub token with push access to basecamp/skills; not needed
+#                    for DRY_RUN=local, nor when SKILLS_TARGET is set
+#
+# Optional env vars:
+#   CLI_NAME       — this CLI's name; the publishing source is <CLI_NAME>-cli
+#   SYNC_SOURCE    — the publishing repo's name (default: <CLI_NAME>-cli). Names the
+#                    manifest, the bot and the commit; the test sets it to play
+#                    another CLI
+#   SKILLS_SOURCE  — directory holding the skills tree (default: skills). A manual
+#                    recovery workflow can point it at a checkout of the release tag
+#                    so the sync logic comes from a newer ref than the content
+#   SKILLS_TARGET  — an existing checkout of basecamp/skills to sync into instead of
+#                    cloning; the remote-URL and branch asserts still run against it
+#   DRY_RUN        — "local": no network. Without SKILLS_TARGET, copy into an empty
+#                    tmpdir and print what would be published; with it, apply and
+#                    commit there but do not push.
+#                    "remote": clone (or use SKILLS_TARGET), apply, print the diff,
+#                    and stop before committing
+#
+
 set -euo pipefail
 
-# Sync skills from basecamp-cli to basecamp/skills distribution repo.
-#
-# Env vars:
-#   SKILLS_TOKEN  - GitHub token with push access to basecamp/skills (required unless DRY_RUN=local)
-#   RELEASE_TAG   - Release tag, e.g. v1.2.3 (required)
-#   SOURCE_SHA    - Source commit SHA (required)
-#   DRY_RUN       - Optional: "local" (no network) or "remote" (clone but skip push)
-
+CLI_NAME="${CLI_NAME:-basecamp}"
+SYNC_SOURCE="${SYNC_SOURCE:-${CLI_NAME}-cli}"
 RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
 SOURCE_SHA="${SOURCE_SHA:?SOURCE_SHA is required}"
+SKILLS_SOURCE="${SKILLS_SOURCE:-skills}"
+SKILLS_TARGET="${SKILLS_TARGET:-}"
+SKILLS_TOKEN="${SKILLS_TOKEN:-}"
 DRY_RUN="${DRY_RUN:-}"
 
-SKILLS_SOURCE="skills"
 TARGET_REPO="basecamp/skills"
 TARGET_BRANCH="main"
 SKILLS_SUBDIR="skills"
+LEGACY_MANIFEST=".managed-skills"
+MANIFEST="${LEGACY_MANIFEST}.${SYNC_SOURCE}"
+# The commit's provenance line; GITHUB_REPOSITORY is exact in CI, the default holds
+# for the basecamp org's <source> naming.
+SOURCE_REPO="${GITHUB_REPOSITORY:-basecamp/${SYNC_SOURCE}}"
 
 # --- Helpers ---
 
 die() { echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARNING: $*" >&2; }
 
+# A skill directory name or a source name: nothing a path could smuggle in.
+plain_name() {
+  [[ "$1" != "." && "$1" != ".." && "$1" =~ ^[a-zA-Z0-9._-]+$ ]]
+}
+
+in_list() {
+  local needle="$1" item
+  shift
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Print the skill names a manifest lists, one per line. Blank and comment lines
+# are skipped silently; anything else that is not a plain name, with a warning.
+read_manifest() {
+  local file="$1" line
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if plain_name "$line"; then
+      echo "$line"
+    else
+      warn "skipping invalid entry in ${file##*/}: $line"
+    fi
+  done < "$file"
+}
+
+# Print the other source whose manifest claims a name, if any.
+claimed_by_other() {
+  local name="$1" file other listed
+  for file in "${target}/${LEGACY_MANIFEST}".*; do
+    [[ -f "$file" ]] || continue
+    other="${file##*/"${LEGACY_MANIFEST}".}"
+    [[ "$other" == "$SYNC_SOURCE" ]] && continue
+    listed=$(read_manifest "$file")
+    if grep -qxF -- "$name" <<< "$listed"; then
+      echo "$other"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The URLs as configured: `remote get-url` would show them after any insteadOf
+# rewrite, so an operator's rewrite could pass this check with a repo that is not
+# the target. A push URL of its own is where `git push origin` would actually go.
 assert_remote_url() {
-  local url
-  url=$(git -C "$1" remote get-url origin)
-  local stripped
-  stripped=$(echo "$url" | sed -E 's/\.git$//')
-  # Validate host + owner/repo for both HTTPS and SSH forms
-  case "$stripped" in
-    https://github.com/"$TARGET_REPO") ;;
-    https://x-access-token:*@github.com/"$TARGET_REPO") ;;
-    git@github.com:"$TARGET_REPO") ;;
-    *) die "origin remote '$(echo "$url" | sed -E 's#(https://[^:@]+:)[^@]*@#\1***@#')' does not point to github.com/$TARGET_REPO" ;;
-  esac
+  local kind url
+  for kind in url pushurl; do
+    url=$(git -C "$1" config --get "remote.origin.${kind}" || true)
+    [[ -z "$url" && "$kind" == pushurl ]] && continue
+    case "${url%.git}" in
+      "https://github.com/${TARGET_REPO}") ;;
+      https://x-access-token:*@github.com/"${TARGET_REPO}") ;;
+      "git@github.com:${TARGET_REPO}") ;;
+      *) die "origin ${kind} '$(echo "$url" | sed -E 's#(https://[^:@]+:)[^@]*@#\1***@#')' does not point to github.com/${TARGET_REPO}" ;;
+    esac
+  done
 }
 
 assert_branch() {
@@ -42,135 +142,168 @@ assert_branch() {
   [[ "$branch" == "$TARGET_BRANCH" ]] || die "checked-out branch is '$branch', expected '$TARGET_BRANCH'"
 }
 
+# --- Validate the knobs ---
+
+plain_name "$SYNC_SOURCE" || die "SYNC_SOURCE '$SYNC_SOURCE' is not a plain name"
+case "$DRY_RUN" in
+  ""|local|remote) ;;
+  *) die "DRY_RUN must be unset, 'local' or 'remote', not '$DRY_RUN'" ;;
+esac
+
 # --- Discover skills ---
 
-skill_dirs=()
+skill_names=()
 for skill_md in "$SKILLS_SOURCE"/*/SKILL.md; do
   [[ -f "$skill_md" ]] || continue
-  skill_dirs+=("$(dirname "$skill_md")")
+  name=$(basename "$(dirname "$skill_md")")
+  plain_name "$name" || die "skill directory '$name' is not a plain name"
+  skill_names+=("$name")
 done
 
-[[ ${#skill_dirs[@]} -gt 0 ]] || die "no skills found under $SKILLS_SOURCE/*/SKILL.md"
-echo "Found ${#skill_dirs[@]} skill(s): ${skill_dirs[*]}"
+[[ ${#skill_names[@]} -gt 0 ]] || die "no skills found under ${SKILLS_SOURCE}/*/SKILL.md"
+echo "Found ${#skill_names[@]} skill(s) in ${SKILLS_SOURCE}/: ${skill_names[*]}"
 
-# --- Copy skills into target, excluding *.go and dotfiles ---
+# --- Copy skills, excluding *.go and dotfiles, preserving subdirectories ---
 
 copy_skills() {
-  local target_dir="$1"
-  for skill_dir in "${skill_dirs[@]}"; do
-    local name
-    name=$(basename "$skill_dir")
-    rm -rf "${target_dir:?}/${name}"
-    mkdir -p "$target_dir/$name"
-    # Copy files, excluding *.go and dotfiles
-    find "$skill_dir" -mindepth 1 \
-      ! -name '*.go' \
-      ! -name '.*' \
-      ! -path '*/.*' \
-      -type f \
-      -exec bash -c '
-        src="$1"; skill_dir="$2"; target_dir="$3"
-        rel="${src#$skill_dir/}"
-        mkdir -p "$(dirname "$target_dir/$rel")"
-        cp "$src" "$target_dir/$rel"
-      ' _ {} "$skill_dir" "$target_dir/$name" \;
+  local skills_dir="$1" name dest
+  for name in "${skill_names[@]}"; do
+    dest="${skills_dir}/${name}"
+    rm -rf "${dest:?}"
+    mkdir -p "$dest"
+    (cd "${SKILLS_SOURCE}/${name}" && find . -type f ! -name '*.go' ! -name '.*' ! -path '*/.*/*' -print0) |
+      while IFS= read -r -d '' file; do
+        mkdir -p "${dest}/$(dirname "$file")"
+        cp "${SKILLS_SOURCE}/${name}/${file}" "${dest}/${file}"
+      done
   done
 }
 
-# --- DRY_RUN=local: copy into tmpdir, diff against empty baseline ---
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
 
-if [[ "$DRY_RUN" == "local" ]]; then
-  tmpdir=$(mktemp -d)
-  trap 'rm -rf "$tmpdir"' EXIT
-  echo "DRY_RUN=local: copying skills into $tmpdir"
-  copy_skills "$tmpdir/$SKILLS_SUBDIR"
+# --- DRY_RUN=local without a target: what would be published ---
+
+if [[ "$DRY_RUN" == "local" && -z "$SKILLS_TARGET" ]]; then
+  preview="${tmpdir}/preview"
+  echo "DRY_RUN=local: copying skills into ${preview}"
+  copy_skills "${preview}/${SKILLS_SUBDIR}"
   echo ""
   echo "=== Skills copied ==="
-  find "$tmpdir" -type f | sort | while read -r f; do
-    echo "  ${f#$tmpdir/}"
+  find "$preview" -type f | LC_ALL=C sort | while read -r file; do
+    echo "  ${file#"${preview}/"}"
   done
   echo ""
   echo "=== Diff (against empty baseline) ==="
-  # Initialize as empty git repo to get a clean diff
-  git -C "$tmpdir" init -q
-  git -C "$tmpdir" add -A
-  git -C "$tmpdir" diff --cached --stat
+  git -C "$preview" init -q
+  git -C "$preview" add -A
+  git -C "$preview" diff --cached --stat
   echo ""
   echo "DRY_RUN=local complete. No network operations performed."
   exit 0
 fi
 
-# --- Clone target repo ---
+# --- Git configuration for the target ---
+#
+# A private global config for every git call below: the bot is the identity for
+# the commit and for the rebase a retried push needs, the token goes in as a URL
+# rewrite so it never appears in argv or in the remote URL, and nothing from the
+# ambient environment (signing, hooks, defaults) reaches the target.
+export GIT_CONFIG_GLOBAL="${tmpdir}/gitconfig"
+cat > "$GIT_CONFIG_GLOBAL" <<GITCFG
+[user]
+	name = ${SYNC_SOURCE}[bot]
+	email = ${SYNC_SOURCE}[bot]@users.noreply.github.com
+GITCFG
+chmod 600 "$GIT_CONFIG_GLOBAL"
+if [[ -n "$SKILLS_TOKEN" ]]; then
+  cat >> "$GIT_CONFIG_GLOBAL" <<GITCFG
+[url "https://x-access-token:${SKILLS_TOKEN}@github.com/"]
+	insteadOf = https://github.com/
+GITCFG
+fi
 
-[[ -n "${SKILLS_TOKEN:-}" ]] || die "SKILLS_TOKEN is required (set DRY_RUN=local for offline testing)"
+# --- Clone the target, or take the checkout given ---
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-
-echo "Cloning $TARGET_REPO into $tmpdir/skills..."
-git clone --depth 1 --branch "$TARGET_BRANCH" \
-  "https://x-access-token:${SKILLS_TOKEN}@github.com/${TARGET_REPO}.git" \
-  "$tmpdir/skills"
-
-target="$tmpdir/skills"
-
-# --- Safety checks ---
+if [[ -n "$SKILLS_TARGET" ]]; then
+  [[ -d "${SKILLS_TARGET}/.git" ]] || die "SKILLS_TARGET '${SKILLS_TARGET}' is not a git checkout"
+  target="$SKILLS_TARGET"
+  echo "Syncing into ${target}"
+else
+  [[ -n "$SKILLS_TOKEN" ]] || die "SKILLS_TOKEN is required (set DRY_RUN=local for offline testing)"
+  target="${tmpdir}/skills"
+  echo "Cloning ${TARGET_REPO} into ${target}..."
+  git clone -q --depth 1 --branch "$TARGET_BRANCH" "https://github.com/${TARGET_REPO}.git" "$target"
+fi
 
 assert_remote_url "$target"
 assert_branch "$target"
+# `git add -A` below would sweep anything else in the checkout into the sync commit.
+[[ -z "$(git -C "$target" status --porcelain)" ]] || die "${target} has uncommitted changes; commit or stash them before syncing into it"
 
-# --- Copy skills ---
+# --- Apply the sync to the target's working tree ---
+#
+# Every decision here is made against the tree as it stands, so a retry after a
+# rejected push runs this again from the remote's new tip instead of replaying
+# decisions made against a stale one.
 
-echo "Copying skills into target..."
-copy_skills "$target/$SKILLS_SUBDIR"
+apply_sync() {
+  local name other
+  local previously_published=()
 
-# --- Remove stale skills using manifest ---
-# .managed-skills lists skill names owned by this sync. Only those are
-# candidates for deletion — other content in the target repo is untouched.
+  # Refuse a name another source has published
+  for name in "${skill_names[@]}"; do
+    if other=$(claimed_by_other "$name"); then
+      die "skills/${name} is published by ${other} (listed in ${LEGACY_MANIFEST}.${other}); rename the skill or settle ownership upstream"
+    fi
+  done
 
-MANIFEST=".managed-skills"
-source_skill_names=()
-for skill_dir in "${skill_dirs[@]}"; do
-  source_skill_names+=("$(basename "$skill_dir")")
-done
+  echo "Copying skills into ${target}/${SKILLS_SUBDIR}/..."
+  copy_skills "${target}/${SKILLS_SUBDIR}"
 
-previously_managed_names=()
-if [[ -f "$target/$MANIFEST" ]]; then
-  while IFS= read -r entry; do
-    [[ -z "$entry" ]] && continue
-    if [[ "$entry" == "." || "$entry" == ".." || ! "$entry" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-      echo "WARNING: skipping invalid manifest entry: $entry" >&2
+  # Remove what this source published before and no longer has
+  while IFS= read -r name; do
+    previously_published+=("$name")
+  done < <(read_manifest "${target}/${MANIFEST}")
+
+  if [[ ! -f "${target}/${MANIFEST}" ]]; then
+    echo "No ${MANIFEST} yet: first run for ${SYNC_SOURCE}, removing nothing"
+  fi
+
+  for name in ${previously_published[@]+"${previously_published[@]}"}; do
+    in_list "$name" "${skill_names[@]}" && continue
+    if other=$(claimed_by_other "$name"); then
+      warn "skills/${name} is no longer in ${SYNC_SOURCE}'s skills but ${other} lists it in ${LEGACY_MANIFEST}.${other}; leaving it in place"
       continue
     fi
-    previously_managed_names+=("$entry")
-  done < "$target/$MANIFEST"
-else
-  # No manifest yet (first run). basecamp-cli is the source of truth, so
-  # treat all */SKILL.md dirs in the target as managed. Any skill not in the
-  # source set will be removed. Use DRY_RUN=remote to preview before pushing.
-  for candidate in "$target/$SKILLS_SUBDIR"/*/SKILL.md; do
-    [[ -f "$candidate" ]] || continue
-    previously_managed_names+=("$(basename "$(dirname "$candidate")")")
+    if [[ -d "${target}/${SKILLS_SUBDIR}/${name}" ]]; then
+      echo "Removing stale skill: ${name}"
+      rm -rf "${target:?}/${SKILLS_SUBDIR}/${name}"
+    fi
   done
-fi
 
-for previously_managed in "${previously_managed_names[@]}"; do
-  found=0
-  for name in "${source_skill_names[@]}"; do
-    [[ "$name" == "$previously_managed" ]] && found=1 && break
-  done
-  if [[ "$found" -eq 0 && -d "$target/$SKILLS_SUBDIR/$previously_managed" ]]; then
-    echo "Removing stale skill: $previously_managed"
-    rm -rf "${target:?}/$SKILLS_SUBDIR/$previously_managed"
-  fi
-done
+  # This source's manifest, and the legacy tombstone
+  printf '%s\n' "${skill_names[@]}" | LC_ALL=C sort > "${target}/${MANIFEST}"
+  cat > "${target}/${LEGACY_MANIFEST}" <<'TOMBSTONE'
+# Superseded by the per-source manifests (.managed-skills.<cli>), one per publishing CLI.
+# Each CLI deletes only the skill directories listed in its own manifest.
+# Kept so a CLI still running the pre-fix sync script deletes nothing: that script skips
+# every line it cannot parse as a skill name and only deletes names it can.
+TOMBSTONE
 
-# Write current manifest
-printf '%s\n' "${source_skill_names[@]}" | sort > "$target/$MANIFEST"
+  git -C "$target" add -A
+}
 
-# --- Commit ---
+commit_sync() {
+  git -C "$target" commit -q -m "$(cat <<EOF
+Sync skills from ${SYNC_SOURCE} ${RELEASE_TAG}
 
-git -C "$target" add -A
+Source: ${SOURCE_REPO}@${SOURCE_SHA}
+EOF
+)"
+}
+
+apply_sync
 
 if git -C "$target" diff --cached --quiet; then
   echo "No changes to commit. Skills are already up to date."
@@ -190,35 +323,43 @@ if [[ "$DRY_RUN" == "remote" ]]; then
   exit 0
 fi
 
-git -C "$target" \
-  -c user.name="basecamp-cli[bot]" \
-  -c user.email="basecamp-cli[bot]@users.noreply.github.com" \
-  commit -m "$(cat <<EOF
-Sync skills from basecamp-cli ${RELEASE_TAG}
+commit_sync
 
-Source: basecamp/basecamp-cli@${SOURCE_SHA}
-EOF
-)"
+if [[ "$DRY_RUN" == "local" ]]; then
+  echo "DRY_RUN=local: committed in ${target}, skipping push."
+  exit 0
+fi
 
-# --- Push (with one retry on non-fast-forward) ---
+# --- Push; when another publisher got there first, apply again from its tip ---
+#
+# A fresh clone racing a sibling's push is rejected as "fetch first"; a clone whose
+# tracking ref already knows the remote moved, as "non-fast-forward". Either way the
+# commit just made was decided against a stale tree, so it is dropped and the sync
+# applied again to the remote's tip — collision guard included — then pushed once more.
 
 push_target() {
   git -C "$target" push origin "$TARGET_BRANCH" 2>&1
 }
 
 if ! output=$(push_target); then
-  if echo "$output" | grep -qi "non-fast-forward"; then
-    echo "Push rejected (non-fast-forward). Pulling with rebase and retrying..."
-    git -C "$target" pull --rebase origin "$TARGET_BRANCH"
-    if ! retry_output=$(push_target); then
-      echo "$retry_output" >&2
-      die "Push failed after retry"
-    fi
-  else
+  if ! echo "$output" | grep -Eqi "fetch first|non-fast-forward"; then
     echo "$output" >&2
     die "Push failed"
+  fi
+  echo "Push rejected (the remote has moved). Applying the sync again from its new tip..."
+  git -C "$target" fetch -q origin "$TARGET_BRANCH"
+  git -C "$target" reset -q --hard FETCH_HEAD
+  apply_sync
+  if git -C "$target" diff --cached --quiet; then
+    echo "Nothing left to publish: the remote already holds these skills."
+    exit 0
+  fi
+  commit_sync
+  if ! retry_output=$(push_target); then
+    echo "$retry_output" >&2
+    die "Push failed after retry"
   fi
 fi
 
 echo ""
-echo "Skills synced to $TARGET_REPO ($TARGET_BRANCH) from $RELEASE_TAG"
+echo "Skills synced to ${TARGET_REPO} (${TARGET_BRANCH}) from ${SYNC_SOURCE} ${RELEASE_TAG}"

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -121,18 +121,22 @@ claimed_by_other() {
 
 # The URLs as configured: `remote get-url` would show them after any insteadOf
 # rewrite, so an operator's rewrite could pass this check with a repo that is not
-# the target. A push URL of its own is where `git push origin` would actually go.
+# the target. Push URLs of its own are where `git push origin` would actually go,
+# and a remote may carry several of either kind, each one a push destination.
 assert_remote_url() {
-  local kind url
+  local kind url urls
   for kind in url pushurl; do
-    url=$(git -C "$1" config --get "remote.origin.${kind}" || true)
-    [[ -z "$url" && "$kind" == pushurl ]] && continue
-    case "${url%.git}" in
-      "https://github.com/${TARGET_REPO}") ;;
-      https://x-access-token:*@github.com/"${TARGET_REPO}") ;;
-      "git@github.com:${TARGET_REPO}") ;;
-      *) die "origin ${kind} '$(echo "$url" | sed -E 's#(https://[^:@]+:)[^@]*@#\1***@#')' does not point to github.com/${TARGET_REPO}" ;;
-    esac
+    urls=$(git -C "$1" config --get-all "remote.origin.${kind}" || true)
+    [[ -z "$urls" && "$kind" == url ]] && die "origin has no url configured"
+    while IFS= read -r url; do
+      [[ -n "$url" ]] || continue
+      case "${url%.git}" in
+        "https://github.com/${TARGET_REPO}") ;;
+        https://x-access-token:*@github.com/"${TARGET_REPO}") ;;
+        "git@github.com:${TARGET_REPO}") ;;
+        *) die "origin ${kind} '$(echo "$url" | sed -E 's#(https://[^:@]+:)[^@]*@#\1***@#')' does not point to github.com/${TARGET_REPO}" ;;
+      esac
+    done <<< "$urls"
   done
 }
 
@@ -206,7 +210,7 @@ fi
 # --- Git configuration for the target ---
 #
 # A private global config for every git call below: the bot is the identity for
-# the commit and for the rebase a retried push needs, the token goes in as a URL
+# the commit, and for the one a rejected push makes again, the token goes in as a URL
 # rewrite so it never appears in argv or in the remote URL, and nothing from the
 # ambient environment (signing, hooks, defaults) reaches the target.
 export GIT_CONFIG_GLOBAL="${tmpdir}/gitconfig"

--- a/scripts/test-sync-skills.sh
+++ b/scripts/test-sync-skills.sh
@@ -245,7 +245,7 @@ assert_output "skills/hey/reference/commands.md"
 assert_output "No network operations performed"
 if grep -q "embed.go" "$out"; then not_ok "preview leaves out embed.go"; else ok "preview leaves out embed.go"; fi
 
-# --- Another publisher pushes first: the push is retried after a rebase ---
+# --- Another publisher pushes first: the sync is applied again from its tip ---
 
 echo "# a concurrent publisher wins the race to origin"
 origin="${work}/origin.git"
@@ -309,6 +309,18 @@ git -C "$target" remote set-url --push origin https://github.com/someone/skills.
 sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
 assert_output "origin pushurl 'https://github.com/someone/skills.git' does not point to github.com/basecamp/skills"
 git -C "$target" config --unset remote.origin.pushurl
+
+echo "# every push URL, and every fetch URL, is a push destination: one bad one is refused"
+git -C "$target" remote set-url --push origin git@github.com:someone/skills.git
+git -C "$target" remote set-url --push --add origin https://github.com/basecamp/skills.git
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "origin pushurl 'git@github.com:someone/skills.git' does not point to github.com/basecamp/skills"
+git -C "$target" config --unset-all remote.origin.pushurl
+git -C "$target" config --replace-all remote.origin.url https://github.com/someone/skills.git
+git -C "$target" remote set-url --add origin https://github.com/basecamp/skills.git
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "origin url 'https://github.com/someone/skills.git' does not point to github.com/basecamp/skills"
+git -C "$target" config --replace-all remote.origin.url https://github.com/basecamp/skills.git
 
 git -C "$target" checkout -q -b not-main
 sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"

--- a/scripts/test-sync-skills.sh
+++ b/scripts/test-sync-skills.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# test-sync-skills.sh — Run sync-skills.sh as two CLIs against one throwaway
+# basecamp/skills checkout and prove neither deletes the other's skills.
+#
+# The target starts in the state basecamp/skills#5 left it: basecamp-cli's skills
+# and the shared .managed-skills listing them. Then hey-cli and basecamp-cli sync
+# in turn, one loses a skill, a pre-fix sibling rewrites the legacy manifest, and
+# two manifests claim one name — after each step both sources' skills must be
+# where they belong. Everything runs with DRY_RUN=local and SKILLS_TARGET, so no
+# network and no token.
+#
+# Usage: scripts/test-sync-skills.sh            (tests scripts/sync-skills.sh)
+#        SYNC_SCRIPT=path/to/sync-skills.sh scripts/test-sync-skills.sh
+
+set -euo pipefail
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SYNC_SCRIPT="${SYNC_SCRIPT:-${here}/sync-skills.sh}"
+[[ -x "$SYNC_SCRIPT" ]] || { echo "ERROR: ${SYNC_SCRIPT} is not an executable script" >&2; exit 1; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The test's own git calls see only this config; the script brings its own.
+export GIT_CONFIG_GLOBAL="${work}/gitconfig" GIT_CONFIG_NOSYSTEM=1
+printf '[user]\n\tname = test\n\temail = test@example.com\n' > "$GIT_CONFIG_GLOBAL"
+
+target="${work}/target"
+out="${work}/out"
+failures=0
+
+# --- Assertions ---
+
+ok() { echo "ok - $*"; }
+not_ok() { echo "not ok - $*"; failures=$((failures + 1)); }
+
+assert() {  # description, command...
+  local desc="$1"
+  shift
+  if "$@"; then ok "$desc"; else not_ok "$desc"; fi
+}
+
+assert_skill() { assert "skills/$1 present" test -f "${target}/skills/$1/SKILL.md"; }
+assert_no_skill() { assert "skills/$1 absent" test ! -e "${target}/skills/$1"; }
+assert_no_path() { assert "$1 not published" test ! -e "${target}/skills/$1"; }
+assert_content() {  # path, expected content
+  assert "$1 holds '$2'" test "$(cat "${target}/$1")" = "$2"
+}
+assert_manifest() {  # source, names...
+  local source="$1" want
+  shift
+  want=$(printf '%s\n' "$@")
+  assert ".managed-skills.${source} lists exactly: $*" test "$(cat "${target}/.managed-skills.${source}")" = "$want"
+}
+assert_no_manifest() { assert ".managed-skills.$1 absent" test ! -e "${target}/.managed-skills.$1"; }
+assert_tombstone() {
+  if [[ -f "${target}/.managed-skills" ]] && ! grep -qv '^#' "${target}/.managed-skills" && grep -q 'Superseded' "${target}/.managed-skills"; then
+    ok ".managed-skills is the comment-only tombstone"
+  else
+    not_ok ".managed-skills is the comment-only tombstone"
+  fi
+}
+assert_author() { assert "last commit authored by $1[bot]" test "$(git -C "$target" log -1 --format=%an)" = "$1[bot]"; }
+assert_clean() { assert "target working tree committed clean" test -z "$(git -C "$target" status --porcelain)"; }
+assert_output() { assert "output says: $1" grep -q -- "$1" "$out"; }
+assert_head() {  # expected sha, description
+  assert "$2" test "$(git -C "$target" rev-parse HEAD)" = "$1"
+}
+
+# --- Running the script ---
+
+sync() {  # source, fixture, [VAR=value...]
+  local source="$1" fixture="$2"
+  shift 2
+  if env "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
+       RELEASE_TAG=v9.9.9 SOURCE_SHA=0123abcd "$SYNC_SCRIPT" > "$out" 2>&1; then
+    ok "sync as ${source} succeeded"
+  else
+    not_ok "sync as ${source} succeeded"
+    sed 's/^/    /' "$out"
+  fi
+}
+
+sync_local() { sync "$1" "$2" DRY_RUN=local SKILLS_TARGET="$target"; }
+
+sync_expecting_failure() {  # source, fixture, [VAR=value...]
+  local source="$1" fixture="$2"
+  shift 2
+  if env "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
+       RELEASE_TAG=v9.9.9 SOURCE_SHA=0123abcd "$SYNC_SCRIPT" > "$out" 2>&1; then
+    not_ok "sync as ${source} refused"
+    sed 's/^/    /' "$out"
+  else
+    ok "sync as ${source} refused"
+  fi
+}
+
+# --- Fixtures ---
+
+write_skill() {  # dir, content
+  mkdir -p "$1"
+  echo "$2" > "$1/SKILL.md"
+}
+
+a="${work}/hey-cli"
+b="${work}/basecamp-cli"
+
+write_skill "${a}/skills/hey" "hey v2"
+mkdir -p "${a}/skills/hey/reference" "${a}/skills/hey/.cache"
+echo "nested" > "${a}/skills/hey/reference/commands.md"
+echo "package hey" > "${a}/skills/hey/embed.go"
+echo "secret" > "${a}/skills/hey/.env"
+echo "cached" > "${a}/skills/hey/.cache/index"
+write_skill "${a}/skills/hey-doctor" "hey-doctor v2"
+
+write_skill "${b}/skills/basecamp" "basecamp v2"
+write_skill "${b}/skills/basecamp-doctor" "basecamp-doctor v2"
+
+# The target as basecamp/skills#5 left it: only basecamp-cli's skills survive,
+# and the shared manifest names them.
+git init -q -b main "$target"
+git -C "$target" remote add origin https://github.com/basecamp/skills.git
+write_skill "${target}/skills/basecamp" "basecamp v1"
+write_skill "${target}/skills/basecamp-doctor" "basecamp-doctor v1"
+printf 'basecamp\nbasecamp-doctor\n' > "${target}/.managed-skills"
+echo "# skills" > "${target}/README.md"
+git -C "$target" add -A
+git -C "$target" commit -q -m "State after basecamp/skills#5"
+
+# --- Interleaved syncs: A, B, A, B ---
+
+echo "# hey-cli syncs first: restores its skills, touches nothing else"
+sync_local hey-cli "$a"
+assert_skill hey
+assert_skill hey-doctor
+assert_skill basecamp
+assert_skill basecamp-doctor
+assert_content skills/basecamp/SKILL.md "basecamp v1"
+assert_content skills/hey/reference/commands.md "nested"
+assert_no_path hey/embed.go
+assert_no_path hey/.env
+assert_no_path hey/.cache
+assert_manifest hey-cli hey hey-doctor
+assert_no_manifest basecamp-cli
+assert_tombstone
+assert_author hey-cli
+assert_clean
+assert_output "first run for hey-cli, removing nothing"
+
+echo "# basecamp-cli syncs: refreshes its skills, leaves hey-cli's"
+sync_local basecamp-cli "$b"
+assert_skill hey
+assert_skill hey-doctor
+assert_skill basecamp
+assert_skill basecamp-doctor
+assert_content skills/basecamp/SKILL.md "basecamp v2"
+assert_manifest hey-cli hey hey-doctor
+assert_manifest basecamp-cli basecamp basecamp-doctor
+assert_tombstone
+assert_author basecamp-cli
+assert_clean
+
+echo "# both sync again with nothing new: no commits, nothing lost"
+head_before=$(git -C "$target" rev-parse HEAD)
+sync_local hey-cli "$a"
+assert_output "No changes to commit"
+sync_local basecamp-cli "$b"
+assert_output "No changes to commit"
+assert_head "$head_before" "HEAD unchanged by the no-op syncs"
+assert_skill hey
+assert_skill hey-doctor
+assert_skill basecamp
+assert_skill basecamp-doctor
+assert_manifest hey-cli hey hey-doctor
+assert_manifest basecamp-cli basecamp basecamp-doctor
+assert_tombstone
+
+# --- hey-cli drops a skill: only that directory goes ---
+
+echo "# hey-cli drops hey-doctor"
+rm -rf "${a}/skills/hey-doctor"
+sync_local hey-cli "$a"
+assert_output "Removing stale skill: hey-doctor"
+assert_no_skill hey-doctor
+assert_skill hey
+assert_skill basecamp
+assert_skill basecamp-doctor
+assert_manifest hey-cli hey
+assert_manifest basecamp-cli basecamp basecamp-doctor
+assert_author hey-cli
+
+# --- A pre-fix sibling rewrote the legacy manifest: still nothing of B's goes ---
+
+echo "# a pre-fix basecamp-cli rewrites .managed-skills with its own names"
+printf 'basecamp\nbasecamp-doctor\n' > "${target}/.managed-skills"
+git -C "$target" commit -q -am "Sync skills from basecamp-cli v0.0.0 (pre-fix script)"
+sync_local hey-cli "$a"
+assert_skill basecamp
+assert_skill basecamp-doctor
+assert_skill hey
+assert_tombstone
+assert_manifest basecamp-cli basecamp basecamp-doctor
+
+# --- Two manifests claim one name: removal is refused with a warning ---
+
+echo "# hey-cli's manifest also lists basecamp, which basecamp-cli owns"
+printf 'basecamp\nhey\n' > "${target}/.managed-skills.hey-cli"
+git -C "$target" commit -q -am "Collision: hey-cli claims basecamp"
+sync_local hey-cli "$a"
+assert_skill basecamp
+assert_content skills/basecamp/SKILL.md "basecamp v2"
+assert_output "WARNING: skills/basecamp is no longer in hey-cli's skills but basecamp-cli lists it"
+assert_manifest hey-cli hey
+assert_manifest basecamp-cli basecamp basecamp-doctor
+
+# --- Publishing a name another source owns is refused before anything changes ---
+
+echo "# hey-cli ships a skill named basecamp"
+write_skill "${a}/skills/basecamp" "hey-cli's basecamp"
+head_before=$(git -C "$target" rev-parse HEAD)
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "ERROR: skills/basecamp is published by basecamp-cli"
+assert_content skills/basecamp/SKILL.md "basecamp v2"
+assert_head "$head_before" "HEAD unchanged by the refused sync"
+assert_clean
+rm -rf "${a}/skills/basecamp"
+
+# --- DRY_RUN=remote applies and shows the diff but commits nothing ---
+
+echo "# DRY_RUN=remote against the checkout"
+echo "hey v3" > "${a}/skills/hey/SKILL.md"
+head_before=$(git -C "$target" rev-parse HEAD)
+sync hey-cli "$a" DRY_RUN=remote SKILLS_TARGET="$target"
+assert_output "DRY_RUN=remote: skipping commit and push"
+assert_output "+hey v3"
+assert_head "$head_before" "HEAD unchanged by DRY_RUN=remote"
+git -C "$target" reset -q --hard
+
+# --- DRY_RUN=local with no target: no network, lists what would be published ---
+
+echo "# DRY_RUN=local without SKILLS_TARGET"
+sync hey-cli "$a" DRY_RUN=local
+assert_output "skills/hey/SKILL.md"
+assert_output "skills/hey/reference/commands.md"
+assert_output "No network operations performed"
+if grep -q "embed.go" "$out"; then not_ok "preview leaves out embed.go"; else ok "preview leaves out embed.go"; fi
+
+# --- Another publisher pushes first: the push is retried after a rebase ---
+
+echo "# a concurrent publisher wins the race to origin"
+origin="${work}/origin.git"
+git init -q --bare -b main "$origin"
+git -C "$target" push -q "$origin" main
+sibling="${work}/sibling"
+git clone -q "$origin" "$sibling"
+echo "# skills (sibling)" > "${sibling}/README.md"
+git -C "$sibling" commit -q -am "Sync skills from basecamp-cli v0.0.1 (concurrent)"
+git -C "$sibling" push -q origin main
+echo "hey v4" > "${a}/skills/hey/SKILL.md"
+# A real push, with github.com/basecamp/skills routed to the local bare repo through
+# the environment — the script's private gitconfig cannot hide that.
+sync hey-cli "$a" SKILLS_TARGET="$target" \
+  GIT_CONFIG_COUNT=1 "GIT_CONFIG_KEY_0=url.${origin}.insteadOf" GIT_CONFIG_VALUE_0=https://github.com/basecamp/skills.git
+assert_output "Push rejected"
+assert_output "Skills synced to basecamp/skills"
+assert "origin main holds the sibling's commit then the sync" \
+  test "$(git -C "$origin" log --format=%s -2 main | tr '\n' '|')" = "Sync skills from hey-cli v9.9.9|Sync skills from basecamp-cli v0.0.1 (concurrent)|"
+assert_content skills/hey/SKILL.md "hey v4"
+assert_content README.md "# skills (sibling)"
+assert_clean
+
+echo "# a concurrent publisher claims a name this source ships: the retry refuses"
+git -C "$sibling" pull -q origin main
+printf 'basecamp\nbasecamp-doctor\nhey\n' > "${sibling}/.managed-skills.basecamp-cli"
+git -C "$sibling" commit -q -am "Collision: basecamp-cli claims hey (concurrent)"
+git -C "$sibling" push -q origin main
+echo "hey v5" > "${a}/skills/hey/SKILL.md"
+sync_expecting_failure hey-cli "$a" SKILLS_TARGET="$target" \
+  GIT_CONFIG_COUNT=1 "GIT_CONFIG_KEY_0=url.${origin}.insteadOf" GIT_CONFIG_VALUE_0=https://github.com/basecamp/skills.git
+assert_output "Push rejected"
+assert_output "ERROR: skills/hey is published by basecamp-cli"
+assert "origin main tip is the sibling's commit" \
+  test "$(git -C "$origin" log -1 --format=%s main)" = "Collision: basecamp-cli claims hey (concurrent)"
+assert_content skills/hey/SKILL.md "hey v4"
+assert_clean
+git -C "$sibling" checkout -q HEAD~1 -- .managed-skills.basecamp-cli
+git -C "$sibling" commit -q -am "basecamp-cli drops its claim on hey"
+git -C "$sibling" push -q origin main
+git -C "$target" fetch -q "$origin" main
+git -C "$target" reset -q --hard FETCH_HEAD
+
+# --- Safety asserts on the checkout ---
+
+echo "# a checkout with uncommitted changes is refused"
+echo "stray" > "${target}/stray.txt"
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "has uncommitted changes"
+rm "${target}/stray.txt"
+
+echo "# a checkout that is not basecamp/skills on main is refused"
+wrong="${work}/wrong-remote"
+git init -q -b main "$wrong"
+git -C "$wrong" remote add origin https://github.com/basecamp/other.git
+git -C "$wrong" commit -q --allow-empty -m "init"
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$wrong"
+assert_output "does not point to github.com/basecamp/skills"
+
+git -C "$target" remote set-url --push origin https://github.com/someone/skills.git
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "origin pushurl 'https://github.com/someone/skills.git' does not point to github.com/basecamp/skills"
+git -C "$target" config --unset remote.origin.pushurl
+
+git -C "$target" checkout -q -b not-main
+sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+assert_output "checked-out branch is 'not-main', expected 'main'"
+git -C "$target" checkout -q main
+
+# --- Verdict ---
+
+echo ""
+if [[ "$failures" -eq 0 ]]; then
+  echo "sync-skills: all assertions passed"
+else
+  echo "sync-skills: ${failures} assertion(s) failed" >&2
+  exit 1
+fi

--- a/scripts/test-sync-skills.sh
+++ b/scripts/test-sync-skills.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # test-sync-skills.sh — Run sync-skills.sh as two CLIs against one throwaway
-# basecamp/skills checkout and prove neither deletes the other's skills.
+# basecamp/skills and prove neither deletes the other's skills.
 #
-# The target starts in the state basecamp/skills#5 left it: basecamp-cli's skills
-# and the shared .managed-skills listing them. Then hey-cli and basecamp-cli sync
-# in turn, one loses a skill, a pre-fix sibling rewrites the legacy manifest, and
-# two manifests claim one name — after each step both sources' skills must be
-# where they belong. Everything runs with DRY_RUN=local and SKILLS_TARGET, so no
-# network and no token.
+# The target is a local bare repository the script clones from and pushes to
+# through SKILLS_REPO_URL, exactly as it would basecamp/skills — so every run
+# here is a real clone, commit and push, and the test reads the result back
+# from a clone of its own. It starts in the state basecamp/skills#5 left it:
+# basecamp-cli's skills and the shared .managed-skills listing them. Then
+# hey-cli and basecamp-cli sync in turn, one loses a skill, a pre-fix sibling
+# rewrites the legacy manifest, two manifests claim one name, and a sibling
+# wins the race to push — after each step both sources' skills must be where
+# they belong. No network and no token.
 #
 # Usage: scripts/test-sync-skills.sh            (tests scripts/sync-skills.sh)
 #        SYNC_SCRIPT=path/to/sync-skills.sh scripts/test-sync-skills.sh
@@ -25,6 +28,10 @@ trap 'rm -rf "$work"' EXIT
 export GIT_CONFIG_GLOBAL="${work}/gitconfig" GIT_CONFIG_NOSYSTEM=1
 printf '[user]\n\tname = test\n\temail = test@example.com\n' > "$GIT_CONFIG_GLOBAL"
 
+# A file:// URL rather than a path: git ignores --depth for a path, and the
+# script's clone is shallow, so the retry has to fetch as it would from GitHub.
+origin="${work}/origin.git"
+origin_url="file://${origin}"
 target="${work}/target"
 out="${work}/out"
 failures=0
@@ -61,38 +68,54 @@ assert_tombstone() {
   fi
 }
 assert_author() { assert "last commit authored by $1[bot]" test "$(git -C "$target" log -1 --format=%an)" = "$1[bot]"; }
-assert_clean() { assert "target working tree committed clean" test -z "$(git -C "$target" status --porcelain)"; }
 assert_output() { assert "output says: $1" grep -q -- "$1" "$out"; }
 assert_head() {  # expected sha, description
-  assert "$2" test "$(git -C "$target" rev-parse HEAD)" = "$1"
+  assert "$2" test "$(git -C "$origin" rev-parse main)" = "$1"
 }
 
+origin_head() { git -C "$origin" rev-parse main; }
+
 # --- Running the script ---
+#
+# Every run clones origin afresh, as a release would clone basecamp/skills, and
+# the target clone is brought to origin's tip afterwards for the assertions.
+
+refresh_target() {
+  git -C "$target" fetch -q origin main
+  git -C "$target" reset -q --hard FETCH_HEAD
+}
 
 sync() {  # source, fixture, [VAR=value...]
   local source="$1" fixture="$2"
   shift 2
-  if env "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
+  if env SKILLS_REPO_URL="$origin_url" "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
        RELEASE_TAG=v9.9.9 SOURCE_SHA=0123abcd "$SYNC_SCRIPT" > "$out" 2>&1; then
     ok "sync as ${source} succeeded"
   else
     not_ok "sync as ${source} succeeded"
     sed 's/^/    /' "$out"
   fi
+  refresh_target
 }
-
-sync_local() { sync "$1" "$2" DRY_RUN=local SKILLS_TARGET="$target"; }
 
 sync_expecting_failure() {  # source, fixture, [VAR=value...]
   local source="$1" fixture="$2"
   shift 2
-  if env "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
+  if env SKILLS_REPO_URL="$origin_url" "$@" SYNC_SOURCE="$source" SKILLS_SOURCE="${fixture}/skills" \
        RELEASE_TAG=v9.9.9 SOURCE_SHA=0123abcd "$SYNC_SCRIPT" > "$out" 2>&1; then
     not_ok "sync as ${source} refused"
     sed 's/^/    /' "$out"
   else
     ok "sync as ${source} refused"
   fi
+  refresh_target
+}
+
+# Commit the target's working tree and push it, as a hand-made or pre-fix commit
+publish() {  # message
+  git -C "$target" add -A
+  git -C "$target" commit -q -m "$1"
+  git -C "$target" push -q origin main
 }
 
 # --- Fixtures ---
@@ -118,19 +141,20 @@ write_skill "${b}/skills/basecamp-doctor" "basecamp-doctor v2"
 
 # The target as basecamp/skills#5 left it: only basecamp-cli's skills survive,
 # and the shared manifest names them.
+git init -q --bare -b main "$origin"
 git init -q -b main "$target"
-git -C "$target" remote add origin https://github.com/basecamp/skills.git
+git -C "$target" remote add origin "$origin_url"
 write_skill "${target}/skills/basecamp" "basecamp v1"
 write_skill "${target}/skills/basecamp-doctor" "basecamp-doctor v1"
 printf 'basecamp\nbasecamp-doctor\n' > "${target}/.managed-skills"
 echo "# skills" > "${target}/README.md"
-git -C "$target" add -A
-git -C "$target" commit -q -m "State after basecamp/skills#5"
+publish "State after basecamp/skills#5"
 
 # --- Interleaved syncs: A, B, A, B ---
 
 echo "# hey-cli syncs first: restores its skills, touches nothing else"
-sync_local hey-cli "$a"
+sync hey-cli "$a"
+assert_output "Skills synced to basecamp/skills"
 assert_skill hey
 assert_skill hey-doctor
 assert_skill basecamp
@@ -144,11 +168,12 @@ assert_manifest hey-cli hey hey-doctor
 assert_no_manifest basecamp-cli
 assert_tombstone
 assert_author hey-cli
-assert_clean
 assert_output "first run for hey-cli, removing nothing"
+assert "origin main is the seed commit then hey-cli's sync" \
+  test "$(git -C "$origin" log --format=%s -2 main | tr '\n' '|')" = "Sync skills from hey-cli v9.9.9|State after basecamp/skills#5|"
 
 echo "# basecamp-cli syncs: refreshes its skills, leaves hey-cli's"
-sync_local basecamp-cli "$b"
+sync basecamp-cli "$b"
 assert_skill hey
 assert_skill hey-doctor
 assert_skill basecamp
@@ -158,15 +183,14 @@ assert_manifest hey-cli hey hey-doctor
 assert_manifest basecamp-cli basecamp basecamp-doctor
 assert_tombstone
 assert_author basecamp-cli
-assert_clean
 
 echo "# both sync again with nothing new: no commits, nothing lost"
-head_before=$(git -C "$target" rev-parse HEAD)
-sync_local hey-cli "$a"
+head_before=$(origin_head)
+sync hey-cli "$a"
 assert_output "No changes to commit"
-sync_local basecamp-cli "$b"
+sync basecamp-cli "$b"
 assert_output "No changes to commit"
-assert_head "$head_before" "HEAD unchanged by the no-op syncs"
+assert_head "$head_before" "origin main unchanged by the no-op syncs"
 assert_skill hey
 assert_skill hey-doctor
 assert_skill basecamp
@@ -179,7 +203,7 @@ assert_tombstone
 
 echo "# hey-cli drops hey-doctor"
 rm -rf "${a}/skills/hey-doctor"
-sync_local hey-cli "$a"
+sync hey-cli "$a"
 assert_output "Removing stale skill: hey-doctor"
 assert_no_skill hey-doctor
 assert_skill hey
@@ -193,8 +217,8 @@ assert_author hey-cli
 
 echo "# a pre-fix basecamp-cli rewrites .managed-skills with its own names"
 printf 'basecamp\nbasecamp-doctor\n' > "${target}/.managed-skills"
-git -C "$target" commit -q -am "Sync skills from basecamp-cli v0.0.0 (pre-fix script)"
-sync_local hey-cli "$a"
+publish "Sync skills from basecamp-cli v0.0.0 (pre-fix script)"
+sync hey-cli "$a"
 assert_skill basecamp
 assert_skill basecamp-doctor
 assert_skill hey
@@ -205,8 +229,8 @@ assert_manifest basecamp-cli basecamp basecamp-doctor
 
 echo "# hey-cli's manifest also lists basecamp, which basecamp-cli owns"
 printf 'basecamp\nhey\n' > "${target}/.managed-skills.hey-cli"
-git -C "$target" commit -q -am "Collision: hey-cli claims basecamp"
-sync_local hey-cli "$a"
+publish "Collision: hey-cli claims basecamp"
+sync hey-cli "$a"
 assert_skill basecamp
 assert_content skills/basecamp/SKILL.md "basecamp v2"
 assert_output "WARNING: skills/basecamp is no longer in hey-cli's skills but basecamp-cli lists it"
@@ -217,115 +241,96 @@ assert_manifest basecamp-cli basecamp basecamp-doctor
 
 echo "# hey-cli ships a skill named basecamp"
 write_skill "${a}/skills/basecamp" "hey-cli's basecamp"
-head_before=$(git -C "$target" rev-parse HEAD)
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
+head_before=$(origin_head)
+sync_expecting_failure hey-cli "$a"
 assert_output "ERROR: skills/basecamp is published by basecamp-cli"
 assert_content skills/basecamp/SKILL.md "basecamp v2"
-assert_head "$head_before" "HEAD unchanged by the refused sync"
-assert_clean
+assert_head "$head_before" "origin main unchanged by the refused sync"
 rm -rf "${a}/skills/basecamp"
 
-# --- DRY_RUN=remote applies and shows the diff but commits nothing ---
+# --- DRY_RUN=remote clones and shows the diff but commits nothing ---
 
-echo "# DRY_RUN=remote against the checkout"
+echo "# DRY_RUN=remote against origin"
 echo "hey v3" > "${a}/skills/hey/SKILL.md"
-head_before=$(git -C "$target" rev-parse HEAD)
-sync hey-cli "$a" DRY_RUN=remote SKILLS_TARGET="$target"
+head_before=$(origin_head)
+sync hey-cli "$a" DRY_RUN=remote
 assert_output "DRY_RUN=remote: skipping commit and push"
 assert_output "+hey v3"
-assert_head "$head_before" "HEAD unchanged by DRY_RUN=remote"
-git -C "$target" reset -q --hard
+assert_head "$head_before" "origin main unchanged by DRY_RUN=remote"
+assert_content skills/hey/SKILL.md "hey v2"
 
-# --- DRY_RUN=local with no target: no network, lists what would be published ---
+# --- DRY_RUN=local: no clone at all, lists what would be published ---
 
-echo "# DRY_RUN=local without SKILLS_TARGET"
-sync hey-cli "$a" DRY_RUN=local
+echo "# DRY_RUN=local never reaches the repository"
+sync hey-cli "$a" DRY_RUN=local SKILLS_REPO_URL="file://${work}/nowhere.git"
 assert_output "skills/hey/SKILL.md"
 assert_output "skills/hey/reference/commands.md"
 assert_output "No network operations performed"
 if grep -q "embed.go" "$out"; then not_ok "preview leaves out embed.go"; else ok "preview leaves out embed.go"; fi
 
+# --- Without a token, github.com is refused before anything is cloned ---
+
+echo "# the default target needs SKILLS_TOKEN"
+sync_expecting_failure hey-cli "$a" SKILLS_REPO_URL=https://github.com/basecamp/skills.git
+assert_output "ERROR: SKILLS_TOKEN is required"
+if grep -q "Cloning" "$out"; then not_ok "refused before cloning"; else ok "refused before cloning"; fi
+
 # --- Another publisher pushes first: the sync is applied again from its tip ---
+#
+# The script clones afresh, so the sibling's push has to land after that clone and
+# before the push. A post-commit hook, reached through the GIT_CONFIG_* environment
+# the script's private gitconfig cannot hide, pushes the sibling's commit at exactly
+# that moment; the script's push is then rejected as "fetch first".
+
+sibling="${work}/sibling"
+git clone -q "$origin_url" "$sibling"
+hooks="${work}/hooks"
+mkdir -p "$hooks"
+printf '#!/usr/bin/env bash\ngit -C "%s" push -q origin main\n' "$sibling" > "${hooks}/post-commit"
+chmod +x "${hooks}/post-commit"
+racing() {  # source, fixture: sync with the sibling pushing between clone and push
+  sync "$1" "$2" GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath "GIT_CONFIG_VALUE_0=${hooks}"
+}
+racing_expecting_failure() {
+  sync_expecting_failure "$1" "$2" GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath "GIT_CONFIG_VALUE_0=${hooks}"
+}
 
 echo "# a concurrent publisher wins the race to origin"
-origin="${work}/origin.git"
-git init -q --bare -b main "$origin"
-git -C "$target" push -q "$origin" main
-sibling="${work}/sibling"
-git clone -q "$origin" "$sibling"
 echo "# skills (sibling)" > "${sibling}/README.md"
 git -C "$sibling" commit -q -am "Sync skills from basecamp-cli v0.0.1 (concurrent)"
-git -C "$sibling" push -q origin main
+sibling_head=$(git -C "$sibling" rev-parse HEAD)
 echo "hey v4" > "${a}/skills/hey/SKILL.md"
-# A real push, with github.com/basecamp/skills routed to the local bare repo through
-# the environment — the script's private gitconfig cannot hide that.
-sync hey-cli "$a" SKILLS_TARGET="$target" \
-  GIT_CONFIG_COUNT=1 "GIT_CONFIG_KEY_0=url.${origin}.insteadOf" GIT_CONFIG_VALUE_0=https://github.com/basecamp/skills.git
+racing hey-cli "$a"
 assert_output "Push rejected"
 assert_output "Skills synced to basecamp/skills"
 assert "origin main holds the sibling's commit then the sync" \
   test "$(git -C "$origin" log --format=%s -2 main | tr '\n' '|')" = "Sync skills from hey-cli v9.9.9|Sync skills from basecamp-cli v0.0.1 (concurrent)|"
+assert "the sync commit was made on the sibling's tip" test "$(git -C "$origin" rev-parse main^)" = "$sibling_head"
 assert_content skills/hey/SKILL.md "hey v4"
 assert_content README.md "# skills (sibling)"
-assert_clean
+assert_author hey-cli
 
 echo "# a concurrent publisher claims a name this source ships: the retry refuses"
 git -C "$sibling" pull -q origin main
 printf 'basecamp\nbasecamp-doctor\nhey\n' > "${sibling}/.managed-skills.basecamp-cli"
 git -C "$sibling" commit -q -am "Collision: basecamp-cli claims hey (concurrent)"
-git -C "$sibling" push -q origin main
+sibling_head=$(git -C "$sibling" rev-parse HEAD)
 echo "hey v5" > "${a}/skills/hey/SKILL.md"
-sync_expecting_failure hey-cli "$a" SKILLS_TARGET="$target" \
-  GIT_CONFIG_COUNT=1 "GIT_CONFIG_KEY_0=url.${origin}.insteadOf" GIT_CONFIG_VALUE_0=https://github.com/basecamp/skills.git
+racing_expecting_failure hey-cli "$a"
 assert_output "Push rejected"
 assert_output "ERROR: skills/hey is published by basecamp-cli"
-assert "origin main tip is the sibling's commit" \
-  test "$(git -C "$origin" log -1 --format=%s main)" = "Collision: basecamp-cli claims hey (concurrent)"
+assert_head "$sibling_head" "origin main tip is the sibling's commit"
 assert_content skills/hey/SKILL.md "hey v4"
-assert_clean
+
+echo "# the sibling drops its claim: the next release publishes"
 git -C "$sibling" checkout -q HEAD~1 -- .managed-skills.basecamp-cli
 git -C "$sibling" commit -q -am "basecamp-cli drops its claim on hey"
 git -C "$sibling" push -q origin main
-git -C "$target" fetch -q "$origin" main
-git -C "$target" reset -q --hard FETCH_HEAD
-
-# --- Safety asserts on the checkout ---
-
-echo "# a checkout with uncommitted changes is refused"
-echo "stray" > "${target}/stray.txt"
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
-assert_output "has uncommitted changes"
-rm "${target}/stray.txt"
-
-echo "# a checkout that is not basecamp/skills on main is refused"
-wrong="${work}/wrong-remote"
-git init -q -b main "$wrong"
-git -C "$wrong" remote add origin https://github.com/basecamp/other.git
-git -C "$wrong" commit -q --allow-empty -m "init"
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$wrong"
-assert_output "does not point to github.com/basecamp/skills"
-
-git -C "$target" remote set-url --push origin https://github.com/someone/skills.git
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
-assert_output "origin pushurl 'https://github.com/someone/skills.git' does not point to github.com/basecamp/skills"
-git -C "$target" config --unset remote.origin.pushurl
-
-echo "# every push URL, and every fetch URL, is a push destination: one bad one is refused"
-git -C "$target" remote set-url --push origin git@github.com:someone/skills.git
-git -C "$target" remote set-url --push --add origin https://github.com/basecamp/skills.git
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
-assert_output "origin pushurl 'git@github.com:someone/skills.git' does not point to github.com/basecamp/skills"
-git -C "$target" config --unset-all remote.origin.pushurl
-git -C "$target" config --replace-all remote.origin.url https://github.com/someone/skills.git
-git -C "$target" remote set-url --add origin https://github.com/basecamp/skills.git
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
-assert_output "origin url 'https://github.com/someone/skills.git' does not point to github.com/basecamp/skills"
-git -C "$target" config --replace-all remote.origin.url https://github.com/basecamp/skills.git
-
-git -C "$target" checkout -q -b not-main
-sync_expecting_failure hey-cli "$a" DRY_RUN=local SKILLS_TARGET="$target"
-assert_output "checked-out branch is 'not-main', expected 'main'"
-git -C "$target" checkout -q main
+sync hey-cli "$a"
+assert_output "Skills synced to basecamp/skills"
+assert_content skills/hey/SKILL.md "hey v5"
+assert_manifest basecamp-cli basecamp basecamp-doctor
+assert_manifest hey-cli hey
 
 # --- Verdict ---
 


### PR DESCRIPTION
## The bug

basecamp/skills is shared by several CLIs, and each one's `scripts/sync-skills.sh` recorded what it published in the same file, `.managed-skills`, then deleted every name in that file its own `skills/` tree lacked. So the CLIs took turns deleting each other's skills (basecamp/skills#5):

- basecamp/skills@08ef7ea — hey-cli v0.1.1 deleted `skills/basecamp` and `skills/basecamp-doctor`
- basecamp/skills@728a916 — basecamp-cli v0.10.0 deleted `skills/hey`
- basecamp/skills@42716d7 — basecamp-cli v0.11.0 deleted `skills/hey` again

Today the distribution repo holds only the basecamp skills; HEY's is gone.

## The fix

- **Per-source manifest.** Each publisher owns `.managed-skills.<source>` at the target root (`basecamp-cli`, `hey-cli`, …), one sorted name per line, and reads only its own file to decide what to remove.
- **Removal only within own manifest, with a cross-manifest guard.** `skills/<name>` is removed only when this source's manifest lists it, this release no longer ships it, *and* no other `.managed-skills.*` claims it. Two publishers claiming one name is a collision to settle upstream, so it is warned about and left alone. Nothing else ever calls `rm -rf` on the target besides the per-skill refresh (a name in this source's set, immediately re-copied).
- **No first-run fallback.** A target with no `.managed-skills.<source>` yet removes nothing and writes the manifest from the current set. The old "no manifest, so everything under `skills/` is ours" fallback is gone — it is exactly what deleted the sibling's skills.
- **Legacy tombstone.** `.managed-skills` stays but is rewritten on every run as a comment-only file. The pre-fix script validates each line against `^[a-zA-Z0-9._-]+$` and skips the rest, so a CLI still running it deletes nothing; had the file been deleted instead, that script's fallback would have claimed every `skills/*`. This is what makes the rollout order across CLIs irrelevant.
- `SYNC_SOURCE` overrides the source name (bot identity and commit message derive from it) so the test can play the other CLI; `SKILLS_REPO_URL` says where the target is cloned from and pushed to (the test points it at a local bare repository). The script always clones the target fresh and pushes only the commit it made — there is no checkout to hand it. `DRY_RUN=local` previews the copy offline against an empty tree; `DRY_RUN=remote` clones the real target and stops before committing. The copy filter is unchanged.

The script is byte-identical to the shared CLI seed's (`seed/scripts/sync-skills.sh` in basecamp/cli#78 at 1df3bfe5) apart from the `CLI_NAME` default, which is what carries the per-repo `SYNC_SOURCE`. The seed went three steps beyond the design, and this PR carries them:

- **Publish-side guard.** The sync refuses outright (before touching anything) to publish a name another source's manifest holds, not only to delete one.
- **Fetch-first retry.** A rejected push — `fetch first` on a depth-1 clone (the old `non-fast-forward` match never fires there) or `non-fast-forward` — drops the stale commit, resets to the remote's new tip and applies the whole sync again, collision guard included, before pushing once more; no rebase of decisions made against a stale tree.
- **Hygiene.** `SYNC_SOURCE` and `DRY_RUN` are validated, and the token reaches git as a github.com-scoped `http.extraheader` (`AUTHORIZATION: basic …`, the form actions/checkout writes) in a private mode-600 `GIT_CONFIG_GLOBAL` removed with the tmpdir, so it appears in neither the remote URL nor any git argv — an `insteadOf` rewrite, the first cut here, still hands the credential-bearing URL to `git-remote-https` in argv.
- The script also gains `SKILLS_SOURCE`, which hey-cli's already had, so the two scripts are now identical apart from the default source name, and the manual `Sync skills` workflow adopts hey-cli's two-checkout pattern (sync logic from the dispatching ref, content from the release tag).
- **Latest-release guard on the release-time job.** The `sync-skills` job in `release.yml` now makes the check the manual workflow already makes — the tag must be the repository's latest stable release — so an older release whose run stalls, or whose failed sync is rerun after a newer release has shipped, skips the sync instead of rolling basecamp/skills back. The concurrency group serialises the syncs but never ordered them.

## Migration walkthrough

A local bare clone of basecamp/skills `main` as of today as the target (`SKILLS_REPO_URL` pointed at it, so every clone and push lands there and nowhere else), then this branch's script run against it as basecamp-cli, then the sibling hey-cli branch's script run against the result:

```
=== BEFORE (basecamp/skills main @ 42716d7) ===
skills
skills/basecamp
skills/basecamp-doctor
--- .managed-skills
basecamp
basecamp-doctor

=== basecamp-cli script (SKILLS_REPO_URL=<local clone of basecamp/skills>) ===
Found 2 skill(s) in skills/: basecamp-doctor basecamp
Cloning basecamp/skills into /var/folders/64/xwfgjgld7f704v23qrmz7zr40000gn/T/tmp.2tEKUmRH55/skills...
Copying skills into /var/folders/64/xwfgjgld7f704v23qrmz7zr40000gn/T/tmp.2tEKUmRH55/skills/skills/...
No .managed-skills.basecamp-cli yet: first run for basecamp-cli, removing nothing

=== Changes ===
 .managed-skills                 |  6 ++++--
 .managed-skills.basecamp-cli    |  2 ++
 skills/basecamp-doctor/SKILL.md |  1 +
 skills/basecamp/SKILL.md        | 16 ++++++++++++----
 4 files changed, 19 insertions(+), 6 deletions(-)


Skills synced to basecamp/skills (main) from basecamp-cli v0.12.0

=== hey-cli script (same target) ===
Found 1 skill(s) in skills/: hey
Cloning basecamp/skills into /var/folders/64/xwfgjgld7f704v23qrmz7zr40000gn/T/tmp.fSUss8L1TP/skills...
Copying skills into /var/folders/64/xwfgjgld7f704v23qrmz7zr40000gn/T/tmp.fSUss8L1TP/skills/skills/...
No .managed-skills.hey-cli yet: first run for hey-cli, removing nothing

=== Changes ===
 .managed-skills.hey-cli |   1 +
 skills/hey/SKILL.md     | 812 ++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 813 insertions(+)


Skills synced to basecamp/skills (main) from hey-cli v1.5.0

=== AFTER: find skills -maxdepth 1 ===
skills
skills/basecamp
skills/basecamp-doctor
skills/hey

=== AFTER: cat .managed-skills* ===
--- .managed-skills
# Superseded by the per-source manifests (.managed-skills.<cli>), one per publishing CLI.
# Each CLI deletes only the skill directories listed in its own manifest.
# Kept so a CLI still running the pre-fix sync script deletes nothing: that script skips
# every line it cannot parse as a skill name and only deletes names it can.
--- .managed-skills.basecamp-cli
basecamp
basecamp-doctor
--- .managed-skills.hey-cli
hey

--- git log ---
cb1b346 hey-cli[bot] Sync skills from hey-cli v1.5.0
c5486a8 basecamp-cli[bot] Sync skills from basecamp-cli v0.12.0
42716d7 basecamp-cli[bot] Sync skills from basecamp-cli v0.11.0
```

So a hey-cli release after the sibling PR merges restores HEY's skill to basecamp/skills, and no release of either CLI touches the other's skills again.

## Test

`scripts/test-sync-skills.sh` (the seed's test, plus an `unset SKILLS_TOKEN` up front so a token in the caller's environment cannot carry the github.com case to the real target; `make test-sync-skills`, in `make check`/`bin/ci` and the test workflow's e2e job) builds a throwaway target reproducing basecamp/skills as the history above left it — the basecamp skills present, `skills/hey` gone, the legacy `.managed-skills` listing the basecamp names, plus a README that must survive — and two fixture trees (one with a nested file, a `*.go`, a dotfile and a dot-directory that must not be copied). It runs the script interleaved hey-cli, basecamp-cli, hey-cli, basecamp-cli, asserting after each run that both sources' skills are present, each manifest lists exactly its own names and `.managed-skills` is the tombstone. Then: a skill dropped from one tree removes only that directory; a stale legacy manifest listing the sibling's names (a pre-fix sibling having run) deletes nothing; a name listed in both manifests survives with a warning; publishing a name another source owns is refused before anything changes; `DRY_RUN=remote` shows the diff and commits nothing; the `DRY_RUN=local` preview stays offline; a concurrent publisher winning the race to origin (a real push into a local bare repo) is absorbed by the fetch-first retry, and a concurrent claim on a name this source ships makes that retry refuse (and the sibling dropping the claim lets the next release publish); a github.com target without a token is refused before anything is cloned; and the commit author is `<source>[bot]`.

`scripts/sync-skills.sh` is on the sensitive-change list, so expect the gate label on this PR.

The sibling PR in hey-cli carries the same change: https://github.com/basecamp/hey-cli/pull/434


