### PR TITLE
Pin the vendorHash refresh at basecamp/.github's merged revision

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
   refresh-nix-vendor-hash:
     name: Refresh the Nix vendorHash
     if: github.event_name == 'workflow_dispatch' || (github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]') # zizmor: ignore[bot-conditions] -- dual check: actor validates the current trigger (and stops the App bot's own push from looping back), user.login validates PR origin; on:pull_request, not pull_request_target, so GitHub sets the actor from who pushed
-    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@49eaa2156461cee5ac15c5236d3ff3f5fe900d3f
+    uses: basecamp/.github/.github/workflows/dependabot-sync-nix-vendor-hash.yml@293dc747a2cee44c5b4dae72067adeb681636d26
     with:
       pr: ${{ inputs.pr }}
       # cli-release-bot's client id — the `release` environment's


### PR DESCRIPTION
The caller from #702 pinned `dependabot-sync-nix-vendor-hash.yml` at the head of basecamp/.github#19's branch. That PR squash-merged as `293dc74`, so the pinned SHA is not on basecamp/.github's default branch and zizmor's `impostor-commit` audit fails on main. This re-pins to the merge commit, the same workflow on the default branch. zizmor 1.30.0 online and actionlint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pins the `dependabot-sync-nix-vendor-hash` workflow to its squash-merge commit so zizmor's `impostor-commit` audit passes on main. The previous pin referenced a branch head SHA from basecamp/.github#19 that isn't on the default branch; the new pin points to merge commit `293dc74`, which is the same workflow on the default branch.

<sup>Written for commit 2ce36841d48de331031e2a0677201e3f7b6a8a4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-cli/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

