### PR TITLE
Revoke the credential with the server on logout, profile delete and auth revoke

### DIFF
--- a/.surface
+++ b/.surface
@@ -523,6 +523,7 @@ CMD basecamp auth
 CMD basecamp auth login
 CMD basecamp auth logout
 CMD basecamp auth refresh
+CMD basecamp auth revoke
 CMD basecamp auth status
 CMD basecamp auth token
 CMD basecamp bonfire
@@ -2022,6 +2023,27 @@ FLAG basecamp auth refresh --stats type=bool
 FLAG basecamp auth refresh --styled type=bool
 FLAG basecamp auth refresh --todolist type=string
 FLAG basecamp auth refresh --verbose type=count
+FLAG basecamp auth revoke --account type=string
+FLAG basecamp auth revoke --agent type=bool
+FLAG basecamp auth revoke --cache-dir type=string
+FLAG basecamp auth revoke --count type=bool
+FLAG basecamp auth revoke --help type=bool
+FLAG basecamp auth revoke --hints type=bool
+FLAG basecamp auth revoke --ids-only type=bool
+FLAG basecamp auth revoke --in type=string
+FLAG basecamp auth revoke --jq type=string
+FLAG basecamp auth revoke --json type=bool
+FLAG basecamp auth revoke --markdown type=bool
+FLAG basecamp auth revoke --md type=bool
+FLAG basecamp auth revoke --no-hints type=bool
+FLAG basecamp auth revoke --no-stats type=bool
+FLAG basecamp auth revoke --profile type=string
+FLAG basecamp auth revoke --project type=string
+FLAG basecamp auth revoke --quiet type=bool
+FLAG basecamp auth revoke --stats type=bool
+FLAG basecamp auth revoke --styled type=bool
+FLAG basecamp auth revoke --todolist type=string
+FLAG basecamp auth revoke --verbose type=count
 FLAG basecamp auth status --account type=string
 FLAG basecamp auth status --agent type=bool
 FLAG basecamp auth status --cache-dir type=string
@@ -18212,6 +18234,7 @@ SUB basecamp auth
 SUB basecamp auth login
 SUB basecamp auth logout
 SUB basecamp auth refresh
+SUB basecamp auth revoke
 SUB basecamp auth status
 SUB basecamp auth token
 SUB basecamp bonfire

--- a/e2e/smoke/smoke_lifecycle.bats
+++ b/e2e/smoke/smoke_lifecycle.bats
@@ -16,6 +16,10 @@ load smoke_helper
   mark_out_of_scope "Requires OAuth credentials"
 }
 
+@test "auth revoke is out of scope" {
+  mark_out_of_scope "Revokes the account's OAuth credentials"
+}
+
 @test "login is out of scope" {
   mark_out_of_scope "Alias for auth login — interactive OAuth flow"
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -744,6 +744,7 @@ func (m *Manager) loginDevice(ctx context.Context, credKey string, oauthCfg *oau
 		RefreshToken:  token.RefreshToken,
 		OAuthType:     oauthTypeBC5,
 		TokenEndpoint: oauthCfg.TokenEndpoint,
+		Issuer:        oauthCfg.Issuer,
 		Scope:         effectiveScope,
 		// The RFC 8707 account binding: a trusted-client device login mints a
 		// multi-account refresh token, and refreshing one without echoing this
@@ -808,12 +809,6 @@ func (m *Manager) ImportToken(token, scope, userID, userEmail string, expiresAt 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.store.Save(m.credentialKey(), creds)
-}
-
-// Logout removes stored credentials.
-func (m *Manager) Logout() error {
-	credKey := m.credentialKey()
-	return m.store.Delete(credKey)
 }
 
 // discovery is the outcome of provider selection: the OAuth config to use

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -321,12 +321,17 @@ func TestLogout(t *testing.T) {
 	}
 	manager.store.Save("https://3.basecampapi.com", creds)
 
-	// Logout
-	err := manager.Logout()
+	// Credentials without an OAuth type are Launchpad's: nothing to revoke,
+	// but the local copy still goes.
+	result, err := manager.Logout(context.Background())
 	require.NoError(t, err, "Logout failed")
+	assert.Equal(t, &LogoutResult{Skipped: RevokeSkippedLaunchpad}, result)
 
 	// Should no longer be authenticated
 	assert.False(t, manager.IsAuthenticated(), "Should not be authenticated after logout")
+
+	_, err = manager.Logout(context.Background())
+	assert.ErrorIs(t, err, ErrNoCredential)
 }
 
 func TestCredentialsJSON(t *testing.T) {

--- a/internal/auth/device_test.go
+++ b/internal/auth/device_test.go
@@ -29,6 +29,7 @@ type deviceAS struct {
 	mu          sync.Mutex
 	deviceForms []url.Values
 	tokenForms  []url.Values
+	revokeForms []url.Values
 
 	// metadata renders the AS metadata JSON. Defaults to a device-capable doc
 	// with issuer = the server's own origin.
@@ -37,6 +38,8 @@ type deviceAS struct {
 	deviceAuth func() (status int, body string)
 	// token renders the nth (0-based) token poll response.
 	token func(call int) (status int, body string)
+	// revoke renders the nth (0-based) RFC 7009 revocation response.
+	revoke func(call int) (status int, body string)
 }
 
 func startDeviceAS(t *testing.T) *deviceAS {
@@ -69,12 +72,24 @@ func startDeviceAS(t *testing.T) *deviceAS {
 		w.WriteHeader(status)
 		fmt.Fprint(w, body)
 	}
+	revokeHandler := func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		as.mu.Lock()
+		call := len(as.revokeForms)
+		as.revokeForms = append(as.revokeForms, r.PostForm)
+		as.mu.Unlock()
+		status, body := as.revoke(call)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprint(w, body)
+	}
 	mux.HandleFunc("/oauth/device", deviceHandler)
 	mux.HandleFunc("/oauth/token", tokenHandler)
 	// The paths Basecamp mounts, which a pinned BASECAMP_OAUTH_ISSUER derives
 	// without reading metadata.
 	mux.HandleFunc("/oauth/device_authorizations", deviceHandler)
 	mux.HandleFunc("/oauth/tokens", tokenHandler)
+	mux.HandleFunc("/oauth/revocations", revokeHandler)
 
 	as.srv = httptest.NewServer(mux)
 	t.Cleanup(as.srv.Close)
@@ -84,9 +99,12 @@ func startDeviceAS(t *testing.T) *deviceAS {
 			"issuer": %q,
 			"token_endpoint": %q,
 			"device_authorization_endpoint": %q,
+			"revocation_endpoint": %q,
+			"revocation_endpoint_auth_methods_supported": ["none", "client_secret_post"],
 			"grant_types_supported": ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"]
-		}`, as.srv.URL, as.srv.URL+"/oauth/token", as.srv.URL+"/oauth/device")
+		}`, as.srv.URL, as.srv.URL+"/oauth/token", as.srv.URL+"/oauth/device", as.srv.URL+"/oauth/revocations")
 	}
+	as.revoke = func(int) (int, string) { return http.StatusOK, `{}` }
 	as.deviceAuth = func() (int, string) {
 		return http.StatusOK, fmt.Sprintf(
 			`{"device_code":"dev-code-1","user_code":"ABCD-EFGH","verification_uri":%q,"verification_uri_complete":%q,"expires_in":600,"interval":1}`,
@@ -108,6 +126,12 @@ func (as *deviceAS) tokenCalls() []url.Values {
 	as.mu.Lock()
 	defer as.mu.Unlock()
 	return append([]url.Values(nil), as.tokenForms...)
+}
+
+func (as *deviceAS) revokeCalls() []url.Values {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	return append([]url.Values(nil), as.revokeForms...)
 }
 
 // startResourceServer starts a mock protected resource advertising the given

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -143,10 +144,14 @@ func (s *Store) Load(origin string) (*Credentials, error) {
 	}
 	var creds Credentials
 	if err := json.Unmarshal(data, &creds); err != nil {
-		return nil, fmt.Errorf("invalid credentials: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidCredentials, err)
 	}
 	return &creds, nil
 }
+
+// ErrInvalidCredentials marks a stored blob that is present but not a
+// credential any command can read — as opposed to nothing stored at all.
+var ErrInvalidCredentials = errors.New("invalid credentials")
 
 // Save stores credentials for the given origin.
 func (s *Store) Save(origin string, creds *Credentials) error {

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/basecamp/cli/credstore"
 	"github.com/charmbracelet/x/term"
+	"github.com/zalando/go-keyring"
 )
 
 // Credentials holds OAuth tokens and metadata.
@@ -140,6 +142,9 @@ func (s *Store) Load(origin string) (*Credentials, error) {
 	s.warnFallback()
 	data, err := s.ensure().Load(origin)
 	if err != nil {
+		if isMissingCredential(err) {
+			return nil, fmt.Errorf("%w: %w", ErrNoCredential, err)
+		}
 		return nil, err
 	}
 	var creds Credentials
@@ -149,9 +154,23 @@ func (s *Store) Load(origin string) (*Credentials, error) {
 	return &creds, nil
 }
 
+// ErrNoCredential marks a key with nothing stored under it — as opposed to
+// a store that could not be read, which is not "not logged in".
+var ErrNoCredential = errors.New("no stored credential")
+
 // ErrInvalidCredentials marks a stored blob that is present but not a
 // credential any command can read — as opposed to nothing stored at all.
 var ErrInvalidCredentials = errors.New("invalid credentials")
+
+// isMissingCredential tells a missing entry apart from a store that could
+// not be read. credstore has no sentinel of its own: the keyring backend
+// wraps go-keyring's ErrNotFound (and every other keyring failure, a locked
+// keychain included, under the same "credentials not found:" prefix), and
+// the file backend reports a miss as "credentials not found for <key>" —
+// the one phrase the file backend uses for nothing else.
+func isMissingCredential(err error) bool {
+	return errors.Is(err, keyring.ErrNotFound) || strings.Contains(err.Error(), "credentials not found for ")
+}
 
 // Save stores credentials for the given origin.
 func (s *Store) Save(origin string, creds *Credentials) error {

--- a/internal/auth/keyring.go
+++ b/internal/auth/keyring.go
@@ -19,8 +19,14 @@ type Credentials struct {
 	Scope         string `json:"scope"`
 	OAuthType     string `json:"oauth_type"` // "bc5", "launchpad", or legacy "bc3"
 	TokenEndpoint string `json:"token_endpoint"`
-	UserID        string `json:"user_id,omitempty"`
-	UserEmail     string `json:"user_email,omitempty"`
+
+	// Issuer is the RFC 8414 issuer of the authorization server that minted
+	// a BC5 credential — where its metadata, and so its revocation endpoint,
+	// is found at logout. Credentials stored before it was recorded derive
+	// it from TokenEndpoint (see credentialIssuer).
+	Issuer    string `json:"issuer,omitempty"`
+	UserID    string `json:"user_id,omitempty"`
+	UserEmail string `json:"user_email,omitempty"`
 
 	// Source records how the credential was obtained when that is not the
 	// OAuth flow: "token" for an imported personal access token, which has

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -61,23 +61,32 @@ type LogoutResult struct {
 // it can be, then removes it from local storage regardless. ErrNoCredential
 // means there was nothing to remove.
 func (m *Manager) Logout(ctx context.Context) (*LogoutResult, error) {
-	return m.LogoutCredential(ctx, m.credentialKey())
+	return m.LogoutCredential(ctx, m.credentialKey(), "")
 }
 
 // LogoutCredential is Logout for the credential stored under credKey — the
-// path profile deletion takes for "profile:<name>".
-func (m *Manager) LogoutCredential(ctx context.Context, credKey string) (*LogoutResult, error) {
+// path profile deletion takes for "profile:<name>". baseURL anchors the
+// egress policy of the revocation request: the deleted profile's own base
+// URL, which need not be the active configuration's — a loopback
+// development profile deleted while production is active must still reach
+// its loopback issuer. Empty means the active configuration.
+func (m *Manager) LogoutCredential(ctx context.Context, credKey, baseURL string) (*LogoutResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	creds, err := m.store.Load(credKey)
-	if err != nil {
-		// Nothing usable under the key: absent, or a blob no command can
-		// read. Either way the key ends up clear.
-		_ = m.store.Delete(credKey)
+	switch {
+	case errors.Is(err, ErrInvalidCredentials):
+		// A blob no command can read is still stored; clearing it is the
+		// one thing a logout can do for it, and failing to is reported.
+		if err := m.store.Delete(credKey); err != nil {
+			return nil, err
+		}
+		return nil, ErrNoCredential
+	case err != nil:
 		return nil, ErrNoCredential
 	}
-	result := m.revokeForDiscard(ctx, creds)
+	result := m.revokeForDiscard(ctx, creds, baseURL)
 	if err := m.store.Delete(credKey); err != nil {
 		return nil, err
 	}
@@ -87,11 +96,11 @@ func (m *Manager) LogoutCredential(ctx context.Context, credKey string) (*Logout
 // revokeForDiscard revokes creds when they are the CLI's to revoke and
 // classifies the outcome for the caller's copy. Best effort by design: the
 // caller discards the credential locally whatever happened here.
-func (m *Manager) revokeForDiscard(ctx context.Context, creds *Credentials) *LogoutResult {
+func (m *Manager) revokeForDiscard(ctx context.Context, creds *Credentials, baseURL string) *LogoutResult {
 	if skipped := revokeSkipReason(creds); skipped != "" {
 		return &LogoutResult{Skipped: skipped}
 	}
-	if err := m.Revoke(ctx, creds); err != nil {
+	if err := m.revoke(ctx, creds, baseURL); err != nil {
 		return &LogoutResult{Err: err}
 	}
 	return &LogoutResult{Revoked: true}
@@ -151,6 +160,10 @@ func revokeSkipReason(creds *Credentials) string {
 // could not be reached, did not describe a revocation endpoint, or did not
 // answer 200; the tokens never appear in it.
 func (m *Manager) Revoke(ctx context.Context, creds *Credentials) error {
+	return m.revoke(ctx, creds, "")
+}
+
+func (m *Manager) revoke(ctx context.Context, creds *Credentials, baseURL string) error {
 	if creds.RefreshToken == "" && creds.AccessToken == "" {
 		return errors.New("stored credential carries no token")
 	}
@@ -158,7 +171,7 @@ func (m *Manager) Revoke(ctx context.Context, creds *Credentials) error {
 	if err != nil {
 		return err
 	}
-	client, err := m.bc5Client()
+	client, err := m.revocationClient(baseURL)
 	if err != nil {
 		return err
 	}
@@ -178,6 +191,17 @@ func (m *Manager) Revoke(ctx context.Context, creds *Credentials) error {
 		}
 	}
 	return nil
+}
+
+// revocationClient is the egress lane a revocation rides: the BC5 lane of
+// the active configuration, or one built on baseURL when the credential
+// belongs to a profile anchored elsewhere. A caller-owned httpClient
+// carries everything, as it does for every other OAuth request.
+func (m *Manager) revocationClient(baseURL string) (*http.Client, error) {
+	if m.httpClient != nil || baseURL == "" || baseURL == m.cfg.BaseURL {
+		return m.bc5Client()
+	}
+	return m.buildLaneClient(baseURL, "profile base URL")
 }
 
 // credentialIssuer names the authorization server that minted creds. Logins

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -65,16 +65,28 @@ type LogoutResult struct {
 	// Remaining names what Err left usable (one of the Remaining* values);
 	// empty when Err is nil.
 	Remaining string
+	// ExpiresAt is the stored access token's expiry (Unix seconds; zero
+	// when the server reported none), for saying how long RemainingAccess
+	// lasts.
+	ExpiresAt int64
 }
 
 // Outstanding describes, for a human, what a failed revocation left usable;
-// empty when nothing did.
+// empty when nothing did. The access token's lifetime is the one the server
+// reported for it, not an assumed one.
 func (r *LogoutResult) Outstanding() string {
 	switch r.Remaining {
 	case RemainingRefresh:
 		return "the refresh token stays valid until it is revoked"
 	case RemainingAccess:
-		return "only the access token remains and it expires within the hour"
+		switch left := time.Until(time.Unix(r.ExpiresAt, 0)).Round(time.Minute); {
+		case r.ExpiresAt == 0:
+			return "only the access token remains and it reports no expiry"
+		case left <= 0:
+			return "only the access token remains and it has already expired"
+		default:
+			return "only the access token remains and it expires in " + left.String()
+		}
 	default:
 		return ""
 	}
@@ -129,7 +141,7 @@ func (m *Manager) revokeForDiscard(ctx context.Context, creds *Credentials, base
 		return &LogoutResult{Skipped: skipped}
 	}
 	if remaining, err := m.revoke(ctx, creds, baseURL); err != nil {
-		return &LogoutResult{Err: err, Remaining: remaining}
+		return &LogoutResult{Err: err, Remaining: remaining, ExpiresAt: creds.ExpiresAt}
 	}
 	return &LogoutResult{Revoked: true}
 }

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -1,0 +1,268 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/basecamp/basecamp-cli/internal/output"
+)
+
+// revokeRequestTimeout bounds each revocation round trip — the metadata
+// fetch and each token POST. A logout must not hang on a slow server: the
+// local delete happens regardless, and an unrevoked access token expires on
+// its own within the hour. Replaceable in tests.
+var revokeRequestTimeout = 10 * time.Second
+
+// maxRevocationBodyBytes bounds what is read from the authorization server
+// during revocation. RFC 8414 metadata is a few hundred bytes and an RFC
+// 7009 response body is empty or a one-line error.
+const maxRevocationBodyBytes = 64 * 1024
+
+// wellKnownAuthorizationServer is the RFC 8414 metadata path under an
+// issuer origin.
+const wellKnownAuthorizationServer = "/.well-known/oauth-authorization-server"
+
+// ErrNoCredential reports that nothing is stored under the credential key a
+// logout was asked to clear.
+var ErrNoCredential = errors.New("no stored credential")
+
+// Reasons a credential is removed locally without a revocation attempt.
+const (
+	// RevokeSkippedLaunchpad: the legacy provider has no revocation endpoint.
+	// Credentials from the removed "bc3" development flow land here too —
+	// the server that minted them is gone.
+	RevokeSkippedLaunchpad = "launchpad"
+	// RevokeSkippedImported: an imported personal access token is not the
+	// CLI's to revoke — the same token lives in the operator's secret store
+	// and stays valid until revoked in Basecamp.
+	RevokeSkippedImported = "imported_token"
+)
+
+// LogoutResult reports what became of a credential server-side. The local
+// copy is gone either way.
+type LogoutResult struct {
+	// Revoked reports that the authorization server accepted the revocation.
+	Revoked bool
+	// Skipped names why no revocation was attempted (one of the
+	// RevokeSkipped* reasons); empty when one was.
+	Skipped string
+	// Err is why an attempted revocation did not go through; nil otherwise.
+	Err error
+}
+
+// Logout revokes the current credential with its authorization server when
+// it can be, then removes it from local storage regardless. ErrNoCredential
+// means there was nothing to remove.
+func (m *Manager) Logout(ctx context.Context) (*LogoutResult, error) {
+	return m.LogoutCredential(ctx, m.credentialKey())
+}
+
+// LogoutCredential is Logout for the credential stored under credKey — the
+// path profile deletion takes for "profile:<name>".
+func (m *Manager) LogoutCredential(ctx context.Context, credKey string) (*LogoutResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	creds, err := m.store.Load(credKey)
+	if err != nil {
+		// Nothing usable under the key: absent, or a blob no command can
+		// read. Either way the key ends up clear.
+		_ = m.store.Delete(credKey)
+		return nil, ErrNoCredential
+	}
+	result := m.revokeForDiscard(ctx, creds)
+	if err := m.store.Delete(credKey); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// revokeForDiscard revokes creds when they are the CLI's to revoke and
+// classifies the outcome for the caller's copy. Best effort by design: the
+// caller discards the credential locally whatever happened here.
+func (m *Manager) revokeForDiscard(ctx context.Context, creds *Credentials) *LogoutResult {
+	if skipped := revokeSkipReason(creds); skipped != "" {
+		return &LogoutResult{Skipped: skipped}
+	}
+	if err := m.Revoke(ctx, creds); err != nil {
+		return &LogoutResult{Err: err}
+	}
+	return &LogoutResult{Revoked: true}
+}
+
+// RevokeStored revokes the current credential with its authorization server
+// and, that done, removes the local copy — a revoked refresh family leaves
+// nothing usable behind. Unlike Logout it is not best effort: a credential
+// that could not be revoked stays stored so the operator can try again,
+// and one that is not the CLI's to revoke (Launchpad, an imported token)
+// is refused with the reason. ErrNoCredential means nothing is stored.
+func (m *Manager) RevokeStored(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	credKey := m.credentialKey()
+	creds, err := m.store.Load(credKey)
+	if err != nil {
+		return ErrNoCredential
+	}
+	switch revokeSkipReason(creds) {
+	case RevokeSkippedLaunchpad:
+		return output.ErrUsageHint("Launchpad tokens cannot be revoked from the CLI",
+			"Forget the credential locally instead: basecamp auth logout")
+	case RevokeSkippedImported:
+		return output.ErrUsageHint("An imported personal access token is not the CLI's to revoke; revoke it in Basecamp",
+			"Forget the credential locally instead: basecamp auth logout")
+	}
+	if err := m.Revoke(ctx, creds); err != nil {
+		e := output.ErrAPI(0, "could not revoke the token server-side: "+err.Error()+"; the credential is kept so you can retry")
+		e.Hint = "Retry: basecamp auth revoke — or forget it locally: basecamp auth logout"
+		e.Cause = err
+		return e
+	}
+	return m.store.Delete(credKey)
+}
+
+// revokeSkipReason says why creds are not the CLI's to revoke, or "" when
+// they are: a BC5 credential minted by an OAuth login.
+func revokeSkipReason(creds *Credentials) string {
+	switch {
+	case creds.Source == CredentialSourceToken:
+		return RevokeSkippedImported
+	case creds.OAuthType != oauthTypeBC5:
+		return RevokeSkippedLaunchpad
+	default:
+		return ""
+	}
+}
+
+// Revoke asks the credential's authorization server to revoke it (RFC
+// 7009) as the public basecamp-cli client: the refresh token first, which
+// revokes its whole family, then the access token — the type hint is
+// advisory and the second request is cheap insurance. Both ride the BC5
+// lane client, so the metadata and revocation endpoints are judged by the
+// same address policy as every other BC5 request. An error means the server
+// could not be reached, did not describe a revocation endpoint, or did not
+// answer 200; the tokens never appear in it.
+func (m *Manager) Revoke(ctx context.Context, creds *Credentials) error {
+	if creds.RefreshToken == "" && creds.AccessToken == "" {
+		return errors.New("stored credential carries no token")
+	}
+	issuer, err := credentialIssuer(creds)
+	if err != nil {
+		return err
+	}
+	client, err := m.bc5Client()
+	if err != nil {
+		return err
+	}
+	endpoint, err := m.revocationEndpoint(ctx, client, issuer)
+	if err != nil {
+		return err
+	}
+	for _, tok := range []struct{ value, hint string }{
+		{creds.RefreshToken, "refresh_token"},
+		{creds.AccessToken, "access_token"},
+	} {
+		if tok.value == "" {
+			continue
+		}
+		if err := revokeToken(ctx, client, endpoint, tok.value, tok.hint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// credentialIssuer names the authorization server that minted creds. Logins
+// record it; credentials stored before Issuer existed carry only the token
+// endpoint, and Basecamp mounts that under the issuer origin
+// (https://3.basecamp.com/oauth/tokens), so the endpoint's origin is the
+// issuer.
+func credentialIssuer(creds *Credentials) (string, error) {
+	if creds.Issuer != "" {
+		return strings.TrimRight(creds.Issuer, "/"), nil
+	}
+	u, err := url.Parse(creds.TokenEndpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", errors.New("stored credential names no authorization server")
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// revocationEndpoint reads the issuer's RFC 8414 metadata for its
+// revocation_endpoint. The SDK's discovery drops that field, so the fetch
+// is local: one GET, one decoded field, checked like every other
+// server-named OAuth endpoint before it receives a token.
+func (m *Manager) revocationEndpoint(ctx context.Context, client *http.Client, issuer string) (string, error) {
+	metadataURL := issuer + wellKnownAuthorizationServer
+	if err := requireSecureOAuthEndpoint("issuer metadata URL", metadataURL); err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, revokeRequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching authorization server metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("authorization server metadata returned HTTP %d", resp.StatusCode)
+	}
+
+	var doc struct {
+		RevocationEndpoint string `json:"revocation_endpoint"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRevocationBodyBytes)).Decode(&doc); err != nil {
+		return "", fmt.Errorf("parsing authorization server metadata: %w", err)
+	}
+	if doc.RevocationEndpoint == "" {
+		return "", errors.New("authorization server advertises no revocation endpoint")
+	}
+	if err := requireSecureOAuthEndpoint("revocation endpoint", doc.RevocationEndpoint); err != nil {
+		return "", err
+	}
+	return doc.RevocationEndpoint, nil
+}
+
+// revokeToken POSTs one RFC 7009 revocation as the public client. The
+// server answers 200 whatever the token's state, so any other status is a
+// refusal worth reporting; the response body is drained and never read.
+func revokeToken(ctx context.Context, client *http.Client, endpoint, token, hint string) error {
+	what := strings.ReplaceAll(hint, "_", " ")
+	ctx, cancel := context.WithTimeout(ctx, revokeRequestTimeout)
+	defer cancel()
+	form := url.Values{
+		"token":           {token},
+		"token_type_hint": {hint},
+		"client_id":       {bc5ClientID},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("revoking the %s: %w", what, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRevocationBodyBytes))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("revoking the %s: the server answered HTTP %d", what, resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -165,8 +165,11 @@ func (m *Manager) RevokeStored(ctx context.Context) error {
 		// retryable, a refusal does not — under the revocation's own message
 		// and remedy.
 		e := *output.AsError(err)
-		e.Message = "could not revoke the token server-side: " + e.Message + "; the credential is kept so you can retry"
-		e.Hint = "Retry: basecamp auth revoke — or forget it locally: basecamp auth logout"
+		e.Message = "could not revoke the token server-side: " + e.Message + "; the credential is kept"
+		e.Hint = "Forget it locally: basecamp auth logout"
+		if e.Retryable {
+			e.Hint = "Retry: basecamp auth revoke — or forget it locally: basecamp auth logout"
+		}
 		e.Cause = err
 		return &e
 	}
@@ -321,10 +324,17 @@ func (m *Manager) revocationEndpoint(ctx context.Context, client *http.Client, i
 	}
 
 	var doc struct {
+		Issuer             string `json:"issuer"`
 		RevocationEndpoint string `json:"revocation_endpoint"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRevocationBodyBytes)).Decode(&doc); err != nil {
 		return "", fmt.Errorf("parsing authorization server metadata: %w", err)
+	}
+	// Bind the document to the issuer it was fetched for (RFC 8414 §3.3),
+	// as login discovery does: the GET may follow redirects, and another
+	// server's perfectly valid metadata must not name where the tokens go.
+	if strings.TrimRight(doc.Issuer, "/") != issuer {
+		return "", errors.New("authorization server metadata names a different issuer")
 	}
 	if doc.RevocationEndpoint == "" {
 		return "", errors.New("authorization server advertises no revocation endpoint")

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -29,10 +29,6 @@ const maxRevocationBodyBytes = 64 * 1024
 // issuer origin.
 const wellKnownAuthorizationServer = "/.well-known/oauth-authorization-server"
 
-// ErrNoCredential reports that nothing is stored under the credential key a
-// logout was asked to clear.
-var ErrNoCredential = errors.New("no stored credential")
-
 // Reasons a credential is removed locally without a revocation attempt.
 const (
 	// RevokeSkippedLaunchpad: the legacy provider has no revocation endpoint.
@@ -45,6 +41,16 @@ const (
 	RevokeSkippedImported = "imported_token"
 )
 
+// What a failed revocation left usable.
+const (
+	// RemainingRefresh: the refresh token was not revoked, so the whole
+	// family — its access token included — stays valid until it is.
+	RemainingRefresh = "refresh_token"
+	// RemainingAccess: only the access token remains (the refresh token was
+	// revoked, or there never was one); it expires on its own.
+	RemainingAccess = "access_token"
+)
+
 // LogoutResult reports what became of a credential server-side. The local
 // copy is gone either way.
 type LogoutResult struct {
@@ -55,6 +61,22 @@ type LogoutResult struct {
 	Skipped string
 	// Err is why an attempted revocation did not go through; nil otherwise.
 	Err error
+	// Remaining names what Err left usable (one of the Remaining* values);
+	// empty when Err is nil.
+	Remaining string
+}
+
+// Outstanding describes, for a human, what a failed revocation left usable;
+// empty when nothing did.
+func (r *LogoutResult) Outstanding() string {
+	switch r.Remaining {
+	case RemainingRefresh:
+		return "the refresh token stays valid until it is revoked"
+	case RemainingAccess:
+		return "only the access token remains and it expires within the hour"
+	default:
+		return ""
+	}
 }
 
 // Logout revokes the current credential with its authorization server when
@@ -76,6 +98,8 @@ func (m *Manager) LogoutCredential(ctx context.Context, credKey, baseURL string)
 
 	creds, err := m.store.Load(credKey)
 	switch {
+	case errors.Is(err, ErrNoCredential):
+		return nil, ErrNoCredential
 	case errors.Is(err, ErrInvalidCredentials):
 		// A blob no command can read is still stored; clearing it is the
 		// one thing a logout can do for it, and failing to is reported.
@@ -84,7 +108,10 @@ func (m *Manager) LogoutCredential(ctx context.Context, credKey, baseURL string)
 		}
 		return nil, ErrNoCredential
 	case err != nil:
-		return nil, ErrNoCredential
+		// A store that could not be read (a locked keyring, an unreadable
+		// file) is not "not logged in": the credential may well be there,
+		// live on both sides, and a logout that says otherwise is a lie.
+		return nil, err
 	}
 	result := m.revokeForDiscard(ctx, creds, baseURL)
 	if err := m.store.Delete(credKey); err != nil {
@@ -100,8 +127,8 @@ func (m *Manager) revokeForDiscard(ctx context.Context, creds *Credentials, base
 	if skipped := revokeSkipReason(creds); skipped != "" {
 		return &LogoutResult{Skipped: skipped}
 	}
-	if err := m.revoke(ctx, creds, baseURL); err != nil {
-		return &LogoutResult{Err: err}
+	if remaining, err := m.revoke(ctx, creds, baseURL); err != nil {
+		return &LogoutResult{Err: err, Remaining: remaining}
 	}
 	return &LogoutResult{Revoked: true}
 }
@@ -118,8 +145,11 @@ func (m *Manager) RevokeStored(ctx context.Context) error {
 
 	credKey := m.credentialKey()
 	creds, err := m.store.Load(credKey)
-	if err != nil {
+	if errors.Is(err, ErrNoCredential) {
 		return ErrNoCredential
+	}
+	if err != nil {
+		return err
 	}
 	switch revokeSkipReason(creds) {
 	case RevokeSkippedLaunchpad:
@@ -130,12 +160,34 @@ func (m *Manager) RevokeStored(ctx context.Context) error {
 			"Forget the credential locally instead: basecamp auth logout")
 	}
 	if err := m.Revoke(ctx, creds); err != nil {
-		e := output.ErrAPI(0, "could not revoke the token server-side: "+err.Error()+"; the credential is kept so you can retry")
+		// Keep the failure's taxonomy — a transport failure or a 5xx stays
+		// retryable, a refusal does not — under the revocation's own message
+		// and remedy.
+		e := *output.AsError(err)
+		e.Message = "could not revoke the token server-side: " + e.Message + "; the credential is kept so you can retry"
 		e.Hint = "Retry: basecamp auth revoke — or forget it locally: basecamp auth logout"
 		e.Cause = err
-		return e
+		return &e
 	}
 	return m.store.Delete(credKey)
+}
+
+// transportFailure is a revocation request that got no answer: retryable,
+// under a message that names the step rather than the SDK's generic one.
+func transportFailure(msg string, cause error) error {
+	e := output.ErrNetwork(cause)
+	e.Message = msg + ": " + cause.Error()
+	e.Hint = ""
+	return e
+}
+
+// statusFailure is a revocation request the server answered with something
+// other than 200: retryable when the server says to come back (5xx, 429),
+// final otherwise.
+func statusFailure(msg string, status int) error {
+	e := output.ErrAPI(status, msg)
+	e.Retryable = status >= 500 || status == http.StatusTooManyRequests
+	return e
 }
 
 // revokeSkipReason says why creds are not the CLI's to revoke, or "" when
@@ -160,37 +212,44 @@ func revokeSkipReason(creds *Credentials) string {
 // could not be reached, did not describe a revocation endpoint, or did not
 // answer 200; the tokens never appear in it.
 func (m *Manager) Revoke(ctx context.Context, creds *Credentials) error {
-	return m.revoke(ctx, creds, "")
+	_, err := m.revoke(ctx, creds, "")
+	return err
 }
 
-func (m *Manager) revoke(ctx context.Context, creds *Credentials, baseURL string) error {
+// revoke reports, alongside a failure, which token it left usable: the
+// refresh token until its own POST is accepted, only the access token after.
+func (m *Manager) revoke(ctx context.Context, creds *Credentials, baseURL string) (remaining string, err error) {
+	remaining = RemainingAccess
+	if creds.RefreshToken != "" {
+		remaining = RemainingRefresh
+	}
 	if creds.RefreshToken == "" && creds.AccessToken == "" {
-		return errors.New("stored credential carries no token")
+		return remaining, errors.New("stored credential carries no token")
 	}
 	issuer, err := credentialIssuer(creds)
 	if err != nil {
-		return err
+		return remaining, err
 	}
 	client, err := m.revocationClient(baseURL)
 	if err != nil {
-		return err
+		return remaining, err
 	}
 	endpoint, err := m.revocationEndpoint(ctx, client, issuer)
 	if err != nil {
-		return err
+		return remaining, err
 	}
-	for _, tok := range []struct{ value, hint string }{
-		{creds.RefreshToken, "refresh_token"},
-		{creds.AccessToken, "access_token"},
-	} {
-		if tok.value == "" {
-			continue
+	if creds.RefreshToken != "" {
+		if err := revokeToken(ctx, client, endpoint, creds.RefreshToken, RemainingRefresh); err != nil {
+			return remaining, err
 		}
-		if err := revokeToken(ctx, client, endpoint, tok.value, tok.hint); err != nil {
-			return err
+		remaining = RemainingAccess
+	}
+	if creds.AccessToken != "" {
+		if err := revokeToken(ctx, client, endpoint, creds.AccessToken, RemainingAccess); err != nil {
+			return remaining, err
 		}
 	}
-	return nil
+	return "", nil
 }
 
 // revocationClient is the egress lane a revocation rides: the BC5 lane of
@@ -239,11 +298,11 @@ func (m *Manager) revocationEndpoint(ctx context.Context, client *http.Client, i
 	req.Header.Set("Accept", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("fetching authorization server metadata: %w", err)
+		return "", transportFailure("fetching authorization server metadata", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("authorization server metadata returned HTTP %d", resp.StatusCode)
+		return "", statusFailure(fmt.Sprintf("authorization server metadata returned HTTP %d", resp.StatusCode), resp.StatusCode)
 	}
 
 	var doc struct {
@@ -281,12 +340,12 @@ func revokeToken(ctx context.Context, client *http.Client, endpoint, token, hint
 	req.Header.Set("Accept", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("revoking the %s: %w", what, err)
+		return transportFailure("revoking the "+what, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRevocationBodyBytes))
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("revoking the %s: the server answered HTTP %d", what, resp.StatusCode)
+		return statusFailure(fmt.Sprintf("revoking the %s: the server answered HTTP %d", what, resp.StatusCode), resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/auth/revoke.go
+++ b/internal/auth/revoke.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -182,12 +183,26 @@ func transportFailure(msg string, cause error) error {
 }
 
 // statusFailure is a revocation request the server answered with something
-// other than 200: retryable when the server says to come back (5xx, 429),
-// final otherwise.
-func statusFailure(msg string, status int) error {
-	e := output.ErrAPI(status, msg)
-	e.Retryable = status >= 500 || status == http.StatusTooManyRequests
-	return e
+// other than 200, classified the way the SDK classifies any other response:
+// 429 is a rate limit (retryable, with its Retry-After), 507 an account
+// limit (a verdict, not retryable), any other 5xx retryable, the rest final.
+func statusFailure(msg string, resp *http.Response) error {
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		retryAfter, _ := strconv.Atoi(strings.TrimSpace(resp.Header.Get("Retry-After")))
+		e := output.ErrRateLimit(retryAfter)
+		e.Message = msg
+		e.HTTPStatus = resp.StatusCode
+		return e
+	case http.StatusInsufficientStorage:
+		e := output.ErrAPI(resp.StatusCode, msg)
+		e.Code = output.CodeLimitExceeded
+		return e
+	default:
+		e := output.ErrAPI(resp.StatusCode, msg)
+		e.Retryable = resp.StatusCode >= 500 && resp.StatusCode < 600
+		return e
+	}
 }
 
 // revokeSkipReason says why creds are not the CLI's to revoke, or "" when
@@ -302,7 +317,7 @@ func (m *Manager) revocationEndpoint(ctx context.Context, client *http.Client, i
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", statusFailure(fmt.Sprintf("authorization server metadata returned HTTP %d", resp.StatusCode), resp.StatusCode)
+		return "", statusFailure(fmt.Sprintf("authorization server metadata returned HTTP %d", resp.StatusCode), resp)
 	}
 
 	var doc struct {
@@ -345,7 +360,7 @@ func revokeToken(ctx context.Context, client *http.Client, endpoint, token, hint
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRevocationBodyBytes))
 	if resp.StatusCode != http.StatusOK {
-		return statusFailure(fmt.Sprintf("revoking the %s: the server answered HTTP %d", what, resp.StatusCode), resp.StatusCode)
+		return statusFailure(fmt.Sprintf("revoking the %s: the server answered HTTP %d", what, resp.StatusCode), resp)
 	}
 	return nil
 }

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -1,0 +1,305 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/config"
+	"github.com/basecamp/basecamp-cli/internal/output"
+)
+
+// bc5Credentials is a device-flow credential minted by as.
+func bc5Credentials(as *deviceAS) *Credentials {
+	return &Credentials{
+		AccessToken:   "dev-tok",
+		RefreshToken:  "dev-ref",
+		OAuthType:     "bc5",
+		TokenEndpoint: as.srv.URL + "/oauth/token",
+		Issuer:        as.srv.URL,
+		Scope:         "full",
+		ExpiresAt:     time.Now().Unix() + 3600,
+	}
+}
+
+func assertRevoked(t *testing.T, calls []url.Values, tokens ...string) {
+	t.Helper()
+	require.Len(t, calls, len(tokens))
+	for i, token := range tokens {
+		hint := "access_token"
+		if token == "dev-ref" {
+			hint = "refresh_token"
+		}
+		assert.Equal(t, token, calls[i].Get("token"))
+		assert.Equal(t, hint, calls[i].Get("token_type_hint"))
+		assert.Equal(t, bc5ClientID, calls[i].Get("client_id"))
+		assert.Empty(t, calls[i].Get("client_secret"), "the public client has no secret")
+	}
+}
+
+func TestRevoke_PostsRefreshThenAccessAsThePublicClient(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	require.NoError(t, m.Revoke(context.Background(), bc5Credentials(as)))
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+}
+
+func TestRevoke_DerivesTheIssuerFromTheTokenEndpoint(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	creds := bc5Credentials(as)
+	creds.Issuer = ""
+
+	require.NoError(t, m.Revoke(context.Background(), creds))
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+}
+
+func TestRevoke_SendsOnlyTheTokensItHolds(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	creds := bc5Credentials(as)
+	creds.RefreshToken = ""
+
+	require.NoError(t, m.Revoke(context.Background(), creds))
+	assertRevoked(t, as.revokeCalls(), "dev-tok")
+
+	creds.AccessToken = ""
+	err := m.Revoke(context.Background(), creds)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token")
+}
+
+func TestRevoke_FailsWhenTheServerAdvertisesNoEndpoint(t *testing.T) {
+	as := startDeviceAS(t)
+	as.metadata = func() string {
+		return fmt.Sprintf(`{"issuer": %q, "token_endpoint": %q}`, as.srv.URL, as.srv.URL+"/oauth/token")
+	}
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no revocation endpoint")
+	assert.Empty(t, as.revokeCalls())
+}
+
+func TestRevoke_FailsWhenMetadataIsUnavailable(t *testing.T) {
+	as := startDeviceAS(t)
+	as.metadata = func() string { return `not json` }
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing authorization server metadata")
+	assert.Empty(t, as.revokeCalls())
+
+	gone, _ := countingServer(t)
+	creds := bc5Credentials(as)
+	creds.Issuer = gone.URL
+	err = m.Revoke(context.Background(), creds)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+	assert.Empty(t, as.revokeCalls())
+}
+
+// A revocation endpoint is server-named data and receives the tokens, so it
+// passes the same check as every other OAuth endpoint before any POST.
+func TestRevoke_RefusesAnInsecureRevocationEndpoint(t *testing.T) {
+	as := startDeviceAS(t)
+	as.metadata = func() string {
+		return fmt.Sprintf(`{"issuer": %q, "token_endpoint": %q, "revocation_endpoint": "http://revocations.example/oauth/revocations"}`,
+			as.srv.URL, as.srv.URL+"/oauth/token")
+	}
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid revocation endpoint")
+	assert.Empty(t, as.revokeCalls())
+}
+
+func TestRevoke_ReportsARefusalWithoutTheToken(t *testing.T) {
+	as := startDeviceAS(t)
+	as.revoke = func(int) (int, string) { return http.StatusServiceUnavailable, `{"error":"temporarily_unavailable"}` }
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "revoking the refresh token")
+	assert.Contains(t, err.Error(), "HTTP 503")
+	assert.NotContains(t, err.Error(), "dev-ref")
+	assert.NotContains(t, err.Error(), "dev-tok")
+	assert.Len(t, as.revokeCalls(), 1, "a refused refresh revocation stops the sequence")
+}
+
+func TestRevoke_BoundsEachRequest(t *testing.T) {
+	as := startDeviceAS(t)
+	as.revoke = func(int) (int, string) {
+		time.Sleep(300 * time.Millisecond)
+		return http.StatusOK, `{}`
+	}
+	m := newDeviceTestManager(t, as.srv.URL)
+	prev := revokeRequestTimeout
+	revokeRequestTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { revokeRequestTimeout = prev })
+
+	start := time.Now()
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 250*time.Millisecond)
+}
+
+func TestLogout_RevokesThenDeletes(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.Save(credKey, bc5Credentials(as)))
+
+	result, err := m.Logout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, &LogoutResult{Revoked: true}, result)
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+	_, err = m.store.Load(credKey)
+	assert.Error(t, err, "the local copy is gone")
+}
+
+func TestLogout_DeletesEvenWhenRevocationFails(t *testing.T) {
+	as := startDeviceAS(t)
+	as.revoke = func(int) (int, string) { return http.StatusInternalServerError, `{}` }
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.Save(credKey, bc5Credentials(as)))
+
+	result, err := m.Logout(context.Background())
+	require.NoError(t, err)
+	assert.False(t, result.Revoked)
+	assert.Empty(t, result.Skipped)
+	require.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "HTTP 500")
+	_, err = m.store.Load(credKey)
+	assert.Error(t, err, "the local copy is gone regardless")
+}
+
+func TestLogout_SkipsWhatIsNotItsToRevoke(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+
+	launchpad := &Credentials{AccessToken: "lp-tok", RefreshToken: "lp-ref", OAuthType: "launchpad", TokenEndpoint: "https://launchpad.37signals.com/authorization/token"}
+	require.NoError(t, m.store.Save(credKey, launchpad))
+	result, err := m.Logout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, &LogoutResult{Skipped: RevokeSkippedLaunchpad}, result)
+
+	imported := bc5Credentials(as)
+	imported.RefreshToken = ""
+	imported.Source = CredentialSourceToken
+	require.NoError(t, m.store.Save(credKey, imported))
+	result, err = m.Logout(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, &LogoutResult{Skipped: RevokeSkippedImported}, result)
+
+	assert.Empty(t, as.revokeCalls())
+	_, err = m.store.Load(credKey)
+	assert.Error(t, err)
+}
+
+func TestLogoutCredential_ClearsTheNamedKey(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	require.NoError(t, m.store.Save("profile:bot", bc5Credentials(as)))
+	require.NoError(t, m.store.Save(config.NormalizeBaseURL(as.srv.URL), bc5Credentials(as)))
+
+	result, err := m.LogoutCredential(context.Background(), "profile:bot")
+	require.NoError(t, err)
+	assert.True(t, result.Revoked)
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+	_, err = m.store.Load("profile:bot")
+	assert.Error(t, err)
+	assert.True(t, m.IsAuthenticated(), "the other credential is untouched")
+
+	_, err = m.LogoutCredential(context.Background(), "profile:bot")
+	assert.ErrorIs(t, err, ErrNoCredential)
+}
+
+// A stored login records where it can be revoked.
+func TestLoginDevice_RecordsTheIssuer(t *testing.T) {
+	as := startDeviceAS(t)
+	resource := startResourceServer(t, as.srv.URL)
+	m := newDeviceTestManager(t, resource.URL)
+
+	_, err := m.Login(context.Background(), LoginOptions{
+		Remote:        true,
+		Logger:        func(string) {},
+		deviceOptions: []oauth.DeviceOption{instantSleep()},
+	})
+	require.NoError(t, err)
+	creds, err := m.store.Load(config.NormalizeBaseURL(resource.URL))
+	require.NoError(t, err)
+	assert.Equal(t, as.srv.URL, creds.Issuer)
+	assert.Empty(t, as.revokeCalls(), "an accepted login revokes nothing")
+}
+
+func TestRevokeStored_RevokesThenDeletes(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.Save(credKey, bc5Credentials(as)))
+
+	require.NoError(t, m.RevokeStored(context.Background()))
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+	_, err := m.store.Load(credKey)
+	assert.Error(t, err, "a revoked credential is useless and goes")
+
+	assert.ErrorIs(t, m.RevokeStored(context.Background()), ErrNoCredential)
+}
+
+// Unlike a logout, a revoke that did not happen keeps the credential: the
+// operator asked for the token to be dead, and forgetting it locally would
+// make that impossible from here.
+func TestRevokeStored_KeepsTheCredentialWhenTheServerRefuses(t *testing.T) {
+	as := startDeviceAS(t)
+	as.revoke = func(int) (int, string) { return http.StatusServiceUnavailable, `{}` }
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.Save(credKey, bc5Credentials(as)))
+
+	err := m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not revoke the token server-side")
+	assert.Contains(t, err.Error(), "HTTP 503")
+	assert.Contains(t, err.Error(), "kept so you can retry")
+	assert.NotContains(t, err.Error(), "dev-ref")
+	assert.Contains(t, output.AsError(err).Hint, "basecamp auth revoke")
+	assert.True(t, m.IsAuthenticated(), "the credential stays for a retry")
+}
+
+func TestRevokeStored_RefusesWhatIsNotItsToRevoke(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+
+	require.NoError(t, m.store.Save(credKey, &Credentials{AccessToken: "lp-tok", OAuthType: "launchpad"}))
+	err := m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Launchpad tokens cannot be revoked from the CLI")
+	assert.Contains(t, output.AsError(err).Hint, "basecamp auth logout")
+
+	imported := bc5Credentials(as)
+	imported.Source = CredentialSourceToken
+	require.NoError(t, m.store.Save(credKey, imported))
+	err = m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "revoke it in Basecamp")
+
+	assert.Empty(t, as.revokeCalls())
+	assert.True(t, m.IsAuthenticated(), "a refused revoke changes nothing")
+}

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -218,7 +218,7 @@ func TestLogoutCredential_ClearsTheNamedKey(t *testing.T) {
 	require.NoError(t, m.store.Save("profile:bot", bc5Credentials(as)))
 	require.NoError(t, m.store.Save(config.NormalizeBaseURL(as.srv.URL), bc5Credentials(as)))
 
-	result, err := m.LogoutCredential(context.Background(), "profile:bot")
+	result, err := m.LogoutCredential(context.Background(), "profile:bot", "")
 	require.NoError(t, err)
 	assert.True(t, result.Revoked)
 	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
@@ -226,8 +226,49 @@ func TestLogoutCredential_ClearsTheNamedKey(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, m.IsAuthenticated(), "the other credential is untouched")
 
-	_, err = m.LogoutCredential(context.Background(), "profile:bot")
+	_, err = m.LogoutCredential(context.Background(), "profile:bot", "")
 	assert.ErrorIs(t, err, ErrNoCredential)
+}
+
+// The revocation's egress policy follows the profile being deleted, not the
+// active configuration: with production active, a loopback development
+// profile's issuer is still reachable when the delete is anchored on that
+// profile's own base URL.
+func TestLogoutCredential_AnchorsTheLaneOnTheProfileBaseURL(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, "https://3.basecampapi.com")
+	m.httpClient = nil // the real per-anchor lanes, address policy included
+	m.Warnf = func(string, ...any) {}
+
+	require.NoError(t, m.store.Save("profile:dev", bc5Credentials(as)))
+	result, err := m.LogoutCredential(context.Background(), "profile:dev", "")
+	require.NoError(t, err)
+	assert.False(t, result.Revoked)
+	require.Error(t, result.Err, "the production lane refuses a loopback issuer")
+	assert.Empty(t, as.revokeCalls())
+
+	require.NoError(t, m.store.Save("profile:dev", bc5Credentials(as)))
+	result, err = m.LogoutCredential(context.Background(), "profile:dev", as.srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, &LogoutResult{Revoked: true}, result)
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+}
+
+// A stored blob that is not a credential is cleared, and only then is the
+// key reported empty.
+func TestLogout_ClearsAnUnreadableCredential(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.ensure().Save(credKey, []byte(`["not a credential"]`)))
+	_, err := m.store.Load(credKey)
+	require.ErrorIs(t, err, ErrInvalidCredentials)
+
+	_, err = m.Logout(context.Background())
+	assert.ErrorIs(t, err, ErrNoCredential)
+	_, err = m.store.ensure().Load(credKey)
+	assert.Error(t, err, "the blob is gone")
+	assert.Empty(t, as.revokeCalls())
 }
 
 // A stored login records where it can be revoked.

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -128,6 +128,21 @@ func TestRevoke_RefusesAnInsecureRevocationEndpoint(t *testing.T) {
 	assert.Empty(t, as.revokeCalls())
 }
 
+// Metadata is bound to the issuer it was fetched for: a redirect to another
+// server's valid document must not decide where the tokens are POSTed.
+func TestRevoke_RefusesMetadataForAnotherIssuer(t *testing.T) {
+	as := startDeviceAS(t)
+	other := startDeviceAS(t)
+	as.metadata = func() string { return other.metadata() }
+	m := newDeviceTestManager(t, as.srv.URL)
+
+	err := m.Revoke(context.Background(), bc5Credentials(as))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different issuer")
+	assert.Empty(t, as.revokeCalls())
+	assert.Empty(t, other.revokeCalls())
+}
+
 func TestRevoke_ReportsARefusalWithoutTheToken(t *testing.T) {
 	as := startDeviceAS(t)
 	as.revoke = func(int) (int, string) { return http.StatusServiceUnavailable, `{"error":"temporarily_unavailable"}` }
@@ -398,7 +413,7 @@ func TestRevokeStored_KeepsTheCredentialWhenTheServerRefuses(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not revoke the token server-side")
 	assert.Contains(t, err.Error(), "HTTP 503")
-	assert.Contains(t, err.Error(), "kept so you can retry")
+	assert.Contains(t, err.Error(), "the credential is kept")
 	assert.NotContains(t, err.Error(), "dev-ref")
 	assert.Contains(t, output.AsError(err).Hint, "basecamp auth revoke")
 	assert.True(t, output.AsError(err).Retryable, "a 503 is the server saying come back")
@@ -410,6 +425,8 @@ func TestRevokeStored_KeepsTheCredentialWhenTheServerRefuses(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, output.AsError(err).Retryable, "a 400 will not change on retry")
 	assert.Equal(t, output.CodeAPI, output.AsError(err).Code)
+	assert.NotContains(t, output.AsError(err).Hint, "auth revoke", "no retry is advertised for a final refusal")
+	assert.Contains(t, output.AsError(err).Hint, "basecamp auth logout")
 
 	as.revoke = func(int) (int, string) { return http.StatusTooManyRequests, `{"error":"rate_limited"}` }
 	err = m.RevokeStored(context.Background())

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -226,8 +226,11 @@ func TestLogout_ReportsWhatAFailureLeftUsable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result.Err.Error(), "revoking the access token")
 	assert.Equal(t, RemainingAccess, result.Remaining)
-	assert.Contains(t, result.Outstanding(), "only the access token remains")
+	assert.Contains(t, result.Outstanding(), "only the access token remains and it expires in 1h0m0s", "the lifetime is the one the server reported")
 	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+
+	assert.Equal(t, "only the access token remains and it reports no expiry", (&LogoutResult{Remaining: RemainingAccess}).Outstanding())
+	assert.Equal(t, "only the access token remains and it has already expired", (&LogoutResult{Remaining: RemainingAccess, ExpiresAt: 1}).Outstanding())
 
 	as.metadata = func() string { return `{}` }
 	noRefresh := bc5Credentials(as)

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -409,6 +409,19 @@ func TestRevokeStored_KeepsTheCredentialWhenTheServerRefuses(t *testing.T) {
 	err = m.RevokeStored(context.Background())
 	require.Error(t, err)
 	assert.False(t, output.AsError(err).Retryable, "a 400 will not change on retry")
+	assert.Equal(t, output.CodeAPI, output.AsError(err).Code)
+
+	as.revoke = func(int) (int, string) { return http.StatusTooManyRequests, `{"error":"rate_limited"}` }
+	err = m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, output.CodeRateLimit, output.AsError(err).Code, "a 429 is a rate limit, as everywhere else in the CLI")
+	assert.True(t, output.AsError(err).Retryable)
+
+	as.revoke = func(int) (int, string) { return http.StatusInsufficientStorage, `{}` }
+	err = m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, output.CodeLimitExceeded, output.AsError(err).Code)
+	assert.False(t, output.AsError(err).Retryable, "a 507 is a verdict, not a 5xx to retry")
 
 	as.srv.Close()
 	err = m.RevokeStored(context.Background())

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,8 +10,10 @@ import (
 	"time"
 
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+	"github.com/basecamp/cli/credstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
 
 	"github.com/basecamp/basecamp-cli/internal/config"
 	"github.com/basecamp/basecamp-cli/internal/output"
@@ -184,8 +187,86 @@ func TestLogout_DeletesEvenWhenRevocationFails(t *testing.T) {
 	assert.Empty(t, result.Skipped)
 	require.Error(t, result.Err)
 	assert.Contains(t, result.Err.Error(), "HTTP 500")
+	assert.Equal(t, RemainingRefresh, result.Remaining, "a refused refresh revocation leaves the whole family live")
+	assert.Contains(t, result.Outstanding(), "refresh token stays valid")
 	_, err = m.store.Load(credKey)
 	assert.Error(t, err, "the local copy is gone regardless")
+}
+
+// What a failure left usable depends on where it struck: before the refresh
+// token was accepted the family is live; after, only the access token.
+func TestLogout_ReportsWhatAFailureLeftUsable(t *testing.T) {
+	as := startDeviceAS(t)
+	as.revoke = func(call int) (int, string) {
+		if call == 0 {
+			return http.StatusOK, `{}`
+		}
+		return http.StatusInternalServerError, `{}`
+	}
+	m := newDeviceTestManager(t, as.srv.URL)
+	credKey := config.NormalizeBaseURL(as.srv.URL)
+	require.NoError(t, m.store.Save(credKey, bc5Credentials(as)))
+
+	result, err := m.Logout(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, result.Err.Error(), "revoking the access token")
+	assert.Equal(t, RemainingAccess, result.Remaining)
+	assert.Contains(t, result.Outstanding(), "only the access token remains")
+	assertRevoked(t, as.revokeCalls(), "dev-ref", "dev-tok")
+
+	as.metadata = func() string { return `{}` }
+	noRefresh := bc5Credentials(as)
+	noRefresh.RefreshToken = ""
+	require.NoError(t, m.store.Save(credKey, noRefresh))
+	result, err = m.Logout(context.Background())
+	require.NoError(t, err)
+	require.Error(t, result.Err)
+	assert.Equal(t, RemainingAccess, result.Remaining, "with no refresh token only the access token was ever at stake")
+}
+
+// lockedCredStore is a credential store that cannot be reached at all — a
+// locked keyring, an unreadable file — as opposed to one with nothing in it.
+type lockedCredStore struct{ err error }
+
+func (s lockedCredStore) Load(string) ([]byte, error) { return nil, s.err }
+func (s lockedCredStore) Save(string, []byte) error   { return s.err }
+func (s lockedCredStore) Delete(string) error         { return s.err }
+func (lockedCredStore) MigrateToKeyring() error       { return nil }
+func (lockedCredStore) UsingKeyring() bool            { return false }
+func (lockedCredStore) FallbackWarning() string       { return "" }
+
+// A store that cannot be read is not "not logged in": the credential may be
+// there, live on both sides, so the failure is the answer.
+func TestLogout_PropagatesAnUnreachableStore(t *testing.T) {
+	as := startDeviceAS(t)
+	m := newDeviceTestManager(t, as.srv.URL)
+	swapNewCredStore(t, func(credstore.StoreOptions) credStore { return lockedCredStore{err: errors.New("keyring locked")} })
+	m.store = NewStore(t.TempDir())
+
+	_, err := m.Logout(context.Background())
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoCredential)
+	assert.ErrorContains(t, err, "keyring locked")
+
+	_, err = m.LogoutCredential(context.Background(), "profile:bot", "")
+	assert.ErrorContains(t, err, "keyring locked")
+
+	err = m.RevokeStored(context.Background())
+	assert.NotErrorIs(t, err, ErrNoCredential)
+	assert.ErrorContains(t, err, "keyring locked")
+	assert.Empty(t, as.revokeCalls())
+}
+
+// The file backend's miss is the one error that means "nothing stored".
+func TestStoreLoad_TellsAMissFromAFailure(t *testing.T) {
+	store := newTestStore(t, t.TempDir())
+	_, err := store.Load("profile:absent")
+	assert.ErrorIs(t, err, ErrNoCredential)
+
+	assert.True(t, isMissingCredential(fmt.Errorf("credentials not found: %w", keyring.ErrNotFound)))
+	assert.False(t, isMissingCredential(errors.New("credentials not found: keychain locked")),
+		"a keyring failure under credstore's not-found prefix is not a miss")
+	assert.False(t, isMissingCredential(errors.New("open credentials.json: permission denied")))
 }
 
 func TestLogout_SkipsWhatIsNotItsToRevoke(t *testing.T) {
@@ -320,7 +401,20 @@ func TestRevokeStored_KeepsTheCredentialWhenTheServerRefuses(t *testing.T) {
 	assert.Contains(t, err.Error(), "kept so you can retry")
 	assert.NotContains(t, err.Error(), "dev-ref")
 	assert.Contains(t, output.AsError(err).Hint, "basecamp auth revoke")
+	assert.True(t, output.AsError(err).Retryable, "a 503 is the server saying come back")
+	assert.Equal(t, http.StatusServiceUnavailable, output.AsError(err).HTTPStatus)
 	assert.True(t, m.IsAuthenticated(), "the credential stays for a retry")
+
+	as.revoke = func(int) (int, string) { return http.StatusBadRequest, `{"error":"unsupported_token_type"}` }
+	err = m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.False(t, output.AsError(err).Retryable, "a 400 will not change on retry")
+
+	as.srv.Close()
+	err = m.RevokeStored(context.Background())
+	require.Error(t, err)
+	assert.True(t, output.AsError(err).Retryable, "an unreachable server may come back")
+	assert.Contains(t, err.Error(), "fetching authorization server metadata")
 }
 
 func TestRevokeStored_RefusesWhatIsNotItsToRevoke(t *testing.T) {

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -911,7 +911,7 @@ func describeLogout(done string, result *auth.LogoutResult) (summary string, fie
 		summary = done + " (forgot the imported token; it stays valid until revoked in Basecamp)"
 	case result.Err != nil:
 		fields["reason"] = result.Err.Error()
-		summary = done + " locally; could not revoke the token server-side: " + result.Err.Error() + " — it expires within the hour"
+		summary = done + " locally; could not revoke the token server-side: " + result.Err.Error() + " — the access token expires within the hour, but the refresh token stays valid until it is revoked"
 	default:
 		fields["reason"] = result.Skipped
 		summary = done

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -840,6 +840,9 @@ func buildLogoutCmd(use string) *cobra.Command {
 				return fmt.Errorf("app not initialized")
 			}
 
+			if err := refuseEnvTokenLogout(); err != nil {
+				return err
+			}
 			result, err := app.Auth.Logout(cmd.Context())
 			if errors.Is(err, auth.ErrNoCredential) {
 				return app.OK(map[string]any{
@@ -877,6 +880,9 @@ revoke an imported token in Basecamp.`,
 				return fmt.Errorf("app not initialized")
 			}
 
+			if err := refuseEnvTokenLogout(); err != nil {
+				return err
+			}
 			err := app.Auth.RevokeStored(cmd.Context())
 			if errors.Is(err, auth.ErrNoCredential) {
 				return app.OK(map[string]any{
@@ -895,6 +901,18 @@ revoke an imported token in Basecamp.`,
 	}
 }
 
+// refuseEnvTokenLogout keeps logout and revoke off the stored credential
+// while BASECAMP_TOKEN is the one in use. Every request follows the
+// environment token, so the stored credential is not the session being
+// ended — and revoking it would kill an unrelated refresh family for good.
+func refuseEnvTokenLogout() error {
+	if os.Getenv("BASECAMP_TOKEN") == "" {
+		return nil
+	}
+	return output.ErrUsageHint("BASECAMP_TOKEN is set: the CLI cannot revoke or forget an environment token, and the stored credential is not the one in use",
+		"Unset BASECAMP_TOKEN to log out of the stored credential; revoke an environment token where it was issued.")
+}
+
 // describeLogout renders what became of a credential server-side for a
 // human — appended to `done`, the local outcome — and the fields the JSON
 // envelope carries for it.
@@ -911,7 +929,8 @@ func describeLogout(done string, result *auth.LogoutResult) (summary string, fie
 		summary = done + " (forgot the imported token; it stays valid until revoked in Basecamp)"
 	case result.Err != nil:
 		fields["reason"] = result.Err.Error()
-		summary = done + " locally; could not revoke the token server-side: " + result.Err.Error() + " — the access token expires within the hour, but the refresh token stays valid until it is revoked"
+		fields["remaining"] = result.Remaining
+		summary = done + " locally; could not revoke the token server-side: " + result.Err.Error() + " — " + result.Outstanding()
 	default:
 		fields["reason"] = result.Skipped
 		summary = done

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -834,6 +834,9 @@ func buildLogoutCmd(use string) *cobra.Command {
 		Use:   use,
 		Short: "Log out and revoke the credential",
 		Long:  "Revoke the current credential with the server when it can be, and remove it from local storage.",
+		// A stray argument (`auth logout work`, meant as a profile name) must
+		// not revoke the selected credential instead: select with --profile.
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if app == nil {

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -3,6 +3,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -36,6 +37,7 @@ func NewAuthCmd() *cobra.Command {
 	cmd.AddCommand(
 		newAuthLoginCmd(),
 		newAuthLogoutCmd(),
+		newAuthRevokeCmd(),
 		newAuthStatusCmd(),
 		newAuthRefreshCmd(),
 		newAuthTokenCmd(),
@@ -830,23 +832,91 @@ func authorizedAccountIDs(info *basecamp.AuthorizationInfo) string {
 func buildLogoutCmd(use string) *cobra.Command {
 	return &cobra.Command{
 		Use:   use,
-		Short: "Remove stored credentials",
-		Long:  "Remove stored authentication credentials for the current origin.",
+		Short: "Log out and revoke the credential",
+		Long:  "Revoke the current credential with the server when it can be, and remove it from local storage.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
 			if app == nil {
 				return fmt.Errorf("app not initialized")
 			}
 
-			if err := app.Auth.Logout(); err != nil {
+			result, err := app.Auth.Logout(cmd.Context())
+			if errors.Is(err, auth.ErrNoCredential) {
+				return app.OK(map[string]any{
+					"status":  "not_logged_in",
+					"revoked": false,
+				}, output.WithSummary("Not logged in"))
+			}
+			if err != nil {
 				return err
 			}
 
-			return app.OK(map[string]string{
-				"status": "logged_out",
-			}, output.WithSummary("Successfully logged out"))
+			summary, fields := describeLogout("Logged out", result)
+			fields["status"] = "logged_out"
+			return app.OK(fields, output.WithSummary(summary))
 		},
 	}
+}
+
+func newAuthRevokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke the credential with the server",
+		Long: `Revoke the current credential with its authorization server, then remove it
+from local storage — a revoked token leaves nothing usable behind.
+
+Unlike auth logout, which always forgets the credential and only tries to
+revoke it, this refuses to forget a token it could not revoke: the credential
+stays so the revocation can be retried. Launchpad tokens and imported personal
+access tokens cannot be revoked from the CLI — log out to forget them, and
+revoke an imported token in Basecamp.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app := appctx.FromContext(cmd.Context())
+			if app == nil {
+				return fmt.Errorf("app not initialized")
+			}
+
+			err := app.Auth.RevokeStored(cmd.Context())
+			if errors.Is(err, auth.ErrNoCredential) {
+				return app.OK(map[string]any{
+					"status":  "not_logged_in",
+					"revoked": false,
+				}, output.WithSummary("Not logged in"))
+			}
+			if err != nil {
+				return err
+			}
+			return app.OK(map[string]any{
+				"status":  "revoked",
+				"revoked": true,
+			}, output.WithSummary("Revoked the token with the server and removed the credential"))
+		},
+	}
+}
+
+// describeLogout renders what became of a credential server-side for a
+// human — appended to `done`, the local outcome — and the fields the JSON
+// envelope carries for it.
+func describeLogout(done string, result *auth.LogoutResult) (summary string, fields map[string]any) {
+	fields = map[string]any{"revoked": result.Revoked}
+	switch {
+	case result.Revoked:
+		summary = done + " (token revoked)"
+	case result.Skipped == auth.RevokeSkippedLaunchpad:
+		fields["reason"] = result.Skipped
+		summary = done + " (Launchpad tokens cannot be revoked from the CLI)"
+	case result.Skipped == auth.RevokeSkippedImported:
+		fields["reason"] = result.Skipped
+		summary = done + " (forgot the imported token; it stays valid until revoked in Basecamp)"
+	case result.Err != nil:
+		fields["reason"] = result.Err.Error()
+		summary = done + " locally; could not revoke the token server-side: " + result.Err.Error() + " — it expires within the hour"
+	default:
+		fields["reason"] = result.Skipped
+		summary = done
+	}
+	return summary, fields
 }
 
 // printAgentNudge prints a hint about coding agent setup after login.

--- a/internal/commands/auth_logout_test.go
+++ b/internal/commands/auth_logout_test.go
@@ -1,0 +1,288 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/basecamp-cli/internal/appctx"
+	"github.com/basecamp/basecamp-cli/internal/auth"
+	"github.com/basecamp/basecamp-cli/internal/config"
+	"github.com/basecamp/basecamp-cli/internal/output"
+)
+
+// revocationServer is a BC5 authorization server reduced to what a logout
+// touches: RFC 8414 metadata naming an RFC 7009 revocation endpoint, which
+// records every form it is sent.
+type revocationServer struct {
+	srv *httptest.Server
+
+	mu    sync.Mutex
+	forms []url.Values
+	// metadataStatus overrides the metadata response status when non-zero.
+	metadataStatus int
+}
+
+func startRevocationServer(t *testing.T) *revocationServer {
+	t.Helper()
+	s := &revocationServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		if s.metadataStatus != 0 {
+			w.WriteHeader(s.metadataStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"issuer": %q, "token_endpoint": %q, "revocation_endpoint": %q}`,
+			s.srv.URL, s.srv.URL+"/oauth/tokens", s.srv.URL+"/oauth/revocations")
+	})
+	mux.HandleFunc("/oauth/revocations", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		s.mu.Lock()
+		s.forms = append(s.forms, r.PostForm)
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *revocationServer) revoked() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tokens := make([]string, 0, len(s.forms))
+	for _, f := range s.forms {
+		tokens = append(tokens, f.Get("token"))
+	}
+	return tokens
+}
+
+// newLogoutTestApp wires an app whose credential store holds creds (when
+// non-nil) for the base URL s serves, rendering in the given format.
+func newLogoutTestApp(t *testing.T, s *revocationServer, format output.Format, creds *auth.Credentials) (*appctx.App, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+	t.Setenv("BASECAMP_TOKEN", "")
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	cfg := &config.Config{BaseURL: s.srv.URL, Sources: map[string]string{}}
+	authMgr := auth.NewManager(cfg, s.srv.Client())
+	authMgr.SetStore(auth.NewStore(tmpDir))
+	if creds != nil {
+		require.NoError(t, authMgr.GetStore().Save(authMgr.CredentialKey(), creds))
+	}
+
+	buf := &bytes.Buffer{}
+	app := &appctx.App{
+		Config: cfg,
+		Auth:   authMgr,
+		Output: output.New(output.Options{Format: format, Writer: buf}),
+		Flags:  appctx.GlobalFlags{JSON: format == output.FormatJSON},
+	}
+	return app, buf
+}
+
+func runLogout(t *testing.T, app *appctx.App) error {
+	t.Helper()
+	return runAuthSubcommand(t, app, "logout")
+}
+
+func runAuthSubcommand(t *testing.T, app *appctx.App, sub string) error {
+	t.Helper()
+	cmd := NewAuthCmd()
+	cmd.SetArgs([]string{sub})
+	cmd.SetContext(appctx.WithApp(context.Background(), app))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	return cmd.Execute()
+}
+
+func bc5LogoutCredentials(s *revocationServer) *auth.Credentials {
+	return &auth.Credentials{
+		AccessToken:   "at-1",
+		RefreshToken:  "rt-1",
+		OAuthType:     "bc5",
+		TokenEndpoint: s.srv.URL + "/oauth/tokens",
+		Issuer:        s.srv.URL,
+		Scope:         "full",
+	}
+}
+
+func decodeLogoutJSON(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var envelope struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope), buf.String())
+	return envelope.Data
+}
+
+func TestAuthLogoutRevokesThenForgets(t *testing.T) {
+	s := startRevocationServer(t)
+	app, buf := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+
+	require.NoError(t, runLogout(t, app))
+	assert.Equal(t, []string{"rt-1", "at-1"}, s.revoked(), "refresh token first, then the access token")
+	data := decodeLogoutJSON(t, buf)
+	assert.Equal(t, "logged_out", data["status"])
+	assert.Equal(t, true, data["revoked"])
+	assert.NotContains(t, data, "reason")
+	assert.False(t, app.Auth.IsAuthenticated())
+}
+
+func TestAuthLogoutHumanCopy(t *testing.T) {
+	t.Run("revoked", func(t *testing.T) {
+		s := startRevocationServer(t)
+		app, buf := newLogoutTestApp(t, s, output.FormatStyled, bc5LogoutCredentials(s))
+		require.NoError(t, runLogout(t, app))
+		assert.Contains(t, buf.String(), "Logged out (token revoked)")
+	})
+
+	t.Run("revocation failed", func(t *testing.T) {
+		s := startRevocationServer(t)
+		s.metadataStatus = http.StatusNotFound
+		app, buf := newLogoutTestApp(t, s, output.FormatStyled, bc5LogoutCredentials(s))
+		require.NoError(t, runLogout(t, app), "a failed revocation is not a failed logout")
+		assert.Contains(t, buf.String(), "Logged out locally; could not revoke the token server-side: authorization server metadata returned HTTP 404 — it expires within the hour")
+		assert.Empty(t, s.revoked())
+		assert.False(t, app.Auth.IsAuthenticated(), "the local copy goes regardless")
+	})
+
+	t.Run("launchpad", func(t *testing.T) {
+		s := startRevocationServer(t)
+		creds := &auth.Credentials{AccessToken: "lp-at", RefreshToken: "lp-rt", OAuthType: "launchpad", TokenEndpoint: "https://launchpad.37signals.com/authorization/token"}
+		app, buf := newLogoutTestApp(t, s, output.FormatStyled, creds)
+		require.NoError(t, runLogout(t, app))
+		assert.Contains(t, buf.String(), "Logged out (Launchpad tokens cannot be revoked from the CLI)")
+		assert.Empty(t, s.revoked())
+		assert.False(t, app.Auth.IsAuthenticated())
+	})
+
+	t.Run("imported token", func(t *testing.T) {
+		s := startRevocationServer(t)
+		creds := &auth.Credentials{AccessToken: "pat-1", OAuthType: "bc5", Scope: "full", Source: auth.CredentialSourceToken}
+		app, buf := newLogoutTestApp(t, s, output.FormatStyled, creds)
+		require.NoError(t, runLogout(t, app))
+		assert.Contains(t, buf.String(), "Logged out (forgot the imported token; it stays valid until revoked in Basecamp)")
+		assert.Empty(t, s.revoked(), "an imported token is the operator's, not the CLI's, to revoke")
+		assert.False(t, app.Auth.IsAuthenticated())
+	})
+
+	t.Run("not logged in", func(t *testing.T) {
+		s := startRevocationServer(t)
+		app, buf := newLogoutTestApp(t, s, output.FormatStyled, nil)
+		require.NoError(t, runLogout(t, app), "nothing to log out of is not an error")
+		assert.Contains(t, buf.String(), "Not logged in")
+		assert.Empty(t, s.revoked())
+	})
+}
+
+func TestAuthRevokeRevokesThenForgets(t *testing.T) {
+	s := startRevocationServer(t)
+	app, buf := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+
+	require.NoError(t, runAuthSubcommand(t, app, "revoke"))
+	assert.Equal(t, []string{"rt-1", "at-1"}, s.revoked())
+	data := decodeLogoutJSON(t, buf)
+	assert.Equal(t, "revoked", data["status"])
+	assert.Equal(t, true, data["revoked"])
+	assert.False(t, app.Auth.IsAuthenticated(), "a revoked credential is removed")
+
+	buf.Reset()
+	require.NoError(t, runAuthSubcommand(t, app, "revoke"), "nothing stored is not an error")
+	assert.Equal(t, "not_logged_in", decodeLogoutJSON(t, buf)["status"])
+}
+
+func TestAuthRevokeHumanCopy(t *testing.T) {
+	s := startRevocationServer(t)
+	app, buf := newLogoutTestApp(t, s, output.FormatStyled, bc5LogoutCredentials(s))
+
+	require.NoError(t, runAuthSubcommand(t, app, "revoke"))
+	assert.Contains(t, buf.String(), "Revoked the token with the server and removed the credential")
+}
+
+// Where logout forgets regardless, revoke keeps a credential it could not
+// revoke: the operator asked for the token to be dead, and forgetting it
+// would make that impossible from here.
+func TestAuthRevokeKeepsTheCredentialWhenItCannotRevoke(t *testing.T) {
+	s := startRevocationServer(t)
+	s.metadataStatus = http.StatusNotFound
+	app, _ := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+
+	err := runAuthSubcommand(t, app, "revoke")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not revoke the token server-side: authorization server metadata returned HTTP 404")
+	assert.Contains(t, output.AsError(err).Hint, "basecamp auth revoke")
+	assert.Empty(t, s.revoked())
+	assert.True(t, app.Auth.IsAuthenticated(), "the credential stays for a retry")
+}
+
+func TestAuthRevokeRefusesWhatItCannotRevoke(t *testing.T) {
+	t.Run("launchpad", func(t *testing.T) {
+		s := startRevocationServer(t)
+		creds := &auth.Credentials{AccessToken: "lp-at", RefreshToken: "lp-rt", OAuthType: "launchpad"}
+		app, _ := newLogoutTestApp(t, s, output.FormatJSON, creds)
+		err := runAuthSubcommand(t, app, "revoke")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Launchpad tokens cannot be revoked from the CLI")
+		assert.Contains(t, output.AsError(err).Hint, "basecamp auth logout")
+		assert.True(t, app.Auth.IsAuthenticated())
+	})
+
+	t.Run("imported token", func(t *testing.T) {
+		s := startRevocationServer(t)
+		creds := &auth.Credentials{AccessToken: "pat-1", OAuthType: "bc5", Scope: "full", Source: auth.CredentialSourceToken}
+		app, _ := newLogoutTestApp(t, s, output.FormatJSON, creds)
+		err := runAuthSubcommand(t, app, "revoke")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "revoke it in Basecamp")
+		assert.Empty(t, s.revoked())
+		assert.True(t, app.Auth.IsAuthenticated())
+	})
+}
+
+func TestAuthLogoutJSONCarriesTheReason(t *testing.T) {
+	t.Run("revocation failed", func(t *testing.T) {
+		s := startRevocationServer(t)
+		s.metadataStatus = http.StatusNotFound
+		app, buf := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+		require.NoError(t, runLogout(t, app))
+		data := decodeLogoutJSON(t, buf)
+		assert.Equal(t, "logged_out", data["status"])
+		assert.Equal(t, false, data["revoked"])
+		assert.Equal(t, "authorization server metadata returned HTTP 404", data["reason"])
+	})
+
+	t.Run("imported token", func(t *testing.T) {
+		s := startRevocationServer(t)
+		creds := &auth.Credentials{AccessToken: "pat-1", OAuthType: "bc5", Scope: "full", Source: auth.CredentialSourceToken}
+		app, buf := newLogoutTestApp(t, s, output.FormatJSON, creds)
+		require.NoError(t, runLogout(t, app))
+		data := decodeLogoutJSON(t, buf)
+		assert.Equal(t, "logged_out", data["status"])
+		assert.Equal(t, false, data["revoked"])
+		assert.Equal(t, "imported_token", data["reason"])
+	})
+
+	t.Run("not logged in", func(t *testing.T) {
+		s := startRevocationServer(t)
+		app, buf := newLogoutTestApp(t, s, output.FormatJSON, nil)
+		require.NoError(t, runLogout(t, app))
+		data := decodeLogoutJSON(t, buf)
+		assert.Equal(t, "not_logged_in", data["status"])
+		assert.Equal(t, false, data["revoked"])
+	})
+}

--- a/internal/commands/auth_logout_test.go
+++ b/internal/commands/auth_logout_test.go
@@ -156,7 +156,7 @@ func TestAuthLogoutHumanCopy(t *testing.T) {
 		s.metadataStatus = http.StatusNotFound
 		app, buf := newLogoutTestApp(t, s, output.FormatStyled, bc5LogoutCredentials(s))
 		require.NoError(t, runLogout(t, app), "a failed revocation is not a failed logout")
-		assert.Contains(t, buf.String(), "Logged out locally; could not revoke the token server-side: authorization server metadata returned HTTP 404 — it expires within the hour")
+		assert.Contains(t, buf.String(), "Logged out locally; could not revoke the token server-side: authorization server metadata returned HTTP 404 — the access token expires within the hour, but the refresh token stays valid until it is revoked")
 		assert.Empty(t, s.revoked())
 		assert.False(t, app.Auth.IsAuthenticated(), "the local copy goes regardless")
 	})

--- a/internal/commands/auth_logout_test.go
+++ b/internal/commands/auth_logout_test.go
@@ -225,7 +225,9 @@ func TestAuthRevokeKeepsTheCredentialWhenItCannotRevoke(t *testing.T) {
 	err := runAuthSubcommand(t, app, "revoke")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "could not revoke the token server-side: authorization server metadata returned HTTP 404")
-	assert.Contains(t, output.AsError(err).Hint, "basecamp auth revoke")
+	assert.False(t, output.AsError(err).Retryable, "a 404 will not change on retry")
+	assert.NotContains(t, output.AsError(err).Hint, "basecamp auth revoke", "no retry is advertised for a final refusal")
+	assert.Contains(t, output.AsError(err).Hint, "basecamp auth logout")
 	assert.Empty(t, s.revoked())
 	assert.True(t, app.Auth.IsAuthenticated(), "the credential stays for a retry")
 }
@@ -272,6 +274,24 @@ func TestAuthLogoutAndRevokeRefuseUnderEnvToken(t *testing.T) {
 			assert.NoError(t, loadErr, "the stored credential is left alone")
 		})
 	}
+}
+
+// `auth logout work` is a profile name where none is taken; it must not
+// revoke the selected credential instead.
+func TestAuthLogoutRefusesPositionalArguments(t *testing.T) {
+	s := startRevocationServer(t)
+	app, _ := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+
+	cmd := NewAuthCmd()
+	cmd.SetArgs([]string{"logout", "work"})
+	cmd.SetContext(appctx.WithApp(context.Background(), app))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	require.Error(t, cmd.Execute())
+	assert.Empty(t, s.revoked())
+	assert.True(t, app.Auth.IsAuthenticated(), "the selected credential is untouched")
 }
 
 func TestAuthLogoutJSONCarriesTheReason(t *testing.T) {

--- a/internal/commands/auth_logout_test.go
+++ b/internal/commands/auth_logout_test.go
@@ -156,7 +156,7 @@ func TestAuthLogoutHumanCopy(t *testing.T) {
 		s.metadataStatus = http.StatusNotFound
 		app, buf := newLogoutTestApp(t, s, output.FormatStyled, bc5LogoutCredentials(s))
 		require.NoError(t, runLogout(t, app), "a failed revocation is not a failed logout")
-		assert.Contains(t, buf.String(), "Logged out locally; could not revoke the token server-side: authorization server metadata returned HTTP 404 — the access token expires within the hour, but the refresh token stays valid until it is revoked")
+		assert.Contains(t, buf.String(), "Logged out locally; could not revoke the token server-side: authorization server metadata returned HTTP 404 — the refresh token stays valid until it is revoked")
 		assert.Empty(t, s.revoked())
 		assert.False(t, app.Auth.IsAuthenticated(), "the local copy goes regardless")
 	})
@@ -254,6 +254,26 @@ func TestAuthRevokeRefusesWhatItCannotRevoke(t *testing.T) {
 	})
 }
 
+// With BASECAMP_TOKEN in use the stored credential is not the session being
+// ended, and revoking it would kill an unrelated refresh family for good.
+func TestAuthLogoutAndRevokeRefuseUnderEnvToken(t *testing.T) {
+	for _, sub := range []string{"logout", "revoke"} {
+		t.Run(sub, func(t *testing.T) {
+			s := startRevocationServer(t)
+			app, _ := newLogoutTestApp(t, s, output.FormatJSON, bc5LogoutCredentials(s))
+			t.Setenv("BASECAMP_TOKEN", "bc_at_env")
+
+			err := runAuthSubcommand(t, app, sub)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "BASECAMP_TOKEN is set")
+			assert.Contains(t, output.AsError(err).Hint, "Unset BASECAMP_TOKEN")
+			assert.Empty(t, s.revoked())
+			_, loadErr := app.Auth.GetStore().Load(app.Auth.CredentialKey())
+			assert.NoError(t, loadErr, "the stored credential is left alone")
+		})
+	}
+}
+
 func TestAuthLogoutJSONCarriesTheReason(t *testing.T) {
 	t.Run("revocation failed", func(t *testing.T) {
 		s := startRevocationServer(t)
@@ -264,6 +284,7 @@ func TestAuthLogoutJSONCarriesTheReason(t *testing.T) {
 		assert.Equal(t, "logged_out", data["status"])
 		assert.Equal(t, false, data["revoked"])
 		assert.Equal(t, "authorization server metadata returned HTTP 404", data["reason"])
+		assert.Equal(t, "refresh_token", data["remaining"])
 	})
 
 	t.Run("imported token", func(t *testing.T) {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -121,9 +121,9 @@ func CommandCategories() []CommandCategory {
 			Name: "Auth & Config",
 			Commands: []CommandInfo{
 				{Name: "accounts", Category: "auth", Description: "Manage accounts", Actions: []string{"list", "use", "show", "update", "logo"}},
-				{Name: "auth", Category: "auth", Description: "Authenticate with Basecamp", Actions: []string{"login", "logout", "status", "refresh"}},
+				{Name: "auth", Category: "auth", Description: "Authenticate with Basecamp", Actions: []string{"login", "logout", "revoke", "status", "refresh"}},
 				{Name: "login", Category: "auth", Description: "Authenticate with Basecamp"},
-				{Name: "logout", Category: "auth", Description: "Remove stored credentials"},
+				{Name: "logout", Category: "auth", Description: "Log out and revoke the credential"},
 				{Name: "config", Category: "auth", Description: "Manage configuration", Actions: []string{"show", "init", "set", "unset", "project", "trust", "untrust"}},
 				{Name: "me", Category: "auth", Description: "Show current user profile"},
 				{Name: "setup", Category: "auth", Description: "First-time setup with recommended defaults"},

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -374,15 +374,15 @@ func newProfileDeleteCmd() *cobra.Command {
 
 			summary := fmt.Sprintf("Deleted profile %q", name)
 			fields := map[string]any{"name": name, "status": "deleted"}
-			// The revocation's egress policy follows the profile being deleted.
-			// For the active profile that is the effective configuration —
-			// environment overrides included, as at its login — and for any
-			// other its saved base URL.
-			anchor := app.Config.Profiles[name].BaseURL
-			if name == app.Config.ActiveProfile {
-				anchor = ""
-			}
-			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name, anchor)
+			// The revocation's egress policy is anchored on the deleted
+			// profile's own saved base URL — the operator's configuration for
+			// that profile — never on the active configuration, whose base URL
+			// may belong to another profile or to a transient override. A
+			// credential minted under an override at login time is not
+			// recorded as such (the store must not choose its own policy), so
+			// that case reaches the summary as a failed revocation, not a
+			// silent success.
+			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name, app.Config.Profiles[name].BaseURL)
 			switch {
 			case errors.Is(err, auth.ErrNoCredential):
 				// A profile that never logged in has nothing to revoke.

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/basecamp/basecamp-cli/internal/auth"
 	"github.com/basecamp/basecamp-cli/internal/config"
 	"github.com/basecamp/basecamp-cli/internal/output"
+	"github.com/basecamp/basecamp-cli/internal/richtext"
 )
 
 // NewProfileCmd creates the profile command group.
@@ -386,7 +387,9 @@ func newProfileDeleteCmd() *cobra.Command {
 			case errors.Is(err, auth.ErrNoCredential):
 				// A profile that never logged in has nothing to revoke.
 			case err != nil:
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not delete credentials for profile %q: %v\n", name, err)
+				// Written straight to the terminal, so the store's error text
+				// (paths, endpoint hosts) is scrubbed here rather than at a sink.
+				fmt.Fprintln(cmd.ErrOrStderr(), richtext.SanitizeSingleLine(fmt.Sprintf("Warning: could not delete credentials for profile %q: %v", name, err)))
 			default:
 				var outcome map[string]any
 				summary, outcome = describeLogout(summary, result)

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -373,7 +373,15 @@ func newProfileDeleteCmd() *cobra.Command {
 
 			summary := fmt.Sprintf("Deleted profile %q", name)
 			fields := map[string]any{"name": name, "status": "deleted"}
-			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name, app.Config.Profiles[name].BaseURL)
+			// The revocation's egress policy follows the profile being deleted.
+			// For the active profile that is the effective configuration —
+			// environment overrides included, as at its login — and for any
+			// other its saved base URL.
+			anchor := app.Config.Profiles[name].BaseURL
+			if name == app.Config.ActiveProfile {
+				anchor = ""
+			}
+			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name, anchor)
 			switch {
 			case errors.Is(err, auth.ErrNoCredential):
 				// A profile that never logged in has nothing to revoke.

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -373,7 +373,7 @@ func newProfileDeleteCmd() *cobra.Command {
 
 			summary := fmt.Sprintf("Deleted profile %q", name)
 			fields := map[string]any{"name": name, "status": "deleted"}
-			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name)
+			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name, app.Config.Profiles[name].BaseURL)
 			switch {
 			case errors.Is(err, auth.ErrNoCredential):
 				// A profile that never logged in has nothing to revoke.

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -345,7 +347,7 @@ func newProfileDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a profile",
-		Long:  "Remove a profile configuration and its stored credentials.",
+		Long:  "Remove a profile configuration and its stored credentials, revoking the credential with the server when it can be.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := appctx.FromContext(cmd.Context())
@@ -369,21 +371,25 @@ func newProfileDeleteCmd() *cobra.Command {
 				return err
 			}
 
-			// Remove credentials
-			credKey := "profile:" + name
-			store := app.Auth.GetStore()
-			if err := store.Delete(credKey); err != nil {
+			summary := fmt.Sprintf("Deleted profile %q", name)
+			fields := map[string]any{"name": name, "status": "deleted"}
+			result, err := app.Auth.LogoutCredential(cmd.Context(), "profile:"+name)
+			switch {
+			case errors.Is(err, auth.ErrNoCredential):
+				// A profile that never logged in has nothing to revoke.
+			case err != nil:
 				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not delete credentials for profile %q: %v\n", name, err)
+			default:
+				var outcome map[string]any
+				summary, outcome = describeLogout(summary, result)
+				maps.Copy(fields, outcome)
 			}
 
 			if err := unregisterProfile(name); err != nil {
 				return err
 			}
 
-			return app.OK(map[string]any{
-				"name":   name,
-				"status": "deleted",
-			}, output.WithSummary(fmt.Sprintf("Deleted profile %q", name)))
+			return app.OK(fields, output.WithSummary(summary))
 		},
 	}
 }

--- a/internal/commands/profile_test.go
+++ b/internal/commands/profile_test.go
@@ -891,6 +891,60 @@ func TestProfileDeleteRemovesFromConfig(t *testing.T) {
 	assert.Equal(t, "keep-me", configData["default_profile"], "default should remain unchanged")
 }
 
+// Deleting a profile takes the logout path for its credential: revoked with
+// the server when it can be, forgotten locally either way.
+func TestProfileDeleteRevokesTheCredential(t *testing.T) {
+	s := startRevocationServer(t)
+	cfg := &config.Config{
+		BaseURL:  s.srv.URL,
+		CacheDir: t.TempDir(),
+		Sources:  make(map[string]string),
+		Profiles: map[string]*config.ProfileConfig{
+			"bot": {BaseURL: s.srv.URL},
+		},
+	}
+	app, buf := setupProfileTestApp(t, cfg)
+	authMgr := auth.NewManager(cfg, s.srv.Client())
+	authMgr.SetStore(auth.NewStore(t.TempDir()))
+	require.NoError(t, authMgr.GetStore().Save("profile:bot", bc5LogoutCredentials(s)))
+	app.Auth = authMgr
+	writeConfigFile(t, map[string]any{
+		"profiles": map[string]any{"bot": map[string]any{"base_url": s.srv.URL}},
+	})
+
+	require.NoError(t, executeProfileCommand(newProfileDeleteCmd(), app, "bot"))
+
+	assert.Equal(t, []string{"rt-1", "at-1"}, s.revoked())
+	_, err := authMgr.GetStore().Load("profile:bot")
+	assert.Error(t, err, "the credential is forgotten")
+	data := decodeLogoutJSON(t, buf)
+	assert.Equal(t, "deleted", data["status"])
+	assert.Equal(t, "bot", data["name"])
+	assert.Equal(t, true, data["revoked"])
+	assert.NotContains(t, readConfigFile(t), "profiles")
+}
+
+func TestProfileDeleteWithoutCredentialsRevokesNothing(t *testing.T) {
+	s := startRevocationServer(t)
+	cfg := &config.Config{
+		BaseURL:  s.srv.URL,
+		CacheDir: t.TempDir(),
+		Sources:  make(map[string]string),
+		Profiles: map[string]*config.ProfileConfig{"bot": {BaseURL: s.srv.URL}},
+	}
+	app, buf := setupProfileTestApp(t, cfg)
+	writeConfigFile(t, map[string]any{
+		"profiles": map[string]any{"bot": map[string]any{"base_url": s.srv.URL}},
+	})
+
+	require.NoError(t, executeProfileCommand(newProfileDeleteCmd(), app, "bot"))
+
+	assert.Empty(t, s.revoked())
+	data := decodeLogoutJSON(t, buf)
+	assert.Equal(t, "deleted", data["status"])
+	assert.NotContains(t, data, "revoked", "a profile that never logged in has nothing to report")
+}
+
 func TestProfileDeleteClearsDefaultWhenDeletingDefaultProfile(t *testing.T) {
 	cfg := &config.Config{
 		BaseURL:        "https://3.basecampapi.com",

--- a/skills/basecamp/SKILL.md
+++ b/skills/basecamp/SKILL.md
@@ -1393,6 +1393,7 @@ basecamp auth login --device-code                 # Headless authentication with
 BASECAMP_NONINTERACTIVE=1 basecamp auth login --device-code  # The only OAuth login that runs under BASECAMP_NONINTERACTIVE, and only where the server offers the device flow (Launchpad does not); browser and pasted-callback flows refuse — prefer --with-token
 basecamp auth login --with-token -P bot --account <id>  # Import a personal access token from stdin (pipe it in)
 basecamp auth login --expect-identity <id>        # Discard the login unless it authenticated as this identity
+basecamp auth revoke                              # Revoke the token with the server and forget it; refuses when it cannot revoke (auth logout forgets regardless)
 basecamp profile create <name> --account <id> --expect-identity <id>  # Same assertion for a new profile
 ```
 


### PR DESCRIPTION
## What

- `auth logout` (and the `logout` alias) revokes the credential with its authorization server (RFC 7009) before removing it locally: the refresh token first, which revokes its whole family, then the access token, as the public `basecamp-cli` client. Local removal happens regardless of the server's answer.
- `profile delete <name>` takes the same revoke-then-delete path for `profile:<name>` instead of calling the store directly, with the revocation's egress lane anchored on that profile's own base URL rather than the active configuration's.
- New `auth revoke [-P profile]`: the explicit "kill this token" verb. It revokes and then removes the credential (a revoked refresh family leaves nothing usable), but unlike logout it keeps a credential it could not revoke so the revocation can be retried, and refuses Launchpad and imported tokens with the reason and a hint. Its `Long` spells out the difference from logout.
- The human summary says what happened: `Logged out (token revoked)`; `Logged out locally; could not revoke the token server-side: <reason> — the refresh token stays valid until it is revoked` (or `— only the access token remains and it expires in 42m0s` / `has already expired` / `reports no expiry`, from the stored expiry, when the failure struck after the refresh token was accepted or there was none); `Logged out (Launchpad tokens cannot be revoked from the CLI)`; `Logged out (forgot the imported token; it stays valid until revoked in Basecamp)`. Nothing stored is `Not logged in`, exit 0. JSON keeps `status` and gains `revoked` (plus `reason` and `remaining` when it is false).
- Both `auth logout` and `auth revoke` refuse while `BASECAMP_TOKEN` is set: the stored credential is not the session in use, and revoking it would kill an unrelated refresh family for good.
- A store that cannot be read (a locked keyring, an unreadable file) fails the logout with that error instead of reporting `Not logged in`; only a genuine miss does that, and an unreadable blob is cleared.
- Revocation failures keep their taxonomy: a transport failure or 5xx stays `retryable`, a refusal does not, so `auth revoke`'s "retry" hint and the JSON `retryable` flag agree.
- New `Manager.Revoke`, `Manager.Logout(ctx)` returning a `LogoutResult`, `Manager.LogoutCredential(ctx, key, baseURL)`, and `Manager.RevokeStored(ctx)`; `Store.Load` marks an unreadable blob with `ErrInvalidCredentials` so logout can clear it (and report a failure to) rather than mistake it for nothing stored; `Credentials` gains `issuer`, recorded at login. Credentials stored before that derive the issuer from the token endpoint's origin, which Basecamp mounts under the issuer.
- The SDK's discovery drops `revocation_endpoint`, so the metadata read is a small GET here: the document's `issuer` must equal the issuer it was fetched for (a GET may follow redirects; another server's valid metadata must not name where the tokens go), the endpoint is validated like every other server-named endpoint, and both ride the BC5 lane client so the egress policy applies. Each request is bounded to 10 s.
- `auth logout` takes no arguments (`auth logout work` used to revoke the selected credential); `auth revoke` advertises a retry only when the failure is retryable.
- `.surface` regenerated for the new command; one SKILL.md line under "Authentication errors"; `auth revoke` marked out of scope in the smoke suite alongside `auth logout`.

## Why

The smoke tests flagged "CLI auth logout / profile delete never revokes the server-side token (in-house issuer)": logout only deleted the local copy while the server advertised a revocation endpoint the CLI never called, leaving the refresh token and its access tokens live for anyone who had captured them. The operator also asked for the CLI to be able to revoke its own token explicitly, hence `auth revoke`.

Launchpad has no revocation endpoint, and an imported personal access token is the operator's (the same token lives in their secret store), so those are forgotten locally and the summary says so rather than pretending.

The companion fix for a refused `--expect-identity` login leaving its freshly minted grant live is stacked on this branch as a separate PR.

## Before / After

Before:

```
$ basecamp auth logout
Successfully logged out
```

After:

```
$ basecamp auth logout
Logged out (token revoked)

Status : logged_out
Revoked: yes

$ basecamp auth logout            # authorization server unreachable
Logged out locally; could not revoke the token server-side: fetching authorization server metadata: Get "https://3.basecamp.com/.well-known/oauth-authorization-server": dial tcp: lookup 3.basecamp.com: no such host — the access token expires within the hour, but the refresh token stays valid until it is revoked

Status : logged_out
Revoked: no
Reason : fetching authorization server metadata: Get "https://3.basecamp.com/.well-known/oauth-authorization-server": dial tcp: lookup 3.basecamp.com: no such host

$ basecamp auth logout            # nothing stored
Not logged in

$ basecamp auth logout --json
{
  "ok": true,
  "data": { "revoked": true, "status": "logged_out" },
  "summary": "Logged out (token revoked)"
}

$ basecamp auth revoke
Revoked the token with the server and removed the credential

$ basecamp auth revoke            # authorization server unreachable
Error: could not revoke the token server-side: fetching authorization server metadata: ... ; the credential is kept so you can retry
Retry: basecamp auth revoke — or forget it locally: basecamp auth logout

$ basecamp auth revoke            # imported personal access token
Error: An imported personal access token is not the CLI's to revoke; revoke it in Basecamp
Forget the credential locally instead: basecamp auth logout
```

## Borrowed from Codex

Codex's `logout_with_revoke` revokes best-effort with a 10 s timeout and then always clears the local store, exiting 0 either way; `auth logout` does the same, and additionally sends both tokens (the hint is advisory) and tells the user which of the four outcomes they got. Codex has no explicit revoke verb.

## Testing

- `internal/auth/revoke_test.go`: the two POSTs and their form fields (no client secret), issuer derivation from the token endpoint, only-the-tokens-it-holds, metadata without an endpoint, unparseable/404 metadata, an insecure revocation endpoint refused before any POST, a 503 reported without the token in the message, the per-request timeout, logout deleting on success and on failure, Launchpad and imported tokens skipped, `LogoutCredential` clearing only the named key, a login recording its issuer, and `RevokeStored` deleting on success / keeping the credential on refusal / refusing Launchpad and imported tokens. `startDeviceAS` now serves `/oauth/revocations` and advertises it.
- `internal/commands/auth_logout_test.go`: the JSON shape and every human summary for `auth logout` and `auth revoke`, including `Not logged in` and the kept-credential path. `profile_test.go`: deleting a profile revokes its credential; a profile that never logged in revokes nothing.
- Gates: `make fmt-check vet lint`, `make check-surface check-skill-drift check-smoke-coverage`, and `make test-e2e` pass. Eleven pre-existing terminal-detection tests (`appctx`, `cli`, `commands`, `stdinarg`, `tui/resolve`) fail on this machine for a pristine `origin/main` checkout with the identical set — a pty quirk of the session, not the diff; the full suite was also run on a clean Linux host.
